### PR TITLE
docs: refresh README and landing page to current state

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ agent_memory/
 ├── models.py                  # Memory + RetrievalResult dataclasses
 ├── context.py                 # AgentContext — multi-agent provenance & RBAC
 ├── client.py                  # MemoryClient — HTTP client for distributed mode
-├── cli.py                     # CLI entry point (17+ commands)
+├── cli.py                     # CLI entry point (19 commands)
 ├── api.py                     # Starlette ASGI REST API (8 routes)
 ├── store/
 │   ├── base.py                # Abstract interfaces: DocumentStore, VectorStore, GraphStore
@@ -681,7 +681,7 @@ AZURE_COSMOS_ENDPOINT='https://...' poetry run pytest tests/test_azure_live.py -
 
 ### Test Coverage
 
-- **392+ unit tests** covering all backends, retrieval, config, embeddings, and CLI
+- **607 unit tests** covering all backends, retrieval, config, embeddings, and CLI
 - **14 live integration tests** per cloud backend (Neon, Azure, ArangoDB)
 - **Mock tests** for every cloud backend — no cloud account needed
 - All unit tests run without Docker or API keys
@@ -722,7 +722,7 @@ Same `memwright mcp` command. Same zero-config setup.
 
 ### Python
 
-- Python 3.10, 3.11, 3.12, 3.13
+- Python 3.10, 3.11, 3.12, 3.13, 3.14
 
 ---
 

--- a/agent_memory/cli.py
+++ b/agent_memory/cli.py
@@ -455,7 +455,7 @@ def _cmd_serve(args):
     try:
         from agent_memory.mcp.server import run_server
     except ImportError:
-        print("MCP support requires: poetry add \"agent-memory[mcp]\"")
+        print("MCP package not found. Run: poetry install")
         sys.exit(1)
 
     # Ensure the store exists
@@ -609,7 +609,7 @@ def _cmd_mcp_serve(args):
     try:
         from agent_memory.mcp.server import run_server
     except ImportError:
-        print("MCP support requires: poetry add \"agent-memory[mcp]\"")
+        print("MCP package not found. Run: poetry install")
         sys.exit(1)
 
     store_path = getattr(args, "path", None)

--- a/agent_memory/mcp/server.py
+++ b/agent_memory/mcp/server.py
@@ -192,7 +192,7 @@ def _build_handlers(mem: AgentMemory) -> dict:
 def create_server(memory_path: str):
     """Create an MCP server exposing AgentMemory tools, resources, and prompts.
 
-    Requires: poetry add "agent-memory[mcp]"
+    MCP is a core dependency — included with poetry add memwright.
     """
     try:
         from mcp.server import Server
@@ -200,7 +200,7 @@ def create_server(memory_path: str):
         from mcp.types import Tool, TextContent
     except ImportError:
         print(
-            "MCP package required. Install with: poetry add \"agent-memory[mcp]\"",
+            "MCP package not found. Run: poetry install",
             file=sys.stderr,
         )
         sys.exit(1)

--- a/docs/index.html
+++ b/docs/index.html
@@ -1042,7 +1042,7 @@ footer {
         <span class="cmd">poetry add memwright && claude mcp add memory -- memwright mcp</span>
         <span class="copy-hint">Click to copy</span>
       </div>
-      <p class="hero-meta">Free. Open source. Apache 2.0. Python 3.10–3.13. Works right now.</p>
+      <p class="hero-meta">Free. Open source. Apache 2.0. Python 3.10–3.14. Works right now.</p>
       <div class="hero-ctas">
         <a href="https://github.com/bolnet/agent-memory" class="cta-github" target="_blank" rel="noopener">GitHub</a>
         <a href="https://pypi.org/project/memwright/" class="cta-pypi" target="_blank" rel="noopener">PyPI</a>
@@ -1738,7 +1738,7 @@ $ ./scripts/deploy.sh aws --teardown   # destroy everything</div>
     <h2 class="section-title reveal reveal-delay-1">Battle-tested. Zero Docker. Zero API keys.</h2>
     <div class="stats-bar reveal reveal-delay-2">
       <div class="stat">
-        <div class="stat-num">392+</div>
+        <div class="stat-num">607</div>
         <div class="stat-label">Unit Tests</div>
       </div>
       <div class="stat">
@@ -1765,7 +1765,7 @@ $ ./scripts/deploy.sh aws --teardown   # destroy everything</div>
 <section id="cli" class="section-alt">
   <div class="container">
     <div class="section-tag reveal">CLI</div>
-    <h2 class="section-title reveal reveal-delay-1">17 commands. Full control from the terminal.</h2>
+    <h2 class="section-title reveal reveal-delay-1">19 commands. Full control from the terminal.</h2>
     <p class="section-subtitle reveal reveal-delay-2">Both <code>memwright</code> and <code>agent-memory</code> work.</p>
     <div class="cli-pills reveal reveal-delay-3">
       <span class="cli-pill">init</span>


### PR DESCRIPTION
## Summary
- Test count 392+ → 607
- Python versions: added 3.14 (already in pyproject.toml classifiers)
- CLI commands: 17 → 19
- MCP error messages: removed `[mcp]` extra since mcp is now a core dependency

## Test plan
- [ ] Verify README numbers match `pytest --collect-only` output
- [ ] Verify landing page renders correctly