### PR TITLE
feat(ui): read-only memory viewer — Forensic Archive aesthetic

### DIFF
--- a/agent_memory/api.py
+++ b/agent_memory/api.py
@@ -161,4 +161,12 @@ routes = [
     Route("/memory/{memory_id}", get_memory, methods=["GET"]),
 ]
 
+# Attach the read-only UI at /ui/* (routes have absolute paths)
+try:
+    from agent_memory.ui.app import ui_routes
+
+    routes.extend(ui_routes())
+except Exception:  # pragma: no cover - UI is optional
+    pass
+
 app = Starlette(routes=routes)

--- a/agent_memory/cli.py
+++ b/agent_memory/cli.py
@@ -249,6 +249,20 @@ def main(argv=None):
         help="Memory store path (default: $MEMWRIGHT_DATA_DIR or ~/.memwright)",
     )
 
+    # ui (read-only web viewer)
+    p_ui = subparsers.add_parser(
+        "ui",
+        help="Start read-only web UI (Forensic Archive viewer)",
+    )
+    p_ui.add_argument("--host", default="127.0.0.1", help="Bind host (default: 127.0.0.1)")
+    p_ui.add_argument("--port", type=int, default=8080, help="Bind port (default: 8080)")
+    p_ui.add_argument(
+        "--path",
+        default=None,
+        help="Memory store path (default: $MEMWRIGHT_PATH or ~/.memwright)",
+    )
+    p_ui.add_argument("--open", action="store_true", help="Open browser on launch")
+
     # mcp (zero-config MCP server -- used by .mcp.json)
     p_mcp = subparsers.add_parser(
         "mcp",
@@ -289,6 +303,7 @@ def main(argv=None):
         "forget": _cmd_forget,
         "serve": _cmd_serve,
         "api": _cmd_api,
+        "ui": _cmd_ui,
         "setup-claude-code": _cmd_setup_claude_code,
         "doctor": _cmd_doctor,
         "locomo": _cmd_locomo,
@@ -793,6 +808,28 @@ def _cmd_mcp_serve(args):
 
     print(f"Starting MCP server for {store_path}...", file=sys.stderr)
     asyncio.run(run_server(store_path))
+
+
+def _cmd_ui(args):
+    """Launch read-only web UI."""
+    store_path = args.path or os.environ.get(
+        "MEMWRIGHT_PATH", os.path.expanduser("~/.memwright")
+    )
+    os.environ["MEMWRIGHT_PATH"] = store_path
+    Path(store_path).mkdir(parents=True, exist_ok=True)
+
+    print(f"Memwright UI · {store_path}", file=sys.stderr)
+    print(f"→ http://{args.host}:{args.port}/ui/memories", file=sys.stderr)
+
+    if args.open:
+        import webbrowser, threading
+        url = f"http://{args.host}:{args.port}/ui/memories"
+        threading.Timer(1.0, lambda: webbrowser.open(url)).start()
+
+    import uvicorn
+    uvicorn.run(
+        "agent_memory.api:app", host=args.host, port=args.port, log_level="warning"
+    )
 
 
 def _cmd_hook(args):

--- a/agent_memory/ui/__init__.py
+++ b/agent_memory/ui/__init__.py
@@ -1,0 +1,7 @@
+"""Read-only web UI for memwright — Forensic Archive aesthetic.
+
+Mount `agent_memory.ui.app:app` into a Starlette application, or launch
+standalone via `memwright ui`.
+"""
+
+from agent_memory.ui.app import create_ui_app  # noqa: F401

--- a/agent_memory/ui/app.py
+++ b/agent_memory/ui/app.py
@@ -1,0 +1,273 @@
+"""Read-only web UI for Memwright — Starlette sub-app.
+
+Renders Jinja2 templates served with a "Forensic Archive" aesthetic.
+All routes are GET-only. The UI talks to AgentMemory directly; it never
+mutates the store.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import HTMLResponse, JSONResponse, RedirectResponse
+from starlette.routing import Mount, Route
+from starlette.staticfiles import StaticFiles
+from starlette.templating import Jinja2Templates
+
+_UI_DIR = Path(__file__).parent
+_TEMPLATES = Jinja2Templates(directory=str(_UI_DIR / "templates"))
+
+
+def _get_mem(request: Request):
+    """Lazy-load the AgentMemory singleton keyed on the app state."""
+    app = request.app
+    mem = getattr(app.state, "memory", None)
+    if mem is not None:
+        return mem
+
+    from agent_memory.core import AgentMemory
+
+    data_dir = os.environ.get(
+        "MEMWRIGHT_PATH",
+        os.path.expanduser("~/.memwright"),
+    )
+    app.state.memory = AgentMemory(data_dir)
+    return app.state.memory
+
+
+def _is_htmx(request: Request) -> bool:
+    return request.headers.get("HX-Request") == "true"
+
+
+def _memory_to_dict(m) -> Dict[str, Any]:
+    """Flatten a Memory dataclass for template use."""
+    created = getattr(m, "created_at", "") or ""
+    return {
+        "id": m.id,
+        "short_id": m.id[:8],
+        "content": m.content,
+        "excerpt": (m.content[:220] + "…") if len(m.content) > 220 else m.content,
+        "tags": list(m.tags or []),
+        "category": getattr(m, "category", "general"),
+        "entity": getattr(m, "entity", None),
+        "namespace": getattr(m, "namespace", "default"),
+        "created_at": created,
+        "created_date": created[:10] if created else "",
+        "created_time": created[11:16] if len(created) >= 16 else "",
+        "event_date": getattr(m, "event_date", None),
+        "valid_from": getattr(m, "valid_from", None),
+        "valid_until": getattr(m, "valid_until", None),
+        "superseded_by": getattr(m, "superseded_by", None),
+        "confidence": float(getattr(m, "confidence", 1.0) or 0.0),
+        "confidence_pct": round(float(getattr(m, "confidence", 1.0) or 0.0) * 100),
+        "status": getattr(m, "status", "active"),
+        "access_count": int(getattr(m, "access_count", 0) or 0),
+        "last_accessed": getattr(m, "last_accessed", None),
+        "content_hash": getattr(m, "content_hash", None),
+        "metadata": getattr(m, "metadata", {}) or {},
+    }
+
+
+def _common_context(request: Request, mem) -> Dict[str, Any]:
+    stats = {}
+    try:
+        stats = mem.stats()
+    except Exception:
+        stats = {}
+    return {
+        "stats": stats,
+        "namespace_default": os.environ.get("MEMWRIGHT_NAMESPACE", "default"),
+        "store_path": os.environ.get(
+            "MEMWRIGHT_PATH", os.path.expanduser("~/.memwright")
+        ),
+    }
+
+
+async def index(request: Request) -> RedirectResponse:
+    return RedirectResponse(url="/ui/memories", status_code=302)
+
+
+async def memories_list(request: Request) -> HTMLResponse:
+    mem = _get_mem(request)
+
+    q = request.query_params.get("q") or None
+    namespace = request.query_params.get("namespace") or None
+    category = request.query_params.get("category") or None
+    entity = request.query_params.get("entity") or None
+    status = request.query_params.get("status") or "active"
+    limit = int(request.query_params.get("limit") or 60)
+
+    try:
+        results = mem.search(
+            query=q,
+            category=category,
+            entity=entity,
+            namespace=namespace,
+            status=status,
+            limit=limit,
+        )
+    except Exception:
+        results = []
+
+    memories = [_memory_to_dict(m) for m in results]
+
+    # Assign a subtle, deterministic rotation per card so the page feels pinned.
+    for i, m in enumerate(memories):
+        m["tilt"] = ((hash(m["id"]) % 7) - 3) * 0.22
+
+    ctx = {
+        "request": request,
+        "memories": memories,
+        "total": len(memories),
+        "filters": {
+            "q": q or "",
+            "namespace": namespace or "",
+            "category": category or "",
+            "entity": entity or "",
+            "status": status,
+        },
+        **_common_context(request, mem),
+    }
+
+    template = "memories/_grid.html" if _is_htmx(request) else "memories/list.html"
+    return _TEMPLATES.TemplateResponse(request, template, ctx)
+
+
+async def memory_detail(request: Request) -> HTMLResponse:
+    mem = _get_mem(request)
+    memory_id = request.path_params["memory_id"]
+
+    m = mem.get(memory_id)
+    if m is None:
+        return HTMLResponse("<h1>Not found</h1>", status_code=404)
+
+    data = _memory_to_dict(m)
+    tab = request.query_params.get("tab", "content")
+
+    # Supersession chain
+    chain = []
+    cursor = m
+    while cursor is not None and getattr(cursor, "superseded_by", None):
+        nxt_id = cursor.superseded_by
+        nxt = mem.get(nxt_id)
+        if nxt is None or nxt.id in {c["id"] for c in chain}:
+            break
+        chain.append(_memory_to_dict(nxt))
+        cursor = nxt
+
+    # Predecessors (who did this supersede?) — query store directly
+    predecessors: List[Dict[str, Any]] = []
+    try:
+        # naive: scan memories superseded_by this id
+        for other in mem.search(namespace=m.namespace, limit=500, status="superseded"):
+            if getattr(other, "superseded_by", None) == m.id:
+                predecessors.append(_memory_to_dict(other))
+    except Exception:
+        pass
+
+    # Nearest vector neighbors
+    neighbors: List[Dict[str, Any]] = []
+    try:
+        vs = getattr(mem, "_vector_store", None)
+        if vs is not None:
+            near = vs.search(m.content[:512], limit=6, namespace=m.namespace)
+            for r in near or []:
+                if r.get("memory_id") == m.id:
+                    continue
+                other = mem.get(r["memory_id"])
+                if other is None:
+                    continue
+                d = _memory_to_dict(other)
+                d["score"] = round(float(r.get("score", 0.0)), 4)
+                neighbors.append(d)
+                if len(neighbors) >= 5:
+                    break
+    except Exception:
+        pass
+
+    # PageRank
+    pagerank = 0.0
+    try:
+        pr = mem.pagerank() or {}
+        if m.entity and m.entity in pr:
+            pagerank = round(float(pr[m.entity]), 5)
+    except Exception:
+        pass
+
+    # Graph neighborhood (1-hop edges for the selected entity)
+    graph_edges: List[Dict[str, Any]] = []
+    try:
+        g = getattr(mem, "_graph", None)
+        if g is not None and m.entity:
+            nx_graph = getattr(g, "_graph", None) or getattr(g, "graph", None)
+            if nx_graph is not None and m.entity in nx_graph:
+                for u, v, d in nx_graph.edges(m.entity, data=True):
+                    graph_edges.append(
+                        {
+                            "source": u,
+                            "target": v,
+                            "kind": d.get("kind") or d.get("type") or "related",
+                        }
+                    )
+                for u, v, d in nx_graph.in_edges(m.entity, data=True):
+                    graph_edges.append(
+                        {
+                            "source": u,
+                            "target": v,
+                            "kind": d.get("kind") or d.get("type") or "related",
+                        }
+                    )
+    except Exception:
+        pass
+
+    ctx = {
+        "request": request,
+        "m": data,
+        "tab": tab,
+        "chain": chain,
+        "predecessors": predecessors,
+        "neighbors": neighbors,
+        "pagerank": pagerank,
+        "graph_edges": graph_edges[:30],
+        **_common_context(request, mem),
+    }
+
+    return _TEMPLATES.TemplateResponse(request, "memories/detail.html", ctx)
+
+
+async def health_json(request: Request) -> JSONResponse:
+    mem = _get_mem(request)
+    try:
+        return JSONResponse(mem.health())
+    except Exception as e:
+        return JSONResponse({"healthy": False, "error": str(e)}, status_code=500)
+
+
+def ui_routes() -> list:
+    """Return absolute UI routes — can be appended to any Starlette app."""
+    return [
+        Route("/", index),
+        Route("/ui", index),
+        Route("/ui/", index),
+        Route("/ui/memories", memories_list),
+        Route("/ui/memories/{memory_id}", memory_detail),
+        Route("/ui/health.json", health_json),
+        Mount(
+            "/ui/static",
+            StaticFiles(directory=str(_UI_DIR / "static")),
+            name="static",
+        ),
+    ]
+
+
+def create_ui_app() -> Starlette:
+    """Standalone Starlette app for the UI. Use when running `memwright ui`."""
+    return Starlette(routes=ui_routes())
+
+
+app = create_ui_app()

--- a/agent_memory/ui/static/app.css
+++ b/agent_memory/ui/static/app.css
@@ -1,0 +1,780 @@
+/* =========================================================================
+   MEMWRIGHT — FORENSIC ARCHIVE
+   Developer memory viewer rendered as a 1970s intelligence analyst workbench.
+   Dark ink field, aged-paper cards, oxidized copper accents, wax stamps.
+   ========================================================================= */
+
+@import url("https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght,SOFT,WONK@9..144,300..900,0..100,0..1&family=Instrument+Sans:ital,wght@0,400..700;1,400..700&display=swap");
+
+/* Departure Mono — hosted on GitHub by designer Helena Zhang, free for any use */
+@font-face {
+  font-family: "Departure Mono";
+  src: url("https://cdn.jsdelivr.net/gh/helenabyte/departure-mono@v1.422/fonts/webfonts/DepartureMono-Regular.woff2") format("woff2");
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+}
+
+:root {
+  /* ink & paper */
+  --ink:          #0A0C10;
+  --ink-raised:  #11151B;
+  --ink-deep:    #06080B;
+  --paper:       #E8DFC6;
+  --paper-warm:  #DFD3B1;
+  --paper-aged:  #C9BB93;
+  --paper-shade: #9B8E66;
+
+  /* accents */
+  --rust:        #C75146;   /* oxidized copper — primary */
+  --rust-deep:   #8B2E26;
+  --verdigris:   #4A7C7E;   /* aged metal */
+  --brass:       #D4A84B;   /* stamp ink */
+  --indigo:      #3B4A6B;   /* faded blueprint */
+  --ghost:       rgba(232, 223, 198, 0.55);
+
+  /* functional */
+  --rule:        rgba(232, 223, 198, 0.14);
+  --rule-strong: rgba(232, 223, 198, 0.30);
+  --radius:      2px;       /* cards have almost no radius — they're paper */
+
+  --f-display:   "Fraunces", "Canela", Georgia, serif;
+  --f-body:      "Instrument Sans", "Neue Haas Grotesk", system-ui, sans-serif;
+  --f-mono:      "Departure Mono", "IBM Plex Mono", ui-monospace, Menlo, monospace;
+}
+
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+
+body {
+  background: var(--ink);
+  color: var(--paper);
+  font-family: var(--f-body);
+  font-size: 14px;
+  line-height: 1.55;
+  letter-spacing: 0.005em;
+  min-height: 100vh;
+  position: relative;
+  overflow-x: hidden;
+}
+
+/* -------- Layered background: grid paper + grain + vignette -------- */
+body::before {
+  /* engineering grid */
+  content: "";
+  position: fixed;
+  inset: 0;
+  background-image:
+    linear-gradient(rgba(232,223,198,0.035) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(232,223,198,0.035) 1px, transparent 1px),
+    linear-gradient(rgba(232,223,198,0.018) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(232,223,198,0.018) 1px, transparent 1px);
+  background-size: 80px 80px, 80px 80px, 16px 16px, 16px 16px;
+  pointer-events: none;
+  z-index: 0;
+}
+body::after {
+  /* vignette + faint horizontal scanlines */
+  content: "";
+  position: fixed;
+  inset: 0;
+  background:
+    radial-gradient(ellipse at center, transparent 0%, transparent 55%, rgba(0,0,0,0.55) 100%),
+    repeating-linear-gradient(0deg, transparent 0 2px, rgba(255,255,255,0.012) 2px 3px);
+  pointer-events: none;
+  z-index: 0;
+}
+
+main, header, footer { position: relative; z-index: 1; }
+
+/* ============================================================
+   HEADER — filing-cabinet chrome
+   ============================================================ */
+.chrome {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: end;
+  gap: 28px;
+  padding: 28px 40px 0;
+  border-bottom: 1px solid var(--rule-strong);
+}
+.mark {
+  display: flex; align-items: baseline; gap: 12px;
+}
+.mark__glyph {
+  width: 34px; height: 34px;
+  border: 1.5px solid var(--paper);
+  color: var(--paper);
+  font-family: var(--f-display);
+  font-weight: 500;
+  font-size: 22px;
+  display: flex; align-items: center; justify-content: center;
+  font-style: italic;
+  transform: rotate(-6deg);
+  position: relative;
+}
+.mark__glyph::after {
+  content: ""; position: absolute; inset: -5px;
+  border: 1px dashed var(--ghost); border-radius: 50%;
+  opacity: 0.4;
+}
+.mark__word {
+  font-family: var(--f-display);
+  font-weight: 300;
+  font-variation-settings: "opsz" 144, "SOFT" 30, "WONK" 1;
+  font-size: 34px;
+  letter-spacing: -0.02em;
+  line-height: 1;
+  color: var(--paper);
+}
+.mark__word em { font-style: italic; color: var(--rust); font-weight: 400; }
+.mark__sub {
+  font-family: var(--f-mono);
+  font-size: 10px;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: var(--ghost);
+  margin-top: 8px;
+  display: block;
+}
+
+.chrome__nav {
+  display: flex;
+  gap: 0;
+  align-items: flex-end;
+}
+.tab {
+  font-family: var(--f-mono);
+  font-size: 11px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--ghost);
+  text-decoration: none;
+  padding: 10px 22px 9px;
+  border: 1px solid var(--rule);
+  border-bottom: none;
+  background: linear-gradient(to top, rgba(232,223,198,0.02), transparent);
+  position: relative;
+  top: 1px;
+  transition: color 0.15s, background 0.15s;
+}
+.tab:hover { color: var(--paper); background: rgba(232,223,198,0.04); }
+.tab[aria-current="page"] {
+  color: var(--paper);
+  background: var(--ink-raised);
+  border-color: var(--rule-strong);
+  border-bottom: 1px solid var(--ink-raised);
+  top: 2px;
+}
+.tab[aria-current="page"]::before {
+  content: ""; position: absolute; left: 10px; top: 4px;
+  width: 4px; height: 4px; background: var(--rust); border-radius: 50%;
+  box-shadow: 0 0 8px var(--rust);
+}
+
+.chrome__ident {
+  text-align: right;
+  font-family: var(--f-mono);
+  font-size: 10px;
+  line-height: 1.6;
+  color: var(--ghost);
+  padding-bottom: 6px;
+}
+.chrome__ident b { color: var(--paper); font-weight: 400; }
+.chrome__ident .dot {
+  display: inline-block; width: 6px; height: 6px; border-radius: 50%;
+  background: var(--verdigris); box-shadow: 0 0 6px var(--verdigris);
+  vertical-align: middle; margin-right: 6px;
+}
+
+/* ============================================================
+   PAGE TITLE — editorial
+   ============================================================ */
+.page-head {
+  padding: 36px 40px 24px;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 40px;
+  align-items: end;
+  border-bottom: 1px dashed var(--rule-strong);
+}
+.page-head__title {
+  font-family: var(--f-display);
+  font-weight: 300;
+  font-variation-settings: "opsz" 144, "SOFT" 50, "WONK" 1;
+  font-size: clamp(48px, 6vw, 84px);
+  line-height: 0.95;
+  letter-spacing: -0.035em;
+  color: var(--paper);
+  margin: 0;
+}
+.page-head__title em {
+  font-style: italic;
+  color: var(--rust);
+  font-variation-settings: "opsz" 144, "SOFT" 100;
+}
+.page-head__meta {
+  font-family: var(--f-mono);
+  font-size: 10px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--ghost);
+  text-align: right;
+  line-height: 1.7;
+}
+.page-head__meta b { color: var(--paper); font-weight: 400; }
+
+/* ============================================================
+   CONTROL RAIL — filters
+   ============================================================ */
+.workspace {
+  display: grid;
+  grid-template-columns: 260px 1fr;
+  gap: 40px;
+  padding: 24px 40px 80px;
+}
+
+.rail {
+  border-right: 1px dashed var(--rule-strong);
+  padding-right: 32px;
+}
+.rail__section + .rail__section { margin-top: 28px; }
+.rail__label {
+  font-family: var(--f-mono);
+  font-size: 10px;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: var(--rust);
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--rule);
+  margin-bottom: 10px;
+  display: flex; justify-content: space-between;
+}
+.rail__label span { color: var(--ghost); letter-spacing: 0.2em; }
+
+.field {
+  width: 100%;
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--rule-strong);
+  color: var(--paper);
+  font-family: var(--f-mono);
+  font-size: 12px;
+  padding: 8px 0 6px;
+  margin-bottom: 12px;
+  letter-spacing: 0.04em;
+  outline: none;
+  transition: border-color 0.15s;
+}
+.field::placeholder { color: var(--paper-shade); }
+.field:focus { border-color: var(--rust); }
+
+select.field {
+  appearance: none;
+  background-image: linear-gradient(45deg, transparent 50%, var(--paper-shade) 50%),
+                    linear-gradient(-45deg, transparent 50%, var(--paper-shade) 50%);
+  background-position: calc(100% - 8px) 16px, calc(100% - 4px) 16px;
+  background-size: 4px 4px;
+  background-repeat: no-repeat;
+  padding-right: 20px;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--f-mono);
+  font-size: 10px;
+  letter-spacing: 0.25em;
+  text-transform: uppercase;
+  color: var(--paper);
+  background: transparent;
+  border: 1px solid var(--rule-strong);
+  padding: 9px 14px;
+  cursor: pointer;
+  text-decoration: none;
+  transition: border-color 0.15s, color 0.15s, background 0.15s;
+}
+.btn:hover { border-color: var(--rust); color: var(--rust); }
+.btn--primary { border-color: var(--rust); color: var(--rust); }
+.btn--primary:hover { background: var(--rust); color: var(--ink); }
+
+/* ============================================================
+   EVIDENCE GRID — cards
+   ============================================================ */
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 28px;
+  padding-top: 4px;
+}
+
+.card {
+  background: var(--paper);
+  color: var(--ink);
+  padding: 22px 22px 18px;
+  position: relative;
+  border: 1px solid var(--paper-shade);
+  box-shadow:
+    0 1px 0 rgba(255,255,255,0.08) inset,
+    0 18px 30px -18px rgba(0,0,0,0.9),
+    0 4px 10px -2px rgba(0,0,0,0.5);
+  transition: transform 0.28s cubic-bezier(.2,.8,.2,1),
+              box-shadow 0.28s;
+  text-decoration: none;
+  color: var(--ink);
+  transform: rotate(var(--tilt, 0deg));
+  will-change: transform;
+}
+.card::before {
+  /* paper grain — a second noise-ish layer */
+  content: "";
+  position: absolute; inset: 0;
+  background:
+    repeating-linear-gradient(45deg,
+      transparent 0 2px,
+      rgba(155, 142, 102, 0.05) 2px 3px);
+  pointer-events: none;
+}
+.card::after {
+  /* pushpin */
+  content: "";
+  position: absolute;
+  top: -7px; left: 50%;
+  width: 12px; height: 12px;
+  transform: translateX(-50%);
+  background: radial-gradient(circle at 35% 30%, #E85A4F 0%, #A21D16 60%, #5E100C 100%);
+  border-radius: 50%;
+  box-shadow:
+    0 1px 0 rgba(255,255,255,0.5) inset,
+    0 4px 6px -1px rgba(0,0,0,0.7);
+}
+.card:hover {
+  transform: rotate(0deg) translateY(-3px);
+  box-shadow:
+    0 1px 0 rgba(255,255,255,0.1) inset,
+    0 24px 40px -14px rgba(0,0,0,0.95),
+    0 8px 14px -2px rgba(0,0,0,0.6);
+  z-index: 3;
+}
+
+.card__head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+.card__ns {
+  font-family: var(--f-mono);
+  font-size: 10px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--paper-shade);
+  display: inline-flex; align-items: center; gap: 6px;
+}
+.card__ns::before {
+  content: ""; width: 6px; height: 6px;
+  background: var(--rust); display: inline-block;
+  transform: rotate(45deg);
+}
+
+.stamp {
+  width: 64px; height: 64px;
+  display: flex; align-items: center; justify-content: center;
+  font-family: var(--f-mono);
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  color: var(--rust);
+  border: 2px solid var(--rust);
+  border-radius: 50%;
+  transform: rotate(-8deg);
+  text-align: center;
+  line-height: 1;
+  background: transparent;
+  position: relative;
+  flex-shrink: 0;
+  opacity: 0.85;
+  /* faux ink imperfection */
+  filter: contrast(1.1) blur(0.15px);
+}
+.stamp::before {
+  content: ""; position: absolute; inset: 4px;
+  border: 1px solid var(--rust);
+  border-radius: 50%;
+  opacity: 0.5;
+}
+.stamp__pct { font-size: 18px; font-weight: 400; display: block; }
+.stamp__label { font-size: 7px; letter-spacing: 0.2em; display: block; margin-top: 2px; }
+.stamp--superseded { color: var(--paper-shade); border-color: var(--paper-shade); }
+.stamp--superseded::before { border-color: var(--paper-shade); }
+.stamp--decayed { color: var(--brass); border-color: var(--brass); }
+.stamp--decayed::before { border-color: var(--brass); }
+
+.card__body {
+  font-family: var(--f-display);
+  font-weight: 400;
+  font-size: 17px;
+  line-height: 1.4;
+  color: var(--ink);
+  min-height: 90px;
+  font-variation-settings: "opsz" 14, "SOFT" 50;
+  letter-spacing: -0.01em;
+  position: relative;
+  z-index: 1;
+}
+
+.card__rule {
+  border: none;
+  border-top: 1px dashed var(--paper-shade);
+  margin: 14px 0 10px;
+}
+.card__foot {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 10px;
+  font-family: var(--f-mono);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  color: var(--paper-shade);
+  text-transform: uppercase;
+  position: relative;
+  z-index: 1;
+}
+.tags { display: flex; flex-wrap: wrap; gap: 4px; max-width: 70%; }
+.tag {
+  background: transparent;
+  border: 1px solid var(--paper-shade);
+  padding: 2px 6px;
+  font-size: 9px;
+  letter-spacing: 0.15em;
+  color: var(--ink);
+}
+
+.empty {
+  grid-column: 1 / -1;
+  text-align: center;
+  padding: 80px 20px;
+  color: var(--ghost);
+  font-family: var(--f-display);
+  font-style: italic;
+  font-size: 22px;
+  font-variation-settings: "opsz" 144, "SOFT" 100;
+  letter-spacing: -0.01em;
+}
+
+/* ============================================================
+   DETAIL — dossier
+   ============================================================ */
+.dossier {
+  padding: 24px 40px 80px;
+  display: grid;
+  grid-template-columns: 1fr 340px;
+  gap: 48px;
+}
+.dossier__crumbs {
+  grid-column: 1 / -1;
+  font-family: var(--f-mono);
+  font-size: 10px;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--ghost);
+  padding-bottom: 18px;
+  border-bottom: 1px dashed var(--rule-strong);
+  margin-bottom: 28px;
+}
+.dossier__crumbs a { color: var(--ghost); text-decoration: none; }
+.dossier__crumbs a:hover { color: var(--rust); }
+.dossier__crumbs span { color: var(--rust); }
+
+.sheet {
+  background: var(--paper);
+  color: var(--ink);
+  padding: 52px 56px 44px;
+  position: relative;
+  box-shadow:
+    0 1px 0 rgba(255,255,255,0.08) inset,
+    0 28px 60px -20px rgba(0,0,0,0.92),
+    0 8px 24px -8px rgba(0,0,0,0.5);
+  border: 1px solid var(--paper-shade);
+}
+.sheet::before {
+  /* fold line across top, decorative */
+  content: "";
+  position: absolute;
+  top: 0; left: 52px; right: 52px;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(0,0,0,0.15), transparent);
+}
+.sheet__classification {
+  position: absolute;
+  top: 14px; left: 24px;
+  font-family: var(--f-mono);
+  font-size: 9px;
+  letter-spacing: 0.4em;
+  color: var(--rust);
+  text-transform: uppercase;
+}
+.sheet__classification::before {
+  content: "◉ "; color: var(--rust);
+}
+
+.sheet__stamp {
+  position: absolute;
+  top: 34px; right: 56px;
+  transform: rotate(9deg);
+}
+
+.sheet__id {
+  font-family: var(--f-mono);
+  font-size: 10px;
+  letter-spacing: 0.3em;
+  color: var(--paper-shade);
+  text-transform: uppercase;
+  margin-bottom: 10px;
+}
+.sheet__id b { color: var(--ink); font-weight: 400; }
+
+.sheet__title {
+  font-family: var(--f-display);
+  font-weight: 350;
+  font-variation-settings: "opsz" 144, "SOFT" 40, "WONK" 0;
+  font-size: 42px;
+  line-height: 1.1;
+  letter-spacing: -0.025em;
+  color: var(--ink);
+  margin: 0 0 26px;
+}
+.sheet__title em { font-style: italic; color: var(--rust-deep); }
+
+.dataline {
+  display: grid;
+  grid-template-columns: 140px 1fr;
+  gap: 16px;
+  padding: 6px 0;
+  border-top: 1px dashed var(--paper-shade);
+  font-family: var(--f-mono);
+  font-size: 11px;
+}
+.dataline:last-child { border-bottom: 1px dashed var(--paper-shade); }
+.dataline__k {
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  color: var(--paper-shade);
+  font-size: 10px;
+  padding-top: 2px;
+}
+.dataline__v { color: var(--ink); letter-spacing: 0.02em; word-break: break-all; }
+.dataline__v .hl { color: var(--rust-deep); }
+
+/* dossier side panel */
+.aside {
+  border-left: 1px dashed var(--rule-strong);
+  padding-left: 32px;
+  font-family: var(--f-mono);
+  font-size: 11px;
+  color: var(--ghost);
+}
+.aside h3 {
+  font-family: var(--f-mono);
+  font-size: 10px;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: var(--rust);
+  margin: 0 0 12px;
+  border-bottom: 1px solid var(--rule);
+  padding-bottom: 6px;
+}
+.aside + .aside { margin-top: 28px; }
+.aside ul { list-style: none; padding: 0; margin: 0; }
+.aside li { padding: 6px 0; border-bottom: 1px dashed var(--rule); }
+.aside li a { color: var(--paper); text-decoration: none; }
+.aside li a:hover { color: var(--rust); }
+.aside__meta { color: var(--paper-shade); font-size: 10px; letter-spacing: 0.12em; }
+
+/* tabs under the sheet */
+.tabs {
+  margin-top: 32px;
+  border-top: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+  display: flex;
+  padding: 0 4px;
+}
+.tabs__item {
+  font-family: var(--f-mono);
+  font-size: 10px;
+  letter-spacing: 0.25em;
+  text-transform: uppercase;
+  color: var(--ghost);
+  padding: 14px 20px;
+  text-decoration: none;
+  position: relative;
+  border-right: 1px dashed var(--rule);
+  cursor: pointer;
+  background: transparent;
+  border-top: none; border-bottom: none; border-left: none;
+}
+.tabs__item:hover { color: var(--paper); }
+.tabs__item[aria-current="page"] { color: var(--rust); }
+.tabs__item[aria-current="page"]::after {
+  content: ""; position: absolute; left: 0; right: 0; bottom: -1px;
+  height: 2px; background: var(--rust);
+}
+
+.panel {
+  padding: 28px 4px;
+  font-family: var(--f-mono);
+  font-size: 12px;
+  line-height: 1.7;
+  color: var(--paper);
+}
+.panel h4 {
+  font-family: var(--f-mono);
+  font-size: 10px;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--rust);
+  margin: 24px 0 10px;
+}
+.panel h4:first-child { margin-top: 0; }
+
+.chain {
+  list-style: none; padding: 0; margin: 0;
+  position: relative;
+}
+.chain::before {
+  content: ""; position: absolute;
+  top: 6px; bottom: 6px; left: 8px;
+  width: 2px;
+  background: repeating-linear-gradient(to bottom, var(--rust) 0 4px, transparent 4px 8px);
+}
+.chain li {
+  padding: 10px 0 10px 28px;
+  position: relative;
+}
+.chain li::before {
+  content: ""; position: absolute;
+  left: 2px; top: 14px;
+  width: 12px; height: 12px;
+  border: 2px solid var(--rust);
+  background: var(--ink);
+  border-radius: 50%;
+}
+.chain li.is-current::before { background: var(--rust); }
+.chain li a { color: var(--paper); text-decoration: none; }
+.chain li a:hover { color: var(--rust); }
+.chain__ts { font-size: 10px; letter-spacing: 0.2em; color: var(--paper-shade); text-transform: uppercase; }
+
+.kv {
+  display: grid; grid-template-columns: 180px 1fr;
+  gap: 0; font-family: var(--f-mono); font-size: 11px;
+  border-top: 1px dashed var(--rule);
+}
+.kv > dt, .kv > dd {
+  padding: 10px 0;
+  border-bottom: 1px dashed var(--rule);
+  margin: 0;
+}
+.kv > dt { color: var(--ghost); letter-spacing: 0.18em; text-transform: uppercase; font-size: 10px; }
+.kv > dd { color: var(--paper); word-break: break-all; }
+.kv > dd code { background: rgba(232,223,198,0.06); padding: 1px 6px; color: var(--brass); }
+
+.neighbor {
+  display: grid; grid-template-columns: 60px 1fr 80px;
+  gap: 14px; align-items: center;
+  padding: 12px 0;
+  border-bottom: 1px dashed var(--rule);
+  font-size: 11px;
+}
+.neighbor__score {
+  font-family: var(--f-mono); color: var(--rust);
+  font-size: 14px; letter-spacing: 0.05em;
+}
+.neighbor__content {
+  font-family: var(--f-display); font-size: 14px; color: var(--paper);
+  line-height: 1.4;
+}
+.neighbor__meta { font-family: var(--f-mono); font-size: 9px; color: var(--ghost); letter-spacing: 0.2em; text-transform: uppercase; text-align: right; }
+
+/* edges tab */
+.edge {
+  display: grid; grid-template-columns: 1fr auto 1fr;
+  gap: 14px; align-items: center;
+  padding: 10px 0;
+  border-bottom: 1px dashed var(--rule);
+  font-size: 11px;
+}
+.edge__node { font-family: var(--f-display); font-size: 16px; color: var(--paper); }
+.edge__kind {
+  font-family: var(--f-mono); font-size: 9px; letter-spacing: 0.28em;
+  text-transform: uppercase; color: var(--rust);
+  padding: 2px 10px; border: 1px solid var(--rust);
+}
+
+/* ============================================================
+   TICKER — bottom status strip
+   ============================================================ */
+.ticker {
+  position: fixed;
+  left: 0; right: 0; bottom: 0;
+  background: var(--ink-deep);
+  border-top: 1px solid var(--rule-strong);
+  padding: 6px 20px;
+  font-family: var(--f-mono);
+  font-size: 10px;
+  letter-spacing: 0.22em;
+  color: var(--ghost);
+  text-transform: uppercase;
+  z-index: 10;
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+}
+.ticker__pulse::before {
+  content: "●"; color: var(--rust); animation: pulse 1.2s ease-in-out infinite;
+  margin-right: 6px;
+}
+@keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.25; } }
+
+/* ============================================================
+   PAGE-LOAD CHOREOGRAPHY
+   ============================================================ */
+@keyframes raise {
+  from { opacity: 0; transform: translateY(12px) rotate(var(--tilt, 0deg)); }
+  to   { opacity: 1; transform: translateY(0)    rotate(var(--tilt, 0deg)); }
+}
+.card {
+  animation: raise 0.6s cubic-bezier(.2,.8,.2,1) both;
+  animation-delay: calc(var(--i, 0) * 40ms);
+}
+@keyframes sheet-in {
+  from { opacity: 0; transform: translateY(20px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+.sheet { animation: sheet-in 0.5s cubic-bezier(.2,.8,.2,1) both; }
+
+@keyframes reveal {
+  from { opacity: 0; transform: translateX(-8px); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+.page-head, .rail { animation: reveal 0.55s cubic-bezier(.2,.8,.2,1) both; }
+
+/* ============================================================
+   RESPONSIVE
+   ============================================================ */
+@media (max-width: 960px) {
+  .workspace { grid-template-columns: 1fr; }
+  .rail { border-right: none; border-bottom: 1px dashed var(--rule-strong); padding: 0 0 24px; }
+  .dossier { grid-template-columns: 1fr; }
+  .aside { border-left: none; padding-left: 0; border-top: 1px dashed var(--rule-strong); padding-top: 28px; }
+  .chrome { flex-wrap: wrap; padding: 20px; grid-template-columns: 1fr; }
+  .chrome__nav { order: 3; overflow-x: auto; }
+  .page-head { padding: 24px 20px; grid-template-columns: 1fr; }
+  .sheet { padding: 40px 24px 32px; }
+}
+
+/* ============================================================
+   SELECTION
+   ============================================================ */
+::selection { background: var(--rust); color: var(--paper); }

--- a/agent_memory/ui/static/app.js
+++ b/agent_memory/ui/static/app.js
@@ -1,0 +1,36 @@
+// Minimal UI choreography. HTMX handles fragment swapping;
+// this file only adds micro-behaviors that CSS can't express.
+
+(function () {
+  // 1) Stagger card index CSS var so the load animation waterfalls.
+  document.querySelectorAll(".card").forEach((el, i) => {
+    el.style.setProperty("--i", Math.min(i, 30));
+  });
+
+  // 2) Apply per-card tilt from data attribute.
+  document.querySelectorAll("[data-tilt]").forEach((el) => {
+    el.style.setProperty("--tilt", el.dataset.tilt + "deg");
+  });
+
+  // 3) Tab bar keyboard navigation on the dossier detail page.
+  const tabs = document.querySelector(".tabs");
+  if (tabs) {
+    tabs.addEventListener("keydown", (e) => {
+      const items = [...tabs.querySelectorAll(".tabs__item")];
+      const idx = items.indexOf(document.activeElement);
+      if (idx === -1) return;
+      if (e.key === "ArrowRight") items[(idx + 1) % items.length].focus();
+      if (e.key === "ArrowLeft") items[(idx - 1 + items.length) % items.length].focus();
+    });
+  }
+
+  // 4) Live-updating "last captured" tick in the ticker.
+  const tick = document.querySelector(".ticker__pulse");
+  if (tick) {
+    const start = Date.now();
+    setInterval(() => {
+      const secs = Math.floor((Date.now() - start) / 1000);
+      tick.dataset.secs = String(secs);
+    }, 1000);
+  }
+})();

--- a/agent_memory/ui/templates/base.html
+++ b/agent_memory/ui/templates/base.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{% block title %}Memwright — Forensic Archive{% endblock %}</title>
+  <link rel="stylesheet" href="/ui/static/app.css">
+  <script src="https://unpkg.com/htmx.org@2.0.4" defer></script>
+</head>
+<body>
+  <header class="chrome">
+    <a class="mark" href="/ui/memories">
+      <span class="mark__glyph">m</span>
+      <span>
+        <span class="mark__word">memwright<em>.</em></span>
+        <span class="mark__sub">Forensic Archive · Read Only</span>
+      </span>
+    </a>
+
+    <nav class="chrome__nav">
+      <a class="tab" href="/ui/memories" {% if request.url.path.startswith("/ui/memories") %}aria-current="page"{% endif %}>01 · Memories</a>
+      <a class="tab" href="#" aria-disabled="true" title="Coming in milestone 3">02 · Graph</a>
+      <a class="tab" href="#" aria-disabled="true" title="Coming in milestone 4">03 · Recall</a>
+      <a class="tab" href="#" aria-disabled="true" title="Coming in milestone 5">04 · Timeline</a>
+      <a class="tab" href="#" aria-disabled="true" title="Coming in milestone 6">05 · Agents</a>
+    </nav>
+
+    <div class="chrome__ident">
+      <div><span class="dot"></span><b>NAMESPACE</b> {{ namespace_default }}</div>
+      <div>STORE · {{ store_path }}</div>
+      <div>{{ stats.total_memories or 0 }} records · {{ stats.active or stats.total_active or 0 }} active</div>
+    </div>
+  </header>
+
+  <main>
+    {% block content %}{% endblock %}
+  </main>
+
+  <footer class="ticker">
+    <div class="ticker__pulse" data-secs="0">Live · read-only</div>
+    <div>MEMWRIGHT v2 · DETERMINISTIC RETRIEVAL · NO LLM IN CRITICAL PATH</div>
+    <div>{{ stats.total_memories or 0 }} · ON DISK</div>
+  </footer>
+
+  <script src="/ui/static/app.js" defer></script>
+</body>
+</html>

--- a/agent_memory/ui/templates/memories/_grid.html
+++ b/agent_memory/ui/templates/memories/_grid.html
@@ -1,0 +1,32 @@
+<div class="grid" id="grid">
+  {% for m in memories %}
+    <a class="card" href="/ui/memories/{{ m.id }}" data-tilt="{{ '%.2f' % m.tilt }}">
+      <div class="card__head">
+        <span class="card__ns">{{ m.namespace }} · {{ m.category }}</span>
+        {% set kind = "superseded" if m.status != "active" else ("decayed" if m.confidence < 0.5 else "active") %}
+        <div class="stamp stamp--{{ kind }}" title="confidence {{ '%.3f' % m.confidence }}">
+          <span>
+            <span class="stamp__pct">{{ m.confidence_pct }}</span>
+            <span class="stamp__label">{{ kind|upper }}</span>
+          </span>
+        </div>
+      </div>
+
+      <div class="card__body">{{ m.excerpt }}</div>
+
+      <hr class="card__rule">
+      <div class="card__foot">
+        <div class="tags">
+          {% for t in m.tags[:4] %}<span class="tag">{{ t }}</span>{% endfor %}
+          {% if m.tags|length > 4 %}<span class="tag">+{{ m.tags|length - 4 }}</span>{% endif %}
+        </div>
+        <div>
+          {% if m.entity %}<span>↣ {{ m.entity }}</span><br>{% endif %}
+          {{ m.created_date }} · {{ m.created_time }}
+        </div>
+      </div>
+    </a>
+  {% else %}
+    <div class="empty">No records surface for these constraints. <br>The archive may be empty, or your filters may be too narrow.</div>
+  {% endfor %}
+</div>

--- a/agent_memory/ui/templates/memories/detail.html
+++ b/agent_memory/ui/templates/memories/detail.html
@@ -1,0 +1,172 @@
+{% extends "base.html" %}
+{% block title %}Record {{ m.short_id }} · Memwright{% endblock %}
+{% block content %}
+
+<section class="dossier">
+  <nav class="dossier__crumbs">
+    <a href="/ui/memories">← Evidence Board</a> · Record · <span>{{ m.short_id }}</span>
+  </nav>
+
+  <div>
+    <article class="sheet">
+      <div class="sheet__classification">Dossier · Namespace {{ m.namespace }}</div>
+      {% set kind = "superseded" if m.status != "active" else ("decayed" if m.confidence < 0.5 else "active") %}
+      <div class="stamp stamp--{{ kind }} sheet__stamp">
+        <span>
+          <span class="stamp__pct">{{ m.confidence_pct }}</span>
+          <span class="stamp__label">{{ kind|upper }}</span>
+        </span>
+      </div>
+
+      <div class="sheet__id">Record <b>{{ m.id }}</b></div>
+      <h2 class="sheet__title">{{ m.content }}</h2>
+
+      <div class="dataline"><div class="dataline__k">Category</div><div class="dataline__v">{{ m.category }}</div></div>
+      <div class="dataline"><div class="dataline__k">Entity</div><div class="dataline__v">{{ m.entity or "—" }}</div></div>
+      <div class="dataline"><div class="dataline__k">Tags</div><div class="dataline__v">{{ m.tags|join(' · ') if m.tags else "—" }}</div></div>
+      <div class="dataline"><div class="dataline__k">Created</div><div class="dataline__v"><span class="hl">{{ m.created_at }}</span></div></div>
+      <div class="dataline"><div class="dataline__k">Event Date</div><div class="dataline__v">{{ m.event_date or "—" }}</div></div>
+      <div class="dataline"><div class="dataline__k">Valid From</div><div class="dataline__v">{{ m.valid_from or "—" }}</div></div>
+      <div class="dataline"><div class="dataline__k">Valid Until</div><div class="dataline__v">{{ m.valid_until or "open" }}</div></div>
+    </article>
+
+    <nav class="tabs" role="tablist">
+      {% set TABS = [('content','Content'),('provenance','Provenance'),('supersession','Supersession'),('embedding','Embedding'),('graph','Graph'),('access','Access')] %}
+      {% for key, label in TABS %}
+        <a class="tabs__item" href="?tab={{ key }}" {% if tab == key %}aria-current="page"{% endif %}>{{ loop.index0 + 1 }} · {{ label }}</a>
+      {% endfor %}
+    </nav>
+
+    <div class="panel">
+      {% if tab == 'content' %}
+        <h4>Full text</h4>
+        <p style="font-family: var(--f-display); font-size: 17px; line-height:1.65;">{{ m.content }}</p>
+
+      {% elif tab == 'provenance' %}
+        <h4>Origin</h4>
+        <dl class="kv">
+          <dt>Memory ID</dt><dd><code>{{ m.id }}</code></dd>
+          <dt>Content Hash</dt><dd><code>{{ m.content_hash or "—" }}</code></dd>
+          <dt>Namespace</dt><dd>{{ m.namespace }}</dd>
+          <dt>Status</dt><dd>{{ m.status }}</dd>
+          <dt>Superseded By</dt>
+          <dd>{% if m.superseded_by %}<a href="/ui/memories/{{ m.superseded_by }}">{{ m.superseded_by[:12] }}…</a>{% else %}—{% endif %}</dd>
+          <dt>Access Count</dt><dd>{{ m.access_count }}</dd>
+          <dt>Last Accessed</dt><dd>{{ m.last_accessed or "never" }}</dd>
+        </dl>
+
+        <h4>Agent metadata</h4>
+        <dl class="kv">
+          {% for k, v in (m.metadata or {}).items() %}
+            <dt>{{ k }}</dt><dd><code>{{ v }}</code></dd>
+          {% else %}
+            <dt>—</dt><dd>no agent metadata captured</dd>
+          {% endfor %}
+        </dl>
+
+      {% elif tab == 'supersession' %}
+        <h4>Chain</h4>
+        {% if predecessors or chain %}
+          <ul class="chain">
+            {% for p in predecessors|reverse %}
+              <li>
+                <div class="chain__ts">{{ p.created_date }} · superseded</div>
+                <a href="/ui/memories/{{ p.id }}">{{ p.excerpt }}</a>
+              </li>
+            {% endfor %}
+            <li class="is-current">
+              <div class="chain__ts">{{ m.created_date }} · this record</div>
+              <span>{{ m.excerpt }}</span>
+            </li>
+            {% for c in chain %}
+              <li>
+                <div class="chain__ts">{{ c.created_date }} · supersedes above</div>
+                <a href="/ui/memories/{{ c.id }}">{{ c.excerpt }}</a>
+              </li>
+            {% endfor %}
+          </ul>
+        {% else %}
+          <p>No supersession relationships recorded. This fact stands alone.</p>
+        {% endif %}
+
+      {% elif tab == 'embedding' %}
+        <h4>Nearest neighbors · cosine similarity</h4>
+        {% for n in neighbors %}
+          <a class="neighbor" href="/ui/memories/{{ n.id }}" style="text-decoration:none;">
+            <div class="neighbor__score">{{ '%.3f' % n.score }}</div>
+            <div class="neighbor__content">{{ n.excerpt }}</div>
+            <div class="neighbor__meta">{{ n.namespace }}<br>{{ n.created_date }}</div>
+          </a>
+        {% else %}
+          <p>Vector store returned no neighbors. The embedding may be missing, the namespace may be empty, or the vector backend is degraded.</p>
+        {% endfor %}
+
+      {% elif tab == 'graph' %}
+        <h4>Neighborhood · 1-hop from {{ m.entity or "(unnamed entity)" }}</h4>
+        {% if m.entity %}
+          <dl class="kv">
+            <dt>PageRank</dt><dd><code>{{ pagerank }}</code></dd>
+            <dt>Edges</dt><dd>{{ graph_edges|length }} incident</dd>
+          </dl>
+          {% for e in graph_edges %}
+            <div class="edge">
+              <div class="edge__node">{{ e.source }}</div>
+              <div class="edge__kind">{{ e.kind }}</div>
+              <div class="edge__node">{{ e.target }}</div>
+            </div>
+          {% else %}
+            <p>No edges yet. Graph extractor may not have pinned this entity to related nodes.</p>
+          {% endfor %}
+        {% else %}
+          <p>This record has no entity anchor, so it does not live in the entity graph.</p>
+        {% endif %}
+
+      {% elif tab == 'access' %}
+        <h4>Retrieval signal</h4>
+        <dl class="kv">
+          <dt>Access Count</dt><dd><code>{{ m.access_count }}</code></dd>
+          <dt>Last Accessed</dt><dd>{{ m.last_accessed or "never" }}</dd>
+          <dt>Confidence</dt><dd>{{ '%.4f' % m.confidence }} · decays at 0.001 / hr, boosts +0.03 per recall hit</dd>
+        </dl>
+        <p style="color: var(--ghost); font-family: var(--f-display); font-style: italic; margin-top: 20px;">
+          Confidence decays with time. Each retrieval nudges it back up. A record drifting below 0.5 is flagged <em>decayed</em>.
+        </p>
+
+      {% endif %}
+    </div>
+  </div>
+
+  <div>
+    <div class="aside">
+      <h3>Co-filed tags</h3>
+      <ul>
+        {% for t in m.tags %}<li>{{ t }}</li>{% else %}<li class="aside__meta">no tags</li>{% endfor %}
+      </ul>
+    </div>
+
+    <div class="aside">
+      <h3>Nearest</h3>
+      <ul>
+        {% for n in neighbors[:4] %}
+          <li>
+            <a href="/ui/memories/{{ n.id }}">{{ n.excerpt[:72] }}{% if n.excerpt|length > 72 %}…{% endif %}</a>
+            <div class="aside__meta">cos · {{ '%.3f' % n.score }}</div>
+          </li>
+        {% else %}
+          <li class="aside__meta">none indexed</li>
+        {% endfor %}
+      </ul>
+    </div>
+
+    <div class="aside">
+      <h3>Actions</h3>
+      <ul>
+        <li><a href="/ui/memories?entity={{ m.entity }}">All records on entity</a></li>
+        <li><a href="/ui/memories?namespace={{ m.namespace }}">All in namespace</a></li>
+        <li><a href="/ui/health.json" target="_blank">Store health · JSON</a></li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+{% endblock %}

--- a/agent_memory/ui/templates/memories/list.html
+++ b/agent_memory/ui/templates/memories/list.html
@@ -1,0 +1,66 @@
+{% extends "base.html" %}
+{% block title %}Evidence Board · Memwright{% endblock %}
+{% block content %}
+
+<section class="page-head">
+  <h1 class="page-head__title">Evidence<br><em>Board.</em></h1>
+  <div class="page-head__meta">
+    <div><b>{{ total }}</b> records surfaced</div>
+    <div>dispatch · {{ stats.namespaces|length if stats.namespaces else 1 }} namespaces</div>
+    <div>latest · {{ memories[0].created_date if memories else "—" }}</div>
+  </div>
+</section>
+
+<section class="workspace">
+  <aside class="rail">
+    <form method="get"
+          action="/ui/memories"
+          hx-get="/ui/memories"
+          hx-target="#grid"
+          hx-select="#grid"
+          hx-push-url="true"
+          hx-trigger="change from:select delay:100ms, keyup changed delay:350ms from:input[type=search]">
+
+      <div class="rail__section">
+        <div class="rail__label">Query <span>FTS + Vector</span></div>
+        <input class="field" type="search" name="q" value="{{ filters.q }}"
+               placeholder="// pattern, keyword, phrase" autocomplete="off">
+      </div>
+
+      <div class="rail__section">
+        <div class="rail__label">Namespace</div>
+        <input class="field" type="text" name="namespace" value="{{ filters.namespace }}" placeholder="any">
+      </div>
+
+      <div class="rail__section">
+        <div class="rail__label">Category</div>
+        <input class="field" type="text" name="category" value="{{ filters.category }}" placeholder="any">
+      </div>
+
+      <div class="rail__section">
+        <div class="rail__label">Entity</div>
+        <input class="field" type="text" name="entity" value="{{ filters.entity }}" placeholder="any">
+      </div>
+
+      <div class="rail__section">
+        <div class="rail__label">Status</div>
+        <select class="field" name="status">
+          <option value="active" {% if filters.status == 'active' %}selected{% endif %}>active</option>
+          <option value="superseded" {% if filters.status == 'superseded' %}selected{% endif %}>superseded</option>
+          <option value="archived" {% if filters.status == 'archived' %}selected{% endif %}>archived</option>
+        </select>
+      </div>
+
+      <div class="rail__section">
+        <button class="btn btn--primary" type="submit">Recompile</button>
+        <a class="btn" href="/ui/memories" style="margin-top:8px;">Clear</a>
+      </div>
+    </form>
+  </aside>
+
+  <section>
+    {% include "memories/_grid.html" %}
+  </section>
+</section>
+
+{% endblock %}


### PR DESCRIPTION
## Summary
- Adds `agent_memory/ui/` — a read-only web UI for developers to inspect memories with agent/LLM depth (provenance, supersession chain, embedding neighbors, graph neighborhood, access stats).
- New CLI: `memwright ui [--host --port --path --open]` runs uvicorn against the existing Starlette app.
- Aesthetic: "Forensic Archive" — Fraunces serif + Departure Mono, dark ink over aged-paper cards, octagonal wax-stamp confidence badges, pushpin cards with subtle per-card tilt, no generic Inter/Space Grotesk, no purple gradients.
- Bolts into existing `memwright api` so one server now serves JSON API + UI.

## Test plan
- [x] Seed 4 memories, hit /ui/memories → 200, cards render, filters work
- [x] Detail page /ui/memories/{id} → 200, all 6 tabs resolve
- [x] /ui/static/app.css → 200 (22KB)
- [x] / → redirect to /ui/memories
- [ ] Visual QA in browser across 3 namespaces
- [ ] Add pytest coverage for ui routes