### PR TITLE
feat(ui): complete web viewer — Graph, Recall, Timeline, Agents

### DIFF
--- a/agent_memory/retrieval/orchestrator.py
+++ b/agent_memory/retrieval/orchestrator.py
@@ -278,6 +278,199 @@ class RetrievalOrchestrator:
         blended.sort(key=lambda r: r.score, reverse=True)
         return blended
 
+    def recall_debug(
+        self,
+        query: str,
+        token_budget: int = 2000,
+        namespace: Optional[str] = None,
+    ) -> Dict:
+        """Execute recall and return per-layer debug trace.
+
+        Returns dict with keys: query, layers (list of layer dicts),
+        final (list of result dicts), config.
+        """
+        layers = []
+
+        def _snap(results: List[RetrievalResult]) -> List[Dict]:
+            return [
+                {
+                    "id": r.memory.id,
+                    "content": r.memory.content[:200],
+                    "score": round(r.score, 4),
+                    "source": r.match_source,
+                    "entity": r.memory.entity,
+                    "category": r.memory.category,
+                }
+                for r in results
+            ]
+
+        all_results: List[RetrievalResult] = []
+
+        # Layer 1: Tag match
+        tags = extract_tags(query)
+        tag_results: List[RetrievalResult] = []
+        if tags:
+            tag_memories = self.store.tag_search(tags, namespace=namespace)
+            for mem in tag_memories:
+                tag_results.append(
+                    RetrievalResult(memory=mem, score=1.0, match_source="tag")
+                )
+        all_results.extend(tag_results)
+        layers.append({
+            "name": "Tag Match",
+            "description": "FTS on extracted tags",
+            "tags": tags,
+            "count": len(tag_results),
+            "results": _snap(tag_results),
+        })
+
+        # Layer 2: Graph expansion
+        graph_results: List[RetrievalResult] = []
+        expanded_queries = []
+        graph_context_triples: List[str] = []
+        if self.graph:
+            try:
+                for tag in tags:
+                    related = self.graph.get_related(tag, depth=2)
+                    expanded_queries.extend(related)
+                    if hasattr(self.graph, "get_edges"):
+                        edges = self.graph.get_edges(tag)
+                        for edge in edges:
+                            subj = edge.get("subject", "")
+                            pred = edge.get("predicate", "related_to")
+                            obj = edge.get("object", "")
+                            event_date = edge.get("event_date", "")
+                            date_str = f" ({event_date})" if event_date else ""
+                            graph_context_triples.append(
+                                f"{subj} {pred} {obj}{date_str}"
+                            )
+            except Exception:
+                pass
+
+            seen_ids = {r.memory.id for r in all_results}
+            for entity_name in expanded_queries[:8]:
+                entity_memories = self.store.list_memories(
+                    entity=entity_name, status="active",
+                    namespace=namespace, limit=5,
+                )
+                for mem in entity_memories:
+                    if mem.id not in seen_ids:
+                        r = RetrievalResult(
+                            memory=mem, score=0.5, match_source="graph",
+                        )
+                        graph_results.append(r)
+                        all_results.append(r)
+                        seen_ids.add(mem.id)
+
+            # Graph triples as synthetic memories
+            for triple_str in graph_context_triples[:20]:
+                r = RetrievalResult(
+                    memory=Memory(
+                        content=triple_str,
+                        category="graph_relation",
+                        tags=[],
+                    ),
+                    score=0.6,
+                    match_source="graph",
+                )
+                graph_results.append(r)
+                all_results.append(r)
+
+        layers.append({
+            "name": "Graph Expansion",
+            "description": "BFS depth=2, entity lookup, relation triples",
+            "expanded_entities": expanded_queries[:8],
+            "triples": len(graph_context_triples),
+            "count": len(graph_results),
+            "results": _snap(graph_results),
+        })
+
+        # Layer 3: Vector search
+        vector_results: List[RetrievalResult] = []
+        if self.vector_store:
+            try:
+                vec_results = self.vector_store.search(
+                    query, limit=20, namespace=namespace
+                )
+                seen_ids = {r.memory.id for r in all_results}
+                for vr in vec_results:
+                    mid = vr["memory_id"]
+                    if mid in seen_ids:
+                        continue
+                    memory = self.store.get(mid)
+                    if not memory or memory.status != "active":
+                        continue
+                    if namespace and memory.namespace != namespace:
+                        continue
+                    distance = vr.get("distance", 1.0)
+                    score = max(0.0, 1.0 - distance)
+                    r = RetrievalResult(
+                        memory=memory, score=score, match_source="vector",
+                    )
+                    vector_results.append(r)
+                    all_results.append(r)
+                    seen_ids.add(mid)
+            except Exception:
+                pass
+
+        layers.append({
+            "name": "Vector Search",
+            "description": "Cosine similarity via ChromaDB",
+            "count": len(vector_results),
+            "results": _snap(vector_results),
+        })
+
+        # Layer 4: Fusion + Rank (RRF or graph blend)
+        if self.fusion_mode == "graph_blend" and self.graph and len(all_results) >= 3:
+            fused = self._graph_blend(all_results)
+        else:
+            fused = self._reciprocal_rank_fusion(all_results)
+        fused = temporal_boost(fused, enabled=self.enable_temporal_boost)
+        query_entities = [t for t in tags if t[0].isupper()] if tags else None
+        fused = entity_boost(fused, query_entities)
+
+        layers.append({
+            "name": "Fusion + Rank",
+            "description": f"RRF k=60, temporal boost, entity boost" if self.fusion_mode == "rrf" else "Graph blend + temporal + entity boost",
+            "fusion_mode": self.fusion_mode,
+            "count": len(fused),
+            "results": _snap(fused),
+        })
+
+        # Layer 5: Diversity + Fit (MMR + token budget)
+        if self.enable_mmr:
+            fused = mmr_rerank(fused, lambda_param=self.mmr_lambda)
+        fused = confidence_decay_boost(
+            fused,
+            decay_rate=self.confidence_decay_rate,
+            boost_rate=self.confidence_boost_rate,
+            gate=self.confidence_gate,
+        )
+        final = fit_to_budget(fused, token_budget)
+
+        layers.append({
+            "name": "Diversity + Fit",
+            "description": f"MMR λ={self.mmr_lambda}, confidence decay, token budget={token_budget}",
+            "mmr_enabled": self.enable_mmr,
+            "budget": token_budget,
+            "count": len(final),
+            "results": _snap(final),
+        })
+
+        return {
+            "query": query,
+            "namespace": namespace,
+            "token_budget": token_budget,
+            "layers": layers,
+            "final_count": len(final),
+            "config": {
+                "fusion_mode": self.fusion_mode,
+                "mmr_lambda": self.mmr_lambda,
+                "confidence_gate": self.confidence_gate,
+                "confidence_decay_rate": self.confidence_decay_rate,
+            },
+        }
+
     def recall_as_context(
         self,
         query: str,

--- a/agent_memory/ui/app.py
+++ b/agent_memory/ui/app.py
@@ -240,6 +240,267 @@ async def memory_detail(request: Request) -> HTMLResponse:
     return _TEMPLATES.TemplateResponse(request, "memories/detail.html", ctx)
 
 
+async def graph_page(request: Request) -> HTMLResponse:
+    """Full knowledge graph visualization via Cytoscape.js."""
+    mem = _get_mem(request)
+
+    graph_stats: Dict[str, Any] = {}
+    try:
+        g = getattr(mem, "_graph", None)
+        if g is not None:
+            graph_stats = g.graph_stats()
+    except Exception:
+        pass
+
+    ctx = {
+        "request": request,
+        "graph_stats": graph_stats,
+        **_common_context(request, mem),
+    }
+    return _TEMPLATES.TemplateResponse(request, "memories/graph.html", ctx)
+
+
+async def graph_json(request: Request) -> JSONResponse:
+    """Return full graph data for Cytoscape.js consumption."""
+    mem = _get_mem(request)
+
+    g = getattr(mem, "_graph", None)
+    if g is None:
+        return JSONResponse({"nodes": [], "edges": [], "stats": {}, "pagerank": {}})
+
+    # Optional entity-type filter
+    entity_type = request.query_params.get("type") or None
+
+    entities = g.get_entities(entity_type=entity_type)
+    pr = {}
+    try:
+        pr = mem.pagerank() or {}
+    except Exception:
+        pass
+
+    stats = {}
+    try:
+        stats = g.graph_stats()
+    except Exception:
+        pass
+
+    nodes = []
+    node_keys = {e["key"] for e in entities}
+    for e in entities:
+        nodes.append({
+            "id": e["key"],
+            "label": e["name"],
+            "type": e.get("type", "general"),
+            "pagerank": round(pr.get(e["key"], 0.0), 6),
+        })
+
+    edges = []
+    try:
+        nx_graph = getattr(g, "_graph", None)
+        if nx_graph is not None:
+            for u, v, _key, data in nx_graph.edges(keys=True, data=True):
+                if u in node_keys and v in node_keys:
+                    edges.append({
+                        "source": u,
+                        "target": v,
+                        "type": data.get("relation_type", "RELATED_TO"),
+                    })
+    except Exception:
+        pass
+
+    return JSONResponse({
+        "nodes": nodes,
+        "edges": edges,
+        "stats": stats,
+        "pagerank": pr,
+    })
+
+
+async def recall_page(request: Request) -> HTMLResponse:
+    """Recall pipeline replay — interactive query with layer-by-layer trace."""
+    mem = _get_mem(request)
+    ctx = {
+        "request": request,
+        **_common_context(request, mem),
+    }
+    return _TEMPLATES.TemplateResponse(request, "memories/recall.html", ctx)
+
+
+async def recall_json(request: Request) -> JSONResponse:
+    """Execute recall with debug trace and return per-layer results."""
+    mem = _get_mem(request)
+
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse({"error": "Invalid JSON"}, status_code=400)
+
+    query = body.get("query", "").strip()
+    if not query:
+        return JSONResponse({"error": "query is required"}, status_code=400)
+
+    namespace = body.get("namespace") or None
+    budget = int(body.get("budget", 2000))
+
+    retrieval = getattr(mem, "_retrieval", None)
+    if retrieval is None:
+        return JSONResponse({"error": "No retrieval orchestrator"}, status_code=500)
+
+    try:
+        trace = retrieval.recall_debug(query, token_budget=budget, namespace=namespace)
+    except Exception as e:
+        return JSONResponse({"error": str(e)}, status_code=500)
+
+    return JSONResponse(trace)
+
+
+async def timeline_page(request: Request) -> HTMLResponse:
+    """Temporal timeline — visualise memory validity, supersession, and as-of replay."""
+    mem = _get_mem(request)
+    ctx = {"request": request, **_common_context(request, mem)}
+    return _TEMPLATES.TemplateResponse(request, "memories/timeline.html", ctx)
+
+
+async def timeline_json(request: Request) -> JSONResponse:
+    """Return memories sorted by created_at for timeline rendering."""
+    mem = _get_mem(request)
+
+    namespace = request.query_params.get("namespace") or None
+    entity = request.query_params.get("entity") or None
+    status = request.query_params.get("status") or None
+    date_from = request.query_params.get("from") or None
+    date_to = request.query_params.get("to") or None
+    as_of = request.query_params.get("as_of") or None
+
+    try:
+        search_status = status if status and status != "all" else None
+        results = mem.search(
+            query=None, namespace=namespace, status=search_status, limit=500,
+        )
+    except Exception as e:
+        return JSONResponse({"error": str(e)}, status_code=500)
+
+    memories = []
+    for m in results:
+        if entity and (getattr(m, "entity", None) or "").lower() != entity.lower():
+            continue
+        created = getattr(m, "created_at", "") or ""
+        if date_from and created[:10] < date_from:
+            continue
+        if date_to and created[:10] > date_to:
+            continue
+        if as_of:
+            vf = getattr(m, "valid_from", "") or ""
+            vu = getattr(m, "valid_until", None)
+            if vf and as_of < vf:
+                continue
+            if vu and as_of > vu:
+                continue
+        memories.append(_memory_to_dict(m))
+
+    memories.sort(key=lambda x: x.get("created_at", ""), reverse=True)
+    return JSONResponse({"memories": memories})
+
+
+async def agents_page(request: Request) -> HTMLResponse:
+    """Agent Registry — namespace-level view of agent activity."""
+    mem = _get_mem(request)
+    ctx = {"request": request, **_common_context(request, mem)}
+    return _TEMPLATES.TemplateResponse(request, "memories/agents.html", ctx)
+
+
+async def agents_json(request: Request) -> JSONResponse:
+    """Return namespace-level agent data for the agents UI."""
+    mem = _get_mem(request)
+    detail_ns = request.query_params.get("namespace") or None
+    is_detail = request.query_params.get("detail") == "1"
+    page = int(request.query_params.get("page") or 1)
+    per_page = 20
+
+    if is_detail and detail_ns:
+        try:
+            results = mem.search(namespace=detail_ns, limit=500)
+        except Exception:
+            results = []
+        memories = [_memory_to_dict(m) for m in results]
+        memories.sort(key=lambda m: m.get("created_at") or "", reverse=True)
+        entity_counts: Dict[str, int] = {}
+        cat_counts: Dict[str, int] = {}
+        for m in memories:
+            ent = m.get("entity")
+            if ent:
+                entity_counts[ent] = entity_counts.get(ent, 0) + 1
+            cat = m.get("category") or "general"
+            cat_counts[cat] = cat_counts.get(cat, 0) + 1
+        entity_freq = sorted(
+            [{"name": k, "count": v} for k, v in entity_counts.items()],
+            key=lambda x: x["count"], reverse=True,
+        )[:30]
+        categories = sorted(
+            [{"name": k, "count": v} for k, v in cat_counts.items()],
+            key=lambda x: x["count"], reverse=True,
+        )
+        start = (page - 1) * per_page
+        return JSONResponse({
+            "namespace_detail": {
+                "namespace": detail_ns,
+                "memory_count": len(memories),
+                "page": page,
+                "latest_date": memories[0].get("created_at") if memories else None,
+                "entity_freq": entity_freq,
+                "categories": categories,
+                "memories": memories[start:start + per_page],
+            }
+        })
+
+    # Overview: all namespaces
+    try:
+        all_memories = mem.search(limit=2000)
+    except Exception:
+        all_memories = []
+
+    ns_data: Dict[str, List[Dict[str, Any]]] = {}
+    for m in all_memories:
+        d = _memory_to_dict(m)
+        ns = d.get("namespace") or "default"
+        ns_data.setdefault(ns, []).append(d)
+
+    from datetime import datetime, timedelta
+
+    today = datetime.utcnow().date()
+    namespaces = []
+    for ns_name, mems in sorted(ns_data.items()):
+        mems.sort(key=lambda m: m.get("created_at") or "", reverse=True)
+        cat_counts: Dict[str, int] = {}
+        entity_counts: Dict[str, int] = {}
+        for m in mems:
+            cat_counts[m.get("category") or "general"] = cat_counts.get(m.get("category") or "general", 0) + 1
+            if m.get("entity"):
+                entity_counts[m["entity"]] = entity_counts.get(m["entity"], 0) + 1
+        categories = sorted(
+            [{"name": k, "count": v} for k, v in cat_counts.items()],
+            key=lambda x: x["count"], reverse=True,
+        )
+        top_entities = sorted(
+            [{"name": k, "count": v} for k, v in entity_counts.items()],
+            key=lambda x: x["count"], reverse=True,
+        )[:5]
+        activity = []
+        for days_ago in range(13, -1, -1):
+            d = today - timedelta(days=days_ago)
+            ds = d.isoformat()
+            activity.append({"date": ds, "count": sum(1 for m in mems if (m.get("created_at") or "")[:10] == ds)})
+        namespaces.append({
+            "namespace": ns_name,
+            "memory_count": len(mems),
+            "latest_date": mems[0].get("created_at") if mems else None,
+            "categories": categories,
+            "top_entities": top_entities,
+            "activity": activity,
+        })
+    return JSONResponse({"namespaces": namespaces})
+
+
 async def health_json(request: Request) -> JSONResponse:
     mem = _get_mem(request)
     try:
@@ -256,6 +517,14 @@ def ui_routes() -> list:
         Route("/ui/", index),
         Route("/ui/memories", memories_list),
         Route("/ui/memories/{memory_id}", memory_detail),
+        Route("/ui/graph", graph_page),
+        Route("/ui/graph.json", graph_json),
+        Route("/ui/recall", recall_page),
+        Route("/ui/recall.json", recall_json, methods=["POST"]),
+        Route("/ui/timeline", timeline_page),
+        Route("/ui/timeline.json", timeline_json),
+        Route("/ui/agents", agents_page),
+        Route("/ui/agents.json", agents_json),
         Route("/ui/health.json", health_json),
         Mount(
             "/ui/static",

--- a/agent_memory/ui/static/agents.js
+++ b/agent_memory/ui/static/agents.js
@@ -1,0 +1,300 @@
+// Memwright — Agent Registry
+// Renders namespace-based agent dossier cards with drill-down detail.
+
+(function () {
+  "use strict";
+
+  // ---- Helpers ----
+
+  function esc(str) {
+    var d = document.createElement("div");
+    d.textContent = str || "";
+    return d.innerHTML;
+  }
+
+  function fmtDate(iso) {
+    if (!iso) return "\u2014";
+    return iso.slice(0, 10);
+  }
+
+  function fmtDateTime(iso) {
+    if (!iso) return "\u2014";
+    return iso.slice(0, 10) + " " + (iso.slice(11, 16) || "");
+  }
+
+  function truncate(s, n) {
+    if (!s) return "";
+    return s.length > n ? s.slice(0, n) + "\u2026" : s;
+  }
+
+  // ---- State ----
+
+  var agentsData = null;
+
+  // ---- Fetch ----
+
+  function loadAgents() {
+    var area = document.getElementById("agents-area");
+    area.innerHTML = '<div class="agents-empty">Loading agent namespaces\u2026</div>';
+
+    fetch("/ui/agents.json")
+      .then(function (res) { return res.json(); })
+      .then(function (data) {
+        agentsData = data;
+        renderGrid(data.namespaces, area);
+      })
+      .catch(function (err) {
+        area.innerHTML =
+          '<div class="agents-empty">Failed to load: ' + esc(err.message) + "</div>";
+      });
+  }
+
+  // ---- Grid ----
+
+  function renderGrid(namespaces, container) {
+    if (!namespaces || namespaces.length === 0) {
+      container.innerHTML =
+        '<div class="agents-empty">No agent namespaces found. Memories will appear here once agents write to distinct namespaces.</div>';
+      return;
+    }
+
+    var html = '<div class="agents-grid">';
+
+    namespaces.forEach(function (ns, i) {
+      var catHtml = renderCategoryBar(ns.categories);
+      var entitiesHtml = (ns.top_entities || [])
+        .slice(0, 5)
+        .map(function (e) {
+          return '<span class="agents-entity">' + esc(e.name) + " <em>" + e.count + "</em></span>";
+        })
+        .join("");
+
+      var activityHtml = renderActivity(ns.activity);
+
+      html +=
+        '<div class="agents-card" data-ns="' + esc(ns.namespace) + '" style="--i:' + i + '">' +
+          '<div class="agents-card__tab">' + esc(ns.namespace) + "</div>" +
+          '<div class="agents-card__name">' + esc(ns.namespace) + "</div>" +
+          '<div class="agents-card__stat">' +
+            '<span class="agents-card__count">' + ns.memory_count + "</span>" +
+            '<span class="agents-card__label">memories</span>' +
+          "</div>" +
+          '<hr class="agents-card__rule">' +
+          '<div class="agents-card__section-label">Categories</div>' +
+          catHtml +
+          '<div class="agents-card__section-label">Top Entities</div>' +
+          '<div class="agents-card__entities">' +
+            (entitiesHtml || '<span class="agents-card__none">none extracted</span>') +
+          "</div>" +
+          '<hr class="agents-card__rule">' +
+          '<div class="agents-card__foot">' +
+            '<div class="agents-card__latest">Latest: ' + fmtDate(ns.latest_date) + "</div>" +
+            '<div class="agents-card__activity">' + activityHtml + "</div>" +
+          "</div>" +
+        "</div>";
+    });
+
+    html += "</div>";
+    container.innerHTML = html;
+
+    // Attach click listeners
+    container.querySelectorAll(".agents-card").forEach(function (card) {
+      card.addEventListener("click", function () {
+        var nsName = card.getAttribute("data-ns");
+        openDetail(nsName);
+      });
+    });
+  }
+
+  function renderCategoryBar(categories) {
+    if (!categories || categories.length === 0) {
+      return '<div class="agents-catbar"><span class="agents-card__none">uncategorized</span></div>';
+    }
+
+    var total = categories.reduce(function (sum, c) { return sum + c.count; }, 0);
+    if (total === 0) return '<div class="agents-catbar"></div>';
+
+    var COLORS = {
+      general: "var(--ghost)",
+      decision: "var(--rust)",
+      fact: "var(--verdigris)",
+      preference: "var(--brass)",
+      procedure: "var(--indigo)",
+      context: "var(--paper-shade)",
+    };
+
+    var barHtml = '<div class="agents-catbar__bar">';
+    categories.forEach(function (c) {
+      var pct = Math.max(2, (c.count / total) * 100);
+      var color = COLORS[c.name] || "var(--ghost)";
+      barHtml +=
+        '<div class="agents-catbar__seg" style="width:' + pct + "%;background:" + color + '" title="' + esc(c.name) + ": " + c.count + '"></div>';
+    });
+    barHtml += "</div>";
+
+    var legendHtml = '<div class="agents-catbar__legend">';
+    categories.forEach(function (c) {
+      var color = COLORS[c.name] || "var(--ghost)";
+      legendHtml +=
+        '<span class="agents-catbar__tag"><span class="agents-catbar__dot" style="background:' + color + '"></span>' + esc(c.name) + " " + c.count + "</span>";
+    });
+    legendHtml += "</div>";
+
+    return '<div class="agents-catbar">' + barHtml + legendHtml + "</div>";
+  }
+
+  function renderActivity(activity) {
+    if (!activity || activity.length === 0) return "";
+    // Simple sparkline using Unicode block chars
+    var max = Math.max.apply(null, activity.map(function (a) { return a.count; }));
+    if (max === 0) return "";
+    var BARS = ["\u2581", "\u2582", "\u2583", "\u2584", "\u2585", "\u2586", "\u2587", "\u2588"];
+    return activity
+      .map(function (a) {
+        var idx = Math.round((a.count / max) * (BARS.length - 1));
+        return '<span class="agents-spark" title="' + esc(a.date) + ": " + a.count + '">' + BARS[idx] + "</span>";
+      })
+      .join("");
+  }
+
+  // ---- Detail Panel ----
+
+  function openDetail(nsName) {
+    var overlay = document.getElementById("agents-overlay");
+    var panel = document.getElementById("agents-detail");
+    overlay.hidden = false;
+
+    panel.innerHTML = '<div class="agents-empty">Loading dossier\u2026</div>';
+
+    fetch("/ui/agents.json?namespace=" + encodeURIComponent(nsName) + "&detail=1")
+      .then(function (res) { return res.json(); })
+      .then(function (data) {
+        renderDetail(data, panel);
+      })
+      .catch(function (err) {
+        panel.innerHTML =
+          '<div class="agents-empty">Failed: ' + esc(err.message) + "</div>";
+      });
+  }
+
+  function renderDetail(data, panel) {
+    var ns = data.namespace_detail;
+    if (!ns) {
+      panel.innerHTML = '<div class="agents-empty">No data returned.</div>';
+      return;
+    }
+
+    var html =
+      '<button class="agents-detail__close" id="agents-detail-close">&times; Close</button>' +
+      '<div class="agents-detail__head">' +
+        '<div class="agents-detail__name">' + esc(ns.namespace) + "</div>" +
+        '<div class="agents-detail__meta">' +
+          ns.memory_count + " memories &middot; latest: " + fmtDate(ns.latest_date) +
+        "</div>" +
+      "</div>";
+
+    // Entity frequency table
+    if (ns.entity_freq && ns.entity_freq.length > 0) {
+      html +=
+        '<div class="agents-detail__section-label">Entity Frequency</div>' +
+        '<table class="agents-freq">' +
+          "<thead><tr><th>Entity</th><th>Count</th></tr></thead><tbody>";
+      ns.entity_freq.forEach(function (e) {
+        html += "<tr><td>" + esc(e.name) + "</td><td>" + e.count + "</td></tr>";
+      });
+      html += "</tbody></table>";
+    }
+
+    // Category distribution
+    if (ns.categories && ns.categories.length > 0) {
+      html += '<div class="agents-detail__section-label">Category Distribution</div>';
+      html += renderCategoryBar(ns.categories);
+    }
+
+    // Recent memories (paginated, last 20)
+    html += '<div class="agents-detail__section-label">Recent Memories</div>';
+    if (ns.memories && ns.memories.length > 0) {
+      html += '<div class="agents-detail__list">';
+      ns.memories.forEach(function (m, i) {
+        html +=
+          '<div class="agents-mem">' +
+            '<div class="agents-mem__rank">' + (i + 1) + "</div>" +
+            '<div class="agents-mem__body">' +
+              '<div class="agents-mem__content">' + esc(truncate(m.content, 200)) + "</div>" +
+              '<div class="agents-mem__meta">' +
+                '<span class="agents-mem__cat">' + esc(m.category || "general") + "</span>" +
+                (m.entity ? " &middot; " + esc(m.entity) : "") +
+                " &middot; " + fmtDateTime(m.created_at) +
+              "</div>" +
+            "</div>" +
+            '<div class="agents-mem__conf">' + Math.round((m.confidence || 1) * 100) + "%</div>" +
+          "</div>";
+      });
+      html += "</div>";
+
+      // Pagination controls
+      if (ns.total_count > ns.memories.length) {
+        var page = ns.page || 1;
+        var totalPages = Math.ceil(ns.total_count / 20);
+        html +=
+          '<div class="agents-detail__pager">' +
+            (page > 1
+              ? '<button class="btn agents-pager-btn" data-page="' + (page - 1) + '" data-ns="' + esc(ns.namespace) + '">Prev</button>'
+              : "") +
+            '<span class="agents-detail__pager-info">Page ' + page + " / " + totalPages + "</span>" +
+            (page < totalPages
+              ? '<button class="btn agents-pager-btn" data-page="' + (page + 1) + '" data-ns="' + esc(ns.namespace) + '">Next</button>'
+              : "") +
+          "</div>";
+      }
+    } else {
+      html += '<div class="agents-card__none">No memories in this namespace.</div>';
+    }
+
+    panel.innerHTML = html;
+
+    // Wire close button
+    document.getElementById("agents-detail-close").addEventListener("click", closeDetail);
+
+    // Wire pager buttons
+    panel.querySelectorAll(".agents-pager-btn").forEach(function (btn) {
+      btn.addEventListener("click", function (e) {
+        e.stopPropagation();
+        var pg = btn.getAttribute("data-page");
+        var nsName = btn.getAttribute("data-ns");
+        loadDetailPage(nsName, parseInt(pg), panel);
+      });
+    });
+  }
+
+  function loadDetailPage(nsName, page, panel) {
+    panel.innerHTML = '<div class="agents-empty">Loading page ' + page + "\u2026</div>";
+    fetch("/ui/agents.json?namespace=" + encodeURIComponent(nsName) + "&detail=1&page=" + page)
+      .then(function (res) { return res.json(); })
+      .then(function (data) { renderDetail(data, panel); })
+      .catch(function (err) {
+        panel.innerHTML = '<div class="agents-empty">Failed: ' + esc(err.message) + "</div>";
+      });
+  }
+
+  function closeDetail() {
+    document.getElementById("agents-overlay").hidden = true;
+  }
+
+  // ---- Init ----
+
+  document.getElementById("agents-refresh").addEventListener("click", loadAgents);
+
+  // Close overlay on backdrop click
+  document.getElementById("agents-overlay").addEventListener("click", function (e) {
+    if (e.target === e.currentTarget) closeDetail();
+  });
+
+  // Close on Escape key
+  document.addEventListener("keydown", function (e) {
+    if (e.key === "Escape") closeDetail();
+  });
+
+  // Load on page ready
+  loadAgents();
+})();

--- a/agent_memory/ui/static/app.css
+++ b/agent_memory/ui/static/app.css
@@ -713,6 +713,428 @@ select.field {
 }
 
 /* ============================================================
+   GRAPH — Cytoscape canvas + inspector
+   ============================================================ */
+.graph-area {
+  display: grid;
+  grid-template-columns: 1fr 280px;
+  gap: 0;
+  min-height: calc(100vh - 260px);
+}
+
+.graph-canvas {
+  background: var(--ink-deep);
+  border: 1px solid var(--rule);
+  position: relative;
+  min-height: 500px;
+}
+/* faint grid overlay on graph canvas */
+.graph-canvas::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(rgba(232,223,198,0.025) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(232,223,198,0.025) 1px, transparent 1px);
+  background-size: 40px 40px;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.graph-empty {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--f-display);
+  font-style: italic;
+  font-size: 20px;
+  color: var(--ghost);
+  text-align: center;
+  line-height: 1.6;
+  font-variation-settings: "opsz" 144, "SOFT" 100;
+}
+
+/* ---- Inspector panel ---- */
+.graph-inspector {
+  border-left: 1px solid var(--rule);
+  background: var(--ink-raised);
+  padding: 20px;
+  overflow-y: auto;
+  max-height: calc(100vh - 260px);
+  font-family: var(--f-mono);
+  font-size: 11px;
+  color: var(--ghost);
+}
+
+.graph-inspector__empty {
+  padding: 40px 0;
+  text-align: center;
+  font-family: var(--f-display);
+  font-style: italic;
+  font-size: 15px;
+  color: var(--ghost);
+  font-variation-settings: "opsz" 144, "SOFT" 100;
+  opacity: 0.5;
+}
+
+.graph-inspector__head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 18px;
+  padding-bottom: 14px;
+  border-bottom: 1px dashed var(--rule-strong);
+}
+.graph-inspector__dot {
+  width: 18px; height: 18px;
+  border-radius: 50%;
+  border: 2px solid;
+  flex-shrink: 0;
+}
+.graph-inspector__name {
+  font-family: var(--f-display);
+  font-size: 20px;
+  font-weight: 400;
+  color: var(--paper);
+  line-height: 1.2;
+  font-variation-settings: "opsz" 28, "SOFT" 50;
+}
+.graph-inspector__type {
+  font-family: var(--f-mono);
+  font-size: 9px;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--rust);
+  margin-top: 2px;
+}
+
+.graph-inspector__stats {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+  margin-bottom: 18px;
+  padding-bottom: 14px;
+  border-bottom: 1px dashed var(--rule);
+}
+.graph-inspector__stat { text-align: center; }
+.graph-inspector__stat-val {
+  display: block;
+  font-size: 16px;
+  color: var(--paper);
+  font-family: var(--f-mono);
+}
+.graph-inspector__stat-lbl {
+  display: block;
+  font-size: 8px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--ghost);
+  margin-top: 2px;
+}
+
+.graph-inspector__section-label {
+  font-size: 9px;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--rust);
+  margin: 14px 0 8px;
+  padding-bottom: 4px;
+  border-bottom: 1px solid var(--rule);
+}
+
+.graph-inspector__edges,
+.graph-inspector__neighbors {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+.graph-inspector__edges li {
+  padding: 5px 0;
+  border-bottom: 1px dashed var(--rule);
+  font-size: 10px;
+  color: var(--paper);
+}
+.graph-inspector__edge-type {
+  font-size: 9px;
+  letter-spacing: 0.18em;
+  color: var(--brass);
+  text-transform: uppercase;
+}
+
+.graph-inspector__neighbor {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 0;
+  border-bottom: 1px dashed var(--rule);
+  cursor: pointer;
+  color: var(--paper);
+  font-size: 10px;
+  transition: color 0.15s;
+}
+.graph-inspector__neighbor:hover { color: var(--rust); }
+.graph-inspector__ndot {
+  width: 8px; height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+/* ---- Legend ---- */
+.graph-legend__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+.graph-legend__item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 0;
+  font-family: var(--f-mono);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  color: var(--ghost);
+}
+.graph-legend__dot {
+  width: 10px; height: 10px;
+  border-radius: 50%;
+  border: 1.5px solid;
+  flex-shrink: 0;
+}
+
+/* ============================================================
+   RECALL PIPELINE — layer cascade replay
+   ============================================================ */
+.recall-area {
+  min-height: 400px;
+}
+
+.recall-empty,
+.recall-loading {
+  padding: 80px 20px;
+  text-align: center;
+  font-family: var(--f-display);
+  font-style: italic;
+  font-size: 20px;
+  color: var(--ghost);
+  font-variation-settings: "opsz" 144, "SOFT" 100;
+}
+
+.recall-header {
+  margin-bottom: 28px;
+  padding-bottom: 18px;
+  border-bottom: 1px dashed var(--rule-strong);
+}
+.recall-header__query {
+  font-family: var(--f-display);
+  font-size: 28px;
+  font-weight: 350;
+  color: var(--paper);
+  font-variation-settings: "opsz" 44, "SOFT" 50;
+  font-style: italic;
+}
+.recall-header__meta {
+  font-family: var(--f-mono);
+  font-size: 10px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--ghost);
+  margin-top: 8px;
+}
+
+.recall-pipeline {
+  position: relative;
+}
+
+/* ---- Layer card ---- */
+@keyframes layer-in {
+  from { opacity: 0; transform: translateY(12px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+.recall-layer {
+  background: var(--ink-raised);
+  border: 1px solid var(--rule);
+  border-left: 3px solid var(--layer-color, var(--ghost));
+  padding: 20px 24px;
+  margin-bottom: 0;
+  animation: layer-in 0.4s cubic-bezier(.2,.8,.2,1) both;
+}
+
+.recall-layer__head {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin-bottom: 12px;
+}
+.recall-layer__icon {
+  width: 32px; height: 32px;
+  display: flex; align-items: center; justify-content: center;
+  border: 1.5px solid var(--layer-color, var(--ghost));
+  color: var(--layer-color, var(--ghost));
+  font-family: var(--f-mono);
+  font-size: 14px;
+  flex-shrink: 0;
+}
+.recall-layer__info { flex: 1; }
+.recall-layer__name {
+  font-family: var(--f-mono);
+  font-size: 12px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--layer-color, var(--paper));
+}
+.recall-layer__desc {
+  font-family: var(--f-mono);
+  font-size: 10px;
+  color: var(--ghost);
+  margin-top: 2px;
+}
+.recall-layer__count {
+  font-family: var(--f-mono);
+  font-size: 24px;
+  color: var(--layer-color, var(--paper));
+  font-weight: 400;
+  min-width: 40px;
+  text-align: right;
+}
+
+.recall-layer__meta {
+  font-family: var(--f-mono);
+  font-size: 10px;
+  color: var(--ghost);
+  margin-bottom: 10px;
+  padding: 6px 0;
+  border-top: 1px dashed var(--rule);
+}
+
+.recall-tag {
+  display: inline-block;
+  background: transparent;
+  border: 1px solid var(--rule-strong);
+  padding: 1px 6px;
+  font-size: 9px;
+  letter-spacing: 0.12em;
+  color: var(--paper);
+  margin: 0 2px;
+}
+
+.recall-layer__empty {
+  font-family: var(--f-mono);
+  font-size: 10px;
+  color: var(--ghost);
+  font-style: italic;
+  padding: 8px 0;
+}
+
+/* ---- Result row ---- */
+.recall-layer__results {
+  border-top: 1px dashed var(--rule);
+  max-height: 320px;
+  overflow-y: auto;
+}
+
+.recall-result {
+  display: grid;
+  grid-template-columns: 32px 1fr 120px;
+  gap: 12px;
+  align-items: start;
+  padding: 10px 0;
+  border-bottom: 1px dashed var(--rule);
+  font-size: 11px;
+}
+.recall-result--final {
+  border-left: 2px solid var(--rust);
+  padding-left: 10px;
+}
+
+.recall-result__rank {
+  font-family: var(--f-mono);
+  font-size: 10px;
+  color: var(--ghost);
+  text-align: center;
+  padding-top: 2px;
+}
+.recall-result__body { min-width: 0; }
+.recall-result__content {
+  font-family: var(--f-display);
+  font-size: 13px;
+  color: var(--paper);
+  line-height: 1.4;
+  font-variation-settings: "opsz" 14, "SOFT" 50;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+.recall-result__meta {
+  font-family: var(--f-mono);
+  font-size: 9px;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--ghost);
+  margin-top: 4px;
+}
+.recall-result__source {
+  color: var(--brass);
+}
+
+.recall-result__score {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--f-mono);
+  font-size: 11px;
+  color: var(--rust);
+}
+.recall-result__bar {
+  height: 3px;
+  background: var(--rust);
+  flex-shrink: 0;
+  min-width: 4px;
+  opacity: 0.7;
+}
+
+/* ---- Connector ---- */
+.recall-connector {
+  text-align: center;
+  padding: 4px 0;
+  color: var(--ghost);
+  font-size: 10px;
+  opacity: 0.5;
+}
+
+/* ---- Config sidebar ---- */
+.recall-config-list {
+  font-family: var(--f-mono);
+  font-size: 10px;
+}
+.recall-config-item {
+  padding: 5px 0;
+  border-bottom: 1px dashed var(--rule);
+  color: var(--paper);
+}
+.recall-config-item span {
+  color: var(--ghost);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  margin-right: 8px;
+}
+
+@media (max-width: 960px) {
+  .graph-area {
+    grid-template-columns: 1fr;
+  }
+  .graph-inspector {
+    border-left: none;
+    border-top: 1px solid var(--rule);
+    max-height: 300px;
+  }
+}
+
+/* ============================================================
    TICKER — bottom status strip
    ============================================================ */
 .ticker {
@@ -772,6 +1194,176 @@ select.field {
   .chrome__nav { order: 3; overflow-x: auto; }
   .page-head { padding: 24px 20px; grid-template-columns: 1fr; }
   .sheet { padding: 40px 24px 32px; }
+}
+
+/* ============================================================
+   SELECTION
+   ============================================================ */
+/* ============================================================
+   TIMELINE — temporal spine with supersession chains
+   ============================================================ */
+.tl-content { position: relative; min-height: 400px; }
+.tl-empty, .tl-loading {
+  padding: 80px 20px; text-align: center;
+  font-family: var(--f-display); font-style: italic; font-size: 20px;
+  color: var(--ghost); font-variation-settings: "opsz" 144, "SOFT" 100;
+}
+.tl-empty b { color: var(--rust); font-weight: 400; }
+.tl-asof-hint { font-family: var(--f-mono); font-size: 9px; letter-spacing: 0.12em; color: var(--paper-shade); margin-top: 2px; }
+
+.tl-spine { position: relative; padding: 20px 0 60px; }
+.tl-spine::before {
+  content: ""; position: absolute; top: 0; bottom: 0; left: 50%; width: 2px;
+  background: repeating-linear-gradient(to bottom, var(--rule-strong) 0 6px, transparent 6px 12px);
+  transform: translateX(-50%);
+}
+@keyframes tl-node-in { from { opacity: 0; transform: translateY(16px); } to { opacity: 1; transform: translateY(0); } }
+.tl-node {
+  position: relative; display: grid; grid-template-columns: 1fr 20px 1fr; gap: 0;
+  align-items: start; margin-bottom: 32px; animation: tl-node-in 0.5s cubic-bezier(.2,.8,.2,1) both;
+}
+.tl-node__dot {
+  grid-column: 2; grid-row: 1; width: 12px; height: 12px;
+  background: var(--ink); border: 2px solid var(--rust); border-radius: 50%;
+  justify-self: center; margin-top: 18px; z-index: 2;
+  box-shadow: 0 0 8px rgba(199, 81, 70, 0.3);
+}
+.tl-node__date {
+  position: absolute; left: 50%; transform: translateX(-50%); top: -14px;
+  font-family: var(--f-mono); font-size: 9px; letter-spacing: 0.28em;
+  text-transform: uppercase; color: var(--ghost); white-space: nowrap; z-index: 2;
+}
+.tl-card {
+  background: var(--ink-raised); border: 1px solid var(--rule); padding: 16px 20px 14px;
+  cursor: pointer; transition: border-color 0.2s, transform 0.2s; position: relative;
+}
+.tl-card--left { grid-column: 1; grid-row: 1; margin-right: 16px; border-right: 3px solid var(--rust); }
+.tl-card--right { grid-column: 3; grid-row: 1; margin-left: 16px; border-left: 3px solid var(--rust); }
+.tl-card:hover { border-color: var(--rust); transform: translateY(-2px); z-index: 3; }
+.tl-card--superseded { opacity: 0.55; border-color: var(--rule); }
+.tl-card--superseded .tl-card__content { text-decoration: line-through; text-decoration-color: var(--paper-shade); }
+.tl-card--superseded.tl-card--left { border-right-color: var(--paper-shade); }
+.tl-card--superseded.tl-card--right { border-left-color: var(--paper-shade); }
+.tl-card--superseded:hover { opacity: 0.8; border-color: var(--paper-shade); }
+.tl-card__head { display: flex; justify-content: space-between; align-items: flex-start; gap: 10px; margin-bottom: 8px; }
+.tl-card__entity { font-family: var(--f-display); font-size: 16px; font-weight: 400; color: var(--paper); font-variation-settings: "opsz" 28, "SOFT" 50; line-height: 1.2; }
+.tl-card__category { font-family: var(--f-mono); font-size: 9px; letter-spacing: 0.28em; text-transform: uppercase; color: var(--brass); margin-bottom: 6px; }
+.tl-card__content { font-family: var(--f-display); font-size: 13px; line-height: 1.45; color: var(--paper); font-variation-settings: "opsz" 14, "SOFT" 50; margin-bottom: 10px; }
+.tl-card__meta { display: flex; gap: 12px; font-family: var(--f-mono); font-size: 9px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--ghost); padding-top: 8px; border-top: 1px dashed var(--rule); }
+.tl-card__superseded { font-family: var(--f-mono); font-size: 10px; letter-spacing: 0.12em; color: var(--rust); margin-top: 6px; padding-top: 6px; border-top: 1px dashed var(--rule); }
+.tl-card__arrow { display: inline-block; animation: arrow-pulse 1.5s ease-in-out infinite; }
+@keyframes arrow-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
+.tl-card__validity { font-family: var(--f-mono); font-size: 9px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--verdigris); margin-top: 4px; }
+
+.tl-stamp {
+  width: 42px; height: 42px; display: flex; flex-direction: column; align-items: center; justify-content: center;
+  font-family: var(--f-mono); color: var(--rust); border: 1.5px solid var(--rust); border-radius: 50%;
+  transform: rotate(-6deg); flex-shrink: 0; text-align: center; line-height: 1; opacity: 0.85; filter: contrast(1.1) blur(0.15px);
+}
+.tl-stamp__pct { font-size: 14px; display: block; }
+.tl-stamp__label { font-size: 6px; letter-spacing: 0.18em; display: block; margin-top: 1px; }
+.tl-stamp--superseded { color: var(--paper-shade); border-color: var(--paper-shade); }
+.tl-stamp--decayed { color: var(--brass); border-color: var(--brass); }
+
+.tl-detail {
+  position: fixed; top: 0; right: 0; width: 400px; height: 100vh;
+  background: var(--ink-raised); border-left: 1px solid var(--rule-strong); z-index: 20;
+  overflow-y: auto; box-shadow: -8px 0 40px rgba(0,0,0,0.5); animation: tl-detail-in 0.3s cubic-bezier(.2,.8,.2,1);
+}
+@keyframes tl-detail-in { from { transform: translateX(100%); } to { transform: translateX(0); } }
+.tl-detail__head { display: flex; justify-content: space-between; align-items: center; padding: 18px 20px; border-bottom: 1px dashed var(--rule-strong); }
+.tl-detail__label { font-family: var(--f-mono); font-size: 10px; letter-spacing: 0.32em; text-transform: uppercase; color: var(--rust); }
+.tl-detail__close { background: none; border: 1px solid var(--rule-strong); color: var(--ghost); font-size: 18px; cursor: pointer; width: 30px; height: 30px; display: flex; align-items: center; justify-content: center; transition: color 0.15s, border-color 0.15s; }
+.tl-detail__close:hover { color: var(--rust); border-color: var(--rust); }
+.tl-detail__body { padding: 20px; }
+.tl-detail__id { font-family: var(--f-mono); font-size: 10px; letter-spacing: 0.22em; color: var(--ghost); margin-bottom: 16px; padding-bottom: 12px; border-bottom: 1px dashed var(--rule); word-break: break-all; }
+.tl-detail__row { display: grid; grid-template-columns: 110px 1fr; gap: 12px; padding: 6px 0; border-bottom: 1px dashed var(--rule); font-family: var(--f-mono); font-size: 11px; color: var(--paper); }
+.tl-detail__row span { font-size: 9px; letter-spacing: 0.22em; text-transform: uppercase; color: var(--ghost); }
+.tl-detail__row--rust { color: var(--rust); }
+.tl-detail__section { font-family: var(--f-mono); font-size: 9px; letter-spacing: 0.32em; text-transform: uppercase; color: var(--rust); margin: 18px 0 8px; padding-bottom: 4px; border-bottom: 1px solid var(--rule); }
+.tl-detail__content { font-family: var(--f-display); font-size: 14px; line-height: 1.5; color: var(--paper); font-variation-settings: "opsz" 14, "SOFT" 50; white-space: pre-wrap; word-break: break-word; }
+.tl-detail__tags { display: flex; flex-wrap: wrap; gap: 4px; padding: 10px 0; }
+.tl-detail__tag { font-family: var(--f-mono); font-size: 9px; letter-spacing: 0.15em; text-transform: uppercase; color: var(--paper); border: 1px solid var(--rule-strong); padding: 2px 8px; }
+
+@media (max-width: 960px) {
+  .tl-spine::before { left: 16px; }
+  .tl-node { grid-template-columns: 32px 1fr; }
+  .tl-node__dot { grid-column: 1; justify-self: center; }
+  .tl-node__date { position: static; transform: none; grid-column: 2; margin-bottom: 4px; }
+  .tl-card--left, .tl-card--right { grid-column: 2; grid-row: auto; margin: 0; border-left: 3px solid var(--rust); border-right: 1px solid var(--rule); }
+  .tl-card--superseded.tl-card--left, .tl-card--superseded.tl-card--right { border-left-color: var(--paper-shade); }
+  .tl-detail { width: 100%; }
+}
+
+/* ============================================================
+   AGENTS — Personnel dossier registry
+   ============================================================ */
+.agents-area { min-height: 400px; }
+.agents-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); gap: 28px; padding-top: 4px; }
+.agents-empty { grid-column: 1 / -1; text-align: center; padding: 80px 20px; color: var(--ghost); font-family: var(--f-display); font-style: italic; font-size: 22px; font-variation-settings: "opsz" 144, "SOFT" 100; }
+
+.agents-card {
+  background: var(--paper); color: var(--ink); padding: 28px 24px 20px; position: relative;
+  border: 1px solid var(--paper-shade); cursor: pointer;
+  box-shadow: 0 1px 0 rgba(255,255,255,0.08) inset, 0 18px 30px -18px rgba(0,0,0,0.9), 0 4px 10px -2px rgba(0,0,0,0.5);
+  transition: transform 0.28s cubic-bezier(.2,.8,.2,1), box-shadow 0.28s;
+  animation: raise 0.6s cubic-bezier(.2,.8,.2,1) both; animation-delay: calc(var(--i, 0) * 60ms);
+}
+.agents-card::before { content: ""; position: absolute; inset: 0; background: repeating-linear-gradient(45deg, transparent 0 2px, rgba(155,142,102,0.05) 2px 3px); pointer-events: none; }
+.agents-card__tab { position: absolute; top: -14px; left: 18px; background: var(--paper-aged); color: var(--ink); font-family: var(--f-mono); font-size: 9px; letter-spacing: 0.28em; text-transform: uppercase; padding: 3px 12px 2px; border: 1px solid var(--paper-shade); border-bottom: none; box-shadow: 0 -2px 4px rgba(0,0,0,0.15); }
+.agents-card:hover { transform: translateY(-4px); box-shadow: 0 1px 0 rgba(255,255,255,0.1) inset, 0 28px 50px -14px rgba(0,0,0,0.95), 0 10px 18px -2px rgba(0,0,0,0.6); z-index: 3; }
+.agents-card__name { font-family: var(--f-display); font-weight: 350; font-variation-settings: "opsz" 44, "SOFT" 40, "WONK" 0; font-size: 28px; line-height: 1.15; letter-spacing: -0.02em; color: var(--ink); margin-bottom: 6px; position: relative; z-index: 1; }
+.agents-card__stat { display: flex; align-items: baseline; gap: 8px; margin-bottom: 14px; position: relative; z-index: 1; }
+.agents-card__count { font-family: var(--f-mono); font-size: 32px; color: var(--rust); font-weight: 400; line-height: 1; }
+.agents-card__label { font-family: var(--f-mono); font-size: 10px; letter-spacing: 0.22em; text-transform: uppercase; color: var(--paper-shade); }
+.agents-card__rule { border: none; border-top: 1px dashed var(--paper-shade); margin: 10px 0; }
+.agents-card__section-label { font-family: var(--f-mono); font-size: 9px; letter-spacing: 0.28em; text-transform: uppercase; color: var(--paper-shade); margin: 10px 0 6px; position: relative; z-index: 1; }
+.agents-card__entities { display: flex; flex-wrap: wrap; gap: 4px; position: relative; z-index: 1; }
+.agents-entity { background: transparent; border: 1px solid var(--paper-shade); padding: 2px 7px; font-family: var(--f-mono); font-size: 9px; letter-spacing: 0.12em; color: var(--ink); }
+.agents-entity em { color: var(--rust-deep); font-style: normal; margin-left: 3px; font-size: 8px; }
+.agents-card__none { font-family: var(--f-mono); font-size: 9px; color: var(--paper-shade); font-style: italic; }
+.agents-card__foot { display: flex; justify-content: space-between; align-items: center; gap: 8px; font-family: var(--f-mono); font-size: 10px; color: var(--paper-shade); letter-spacing: 0.08em; position: relative; z-index: 1; }
+.agents-spark { color: var(--rust); font-size: 12px; line-height: 1; letter-spacing: 1px; }
+
+.agents-catbar { position: relative; z-index: 1; }
+.agents-catbar__bar { display: flex; height: 6px; border-radius: 1px; overflow: hidden; gap: 1px; margin-bottom: 4px; }
+.agents-catbar__seg { min-width: 4px; opacity: 0.85; }
+.agents-catbar__legend { display: flex; flex-wrap: wrap; gap: 6px; }
+.agents-catbar__tag { font-family: var(--f-mono); font-size: 8px; letter-spacing: 0.1em; color: var(--ink); display: inline-flex; align-items: center; gap: 3px; }
+.agents-catbar__dot { display: inline-block; width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0; }
+
+.agents-roles { list-style: none; padding: 0; margin: 0; }
+.agents-roles li { display: flex; align-items: center; gap: 8px; padding: 5px 0; border-bottom: 1px dashed var(--rule); font-family: var(--f-mono); font-size: 10px; letter-spacing: 0.15em; text-transform: uppercase; color: var(--ghost); }
+.agents-role-dot { display: inline-block; width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; }
+
+.agents-overlay { position: fixed; inset: 0; z-index: 20; background: rgba(6,8,11,0.85); display: flex; align-items: flex-start; justify-content: center; padding: 60px 20px; overflow-y: auto; }
+.agents-detail { background: var(--ink-raised); border: 1px solid var(--rule-strong); max-width: 760px; width: 100%; padding: 36px 40px 32px; position: relative; box-shadow: 0 32px 80px -20px rgba(0,0,0,0.95); animation: sheet-in 0.35s cubic-bezier(.2,.8,.2,1) both; }
+.agents-detail__close { position: absolute; top: 12px; right: 16px; background: transparent; border: 1px solid var(--rule); color: var(--ghost); font-family: var(--f-mono); font-size: 12px; padding: 4px 10px; cursor: pointer; transition: color 0.15s, border-color 0.15s; }
+.agents-detail__close:hover { color: var(--rust); border-color: var(--rust); }
+.agents-detail__head { margin-bottom: 24px; padding-bottom: 18px; border-bottom: 1px dashed var(--rule-strong); }
+.agents-detail__name { font-family: var(--f-display); font-weight: 350; font-variation-settings: "opsz" 144, "SOFT" 40, "WONK" 0; font-size: 36px; line-height: 1.1; letter-spacing: -0.025em; color: var(--paper); }
+.agents-detail__meta { font-family: var(--f-mono); font-size: 10px; letter-spacing: 0.22em; text-transform: uppercase; color: var(--ghost); margin-top: 6px; }
+.agents-detail__section-label { font-family: var(--f-mono); font-size: 10px; letter-spacing: 0.28em; text-transform: uppercase; color: var(--rust); margin: 22px 0 10px; padding-bottom: 5px; border-bottom: 1px solid var(--rule); }
+
+.agents-freq { width: 100%; border-collapse: collapse; font-family: var(--f-mono); font-size: 11px; }
+.agents-freq th { text-align: left; font-size: 9px; letter-spacing: 0.22em; text-transform: uppercase; color: var(--ghost); padding: 6px 0; border-bottom: 1px solid var(--rule); font-weight: 400; }
+.agents-freq td { padding: 5px 0; border-bottom: 1px dashed var(--rule); color: var(--paper); }
+.agents-freq td:last-child { text-align: right; color: var(--rust); }
+
+.agents-detail__list { max-height: 420px; overflow-y: auto; }
+.agents-mem { display: grid; grid-template-columns: 28px 1fr 48px; gap: 10px; align-items: start; padding: 8px 0; border-bottom: 1px dashed var(--rule); font-size: 11px; }
+.agents-mem__rank { font-family: var(--f-mono); font-size: 10px; color: var(--ghost); text-align: center; padding-top: 2px; }
+.agents-mem__content { font-family: var(--f-display); font-size: 13px; color: var(--paper); line-height: 1.4; font-variation-settings: "opsz" 14, "SOFT" 50; overflow: hidden; text-overflow: ellipsis; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; }
+.agents-mem__meta { font-family: var(--f-mono); font-size: 9px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--ghost); margin-top: 3px; }
+.agents-mem__cat { color: var(--brass); }
+.agents-mem__conf { font-family: var(--f-mono); font-size: 11px; color: var(--rust); text-align: right; }
+.agents-detail__pager { display: flex; align-items: center; justify-content: center; gap: 14px; padding: 16px 0 4px; font-family: var(--f-mono); font-size: 10px; letter-spacing: 0.15em; color: var(--ghost); }
+.agents-card__latest { text-transform: uppercase; letter-spacing: 0.12em; }
+
+@media (max-width: 960px) {
+  .agents-grid { grid-template-columns: 1fr; }
+  .agents-detail { padding: 24px 20px 20px; }
+  .agents-overlay { padding: 30px 10px; }
 }
 
 /* ============================================================

--- a/agent_memory/ui/static/graph.js
+++ b/agent_memory/ui/static/graph.js
@@ -1,0 +1,475 @@
+// Memwright — Knowledge Graph (Cytoscape.js)
+// Forensic Archive aesthetic: aged-paper nodes, oxidized copper edges.
+
+(function () {
+  "use strict";
+
+  // ── Palette keyed to entity types ──────────────────────────────
+  const TYPE_COLORS = {
+    tool:        { bg: "#D4A84B", border: "#A07A20", text: "#0A0C10" }, // brass
+    person:      { bg: "#C75146", border: "#8B2E26", text: "#E8DFC6" }, // rust
+    concept:     { bg: "#4A7C7E", border: "#2D5556", text: "#E8DFC6" }, // verdigris
+    project:     { bg: "#3B4A6B", border: "#242F48", text: "#E8DFC6" }, // indigo
+    organization:{ bg: "#9B8E66", border: "#6B6140", text: "#0A0C10" }, // paper-shade
+    location:    { bg: "#8B6E4E", border: "#5A4530", text: "#E8DFC6" }, // leather
+    event:       { bg: "#7E4A6E", border: "#52304A", text: "#E8DFC6" }, // plum
+    general:     { bg: "#E8DFC6", border: "#C9BB93", text: "#0A0C10" }, // paper
+  };
+
+  const EDGE_COLORS = {
+    USES:        "#D4A84B",
+    AUTHORED_BY: "#C75146",
+    RELATED_TO:  "#4A7C7E",
+    SUPERSEDES:  "#8B2E26",
+    CONTAINS:    "#3B4A6B",
+    DEPENDS_ON:  "#9B8E66",
+  };
+
+  const DEFAULT_EDGE_COLOR = "rgba(232, 223, 198, 0.35)";
+
+  function colorForType(type) {
+    return TYPE_COLORS[type] || TYPE_COLORS.general;
+  }
+
+  function colorForEdge(type) {
+    return EDGE_COLORS[type] || DEFAULT_EDGE_COLOR;
+  }
+
+  // ── State ──────────────────────────────────────────────────────
+  let cy = null;
+  let graphData = null;
+
+  // ── Fetch graph data ───────────────────────────────────────────
+  async function loadGraph() {
+    const res = await fetch("/ui/graph.json");
+    graphData = await res.json();
+    return graphData;
+  }
+
+  // ── Build Cytoscape elements ───────────────────────────────────
+  function buildElements(data) {
+    const nodes = data.nodes.map((n) => ({
+      data: {
+        id: n.id,
+        label: n.label,
+        type: n.type || "general",
+        pagerank: n.pagerank || 0,
+      },
+    }));
+
+    const edges = data.edges.map((e, i) => ({
+      data: {
+        id: "e" + i,
+        source: e.source,
+        target: e.target,
+        type: e.type || "RELATED_TO",
+      },
+    }));
+
+    return [...nodes, ...edges];
+  }
+
+  // ── Sizing ─────────────────────────────────────────────────────
+  function nodeSizeFn(mode) {
+    if (mode === "uniform") return () => 32;
+    if (mode === "degree") {
+      return (ele) => {
+        const d = ele.degree(false) || 1;
+        return Math.max(24, Math.min(80, 20 + d * 6));
+      };
+    }
+    // pagerank (default)
+    return (ele) => {
+      const pr = ele.data("pagerank") || 0;
+      // Scale: 0 → 24px, max → 80px
+      return Math.max(24, Math.min(80, 24 + pr * 4000));
+    };
+  }
+
+  // ── Init Cytoscape ─────────────────────────────────────────────
+  function initCy(elements) {
+    cy = cytoscape({
+      container: document.getElementById("cy"),
+      elements: elements,
+      minZoom: 0.15,
+      maxZoom: 4,
+      // wheelSensitivity left at default to avoid warning on standard mice
+
+      style: [
+        {
+          selector: "node",
+          style: {
+            label: "data(label)",
+            width: 32,
+            height: 32,
+            "background-color": (ele) => colorForType(ele.data("type")).bg,
+            "border-width": 2,
+            "border-color": (ele) => colorForType(ele.data("type")).border,
+            color: "#E8DFC6",
+            "font-family": '"Departure Mono", "IBM Plex Mono", monospace',
+            "font-size": 9,
+            "text-valign": "bottom",
+            "text-margin-y": 6,
+            "text-outline-width": 2,
+            "text-outline-color": "#0A0C10",
+            "text-max-width": 100,
+            "text-wrap": "ellipsis",
+            "overlay-padding": 4,
+            "transition-property": "width, height, border-width, opacity",
+            "transition-duration": "0.2s",
+          },
+        },
+        {
+          selector: "node:selected",
+          style: {
+            "border-width": 3,
+            "border-color": "#C75146",
+            "overlay-color": "#C75146",
+            "overlay-opacity": 0.12,
+          },
+        },
+        {
+          selector: "node.highlighted",
+          style: {
+            "border-width": 3,
+            "border-color": "#C75146",
+            "font-size": 11,
+            "z-index": 10,
+          },
+        },
+        {
+          selector: "node.dimmed",
+          style: {
+            opacity: 0.15,
+          },
+        },
+        {
+          selector: "edge",
+          style: {
+            width: 1.5,
+            "line-color": (ele) => colorForEdge(ele.data("type")),
+            "target-arrow-color": (ele) => colorForEdge(ele.data("type")),
+            "target-arrow-shape": "triangle",
+            "arrow-scale": 0.7,
+            "curve-style": "bezier",
+            opacity: 0.6,
+            "transition-property": "opacity, width",
+            "transition-duration": "0.2s",
+          },
+        },
+        {
+          selector: "edge.highlighted",
+          style: {
+            width: 2.5,
+            opacity: 1,
+            label: "data(type)",
+            "font-family": '"Departure Mono", monospace',
+            "font-size": 8,
+            color: "rgba(232, 223, 198, 0.7)",
+            "text-rotation": "autorotate",
+            "text-outline-width": 2,
+            "text-outline-color": "#0A0C10",
+          },
+        },
+        {
+          selector: "edge.dimmed",
+          style: {
+            opacity: 0.06,
+          },
+        },
+      ],
+
+      layout: {
+        name: "cose",
+        animate: true,
+        animationDuration: 800,
+        nodeRepulsion: () => 8000,
+        idealEdgeLength: () => 80,
+        gravity: 0.3,
+        numIter: 500,
+        padding: 60,
+      },
+    });
+
+    // Fit after layout settles
+    cy.one("layoutstop", () => {
+      cy.fit(cy.elements(), 50);
+    });
+
+    // Apply PageRank sizing
+    applySizing("pagerank");
+
+    // ── Interactions ───────────────────────────────────────────
+    cy.on("tap", "node", (evt) => {
+      const node = evt.target;
+      highlightNeighborhood(node);
+      showInspector(node);
+    });
+
+    cy.on("tap", (evt) => {
+      if (evt.target === cy) {
+        clearHighlight();
+        hideInspector();
+      }
+    });
+  }
+
+  // ── Highlight neighborhood ─────────────────────────────────────
+  function highlightNeighborhood(node) {
+    clearHighlight();
+    const neighborhood = node.closedNeighborhood();
+    cy.elements().addClass("dimmed");
+    neighborhood.removeClass("dimmed").addClass("highlighted");
+  }
+
+  function clearHighlight() {
+    cy.elements().removeClass("dimmed highlighted");
+  }
+
+  // ── Inspector panel ────────────────────────────────────────────
+  function showInspector(node) {
+    const d = node.data();
+    const degree = node.degree(false);
+    const inDeg = node.indegree(false);
+    const outDeg = node.outdegree(false);
+    const neighbors = node.neighborhood("node");
+    const edges = node.connectedEdges();
+
+    const c = colorForType(d.type);
+
+    let html = `
+      <div class="graph-inspector__head">
+        <span class="graph-inspector__dot" style="background:${c.bg};border-color:${c.border}"></span>
+        <div>
+          <div class="graph-inspector__name">${esc(d.label)}</div>
+          <div class="graph-inspector__type">${esc(d.type)}</div>
+        </div>
+      </div>
+      <div class="graph-inspector__stats">
+        <div class="graph-inspector__stat">
+          <span class="graph-inspector__stat-val">${d.pagerank.toFixed(4)}</span>
+          <span class="graph-inspector__stat-lbl">PageRank</span>
+        </div>
+        <div class="graph-inspector__stat">
+          <span class="graph-inspector__stat-val">${degree}</span>
+          <span class="graph-inspector__stat-lbl">Degree</span>
+        </div>
+        <div class="graph-inspector__stat">
+          <span class="graph-inspector__stat-val">${inDeg} / ${outDeg}</span>
+          <span class="graph-inspector__stat-lbl">In / Out</span>
+        </div>
+      </div>
+    `;
+
+    // Connected edges
+    if (edges.length > 0) {
+      html += `<div class="graph-inspector__section-label">Relations</div><ul class="graph-inspector__edges">`;
+      edges.forEach((e) => {
+        const ed = e.data();
+        const isOutgoing = ed.source === d.id;
+        const otherLabel = isOutgoing
+          ? cy.getElementById(ed.target).data("label")
+          : cy.getElementById(ed.source).data("label");
+        const arrow = isOutgoing ? "→" : "←";
+        html += `<li><span class="graph-inspector__edge-type">${esc(ed.type)}</span> ${arrow} ${esc(otherLabel)}</li>`;
+      });
+      html += `</ul>`;
+    }
+
+    // Neighbor list
+    if (neighbors.length > 0) {
+      html += `<div class="graph-inspector__section-label">Neighbors · ${neighbors.length}</div><ul class="graph-inspector__neighbors">`;
+      neighbors
+        .sort((a, b) => (b.data("pagerank") || 0) - (a.data("pagerank") || 0))
+        .forEach((n) => {
+          const nd = n.data();
+          const nc = colorForType(nd.type);
+          html += `<li class="graph-inspector__neighbor" data-id="${esc(nd.id)}"><span class="graph-inspector__ndot" style="background:${nc.bg}"></span>${esc(nd.label)}</li>`;
+        });
+      html += `</ul>`;
+    }
+
+    const panel = document.getElementById("inspector");
+    panel.innerHTML = html;
+    panel.classList.add("is-active");
+
+    // Click neighbor to navigate
+    panel.querySelectorAll(".graph-inspector__neighbor").forEach((el) => {
+      el.addEventListener("click", () => {
+        const target = cy.getElementById(el.dataset.id);
+        if (target.length) {
+          cy.animate({ center: { eles: target }, zoom: 1.5 }, { duration: 400 });
+          highlightNeighborhood(target);
+          showInspector(target);
+        }
+      });
+    });
+  }
+
+  function hideInspector() {
+    const panel = document.getElementById("inspector");
+    panel.innerHTML = `<div class="graph-inspector__empty">Select a node to inspect</div>`;
+    panel.classList.remove("is-active");
+  }
+
+  function esc(str) {
+    const d = document.createElement("div");
+    d.textContent = str || "";
+    return d.innerHTML;
+  }
+
+  // ── Sizing ─────────────────────────────────────────────────────
+  function applySizing(mode) {
+    const fn = nodeSizeFn(mode);
+    cy.nodes().forEach((n) => {
+      const s = fn(n);
+      n.style({ width: s, height: s });
+    });
+  }
+
+  // ── Layout ─────────────────────────────────────────────────────
+  function applyLayout(name) {
+    const opts = { name, animate: true, animationDuration: 600, padding: 40 };
+    if (name === "cose") {
+      opts.nodeRepulsion = () => 8000;
+      opts.idealEdgeLength = () => 80;
+      opts.gravity = 0.3;
+      opts.numIter = 500;
+    }
+    if (name === "concentric") {
+      opts.concentric = (n) => n.data("pagerank") || 0;
+      opts.levelWidth = () => 0.5;
+    }
+    if (name === "breadthfirst") {
+      opts.directed = true;
+      opts.spacingFactor = 1.2;
+    }
+    cy.layout(opts).run();
+  }
+
+  // ── Legend ──────────────────────────────────────────────────────
+  function buildLegend(types) {
+    const container = document.getElementById("graph-legend");
+    let html = `<div class="rail__label">Legend</div><ul class="graph-legend__list">`;
+    const seen = new Set();
+    for (const t of Object.keys(types).sort()) {
+      seen.add(t);
+      const c = colorForType(t);
+      html += `<li class="graph-legend__item"><span class="graph-legend__dot" style="background:${c.bg};border-color:${c.border}"></span>${t} · ${types[t]}</li>`;
+    }
+    html += `</ul>`;
+    container.innerHTML = html;
+  }
+
+  // ── Type filter dropdown ───────────────────────────────────────
+  function populateTypeFilter(types) {
+    const sel = document.getElementById("graph-type-filter");
+    for (const t of Object.keys(types).sort()) {
+      const opt = document.createElement("option");
+      opt.value = t;
+      opt.textContent = `${t} (${types[t]})`;
+      sel.appendChild(opt);
+    }
+  }
+
+  // ── Search ─────────────────────────────────────────────────────
+  function setupSearch() {
+    const input = document.getElementById("graph-search");
+    input.addEventListener("input", () => {
+      const q = input.value.trim().toLowerCase();
+      if (!q) {
+        clearHighlight();
+        cy.nodes().show();
+        return;
+      }
+      cy.nodes().forEach((n) => {
+        const label = (n.data("label") || "").toLowerCase();
+        if (label.includes(q)) {
+          n.show();
+          n.removeClass("dimmed");
+        } else {
+          n.addClass("dimmed");
+        }
+      });
+      // Center on first match
+      const matches = cy.nodes().filter((n) =>
+        (n.data("label") || "").toLowerCase().includes(q)
+      );
+      if (matches.length === 1) {
+        cy.animate({ center: { eles: matches }, zoom: 1.5 }, { duration: 400 });
+        highlightNeighborhood(matches[0]);
+        showInspector(matches[0]);
+      }
+    });
+  }
+
+  // ── Controls ───────────────────────────────────────────────────
+  function setupControls() {
+    document.getElementById("graph-fit").addEventListener("click", () => {
+      cy.animate({ fit: { eles: cy.elements(), padding: 40 } }, { duration: 400 });
+    });
+
+    document.getElementById("graph-reset").addEventListener("click", () => {
+      clearHighlight();
+      hideInspector();
+      document.getElementById("graph-search").value = "";
+      document.getElementById("graph-type-filter").value = "";
+      cy.nodes().show();
+      applyLayout("cose");
+    });
+
+    document.getElementById("graph-layout").addEventListener("change", (e) => {
+      applyLayout(e.target.value);
+    });
+
+    document.getElementById("graph-sizing").addEventListener("change", (e) => {
+      applySizing(e.target.value);
+    });
+
+    document.getElementById("graph-type-filter").addEventListener("change", (e) => {
+      const type = e.target.value;
+      if (!type) {
+        cy.nodes().show();
+        cy.edges().show();
+      } else {
+        cy.nodes().forEach((n) => {
+          if (n.data("type") === type) {
+            n.show();
+          } else {
+            n.hide();
+          }
+        });
+        // Show edges only between visible nodes
+        cy.edges().forEach((edge) => {
+          if (edge.source().visible() && edge.target().visible()) {
+            edge.show();
+          } else {
+            edge.hide();
+          }
+        });
+      }
+    });
+  }
+
+  // ── Boot ───────────────────────────────────────────────────────
+  async function boot() {
+    const data = await loadGraph();
+
+    if (!data.nodes || data.nodes.length === 0) {
+      document.getElementById("cy").innerHTML =
+        '<div class="graph-empty">No entities in graph yet.<br>Add memories with entities to populate.</div>';
+      return;
+    }
+
+    const elements = buildElements(data);
+    initCy(elements);
+
+    const types = data.stats.types || {};
+    buildLegend(types);
+    populateTypeFilter(types);
+    setupSearch();
+    setupControls();
+  }
+
+  boot();
+})();

--- a/agent_memory/ui/static/recall.js
+++ b/agent_memory/ui/static/recall.js
@@ -1,0 +1,162 @@
+// Memwright — Recall Pipeline Replay
+// Renders the 5-layer retrieval cascade step by step.
+
+(function () {
+  "use strict";
+
+  const LAYER_ICONS = ["#", "◇", "⬡", "⚡", "◎"];
+  const LAYER_COLORS = [
+    "var(--brass)",      // Tag Match
+    "var(--verdigris)",  // Graph Expansion
+    "var(--indigo)",     // Vector Search
+    "var(--rust)",       // Fusion + Rank
+    "var(--paper)",      // Diversity + Fit
+  ];
+
+  function esc(str) {
+    const d = document.createElement("div");
+    d.textContent = str || "";
+    return d.innerHTML;
+  }
+
+  async function executeRecall() {
+    const query = document.getElementById("recall-query").value.trim();
+    if (!query) return;
+
+    const ns = document.getElementById("recall-ns").value.trim() || null;
+    const budget = parseInt(document.getElementById("recall-budget").value) || 2000;
+    const area = document.getElementById("recall-area");
+
+    area.innerHTML = '<div class="recall-loading">Executing pipeline…</div>';
+
+    let data;
+    try {
+      const res = await fetch("/ui/recall.json", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ query, namespace: ns, budget }),
+      });
+      data = await res.json();
+      if (data.error) {
+        area.innerHTML = `<div class="recall-empty">${esc(data.error)}</div>`;
+        return;
+      }
+    } catch (e) {
+      area.innerHTML = `<div class="recall-empty">Request failed: ${esc(e.message)}</div>`;
+      return;
+    }
+
+    renderTrace(data, area);
+    renderConfig(data.config);
+  }
+
+  function renderTrace(data, container) {
+    let html = `
+      <div class="recall-header">
+        <div class="recall-header__query">"${esc(data.query)}"</div>
+        <div class="recall-header__meta">
+          ${data.namespace ? `namespace: ${esc(data.namespace)} · ` : ""}budget: ${data.token_budget} tokens · ${data.final_count} results
+        </div>
+      </div>
+      <div class="recall-pipeline">
+    `;
+
+    data.layers.forEach((layer, i) => {
+      const color = LAYER_COLORS[i] || "var(--ghost)";
+      const icon = LAYER_ICONS[i] || "·";
+      const isLast = i === data.layers.length - 1;
+
+      html += `
+        <div class="recall-layer" style="--layer-color: ${color}; animation-delay: ${i * 150}ms">
+          <div class="recall-layer__head">
+            <span class="recall-layer__icon">${icon}</span>
+            <div class="recall-layer__info">
+              <div class="recall-layer__name">Layer ${i + 1} · ${esc(layer.name)}</div>
+              <div class="recall-layer__desc">${esc(layer.description)}</div>
+            </div>
+            <div class="recall-layer__count">${layer.count}</div>
+          </div>
+      `;
+
+      // Layer-specific metadata
+      if (layer.tags && layer.tags.length > 0) {
+        html += `<div class="recall-layer__meta">Tags extracted: ${layer.tags.map((t) => `<span class="recall-tag">${esc(t)}</span>`).join(" ")}</div>`;
+      }
+      if (layer.expanded_entities && layer.expanded_entities.length > 0) {
+        html += `<div class="recall-layer__meta">Expanded entities: ${layer.expanded_entities.map((e) => `<span class="recall-tag">${esc(e)}</span>`).join(" ")}</div>`;
+      }
+      if (layer.fusion_mode) {
+        html += `<div class="recall-layer__meta">Mode: ${esc(layer.fusion_mode)}</div>`;
+      }
+      if (layer.mmr_enabled !== undefined) {
+        html += `<div class="recall-layer__meta">MMR: ${layer.mmr_enabled ? "on" : "off"} · Budget: ${layer.budget}</div>`;
+      }
+
+      // Results
+      if (layer.results && layer.results.length > 0) {
+        html += `<div class="recall-layer__results">`;
+        layer.results.forEach((r, ri) => {
+          const barWidth = Math.max(4, Math.min(100, r.score * 100));
+          html += `
+            <div class="recall-result ${isLast ? "recall-result--final" : ""}">
+              <div class="recall-result__rank">${ri + 1}</div>
+              <div class="recall-result__body">
+                <div class="recall-result__content">${esc(r.content)}</div>
+                <div class="recall-result__meta">
+                  <span class="recall-result__source">${esc(r.source)}</span>
+                  ${r.entity ? `<span>· ${esc(r.entity)}</span>` : ""}
+                  ${r.category ? `<span>· ${esc(r.category)}</span>` : ""}
+                </div>
+              </div>
+              <div class="recall-result__score">
+                <div class="recall-result__bar" style="width:${barWidth}%"></div>
+                <span>${r.score.toFixed(4)}</span>
+              </div>
+            </div>
+          `;
+        });
+        html += `</div>`;
+      } else {
+        html += `<div class="recall-layer__empty">No results from this layer</div>`;
+      }
+
+      html += `</div>`; // close recall-layer
+
+      // Connector arrow between layers
+      if (!isLast) {
+        html += `<div class="recall-connector"><span>▼</span></div>`;
+      }
+    });
+
+    html += `</div>`; // close recall-pipeline
+    container.innerHTML = html;
+  }
+
+  function renderConfig(config) {
+    if (!config) return;
+    const el = document.getElementById("recall-config");
+    let html = `<div class="rail__label">Config</div>`;
+    html += `<div class="recall-config-list">`;
+    for (const [k, v] of Object.entries(config)) {
+      html += `<div class="recall-config-item"><span>${esc(k)}</span> ${esc(String(v))}</div>`;
+    }
+    html += `</div>`;
+    el.innerHTML = html;
+  }
+
+  // Wire up
+  document.getElementById("recall-form").addEventListener("submit", (e) => {
+    e.preventDefault();
+    executeRecall();
+  });
+
+  document.getElementById("recall-go").addEventListener("click", executeRecall);
+
+  // Enter key in query field
+  document.getElementById("recall-query").addEventListener("keydown", (e) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      executeRecall();
+    }
+  });
+})();

--- a/agent_memory/ui/static/timeline.js
+++ b/agent_memory/ui/static/timeline.js
@@ -1,0 +1,241 @@
+// Memwright — Temporal Timeline
+// Vertical timeline with supersession chains, as-of replay, and detail panel.
+
+(function () {
+  "use strict";
+
+  // ---- Helpers ----
+
+  function esc(str) {
+    var d = document.createElement("div");
+    d.textContent = str || "";
+    return d.innerHTML;
+  }
+
+  function excerpt(text, max) {
+    if (!text) return "";
+    return text.length > max ? text.slice(0, max) + "..." : text;
+  }
+
+  function fmtDate(iso) {
+    if (!iso) return "";
+    return iso.slice(0, 10);
+  }
+
+  function fmtTime(iso) {
+    if (!iso || iso.length < 16) return "";
+    return iso.slice(11, 16);
+  }
+
+  function fmtConfidence(val) {
+    return Math.round((val || 0) * 100);
+  }
+
+  // ---- State ----
+
+  var allMemories = [];
+
+  // ---- Fetch ----
+
+  function buildQueryString() {
+    var params = new URLSearchParams();
+    var ns = document.getElementById("tl-namespace").value.trim();
+    var entity = document.getElementById("tl-entity").value.trim();
+    var status = document.getElementById("tl-status").value;
+    var from = document.getElementById("tl-from").value;
+    var to = document.getElementById("tl-to").value;
+    var asOf = document.getElementById("tl-as-of").value;
+
+    if (ns) params.set("namespace", ns);
+    if (entity) params.set("entity", entity);
+    if (status && status !== "all") params.set("status", status);
+    if (from) params.set("from", from);
+    if (to) params.set("to", to);
+    if (asOf) params.set("as_of", asOf);
+
+    return params.toString();
+  }
+
+  async function fetchTimeline() {
+    var area = document.getElementById("timeline-area");
+    area.innerHTML = '<div class="tl-loading">Reconstructing timeline...</div>';
+    hideDetail();
+
+    var qs = buildQueryString();
+    var url = "/ui/timeline.json" + (qs ? "?" + qs : "");
+
+    try {
+      var res = await fetch(url);
+      var data = await res.json();
+      if (data.error) {
+        area.innerHTML = '<div class="tl-empty">' + esc(data.error) + "</div>";
+        return;
+      }
+      allMemories = data.memories || [];
+      renderTimeline(allMemories, area);
+    } catch (e) {
+      area.innerHTML = '<div class="tl-empty">Request failed: ' + esc(e.message) + "</div>";
+    }
+  }
+
+  // ---- Render ----
+
+  function renderTimeline(memories, container) {
+    if (!memories.length) {
+      container.innerHTML = '<div class="tl-empty">No memories match these filters.</div>';
+      return;
+    }
+
+    var html = '<div class="tl-spine">';
+
+    memories.forEach(function (m, i) {
+      var side = i % 2 === 0 ? "left" : "right";
+      var isSuperseded = m.status === "superseded";
+      var cls = "tl-card tl-card--" + side;
+      if (isSuperseded) cls += " tl-card--superseded";
+
+      var confPct = fmtConfidence(m.confidence);
+      var stampCls = "tl-stamp";
+      if (isSuperseded) stampCls += " tl-stamp--superseded";
+      else if (confPct < 60) stampCls += " tl-stamp--decayed";
+
+      html += '<div class="tl-node" style="animation-delay:' + (i * 60) + 'ms">';
+      html += '  <div class="tl-node__dot"></div>';
+      html += '  <div class="tl-node__date">' + esc(fmtDate(m.created_at)) + "</div>";
+      html += '  <div class="' + cls + '" data-idx="' + i + '">';
+
+      // Header row
+      html += '    <div class="tl-card__head">';
+      html += '      <div class="tl-card__entity">' + esc(m.entity || "---") + "</div>";
+      html += '      <div class="' + stampCls + '">';
+      html += '        <span class="tl-stamp__pct">' + confPct + "</span>";
+      html += '        <span class="tl-stamp__label">CONF</span>';
+      html += "      </div>";
+      html += "    </div>";
+
+      // Category
+      if (m.category) {
+        html += '    <div class="tl-card__category">' + esc(m.category) + "</div>";
+      }
+
+      // Content excerpt
+      html += '    <div class="tl-card__content">' + esc(excerpt(m.content, 150)) + "</div>";
+
+      // Temporal metadata
+      html += '    <div class="tl-card__meta">';
+      html += '      <span>' + esc(fmtDate(m.created_at));
+      if (fmtTime(m.created_at)) html += " " + esc(fmtTime(m.created_at));
+      html += "</span>";
+      if (m.namespace) html += '  <span>' + esc(m.namespace) + "</span>";
+      html += "    </div>";
+
+      // Supersession indicator
+      if (m.superseded_by) {
+        html += '    <div class="tl-card__superseded">';
+        html += '      <span class="tl-card__arrow">&#x2192;</span> ';
+        html += "      superseded by " + esc(m.superseded_by.slice(0, 8));
+        html += "    </div>";
+      }
+
+      // Validity window
+      if (m.valid_from || m.valid_until) {
+        html += '    <div class="tl-card__validity">';
+        html += "      VALID " + esc(fmtDate(m.valid_from) || "...");
+        html += " &ndash; " + esc(fmtDate(m.valid_until) || "present");
+        html += "    </div>";
+      }
+
+      html += "  </div>"; // close tl-card
+      html += "</div>"; // close tl-node
+    });
+
+    html += "</div>"; // close tl-spine
+
+    container.innerHTML = html;
+
+    // Bind click handlers
+    container.querySelectorAll(".tl-card").forEach(function (el) {
+      el.addEventListener("click", function () {
+        var idx = parseInt(el.getAttribute("data-idx"), 10);
+        showDetail(allMemories[idx]);
+      });
+    });
+  }
+
+  // ---- Detail panel ----
+
+  function showDetail(m) {
+    var panel = document.getElementById("tl-detail");
+    var body = document.getElementById("tl-detail-body");
+
+    var html = "";
+
+    html += '<div class="tl-detail__id">ID: ' + esc(m.id) + "</div>";
+
+    if (m.entity) {
+      html += '<div class="tl-detail__row"><span>Entity</span>' + esc(m.entity) + "</div>";
+    }
+    html += '<div class="tl-detail__row"><span>Category</span>' + esc(m.category || "general") + "</div>";
+    html += '<div class="tl-detail__row"><span>Namespace</span>' + esc(m.namespace || "default") + "</div>";
+    html += '<div class="tl-detail__row"><span>Status</span>' + esc(m.status) + "</div>";
+    html += '<div class="tl-detail__row"><span>Confidence</span>' + fmtConfidence(m.confidence) + "%</div>";
+    html += '<div class="tl-detail__row"><span>Created</span>' + esc(m.created_at || "") + "</div>";
+
+    if (m.event_date) {
+      html += '<div class="tl-detail__row"><span>Event Date</span>' + esc(m.event_date) + "</div>";
+    }
+    if (m.valid_from) {
+      html += '<div class="tl-detail__row"><span>Valid From</span>' + esc(m.valid_from) + "</div>";
+    }
+    if (m.valid_until) {
+      html += '<div class="tl-detail__row"><span>Valid Until</span>' + esc(m.valid_until) + "</div>";
+    }
+    if (m.superseded_by) {
+      html += '<div class="tl-detail__row tl-detail__row--rust"><span>Superseded By</span>' + esc(m.superseded_by) + "</div>";
+    }
+    if (m.access_count) {
+      html += '<div class="tl-detail__row"><span>Accesses</span>' + m.access_count + "</div>";
+    }
+
+    // Tags
+    if (m.tags && m.tags.length) {
+      html += '<div class="tl-detail__tags">';
+      m.tags.forEach(function (t) {
+        html += '<span class="tl-detail__tag">' + esc(t) + "</span>";
+      });
+      html += "</div>";
+    }
+
+    // Full content
+    html += '<div class="tl-detail__section">Content</div>';
+    html += '<div class="tl-detail__content">' + esc(m.content) + "</div>";
+
+    body.innerHTML = html;
+    panel.hidden = false;
+  }
+
+  function hideDetail() {
+    document.getElementById("tl-detail").hidden = true;
+  }
+
+  // ---- Wire up ----
+
+  document.getElementById("timeline-form").addEventListener("submit", function (e) {
+    e.preventDefault();
+    fetchTimeline();
+  });
+
+  document.getElementById("tl-go").addEventListener("click", fetchTimeline);
+
+  document.getElementById("tl-detail-close").addEventListener("click", hideDetail);
+
+  // Enter key in any text field triggers fetch
+  document.querySelectorAll("#timeline-form .field").forEach(function (el) {
+    el.addEventListener("keydown", function (e) {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        fetchTimeline();
+      }
+    });
+  });
+})();

--- a/agent_memory/ui/templates/base.html
+++ b/agent_memory/ui/templates/base.html
@@ -19,10 +19,10 @@
 
     <nav class="chrome__nav">
       <a class="tab" href="/ui/memories" {% if request.url.path.startswith("/ui/memories") %}aria-current="page"{% endif %}>01 · Memories</a>
-      <a class="tab" href="#" aria-disabled="true" title="Coming in milestone 3">02 · Graph</a>
-      <a class="tab" href="#" aria-disabled="true" title="Coming in milestone 4">03 · Recall</a>
-      <a class="tab" href="#" aria-disabled="true" title="Coming in milestone 5">04 · Timeline</a>
-      <a class="tab" href="#" aria-disabled="true" title="Coming in milestone 6">05 · Agents</a>
+      <a class="tab" href="/ui/graph" {% if request.url.path.startswith("/ui/graph") %}aria-current="page"{% endif %}>02 · Graph</a>
+      <a class="tab" href="/ui/recall" {% if request.url.path.startswith("/ui/recall") %}aria-current="page"{% endif %}>03 · Recall</a>
+      <a class="tab" href="/ui/timeline" {% if request.url.path.startswith("/ui/timeline") %}aria-current="page"{% endif %}>04 · Timeline</a>
+      <a class="tab" href="/ui/agents" {% if request.url.path.startswith("/ui/agents") %}aria-current="page"{% endif %}>05 · Agents</a>
     </nav>
 
     <div class="chrome__ident">

--- a/agent_memory/ui/templates/memories/agents.html
+++ b/agent_memory/ui/templates/memories/agents.html
@@ -1,0 +1,46 @@
+{% extends "base.html" %}
+{% block title %}Agent Registry · Memwright{% endblock %}
+{% block content %}
+
+<section class="page-head">
+  <h1 class="page-head__title">Agent /<br><em>Registry.</em></h1>
+  <div class="page-head__meta">
+    <div>namespace isolation</div>
+    <div>6 RBAC roles</div>
+    <div>provenance tracking</div>
+  </div>
+</section>
+
+<section class="workspace">
+  <aside class="rail">
+    <div class="rail__section">
+      <div class="rail__label">Actions</div>
+      <button class="btn btn--primary" id="agents-refresh">Refresh</button>
+    </div>
+
+    <div class="rail__section">
+      <div class="rail__label">RBAC Roles <span>Reference</span></div>
+      <ul class="agents-roles">
+        <li><span class="agents-role-dot" style="background:var(--rust)"></span> Orchestrator</li>
+        <li><span class="agents-role-dot" style="background:var(--brass)"></span> Planner</li>
+        <li><span class="agents-role-dot" style="background:var(--verdigris)"></span> Executor</li>
+        <li><span class="agents-role-dot" style="background:var(--indigo)"></span> Researcher</li>
+        <li><span class="agents-role-dot" style="background:var(--paper-aged)"></span> Reviewer</li>
+        <li><span class="agents-role-dot" style="background:var(--ghost)"></span> Monitor</li>
+      </ul>
+    </div>
+  </aside>
+
+  <section class="agents-area" id="agents-area">
+    <div class="agents-empty">Loading agent namespaces&hellip;</div>
+  </section>
+</section>
+
+<!-- Detail overlay panel -->
+<div class="agents-overlay" id="agents-overlay" hidden>
+  <div class="agents-detail" id="agents-detail"></div>
+</div>
+
+<script src="/ui/static/agents.js"></script>
+
+{% endblock %}

--- a/agent_memory/ui/templates/memories/graph.html
+++ b/agent_memory/ui/templates/memories/graph.html
@@ -1,0 +1,69 @@
+{% extends "base.html" %}
+{% block title %}Knowledge Graph · Memwright{% endblock %}
+{% block content %}
+
+<section class="page-head">
+  <h1 class="page-head__title">Knowledge<br><em>Graph.</em></h1>
+  <div class="page-head__meta">
+    <div><b>{{ graph_stats.nodes or 0 }}</b> entities</div>
+    <div><b>{{ graph_stats.edges or 0 }}</b> relations</div>
+    <div>layout · force-directed</div>
+  </div>
+</section>
+
+<section class="workspace">
+  <aside class="rail">
+    <div class="rail__section">
+      <div class="rail__label">Search <span>entity</span></div>
+      <input class="field" type="search" id="graph-search"
+             placeholder="// find entity" autocomplete="off">
+    </div>
+
+    <div class="rail__section">
+      <div class="rail__label">Entity Type</div>
+      <select class="field" id="graph-type-filter">
+        <option value="">all types</option>
+      </select>
+    </div>
+
+    <div class="rail__section">
+      <div class="rail__label">Layout</div>
+      <select class="field" id="graph-layout">
+        <option value="cose">force-directed</option>
+        <option value="concentric">concentric</option>
+        <option value="breadthfirst">hierarchical</option>
+        <option value="circle">circle</option>
+        <option value="grid">grid</option>
+      </select>
+    </div>
+
+    <div class="rail__section">
+      <div class="rail__label">Node Size</div>
+      <select class="field" id="graph-sizing">
+        <option value="pagerank">pagerank</option>
+        <option value="degree">degree</option>
+        <option value="uniform">uniform</option>
+      </select>
+    </div>
+
+    <div class="rail__section">
+      <button class="btn btn--primary" id="graph-fit" type="button">Fit View</button>
+      <button class="btn" id="graph-reset" type="button" style="margin-top:8px;">Reset</button>
+    </div>
+
+    <div class="rail__section" id="graph-legend"></div>
+  </aside>
+
+  <section class="graph-area">
+    <div class="graph-canvas" id="cy"></div>
+
+    <div class="graph-inspector" id="inspector">
+      <div class="graph-inspector__empty">Select a node to inspect</div>
+    </div>
+  </section>
+</section>
+
+<script src="https://unpkg.com/cytoscape@3.30.4/dist/cytoscape.min.js"></script>
+<script src="/ui/static/graph.js"></script>
+
+{% endblock %}

--- a/agent_memory/ui/templates/memories/recall.html
+++ b/agent_memory/ui/templates/memories/recall.html
@@ -1,0 +1,48 @@
+{% extends "base.html" %}
+{% block title %}Recall Pipeline · Memwright{% endblock %}
+{% block content %}
+
+<section class="page-head">
+  <h1 class="page-head__title">Recall<br><em>Pipeline.</em></h1>
+  <div class="page-head__meta">
+    <div>5-layer cascade</div>
+    <div>deterministic · no LLM</div>
+    <div>replay · debug</div>
+  </div>
+</section>
+
+<section class="workspace">
+  <aside class="rail">
+    <form id="recall-form" onsubmit="return false;">
+      <div class="rail__section">
+        <div class="rail__label">Query</div>
+        <input class="field" type="search" id="recall-query"
+               placeholder="// what do you remember about…" autocomplete="off">
+      </div>
+
+      <div class="rail__section">
+        <div class="rail__label">Namespace</div>
+        <input class="field" type="text" id="recall-ns" placeholder="any">
+      </div>
+
+      <div class="rail__section">
+        <div class="rail__label">Token Budget</div>
+        <input class="field" type="number" id="recall-budget" value="2000" min="100" max="50000">
+      </div>
+
+      <div class="rail__section">
+        <button class="btn btn--primary" type="submit" id="recall-go">Execute Recall</button>
+      </div>
+    </form>
+
+    <div class="rail__section" id="recall-config"></div>
+  </aside>
+
+  <section class="recall-area" id="recall-area">
+    <div class="recall-empty">Enter a query and execute to replay the 5-layer retrieval cascade.</div>
+  </section>
+</section>
+
+<script src="/ui/static/recall.js"></script>
+
+{% endblock %}

--- a/agent_memory/ui/templates/memories/timeline.html
+++ b/agent_memory/ui/templates/memories/timeline.html
@@ -1,0 +1,75 @@
+{% extends "base.html" %}
+{% block title %}Temporal Timeline · Memwright{% endblock %}
+{% block content %}
+
+<section class="page-head">
+  <h1 class="page-head__title">Temporal<br><em>Timeline.</em></h1>
+  <div class="page-head__meta">
+    <div>validity windows</div>
+    <div>supersession chains</div>
+    <div>as-of replay</div>
+  </div>
+</section>
+
+<section class="workspace">
+  <aside class="rail">
+    <form id="timeline-form" onsubmit="return false;">
+      <div class="rail__section">
+        <div class="rail__label">Namespace</div>
+        <input class="field" type="text" id="tl-namespace" placeholder="any">
+      </div>
+
+      <div class="rail__section">
+        <div class="rail__label">Entity</div>
+        <input class="field" type="text" id="tl-entity" placeholder="any">
+      </div>
+
+      <div class="rail__section">
+        <div class="rail__label">Status</div>
+        <select class="field" id="tl-status">
+          <option value="all">All</option>
+          <option value="active" selected>Active</option>
+          <option value="superseded">Superseded</option>
+        </select>
+      </div>
+
+      <div class="rail__section">
+        <div class="rail__label">Date Range</div>
+        <input class="field" type="date" id="tl-from" placeholder="from">
+        <input class="field" type="date" id="tl-to" placeholder="to">
+      </div>
+
+      <div class="rail__section">
+        <div class="rail__label">As-Of Replay</div>
+        <input class="field" type="datetime-local" id="tl-as-of"
+               placeholder="// point-in-time snapshot">
+        <div class="tl-asof-hint">Filter to memories valid at this moment</div>
+      </div>
+
+      <div class="rail__section">
+        <button class="btn btn--primary" type="submit" id="tl-go">Reconstruct</button>
+      </div>
+    </form>
+  </aside>
+
+  <section class="tl-content" id="tl-content">
+    <div id="timeline-area">
+      <div class="tl-empty">
+        Set filters and press <b>Reconstruct</b> to render the temporal timeline.
+      </div>
+    </div>
+
+    <!-- Detail panel, hidden until a card is clicked -->
+    <div class="tl-detail" id="tl-detail" hidden>
+      <div class="tl-detail__head">
+        <div class="tl-detail__label">Dossier</div>
+        <button class="tl-detail__close" id="tl-detail-close" title="Close">&times;</button>
+      </div>
+      <div class="tl-detail__body" id="tl-detail-body"></div>
+    </div>
+  </section>
+</section>
+
+<script src="/ui/static/timeline.js"></script>
+
+{% endblock %}


### PR DESCRIPTION
## Summary
- Add 4 new UI pages completing all 5 tabs of the Memwright web viewer
- **02·Graph**: Cytoscape.js force-directed visualization with PageRank sizing, entity type coloring, search, layout switching, click-to-inspect panel
- **03·Recall**: 5-layer pipeline replay (tag match → graph expansion → vector search → RRF fusion → MMR diversity) with per-layer debug trace via new `recall_debug()` method
- **04·Timeline**: Temporal spine with alternating cards, supersession chains, validity windows, as-of replay, slide-out detail panel
- **05·Agents**: Namespace dossier cards with category bars, entity tags, activity sparklines, drill-down detail with paginated memory list

## Test plan
- [ ] All 5 tabs load at `/ui/memories`, `/ui/graph`, `/ui/recall`, `/ui/timeline`, `/ui/agents`
- [ ] Graph page renders nodes with PageRank sizing and type-based colors
- [ ] Recall page executes query and shows 5-layer cascade with scores
- [ ] Timeline page loads memories with date/entity/status filters
- [ ] Agents page shows namespace cards with category breakdown
- [ ] Existing 416 tests still pass (8 pre-existing failures unchanged)