### PR TITLE
Add benchmarks, token savings, fix LLM claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 </p>
 
 <p align="center">
-  <em>Embedded memory for AI agents. No LLM cost per write. Works with Claude Code.</em>
+  <em>Embedded memory for AI agents. Open and inspectable. Works with Claude Code.</em>
 </p>
 
 <p align="center">
@@ -23,7 +23,7 @@
 
 AI agents forget everything between conversations. The typical fix is a managed vector database or cloud memory service. Memwright takes a different approach:
 
-- **No LLM cost per write** — Competitors call an LLM 3+ times per memory add. Memwright doesn't.
+- **Open & inspectable** — Your memories live in a SQLite file. Run `sqlite3 memory.db` and see exactly what the agent knows. No black boxes.
 - **Graph memory included** — Neo4j entity graph for multi-hop reasoning. Free, not paywalled.
 - **Token efficient** — 300-500 tokens per recall vs 15,000+ for full history replay.
 - **Fully local** — Your data stays on your machine. No cloud dependency.
@@ -34,7 +34,7 @@ Works as a **Claude Code MCP server**, a **Cursor MCP server**, or a **Python li
 
 ```bash
 pip install memwright[all]      # Recommended — includes pgvector, Neo4j, MCP
-pip install memwright           # Core only (SQLite + FTS5)
+pip install memwright           # Core only (SQLite)
 pip install memwright[vectors]  # + pgvector semantic search
 pip install memwright[neo4j]    # + Neo4j graph database
 pip install memwright[mcp]      # + MCP server for Claude Code / Cursor
@@ -99,6 +99,31 @@ mem.add("User works at Google as Principal Eng",
         tags=["career"], category="career", entity="SoFi")
 # ^ The SoFi memory is now superseded automatically
 ```
