### PR TITLE
Add PyPI trusted publisher workflow

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,0 +1,46 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build tools
+        run: pip install build
+
+      - name: Build package
+        run: python -m build
+
+      - name: Upload distribution artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+    steps:
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/workflow.yml` for automated PyPI publishing via OIDC trusted publishers
- Triggers on GitHub release creation — builds with hatchling and publishes using `pypa/gh-action-pypi-publish`
- Uses `release` environment (already created on GitHub)

## Setup
- Configure trusted publisher on PyPI with workflow name `workflow.yml` and environment `release`
- To publish: create a GitHub release → workflow builds and publishes automatically, no API tokens needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)