### PR TITLE
feat: add install and uninstall slash commands

### DIFF
--- a/commands/install-agent-memory.md
+++ b/commands/install-agent-memory.md
@@ -1,0 +1,242 @@
+---
+description: Install Memwright (agent-memory) for Claude Code — interactive configuration
+argument-hint: "(no args — will ask)"
+allowed-tools: Bash, Read, Write, Edit, Glob
+---
+
+# Install Memwright for Claude Code
+
+You are installing **Memwright** (PyPI: `memwright`, import: `agent_memory`) — a memory layer for agent teams — into the user's Claude Code setup.
+
+This command is **interactive**. The wizard is the single source of truth for every install input — scope, paths, backends, credentials, secrets, hook wiring, verification. **Do NOT silently apply defaults when state already exists. Do NOT collect secrets out-of-band. If the install needs a value, the wizard asks for it.**
+
+Rules:
+- Ask **one** question at a time via `AskUserQuestion` — never batch.
+- Ask Q0 (pre-existing state) questions first — only ask the ones whose preconditions were detected in Step 1.
+- Skip sub-questions that don't apply to the chosen branch (e.g. skip Q-embed-provider when cloud backend selected).
+- Never write secrets into config files — always reference env vars. The wizard asks **where** to persist each secret (gitignored `.env` / shell profile / this-session-only).
+- Merge JSON configs; never clobber existing `mcpServers` or `hooks` entries without an explicit user choice.
+- If a step fails, stop and report — do not retry silently.
+
+---
+
+## Step 1 — Detect current state (before asking anything)
+
+Run these checks in parallel:
+
+```bash
+command -v memwright || echo "NOT_INSTALLED"
+command -v pipx || echo "NO_PIPX"
+python3 --version
+ls ~/.memwright >/dev/null 2>&1 && echo "STORE_EXISTS" || echo "STORE_NEW"
+ls ~/.claude/.mcp.json >/dev/null 2>&1 && echo "GLOBAL_MCP_EXISTS" || echo "GLOBAL_MCP_NONE"
+ls .mcp.json >/dev/null 2>&1 && echo "PROJECT_MCP_EXISTS" || echo "PROJECT_MCP_NONE"
+grep -l "memwright\\|agent-memory" ~/.claude/settings.json 2>/dev/null && echo "HOOKS_WIRED" || echo "HOOKS_NONE"
+```
+
+Report a one-line summary and move to Step 2.
+
+---
+
+## Step 2 — Interview (one question per turn, use AskUserQuestion)
+
+### Q0 — Pre-existing state handling (ask ONLY the ones that apply)
+
+**Q0a. Existing MCP entry** (if any `mcpServers` entry named `memory` or `memwright` already exists)
+- `Update in place` *(Recommended)* — overwrite with wizard settings.
+- `Keep as-is` — skip MCP changes.
+- `Add alongside` — keep existing, add a second entry under a different key.
+
+**Q0b. Existing hooks** (if `settings.json` hooks already reference `memwright` / `agent-memory`)
+- `Keep as-is` *(Recommended)*
+- `Replace with wizard selection`
+- `Remove all Memwright hooks`
+
+**Q0c. Existing store** (if `STORE_PATH` already exists)
+- `Reuse` *(Recommended)* — keep memories and settings, apply new config only.
+- `Pick a new path` — create a fresh store elsewhere.
+- `Reset (destructive)` — wipe and start clean. Requires explicit re-confirm.
+
+### Q1. Scope
+- `Global (~/.claude/.mcp.json)` *(Recommended)*
+- `Project (./.mcp.json)`
+
+### Q2. Store location
+- `Default (~/.memwright/)` *(Recommended)*
+- `Custom path` — follow-up free-text for absolute path.
+
+### Q3. Backend type (top-level Local vs Cloud split)
+- `Local` *(Recommended)* — runs on your machine.
+- `Cloud-managed` — managed service.
+
+### Q3a. Local stack (only if Q3 = Local)
+- `Zero-config embedded` *(Recommended)* — SQLite + ChromaDB + NetworkX. No external services.
+- `Local PostgreSQL` — self-hosted Postgres 16 with pgvector + Apache AGE.
+- `Local ArangoDB` — self-hosted ArangoDB (doc + vector + graph in one).
+
+### Q3b. Cloud platform (only if Q3 = Cloud-managed) — grouped by provider
+- `AWS`
+- `Azure`
+- `GCP`
+
+### Q3b.i. AWS backend variant (only if Q3b = AWS)
+- `ArangoDB Oasis on AWS` *(Recommended)* — single managed service for all three roles.
+- `DynamoDB + OpenSearch Serverless + Neptune` — all-AWS native stack.
+
+### Q3b.ii. Azure backend
+- `Cosmos DB with DiskANN` — doc + vector + graph in Cosmos.
+
+### Q3b.iii. GCP backend
+- `AlloyDB` — Postgres-compatible, pgvector + AGE + ScaNN.
+
+### Q-backend-creds — Credential collection (after backend chosen, before install)
+
+For **every** cloud backend and any local variant that needs credentials (Local Postgres / Local Arango), the wizard collects the required secrets. Required keys per backend:
+
+| Backend | Required env vars |
+|---|---|
+| Local zero-config | *(none)* |
+| Local PostgreSQL | `DATABASE_URL` |
+| Local ArangoDB | `ARANGO_URL`, `ARANGO_USER`, `ARANGO_PASSWORD` |
+| AWS + ArangoDB Oasis | `ARANGO_URL`, `ARANGO_USER`, `ARANGO_PASSWORD` |
+| AWS native | `AWS_REGION`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` (or confirm `~/.aws/credentials`) |
+| Azure Cosmos | `COSMOS_CONNECTION_STRING` |
+| GCP AlloyDB | `DATABASE_URL` |
+
+**Q-backend-creds.1 — How to collect:**
+- `Use existing env vars` *(Recommended if already exported)* — wizard detects and confirms.
+- `Paste them now` — prompts free-text per key.
+- `Skip` — writes config with placeholder; user fills in before restart.
+
+**Q-backend-creds.2 — Where to persist** (only if user pasted values):
+- `Gitignored .env file (~/.memwright/.env, chmod 600)` *(Recommended)*
+- `Shell profile (~/.zshrc or ~/.bashrc)`
+- `This session only` — hold in memory; user must re-export before restart.
+
+### Q4. Embedding provider (only if Q3a = Zero-config embedded; cloud backends bring their own)
+- `Local (all-MiniLM-L6-v2, 384D)` *(Recommended)* — no API key, ~90MB download on first use.
+- `OpenAI (text-embedding-3-small)` — needs `OPENAI_API_KEY`.
+- `OpenRouter` — needs `OPENROUTER_API_KEY`.
+
+### Q-embed-creds (only if OpenAI or OpenRouter chosen)
+Same collect/persist sub-questions as Q-backend-creds.
+
+### Q5. Claude Code hooks (multi-select)
+- `session-start` *(Recommended for multi-agent)* — every agent boots with shared team context (20K tokens).
+- `post-tool-use` *(Recommended for multi-agent)* — auto-capture observations so memory grows across the team.
+- `stop` — session summary on exit; useful for planner→executor→reviewer handoffs.
+- `none` — MCP only, no hooks.
+
+### Q6. Namespace (only if hooks enabled)
+- `Default "user"` *(Recommended)* — single-user laptop.
+- `Custom` — follow-up free-text for project/team slug.
+
+### Q7. Default token budget for `recall()`
+- `2000`
+- `5000`
+- `10000` *(Recommended for multi-agent)*
+- `Custom`
+
+### Q8. Verification & restart preferences
+- `Run doctor + print MCP config automatically` *(Recommended)*
+- `Skip verification`
+
+Always end with a printed restart reminder. No auto-restart.
+
+---
+
+## Step 3 — Install the package
+
+If memwright is not on PATH:
+```bash
+pipx install memwright || python3 -m pip install --user memwright
+```
+If already installed:
+```bash
+pipx upgrade memwright || python3 -m pip install --user -U memwright
+```
+Confirm with `memwright --help | head -5`.
+
+---
+
+## Step 4 — Provision the store (respects Q0c answer)
+
+- If Q0c = Reuse → skip creation, just run doctor.
+- If Q0c = Pick new path → `mkdir -p "$STORE_PATH"`.
+- If Q0c = Reset → re-confirm, then `rm -rf "$STORE_PATH"` and recreate.
+
+Then: `memwright doctor "$STORE_PATH"` must report OK for Document / Vector / Graph / Retrieval.
+
+---
+
+## Step 5 — Persist secrets (respects Q-backend-creds.2 / Q-embed-creds)
+
+- **Gitignored `.env`**: write `KEY=value` lines to `~/.memwright/.env`, `chmod 600`, ensure `.env` is in `.gitignore`.
+- **Shell profile**: append `export KEY=value` to `~/.zshrc` (or `~/.bashrc`). Tell the user to `source` it.
+- **Session-only**: hold in memory for the install run; print a reminder to re-export before restart.
+
+Never inline secrets into `~/.claude/.mcp.json` or `settings.json`.
+
+---
+
+## Step 6 — Write MCP config (respects Q0a + Q1 + Q3)
+
+Merge into the chosen MCP config file. Read first, then update the chosen `mcpServers` entry:
+
+```json
+{
+  "mcpServers": {
+    "memwright": {
+      "command": "memwright",
+      "args": ["mcp", "--path", "<STORE_PATH>"],
+      "env": {
+        "MEMWRIGHT_NAMESPACE": "<NAMESPACE>",
+        "MEMWRIGHT_TOKEN_BUDGET": "<BUDGET>",
+        "MEMWRIGHT_BACKEND": "<local|postgres|arango|aws|azure|gcp>"
+      }
+    }
+  }
+}
+```
+
+Backend-specific env var **names** go in `env` (the values come from the shell/`.env`, never inline).
+
+---
+
+## Step 7 — Wire hooks (respects Q0b + Q5)
+
+Edit `~/.claude/settings.json` (or `.claude/settings.json` for project scope). Only emit the hooks the user selected in Q5.
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      { "matcher": "*", "hooks": [{ "type": "command", "command": "memwright hook session-start" }] }
+    ],
+    "PostToolUse": [
+      { "matcher": "Write|Edit|Bash", "hooks": [{ "type": "command", "command": "memwright hook post-tool-use" }] }
+    ],
+    "Stop": [
+      { "matcher": "*", "hooks": [{ "type": "command", "command": "memwright hook stop" }] }
+    ]
+  }
+}
+```
+
+If Q0b = Replace, strip existing Memwright hook entries before merging.
+
+---
+
+## Step 8 — Verify (if Q8 = Run doctor)
+
+```bash
+memwright doctor "$STORE_PATH" && echo "--- MCP config ---" && cat "$MCP_CONFIG_FILE"
+```
+
+Then tell the user (≤6 lines):
+- What was installed and where
+- Which MCP config file was touched
+- Which hooks were wired
+- Which secrets were written and where
+- The sanity-check command: `memwright doctor ~/.memwright`
+- That they must **restart Claude Code** for the MCP server to attach

