### PR TITLE
refactor: replace pip/pipx with poetry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,5 +41,5 @@ locomo_*.json
 .mcpregistry_*
 agent_memory/infra/lambda/.api_url
 
-# Accidental pip output files
+# Accidental build output files
 =*

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Memwright gives AI agents persistent, searchable memory that stays out of the co
 - **Token budgets** — Set a ceiling (e.g. 2,000 tokens). Memwright fits the best memories within that budget
 - **Contradiction handling** — "User works at Google" automatically supersedes "User works at Meta"
 - **Namespace isolation** — Multi-agent systems get isolated memory partitions per agent, user, or project
-- **Zero config** — `pip install memwright`, add one JSON block, done
+- **Zero config** — `poetry add memwright`, add one JSON block, done
 
 ---
 
@@ -63,7 +63,7 @@ Memwright gives AI agents persistent, searchable memory that stays out of the co
 ### Claude Code (one-liner)
 
 ```bash
-pip install memwright
+poetry add memwright
 claude mcp add memory -- memwright mcp
 ```
 
@@ -493,12 +493,12 @@ mem = AgentMemory("./store", config={
 ### Installing cloud extras
 
 ```bash
-pip install memwright[postgres]    # PostgreSQL
-pip install memwright[arangodb]    # ArangoDB
-pip install memwright[aws]         # AWS (DynamoDB + OpenSearch + Neptune)
-pip install memwright[azure]       # Azure Cosmos DB
-pip install memwright[gcp]         # GCP AlloyDB + Vertex AI
-pip install memwright[all]         # Everything
+poetry add "memwright[postgres]"    # PostgreSQL
+poetry add "memwright[arangodb]"    # ArangoDB
+poetry add "memwright[aws]"         # AWS (DynamoDB + OpenSearch + Neptune)
+poetry add "memwright[azure]"       # Azure Cosmos DB
+poetry add "memwright[gcp]"         # GCP AlloyDB + Vertex AI
+poetry add "memwright[all]"         # Everything
 ```
 
 ---
@@ -735,7 +735,7 @@ Delete the `memory` entry from `~/.claude/.mcp.json` (global) or `.mcp.json` (pe
 ### 2. Uninstall the package
 
 ```bash
-pip uninstall memwright
+poetry remove memwright
 ```
 
 ### 3. Delete stored memories (optional)

--- a/agent_memory/cli.py
+++ b/agent_memory/cli.py
@@ -455,7 +455,7 @@ def _cmd_serve(args):
     try:
         from agent_memory.mcp.server import run_server
     except ImportError:
-        print("MCP support requires: pip install agent-memory[mcp]")
+        print("MCP support requires: poetry add \"agent-memory[mcp]\"")
         sys.exit(1)
 
     # Ensure the store exists
@@ -609,7 +609,7 @@ def _cmd_mcp_serve(args):
     try:
         from agent_memory.mcp.server import run_server
     except ImportError:
-        print("MCP support requires: pip install agent-memory[mcp]")
+        print("MCP support requires: poetry add \"agent-memory[mcp]\"")
         sys.exit(1)
 
     store_path = getattr(args, "path", None)

--- a/agent_memory/locomo.py
+++ b/agent_memory/locomo.py
@@ -8,7 +8,7 @@ Usage:
     agent-memory locomo --judge-model claude-haiku  # Cheaper judge
     agent-memory locomo --data ./locomo10.json       # Use local data file
 
-Requires: pip install memwright[extraction]  (for the LLM judge)
+Requires: poetry add "memwright[extraction]"  (for the LLM judge)
 """
 
 from __future__ import annotations

--- a/agent_memory/mab.py
+++ b/agent_memory/mab.py
@@ -10,7 +10,7 @@ Usage:
     agent-memory mab --max-examples 2              # Quick test
     agent-memory mab --chunk-size 2048             # Smaller chunks
 
-Requires: pip install datasets openai  (not included in memwright base deps)
+Requires: poetry add datasets openai  (not included in memwright base deps)
 """
 
 from __future__ import annotations
@@ -370,7 +370,7 @@ def load_mab(
         from datasets import load_dataset
     except ImportError:
         raise ImportError(
-            "datasets library required. Install with: pip install memwright[benchmark]"
+            "datasets library required. Install with: poetry add \"memwright[benchmark]\""
         )
 
     if categories is None:

--- a/agent_memory/mcp/server.py
+++ b/agent_memory/mcp/server.py
@@ -192,7 +192,7 @@ def _build_handlers(mem: AgentMemory) -> dict:
 def create_server(memory_path: str):
     """Create an MCP server exposing AgentMemory tools, resources, and prompts.
 
-    Requires: pip install agent-memory[mcp]
+    Requires: poetry add "agent-memory[mcp]"
     """
     try:
         from mcp.server import Server
@@ -200,7 +200,7 @@ def create_server(memory_path: str):
         from mcp.types import Tool, TextContent
     except ImportError:
         print(
-            "MCP package required. Install with: pip install agent-memory[mcp]",
+            "MCP package required. Install with: poetry add \"agent-memory[mcp]\"",
             file=sys.stderr,
         )
         sys.exit(1)

--- a/agent_memory/store/azure_backend.py
+++ b/agent_memory/store/azure_backend.py
@@ -144,7 +144,7 @@ class AzureBackend(DocumentStore, VectorStore, GraphStore):
         try:
             import networkx as nx
         except ImportError:
-            raise ImportError("networkx is required for the graph role. Install with: pip install networkx")
+            raise ImportError("networkx is required for the graph role. Install with: poetry add networkx")
 
         self._graph = nx.MultiDiGraph()
 

--- a/bench_claude.py
+++ b/bench_claude.py
@@ -303,25 +303,20 @@ def _check_system_memwright() -> Dict[str, Any]:
     checks: Dict[str, Any] = {
         "memwright_bin": shutil.which("memwright"),
         "agent_memory_bin": shutil.which("agent-memory"),
-        "pipx_installed": False,
-        "pip_installed": False,
+        "poetry_installed": False,
         "user_hooks": [],
         "user_mcp": [],
     }
 
-    # Check pipx
+    # Check poetry
     try:
         result = subprocess.run(
-            ["pipx", "list", "--short"], capture_output=True, text=True, timeout=10,
+            ["poetry", "show", "memwright"], capture_output=True, text=True, timeout=10,
         )
-        if "memwright" in result.stdout.lower():
-            checks["pipx_installed"] = True
+        if result.returncode == 0:
+            checks["poetry_installed"] = True
     except Exception:
         pass
-
-    # Check pip (system python, NOT the local .venv which is the dev environment)
-    # We only care if memwright is installed globally where Claude Code could find it.
-    # Skip this check — PATH and pipx checks are sufficient.
 
     # Check user-level Claude Code settings for memwright hooks
     user_settings = os.path.expanduser("~/.claude/settings.json")
@@ -371,15 +366,15 @@ def verify_memwright_not_installed() -> None:
 
     if checks["memwright_bin"]:
         problems.append(f"  - 'memwright' binary found at: {checks['memwright_bin']}")
-        problems.append(f"    Fix: pipx uninstall memwright")
+        problems.append(f"    Fix: poetry remove memwright")
 
     if checks["agent_memory_bin"]:
         problems.append(f"  - 'agent-memory' binary found at: {checks['agent_memory_bin']}")
-        problems.append(f"    Fix: pipx uninstall memwright  OR  pip uninstall memwright")
+        problems.append(f"    Fix: poetry remove memwright")
 
-    if checks["pipx_installed"]:
-        problems.append(f"  - memwright installed via pipx")
-        problems.append(f"    Fix: pipx uninstall memwright")
+    if checks["poetry_installed"]:
+        problems.append(f"  - memwright installed via poetry")
+        problems.append(f"    Fix: poetry remove memwright")
 
     for hook in checks["user_hooks"]:
         problems.append(f"  - User-level hook found: [{hook['event']}] {hook['command']}")
@@ -394,13 +389,12 @@ def verify_memwright_not_installed() -> None:
         for p in problems:
             print(p)
         print("\n  Run the following to uninstall:")
-        print("    pipx uninstall memwright 2>/dev/null")
-        print("    pip uninstall memwright -y 2>/dev/null")
+        print("    poetry remove memwright")
         print("    # Remove memwright hooks/MCP from ~/.claude/settings.json")
         print()
         sys.exit(1)
 
-    print("  OK: memwright not found in PATH, pipx, user hooks, or user MCP.")
+    print("  OK: memwright not found in PATH, poetry, user hooks, or user MCP.")
 
 
 def verify_memwright_installed() -> str:
@@ -411,21 +405,14 @@ def verify_memwright_installed() -> str:
     memwright_bin = checks["memwright_bin"] or checks["agent_memory_bin"]
 
     if not memwright_bin:
-        print("  memwright not found in PATH. Installing via pipx...")
+        print("  memwright not found in PATH. Installing via poetry...")
         result = subprocess.run(
-            ["pipx", "install", "memwright"],
+            ["poetry", "add", "memwright"],
             capture_output=True, text=True, timeout=120,
         )
         if result.returncode != 0:
-            print(f"  pipx install failed: {result.stderr[:300]}")
-            print("  Trying pip install...")
-            result = subprocess.run(
-                [sys.executable, "-m", "pip", "install", "memwright"],
-                capture_output=True, text=True, timeout=120,
-            )
-            if result.returncode != 0:
-                print(f"  pip install failed: {result.stderr[:300]}")
-                sys.exit(1)
+            print(f"  poetry add failed: {result.stderr[:300]}")
+            sys.exit(1)
 
         memwright_bin = shutil.which("memwright") or shutil.which("agent-memory")
         if not memwright_bin:

--- a/docs/benchmarks.html
+++ b/docs/benchmarks.html
@@ -373,7 +373,7 @@
       <div class="code-block">
         <div class="code-header">Setup</div>
         <pre><code><span class="comment"># Install with benchmark dependencies</span>
-pip install memwright[benchmark]
+poetry add "memwright[benchmark]"
 
 <span class="comment"># Set API keys</span>
 <span class="kw">export</span> OPENROUTER_API_KEY=<span class="str">"your-key"</span>   <span class="comment"># for embeddings</span>
@@ -558,7 +558,7 @@ agent-memory mab \
         <a href="https://pypi.org/project/memwright/">PyPI</a>
         <a href="https://registry.modelcontextprotocol.io/servers/io.github.bolnet/memwright">MCP Registry</a>
       </div>
-      <p class="footer-license">Apache 2.0 License &middot; Results independently reproducible via <code>pip install memwright[benchmark]</code></p>
+      <p class="footer-license">Apache 2.0 License &middot; Results independently reproducible via <code>poetry add "memwright[benchmark]"</code></p>
     </div>
   </footer>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1037,9 +1037,9 @@ footer {
       <div class="hero-eyebrow">Where there's an agent, there's Memwright.</div>
       <h1 class="hero-headline">We solve one problem.<br>We solve it everywhere.</h1>
       <p class="hero-subhead">Your Claude Code session. Your production pipeline. Your multi-agent system with namespace isolation and RBAC. AWS. Azure. GCP. Docker. Or just your laptop with nothing installed.</p>
-      <div class="hero-install" onclick="navigator.clipboard.writeText('pip install memwright && claude mcp add memory -- memwright mcp');this.querySelector('.copy-hint').textContent='Copied!'">
+      <div class="hero-install" onclick="navigator.clipboard.writeText('poetry add memwright && claude mcp add memory -- memwright mcp');this.querySelector('.copy-hint').textContent='Copied!'">
         <span class="prompt">$</span>
-        <span class="cmd">pip install memwright && claude mcp add memory -- memwright mcp</span>
+        <span class="cmd">poetry add memwright && claude mcp add memory -- memwright mcp</span>
         <span class="copy-hint">Click to copy</span>
       </div>
       <p class="hero-meta">Free. Open source. Apache 2.0. Python 3.10–3.13. Works right now.</p>
@@ -1161,7 +1161,7 @@ footer {
           <div class="card-tagline">Zero Everything</div>
           <p>No Docker. No API keys. No cloud account. No database server. Nothing. SQLite + ChromaDB + NetworkX auto-provision from thin air.</p>
           <div class="card-who">Solo developers, side projects, proof of concepts.</div>
-          <pre>$ pip install memwright
+          <pre>$ poetry add memwright
 $ claude mcp add memory -- memwright mcp</pre>
         </div>
 
@@ -1348,7 +1348,7 @@ $ claude mcp add memory -- memwright mcp</pre>
           </div>
           <div style="display:grid;grid-template-columns:100px 1fr 1fr 1fr 1fr 1fr;background:var(--bg-card);border-top:2px solid var(--accent-indigo)">
             <div style="padding:10px 12px;font-weight:500;color:var(--accent-indigo)">Memwright</div>
-            <div style="padding:10px 8px;color:var(--accent-green);font-size:12px">pip install</div>
+            <div style="padding:10px 8px;color:var(--accent-green);font-size:12px">poetry add</div>
             <div style="padding:10px 8px;color:var(--accent-green);font-size:12px">Free, all tiers</div>
             <div style="padding:10px 8px;color:var(--accent-green);font-size:12px">None (PageRank + RRF)</div>
             <div style="padding:10px 8px;color:var(--accent-green);font-size:12px">Yes (zero config)</div>
@@ -1696,7 +1696,7 @@ mem.import_json(<span style="color:var(--accent-green)">"backup.json"</span>)   
     <div class="quickstart-steps">
       <div class="qs-step reveal">
         <div class="qs-step-num">Step 1 — Install &amp; Connect</div>
-        <div class="code-block">$ pip install memwright
+        <div class="code-block">$ poetry add memwright
 $ claude mcp add memory -- memwright mcp</div>
         <p style="margin-top: 0.75rem;">That's it. Restart your client. Approve the server once. Your agent now has 8 memory tools.</p>
       </div>
@@ -1797,7 +1797,7 @@ $ ./scripts/deploy.sh aws --teardown   # destroy everything</div>
 <section id="closing">
   <div class="container">
     <div class="closing-manifesto reveal">
-      <blockquote>We hate dementia. We can't solve it for humans. Not yet. But we can solve it for AI agents. And we did. Your laptop. Your cloud. Your air-gapped server. AWS. Azure. GCP. ArangoDB. PostgreSQL. Docker. Or nothing at all. One pip install. One problem solved. Your agent never forgets.</blockquote>
+      <blockquote>We hate dementia. We can't solve it for humans. Not yet. But we can solve it for AI agents. And we did. Your laptop. Your cloud. Your air-gapped server. AWS. Azure. GCP. ArangoDB. PostgreSQL. Docker. Or nothing at all. One poetry add. One problem solved. Your agent never forgets.</blockquote>
       <div class="closing-tagline reveal reveal-delay-1">Where there's an agent, there's Memwright.</div>
       <div class="hero-ctas reveal reveal-delay-2" style="justify-content: center;">
         <a href="https://github.com/bolnet/agent-memory" class="cta-github" target="_blank" rel="noopener">GitHub</a>
@@ -1855,7 +1855,7 @@ function scrollCarousel(direction) {
 
 // Copy install command
 document.querySelector('.hero-install')?.addEventListener('click', function() {
-  navigator.clipboard.writeText('pip install memwright && claude mcp add memory -- memwright mcp').then(() => {
+  navigator.clipboard.writeText('poetry add memwright && claude mcp add memory -- memwright mcp').then(() => {
     const hint = this.querySelector('.copy-hint');
     hint.textContent = 'Copied!';
     hint.style.opacity = '1';


### PR DESCRIPTION
## Summary
- Replace all `pip install` / `pipx install` references with `poetry add` equivalents across source code, docs, and tooling
- Updated 10 files: README, CLI, MCP server, benchmark scripts, landing page, benchmarks page
- Skipped Dockerfiles (pip is standard in containers), planning docs (historical), and entity extractor (tech entity name list)

## Test plan
- [ ] Verify `poetry add memwright` works from a clean project
- [ ] Check CLI error messages show poetry commands
- [ ] Landing page copy-to-clipboard copies correct command

🤖 Generated with [Claude Code](https://claude.com/claude-code)