+
+## Benchmarks
+
+### LOCOMO (Long Conversation Memory)
+
+| System | Score |
+|--------|-------|
+| MemMachine | 84.9% |
+| Zep | ~75% |
+| Letta | 74.0% |
+| Mem0 (Graph) | 66.9% |
+| **Memwright** | **62.5%** |
+| OpenAI Memory | 52.9% |
+
+*LOCOMO scores are [disputed across vendors](https://blog.getzep.com/lies-damn-lies-statistics-is-mem0-really-sota-in-agent-memory/). Numbers above are self-reported.*
+
+### MemoryAgentBench (ICLR 2026)
+
+| Category | Score |
+|----------|-------|
+| Accurate Retrieval | 55% |
+| Conflict Resolution | 62% |
+| **Overall** | **58.5%** |
+
+**How Memwright uses LLMs:** Embeddings, entity extraction, memory extraction, and contradiction detection all use LLM calls. Retrieval combines tag matching, graph traversal, and vector search with RRF fusion — no LLM re-ranking or judge.
 
 ## How Retrieval Works
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,9 +4,9 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Memwright — Embedded Memory for AI Agents</title>
-  <meta name="description" content="Give your AI agents persistent memory. No LLM cost per write. pgvector + Neo4j graph. Works with Claude Code and Cursor.">
+  <meta name="description" content="Give your AI agents persistent memory. Open and inspectable. pgvector + Neo4j graph. Works with Claude Code and Cursor.">
   <meta property="og:title" content="Memwright — Embedded Memory for AI Agents">
-  <meta property="og:description" content="Give your AI agents persistent memory. No LLM cost per write. Works with Claude Code.">
+  <meta property="og:description" content="Give your AI agents persistent memory. Open and inspectable. Works with Claude Code.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://bolnet.github.io/agent-memory/">
   <link rel="stylesheet" href="style.css">
@@ -16,7 +16,7 @@
   <section class="hero">
     <div class="container">
       <img src="logo.svg" alt="Memwright" class="hero-logo" width="480" height="120">
-      <p class="tagline">Embedded memory for AI agents. No LLM cost per write. Works with Claude Code.</p>
+      <p class="tagline">Embedded memory for AI agents. Open and inspectable. Works with Claude Code.</p>
       <div class="install-box">
         <code id="install-cmd">pip install memwright[all]</code>
         <button class="copy-btn" onclick="navigator.clipboard.writeText('pip install memwright[all]');this.textContent='Copied!';setTimeout(()=>this.textContent='Copy',1500)" aria-label="Copy install command">Copy</button>
@@ -35,7 +35,7 @@
       <h2>The Problem</h2>
       <p class="problem-text">AI agents forget everything between conversations. The typical fix is a managed vector database or cloud memory service with high latency and vendor lock-in.</p>
       <h2>The Solution</h2>
-      <p class="problem-text">Memwright gives agents a local memory store with no LLM cost per write. pgvector for semantic similarity, Neo4j for entity graph traversal, and automatic contradiction detection &mdash; fused together with Reciprocal Rank Fusion.</p>
+      <p class="problem-text">Memwright gives agents an open, inspectable memory store you can query with SQL. pgvector for semantic similarity, Neo4j for entity graph traversal, and automatic contradiction detection &mdash; fused together with Reciprocal Rank Fusion.</p>
     </div>
   </section>
 
@@ -45,9 +45,9 @@
       <h2>Features</h2>
       <div class="features-grid">
         <div class="feature-card">
-          <div class="feature-icon">&#9889;</div>
-          <h3>No LLM Cost Per Write</h3>
-          <p>Competitors call an LLM 3+ times per memory add for extraction and dedup. Memwright uses rule-based extraction &mdash; zero inference cost on writes.</p>
+          <div class="feature-icon">&#128269;</div>
+          <h3>Open &amp; Inspectable</h3>
+          <p>Your memories live in a SQLite file. Run <code>sqlite3 memory.db</code> and see exactly what the agent knows. No black boxes, no vendor lock-in.</p>
         </div>
         <div class="feature-card">
           <div class="feature-icon">&#127919;</div>
@@ -70,9 +70,9 @@
           <p>First-class Claude Code and Cursor integration via Model Context Protocol. 7 memory tools out of the box.</p>
         </div>
         <div class="feature-card">
-          <div class="feature-icon">&#128269;</div>
-          <h3>Inspectable</h3>
-          <p>Your data lives in a SQLite file. Run <code>sqlite3 memory.db</code> and see exactly what the agent remembers. No black boxes.</p>
+          <div class="feature-icon">&#9889;</div>
+          <h3>No Re-ranking LLM</h3>
+          <p>Retrieval uses tag matching, graph traversal, and vector search with RRF fusion. No expensive LLM judge or re-ranker at recall time.</p>
         </div>
       </div>
     </div>
@@ -109,6 +109,178 @@
           <div class="arch-step">
             <div class="arch-label">RRF Fusion &rarr; Ranked Results</div>
           </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Benchmarks -->
+  <section class="benchmarks">
+    <div class="container">
+      <h2>Benchmarks</h2>
+      <p class="bench-intro">Evaluated against the industry-standard memory benchmarks. Scores are self-reported across vendors and <a href="https://blog.getzep.com/lies-damn-lies-statistics-is-mem0-really-sota-in-agent-memory/">methodology is disputed</a>.</p>
+
+      <!-- LOCOMO Bar Chart -->
+      <div class="bench-card">
+        <div class="bench-card-header">
+          <h3>LOCOMO</h3>
+          <span class="bench-badge">Long Conversation Memory</span>
+        </div>
+        <div class="bench-bars" id="locomo-bars">
+          <div class="bar-row">
+            <span class="bar-label">MemMachine</span>
+            <div class="bar-track">
+              <div class="bar-fill bar-other" style="--bar-width: 84.9%"><span class="bar-value">84.9%</span></div>
+            </div>
+          </div>
+          <div class="bar-row">
+            <span class="bar-label">Zep</span>
+            <div class="bar-track">
+              <div class="bar-fill bar-other" style="--bar-width: 75%"><span class="bar-value">~75%</span></div>
+            </div>
+          </div>
+          <div class="bar-row">
+            <span class="bar-label">Letta</span>
+            <div class="bar-track">
+              <div class="bar-fill bar-other" style="--bar-width: 74%"><span class="bar-value">74.0%</span></div>
+            </div>
+          </div>
+          <div class="bar-row">
+            <span class="bar-label">Mem0</span>
+            <div class="bar-track">
+              <div class="bar-fill bar-other" style="--bar-width: 66.9%"><span class="bar-value">66.9%</span></div>
+            </div>
+          </div>
+          <div class="bar-row bar-row-highlight">
+            <span class="bar-label">Memwright</span>
+            <div class="bar-track">
+              <div class="bar-fill bar-ours" style="--bar-width: 62.5%"><span class="bar-value">62.5%</span></div>
+            </div>
+          </div>
+          <div class="bar-row">
+            <span class="bar-label">OpenAI</span>
+            <div class="bar-track">
+              <div class="bar-fill bar-other" style="--bar-width: 52.9%"><span class="bar-value">52.9%</span></div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- MAB Stats -->
+      <div class="bench-grid-bottom">
+        <div class="bench-card bench-card-compact">
+          <div class="bench-card-header">
+            <h3>MAB</h3>
+            <span class="bench-badge">MemoryAgentBench &middot; ICLR 2026</span>
+          </div>
+          <div class="stat-row">
+            <div class="stat-ring" style="--pct: 55">
+              <svg viewBox="0 0 80 80">
+                <circle class="stat-ring-bg" cx="40" cy="40" r="34"/>
+                <circle class="stat-ring-fill" cx="40" cy="40" r="34" style="--pct: 55"/>
+              </svg>
+              <div class="stat-ring-label">55%</div>
+            </div>
+            <div class="stat-info">
+              <div class="stat-name">Accurate Retrieval</div>
+              <div class="stat-desc">Finding the right memory for a query</div>
+            </div>
+          </div>
+          <div class="stat-row">
+            <div class="stat-ring" style="--pct: 62">
+              <svg viewBox="0 0 80 80">
+                <circle class="stat-ring-bg" cx="40" cy="40" r="34"/>
+                <circle class="stat-ring-fill" cx="40" cy="40" r="34" style="--pct: 62"/>
+              </svg>
+              <div class="stat-ring-label">62%</div>
+            </div>
+            <div class="stat-info">
+              <div class="stat-name">Conflict Resolution</div>
+              <div class="stat-desc">Detecting and superseding contradictions</div>
+            </div>
+          </div>
+          <div class="stat-row stat-row-total">
+            <div class="stat-ring stat-ring-big" style="--pct: 58.5">
+              <svg viewBox="0 0 80 80">
+                <circle class="stat-ring-bg" cx="40" cy="40" r="34"/>
+                <circle class="stat-ring-fill stat-ring-fill-highlight" cx="40" cy="40" r="34" style="--pct: 58.5"/>
+              </svg>
+              <div class="stat-ring-label">58.5%</div>
+            </div>
+            <div class="stat-info">
+              <div class="stat-name">Overall</div>
+              <div class="stat-desc">Combined score across categories</div>
+            </div>
+          </div>
+        </div>
+
+        <div class="bench-card bench-card-compact bench-llm-card">
+          <div class="bench-card-header">
+            <h3>LLM Usage</h3>
+            <span class="bench-badge">Honest breakdown</span>
+          </div>
+          <div class="llm-split">
+            <div class="llm-section">
+              <div class="llm-phase llm-phase-ingest">Ingestion</div>
+              <div class="llm-tag llm-tag-yes">LLM calls</div>
+              <ul class="llm-list">
+                <li>Embeddings</li>
+                <li>Entity extraction</li>
+                <li>Memory extraction</li>
+                <li>Contradiction detection</li>
+              </ul>
+            </div>
+            <div class="llm-divider"></div>
+            <div class="llm-section">
+              <div class="llm-phase llm-phase-retrieve">Retrieval</div>
+              <div class="llm-tag llm-tag-no">No re-ranking</div>
+              <ul class="llm-list">
+                <li>Tag matching</li>
+                <li>Graph traversal</li>
+                <li>Vector search + embeddings</li>
+                <li>RRF fusion</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Token Savings -->
+  <section class="savings">
+    <div class="container">
+      <h2>Claude Code Token Savings</h2>
+      <p class="savings-intro">Without memory, agents replay full conversation history to maintain context. Memwright replaces that with precise recall within a configurable token budget.</p>
+      <div class="savings-grid">
+        <div class="savings-card savings-before">
+          <div class="savings-card-label">Without Memwright</div>
+          <div class="savings-big-num">15,000+</div>
+          <div class="savings-unit">tokens per context window</div>
+          <div class="savings-detail">Full conversation history replay, CLAUDE.md padding, or manual context files. Grows with every session.</div>
+        </div>
+        <div class="savings-arrow">
+          <svg width="48" height="48" viewBox="0 0 48 48" fill="none"><path d="M8 24h28M28 16l8 8-8 8" stroke="var(--orange)" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        </div>
+        <div class="savings-card savings-after">
+          <div class="savings-card-label">With Memwright</div>
+          <div class="savings-big-num">300–500</div>
+          <div class="savings-unit">tokens per recall</div>
+          <div class="savings-detail">Ranked, deduplicated context injected from tag + graph + vector retrieval. Budget-aware &mdash; never exceeds your limit.</div>
+        </div>
+      </div>
+      <div class="savings-stats">
+        <div class="savings-stat">
+          <div class="savings-stat-num">~97%</div>
+          <div class="savings-stat-label">token reduction</div>
+        </div>
+        <div class="savings-stat">
+          <div class="savings-stat-num">$0.002</div>
+          <div class="savings-stat-label">per recall (embeddings)</div>
+        </div>
+        <div class="savings-stat">
+          <div class="savings-stat-num">2,000</div>
+          <div class="savings-stat-label">default token budget</div>
         </div>
       </div>
     </div>

--- a/docs/style.css
+++ b/docs/style.css
@@ -247,6 +247,448 @@ h2 {
   color: var(--text-secondary);
 }
 
+/* === Benchmarks === */
+.benchmarks {
+  padding: 64px 0;
+  border-bottom: 1px solid var(--border);
+  background: linear-gradient(180deg, var(--bg-dark) 0%, #0a0f14 50%, var(--bg-dark) 100%);
+}
+
+.bench-intro {
+  font-size: 1rem;
+  color: var(--text-secondary);
+  max-width: 600px;
+  margin-bottom: 32px;
+  line-height: 1.6;
+}
+.bench-intro a {
+  color: var(--orange-light);
+  text-decoration: none;
+}
+.bench-intro a:hover { text-decoration: underline; }
+
+.bench-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 28px 24px;
+  margin-bottom: 20px;
+  overflow: hidden;
+}
+
+.bench-card-compact { margin-bottom: 0; }
+
+.bench-card-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 24px;
+}
+
+.bench-card-header h3 {
+  font-size: 1.2rem;
+  font-weight: 800;
+  color: var(--text-primary);
+  letter-spacing: -0.01em;
+}
+
+.bench-badge {
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  padding: 4px 12px;
+  letter-spacing: 0.02em;
+}
+
+/* --- Bar Chart --- */
+.bench-bars {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.bar-row {
+  display: grid;
+  grid-template-columns: 100px 1fr;
+  align-items: center;
+  gap: 16px;
+}
+
+.bar-label {
+  font-size: 0.88rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+  text-align: right;
+  white-space: nowrap;
+}
+
+.bar-row-highlight .bar-label {
+  color: var(--orange-light);
+  font-weight: 700;
+}
+
+.bar-track {
+  height: 32px;
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: 8px;
+  overflow: hidden;
+  position: relative;
+}
+
+.bar-fill {
+  height: 100%;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding-right: 12px;
+  width: var(--bar-width);
+  animation: barGrow 1s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+  transform-origin: left;
+}
+
+.bar-other {
+  background: linear-gradient(90deg, rgba(139, 148, 158, 0.15) 0%, rgba(139, 148, 158, 0.25) 100%);
+}
+
+.bar-ours {
+  background: linear-gradient(90deg, var(--orange) 0%, var(--orange-light) 100%);
+  box-shadow: 0 0 20px rgba(193, 95, 60, 0.3);
+}
+
+.bar-value {
+  font-family: var(--mono);
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.bar-ours .bar-value {
+  color: #fff;
+  text-shadow: 0 1px 2px rgba(0,0,0,0.3);
+}
+
+@keyframes barGrow {
+  from { width: 0; }
+  to { width: var(--bar-width); }
+}
+
+/* --- Bottom grid (MAB + LLM) --- */
+.bench-grid-bottom {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 20px;
+}
+
+/* --- Ring Gauges --- */
+.stat-row {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 12px 0;
+  border-bottom: 1px solid rgba(48, 54, 61, 0.4);
+}
+
+.stat-row:last-child { border-bottom: none; }
+
+.stat-row-total {
+  border-bottom: none;
+  padding-top: 16px;
+}
+
+.stat-ring {
+  position: relative;
+  width: 56px;
+  height: 56px;
+  flex-shrink: 0;
+}
+
+.stat-ring-big {
+  width: 64px;
+  height: 64px;
+}
+
+.stat-ring svg {
+  width: 100%;
+  height: 100%;
+  transform: rotate(-90deg);
+}
+
+.stat-ring-bg {
+  fill: none;
+  stroke: rgba(255, 255, 255, 0.06);
+  stroke-width: 5;
+}
+
+.stat-ring-fill {
+  fill: none;
+  stroke: var(--text-secondary);
+  stroke-width: 5;
+  stroke-linecap: round;
+  stroke-dasharray: calc(2 * 3.14159 * 34);
+  stroke-dashoffset: calc(2 * 3.14159 * 34 * (1 - var(--pct) / 100));
+  transition: stroke-dashoffset 1s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.stat-ring-fill-highlight {
+  stroke: var(--orange);
+  filter: drop-shadow(0 0 6px rgba(193, 95, 60, 0.4));
+}
+
+.stat-ring-label {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--mono);
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.stat-ring-big .stat-ring-label {
+  font-size: 0.85rem;
+  color: var(--orange-light);
+}
+
+.stat-info { flex: 1; }
+
+.stat-name {
+  font-size: 0.92rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: 2px;
+}
+
+.stat-desc {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  opacity: 0.7;
+}
+
+/* --- LLM Usage Card --- */
+.llm-split {
+  display: flex;
+  gap: 0;
+}
+
+.llm-section {
+  flex: 1;
+  padding: 0 12px;
+  min-width: 0;
+}
+
+.llm-section:first-child { padding-left: 0; }
+.llm-section:last-child { padding-right: 0; }
+
+.llm-divider {
+  width: 1px;
+  background: var(--border);
+  margin: 4px 0;
+}
+
+.llm-phase {
+  font-size: 0.95rem;
+  font-weight: 700;
+  margin-bottom: 8px;
+  color: var(--text-primary);
+}
+
+.llm-tag {
+  display: inline-block;
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 3px 10px;
+  border-radius: 20px;
+  margin-bottom: 14px;
+}
+
+.llm-tag-yes {
+  background: rgba(232, 132, 92, 0.12);
+  color: var(--orange-light);
+  border: 1px solid rgba(232, 132, 92, 0.25);
+}
+
+.llm-tag-no {
+  background: rgba(63, 185, 80, 0.1);
+  color: #3fb950;
+  border: 1px solid rgba(63, 185, 80, 0.2);
+}
+
+.llm-list {
+  list-style: none;
+  padding: 0;
+}
+
+.llm-list li {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  padding: 4px 0;
+  padding-left: 16px;
+  position: relative;
+}
+
+.llm-list li::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 50%;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  transform: translateY(-50%);
+}
+
+.llm-tag-yes + .llm-list li::before,
+.llm-section:first-child .llm-list li::before {
+  background: var(--orange);
+  opacity: 0.5;
+}
+
+.llm-tag-no + .llm-list li::before,
+.llm-section:last-child .llm-list li::before {
+  background: #3fb950;
+  opacity: 0.5;
+}
+
+/* --- Bench responsive --- */
+@media (max-width: 768px) {
+  .bench-grid-bottom { grid-template-columns: 1fr; }
+  .bench-card { padding: 20px; }
+  .bar-row { grid-template-columns: 80px 1fr; }
+  .llm-split { flex-direction: column; gap: 20px; }
+  .llm-divider { width: 100%; height: 1px; margin: 0; }
+  .llm-section { padding: 0 !important; }
+}
+
+/* === Token Savings === */
+.savings {
+  padding: 64px 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.savings-intro {
+  font-size: 1rem;
+  color: var(--text-secondary);
+  max-width: 600px;
+  margin-bottom: 36px;
+  line-height: 1.6;
+}
+
+.savings-grid {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  margin-bottom: 36px;
+}
+
+.savings-card {
+  flex: 1;
+  min-width: 0;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 32px 28px;
+  text-align: center;
+}
+
+.savings-before {
+  border-color: rgba(248, 81, 73, 0.3);
+  background: linear-gradient(180deg, rgba(248, 81, 73, 0.04) 0%, var(--bg-card) 100%);
+}
+
+.savings-after {
+  border-color: rgba(63, 185, 80, 0.3);
+  background: linear-gradient(180deg, rgba(63, 185, 80, 0.04) 0%, var(--bg-card) 100%);
+}
+
+.savings-card-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-secondary);
+  margin-bottom: 12px;
+}
+
+.savings-before .savings-card-label { color: #f85149; }
+.savings-after .savings-card-label { color: #3fb950; }
+
+.savings-big-num {
+  font-family: var(--mono);
+  font-size: 2.5rem;
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  line-height: 1;
+  margin-bottom: 4px;
+}
+
+.savings-before .savings-big-num { color: #f85149; }
+.savings-after .savings-big-num { color: #3fb950; }
+
+.savings-unit {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  margin-bottom: 16px;
+}
+
+.savings-detail {
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+  opacity: 0.7;
+  line-height: 1.5;
+}
+
+.savings-arrow {
+  flex-shrink: 0;
+}
+
+.savings-stats {
+  display: flex;
+  gap: 0;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.savings-stat {
+  flex: 1;
+  text-align: center;
+  padding: 20px 16px;
+  border-right: 1px solid var(--border);
+}
+
+.savings-stat:last-child { border-right: none; }
+
+.savings-stat-num {
+  font-family: var(--mono);
+  font-size: 1.5rem;
+  font-weight: 800;
+  color: var(--orange-light);
+  margin-bottom: 4px;
+}
+
+.savings-stat-label {
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+}
+
+@media (max-width: 768px) {
+  .savings-grid { flex-direction: column; }
+  .savings-arrow { transform: rotate(90deg); }
+  .savings-stats { flex-direction: column; }
+  .savings-stat { border-right: none; border-bottom: 1px solid var(--border); }
+  .savings-stat:last-child { border-bottom: none; }
+  .savings-big-num { font-size: 2rem; }
+}
+
 /* === Quick Start === */
 .quickstart {
   padding: 64px 0;


### PR DESCRIPTION
## Summary
- Remove false "No LLM cost per write" and "LLM-free retrieval" claims — both ingestion and retrieval use LLM calls (embeddings)
- New lead differentiator: "Open and inspectable" (SQLite, no black boxes)
- Add LOCOMO benchmark comparison chart (MemMachine, Zep, Letta, Mem0, OpenAI)
- Add MAB (ICLR 2026) ring gauge visualizations
- Add honest LLM Usage breakdown card (ingestion vs retrieval)
- Add Claude Code Token Savings section (15K+ → 300-500 tokens)
- Visual bar charts, ring gauges, before/after cards with polished CSS

## Test plan
- [ ] Verify landing page renders correctly at desktop and mobile
- [ ] Verify README benchmark tables render on GitHub
- [ ] Check all links (Zep blog, GitHub, PyPI, MCP Registry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)