--- a/commands/uninstall-agent-memory.md
+++ b/commands/uninstall-agent-memory.md
@@ -1,0 +1,89 @@
+# Uninstall Memwright from Claude Code
+
+You are uninstalling **Memwright** (PyPI: `memwright`) from the user's Claude Code setup.
+
+This command reverses everything `/install-agent-memory` did: removes the MCP server entry, strips hooks from `settings.json`, uninstalls the CLI, and — only with explicit user confirmation — deletes the local memory store.
+
+## Prerequisites
+
+- This command runs interactively. Use `AskUserQuestion` for each decision.
+- Never delete files without confirmation.
+- Never delete JSON keys other than those Memwright installed.
+
+## Flow
+
+### Step 1 — Detect installed state
+
+Check each of the following and build a removal plan. Report what you find before asking anything:
+
+1. **CLI binary**: `command -v memwright` and `pipx list | grep memwright`
+2. **Global MCP config**: `~/.claude/.mcp.json` — look for the `mcpServers.memwright` key
+3. **Project MCP config**: `./.mcp.json` in the current working directory — same key
+4. **Global hooks**: `~/.claude/settings.json` — scan `hooks.SessionStart`, `hooks.PostToolUse`, `hooks.Stop` for any command containing `memwright`
+5. **Project hooks**: `./.claude/settings.json` — same scan
+6. **Store path(s)**: default `~/.memwright/`, plus any `--path` value pulled from the MCP config args
+
+If nothing is installed, stop and tell the user "Memwright is not installed — nothing to remove."
+
+### Step 2 — Confirm the uninstall scope (single AskUserQuestion)
+
+Ask: "Remove memwright from: (a) global only, (b) project only, (c) both, (d) cancel?" — pre-select whatever scopes you actually found configured.
+
+### Step 3 — Remove MCP server entry
+
+For each chosen scope:
+
+- Read the `.mcp.json` file.
+- Delete only `mcpServers.memwright`. Preserve all other servers.
+- If `mcpServers` becomes empty, leave it as `{}` (don't delete the key — other tools may expect it).
+- Write the file back with the same 2-space indent JSON formatting it had before.
+
+### Step 4 — Remove hooks from settings.json
+
+For each chosen scope:
+
+- Read the `settings.json` file.
+- In `hooks.SessionStart`, `hooks.PostToolUse`, `hooks.Stop`: filter out any entry whose inner `hooks[].command` contains the substring `memwright`. If an outer matcher group becomes empty, drop the group.
+- If a hook array becomes empty (`"Stop": []`), delete the key.
+- If `hooks` itself becomes empty after removal, delete it.
+- Preserve every other hook (including other tools that share `"matcher": "*"` slots).
+
+### Step 5 — Uninstall the CLI
+
+Run `pipx uninstall memwright`. If pipx isn't the install method, fall back to `pip uninstall -y memwright`. Capture and show the output.
+
+### Step 6 — Ask about the memory store (second AskUserQuestion)
+
+Ask: "Delete local memory store at `<path>`? This permanently removes all captured memories, vectors, and graph state."
+
+Options:
+- **Yes, delete** — run `rm -rf <path>` after echoing the full path for the record.
+- **Keep** — leave the store intact (default, safer).
+
+If multiple store paths were detected (e.g. different `--path` values across scopes), ask once per unique path.
+
+### Step 7 — Verify
+
+Run:
+- `command -v memwright` — should report nothing
+- `pipx list 2>&1 | grep -i memwright || echo "not present"`
+- Re-read modified JSON files and confirm no `memwright` substring remains
+
+Output a summary:
+
+```
+Removed:
+  - MCP server entry (global)
+  - 3 hooks (SessionStart, PostToolUse, Stop)
+  - pipx package `memwright`
+Preserved:
+  - ~/.memwright/  (kept at user request)
+```
+
+## Safety rules
+
+- Never use `jq -e` or any command that would exit non-zero and abort the script halfway through JSON edits. Read → parse → mutate in memory → write atomically.
+- Never pass `--force` to `rm`. The `-rf` is already enough; a typo on the path should fail loudly.
+- Never delete `settings.local.json` or other files the installer didn't create.
+- If any JSON file fails to parse, stop and show the user — don't try to repair unknown damage.
+- If the user says "cancel" at any confirmation, stop immediately and make no changes.


### PR DESCRIPTION
## Summary
- Add `commands/install-agent-memory.md` to the repo — it was referenced from CLAUDE.md ("install agent memory" → `/install-agent-memory`) but never actually committed.
- Add `commands/uninstall-agent-memory.md` as the mirror flow: detects scope (global/project), strips only the `mcpServers.memwright` key, filters memwright entries out of `settings.json` hooks (preserving other hooks and matcher groups), runs `pipx uninstall memwright`, and asks before `rm -rf` of the local store.

## Test plan
- [x] Manually executed the uninstall flow end-to-end on this machine — MCP entry removed, 3 hooks filtered, pipx package removed, store deleted, JSON still valid.
- [ ] Fresh reinstall via `/install-agent-memory` after merge, then re-run `/uninstall-agent-memory` on CI-style path to confirm idempotency.