### PR TITLE
feat(ui): health, config, pagination, export, dark mode, mobile

### DIFF
--- a/agent_memory/ui/app.py
+++ b/agent_memory/ui/app.py
@@ -7,6 +7,8 @@ mutates the store.
 
 from __future__ import annotations
 
+import csv
+import io
 import json
 import os
 from pathlib import Path
@@ -14,7 +16,7 @@ from typing import Any, Dict, List, Optional
 
 from starlette.applications import Starlette
 from starlette.requests import Request
-from starlette.responses import HTMLResponse, JSONResponse, RedirectResponse
+from starlette.responses import HTMLResponse, JSONResponse, RedirectResponse, Response
 from starlette.routing import Mount, Route
 from starlette.staticfiles import StaticFiles
 from starlette.templating import Jinja2Templates
@@ -92,29 +94,64 @@ async def index(request: Request) -> RedirectResponse:
     return RedirectResponse(url="/ui/memories", status_code=302)
 
 
-async def memories_list(request: Request) -> HTMLResponse:
-    mem = _get_mem(request)
+def _parse_filters(request: Request) -> Dict[str, Optional[str]]:
+    """Extract filter params from request, returning a frozen dict."""
+    return {
+        "q": request.query_params.get("q") or None,
+        "namespace": request.query_params.get("namespace") or None,
+        "category": request.query_params.get("category") or None,
+        "entity": request.query_params.get("entity") or None,
+        "status": request.query_params.get("status") or "active",
+    }
 
-    q = request.query_params.get("q") or None
-    namespace = request.query_params.get("namespace") or None
-    category = request.query_params.get("category") or None
-    entity = request.query_params.get("entity") or None
-    status = request.query_params.get("status") or "active"
-    limit = int(request.query_params.get("limit") or 60)
 
+def _search_with_filters(
+    mem, filters: Dict[str, Optional[str]], limit: int,
+) -> List:
+    """Run mem.search with the given filters dict."""
     try:
-        results = mem.search(
-            query=q,
-            category=category,
-            entity=entity,
-            namespace=namespace,
-            status=status,
+        return mem.search(
+            query=filters["q"],
+            category=filters["category"],
+            entity=filters["entity"],
+            namespace=filters["namespace"],
+            status=filters["status"] or "active",
             limit=limit,
         )
     except Exception:
-        results = []
+        return []
 
-    memories = [_memory_to_dict(m) for m in results]
+
+def _filters_display(filters: Dict[str, Optional[str]]) -> Dict[str, str]:
+    """Return a template-friendly copy with empty strings instead of None."""
+    return {k: (v or "") for k, v in filters.items()}
+
+
+def _filter_query_string(filters: Dict[str, Optional[str]]) -> str:
+    """Build a URL query string fragment from active filters (no leading &)."""
+    parts = []
+    for k, v in filters.items():
+        if v:
+            parts.append(f"{k}={v}")
+    return "&".join(parts)
+
+
+async def memories_list(request: Request) -> HTMLResponse:
+    mem = _get_mem(request)
+    per_page = 60
+    page = max(1, int(request.query_params.get("page") or 1))
+
+    filters = _parse_filters(request)
+
+    # Fetch one extra to detect a next page
+    results = _search_with_filters(mem, filters, limit=(page * per_page) + 1)
+
+    # Slice for the current page
+    offset = (page - 1) * per_page
+    page_results = results[offset : offset + per_page]
+    has_next = len(results) > offset + per_page
+
+    memories = [_memory_to_dict(m) for m in page_results]
 
     # Assign a subtle, deterministic rotation per card so the page feels pinned.
     for i, m in enumerate(memories):
@@ -124,18 +161,62 @@ async def memories_list(request: Request) -> HTMLResponse:
         "request": request,
         "memories": memories,
         "total": len(memories),
-        "filters": {
-            "q": q or "",
-            "namespace": namespace or "",
-            "category": category or "",
-            "entity": entity or "",
-            "status": status,
-        },
+        "page": page,
+        "per_page": per_page,
+        "has_next": has_next,
+        "has_prev": page > 1,
+        "filters": _filters_display(filters),
+        "filter_qs": _filter_query_string(filters),
         **_common_context(request, mem),
     }
 
     template = "memories/_grid.html" if _is_htmx(request) else "memories/list.html"
     return _TEMPLATES.TemplateResponse(request, template, ctx)
+
+
+async def memories_export_json(request: Request) -> JSONResponse:
+    """Export matching memories as a JSON array (up to 5000)."""
+    mem = _get_mem(request)
+    filters = _parse_filters(request)
+    results = _search_with_filters(mem, filters, limit=5000)
+    data = [_memory_to_dict(m) for m in results]
+    return JSONResponse(
+        data,
+        headers={
+            "Content-Disposition": 'attachment; filename="memwright-export.json"',
+        },
+    )
+
+
+async def memories_export_csv(request: Request) -> Response:
+    """Export matching memories as CSV (up to 5000)."""
+    mem = _get_mem(request)
+    filters = _parse_filters(request)
+    results = _search_with_filters(mem, filters, limit=5000)
+    data = [_memory_to_dict(m) for m in results]
+
+    columns = [
+        "id", "content", "category", "entity", "namespace",
+        "created_at", "status", "confidence", "tags",
+        "event_date", "valid_from", "valid_until",
+        "superseded_by", "access_count", "content_hash",
+    ]
+
+    buf = io.StringIO()
+    writer = csv.DictWriter(buf, fieldnames=columns, extrasaction="ignore")
+    writer.writeheader()
+    for row in data:
+        # Flatten tags list to semicolon-separated string
+        row_copy = {**row, "tags": ";".join(row.get("tags") or [])}
+        writer.writerow(row_copy)
+
+    return Response(
+        content=buf.getvalue(),
+        media_type="text/csv",
+        headers={
+            "Content-Disposition": 'attachment; filename="memwright-export.csv"',
+        },
+    )
 
 
 async def memory_detail(request: Request) -> HTMLResponse:
@@ -501,12 +582,116 @@ async def agents_json(request: Request) -> JSONResponse:
     return JSONResponse({"namespaces": namespaces})
 
 
+async def health_page(request: Request) -> HTMLResponse:
+    """System Health dashboard — component diagnostics with auto-refresh."""
+    mem = _get_mem(request)
+    ctx = {"request": request, **_common_context(request, mem)}
+    return _TEMPLATES.TemplateResponse(request, "memories/health.html", ctx)
+
+
 async def health_json(request: Request) -> JSONResponse:
     mem = _get_mem(request)
     try:
         return JSONResponse(mem.health())
     except Exception as e:
         return JSONResponse({"healthy": False, "error": str(e)}, status_code=500)
+
+
+async def config_page(request: Request) -> HTMLResponse:
+    """Configuration viewer — system parameters, backends, retrieval tuning."""
+    mem = _get_mem(request)
+    ctx = {"request": request, **_common_context(request, mem)}
+    return _TEMPLATES.TemplateResponse(request, "memories/config.html", ctx)
+
+
+async def config_json(request: Request) -> JSONResponse:
+    """Return full configuration snapshot as JSON."""
+    mem = _get_mem(request)
+
+    config = mem.config
+    retrieval = getattr(mem, "_retrieval", None)
+
+    from agent_memory.store.registry import resolve_backends
+    backends = getattr(config, "backends", None) or ["sqlite", "chroma", "networkx"]
+    try:
+        role_assignments = resolve_backends(backends)
+    except Exception:
+        role_assignments = {}
+
+    store_paths: Dict[str, Any] = {}
+    doc_store = getattr(mem, "_store", None)
+    if doc_store and hasattr(doc_store, "db_path"):
+        store_paths["db_path"] = str(doc_store.db_path)
+        try:
+            store_paths["db_size_bytes"] = doc_store.db_path.stat().st_size
+        except Exception:
+            pass
+    graph = getattr(mem, "_graph", None)
+    if graph and hasattr(graph, "graph_path"):
+        store_paths["graph_path"] = str(graph.graph_path)
+
+    embedding: Dict[str, Any] = {}
+    vector_store = getattr(mem, "_vector_store", None)
+    if vector_store:
+        if hasattr(vector_store, "provider"):
+            embedding["provider"] = vector_store.provider
+        if hasattr(vector_store, "count"):
+            try:
+                embedding["vector_count"] = vector_store.count()
+            except Exception:
+                pass
+
+    retrieval_data: Dict[str, Any] = {
+        "fusion_mode": getattr(config, "fusion_mode", "rrf"),
+        "enable_mmr": getattr(config, "enable_mmr", True),
+        "mmr_lambda": getattr(config, "mmr_lambda", 0.7),
+        "min_results": getattr(config, "min_results", 3),
+        "default_token_budget": getattr(config, "default_token_budget", 16000),
+        "confidence_gate": getattr(config, "confidence_gate", 0.0),
+        "confidence_decay_rate": getattr(config, "confidence_decay_rate", 0.001),
+        "confidence_boost_rate": getattr(config, "confidence_boost_rate", 0.03),
+        "rrf_k": 60,
+        "graph_bfs_depth": 2,
+    }
+
+    health_data: Dict[str, Any] = {}
+    try:
+        health_data = mem.health()
+    except Exception:
+        health_data = {"healthy": False, "checks": []}
+
+    for check in health_data.get("checks", []):
+        if check.get("name") == "Retrieval Pipeline":
+            retrieval_data["active_layers"] = check.get("layers", [])
+            retrieval_data["max_layers"] = check.get("max_layers", 3)
+
+    stats: Dict[str, Any] = {}
+    try:
+        stats = mem.stats()
+    except Exception:
+        pass
+
+    graph_stats: Dict[str, Any] = {}
+    if graph and hasattr(graph, "graph_stats"):
+        try:
+            graph_stats = graph.graph_stats()
+        except Exception:
+            pass
+
+    result: Dict[str, Any] = {
+        "store_path": str(mem.path),
+        "backends": backends,
+        "role_assignments": role_assignments,
+        "store_paths": store_paths,
+        "embedding": embedding,
+        "retrieval": retrieval_data,
+        "stats": stats,
+        "graph_stats": graph_stats,
+        "backend_configs": getattr(config, "backend_configs", {}),
+        "health": health_data,
+    }
+
+    return JSONResponse(result)
 
 
 def ui_routes() -> list:
@@ -516,6 +701,8 @@ def ui_routes() -> list:
         Route("/ui", index),
         Route("/ui/", index),
         Route("/ui/memories", memories_list),
+        Route("/ui/memories/export.json", memories_export_json),
+        Route("/ui/memories/export.csv", memories_export_csv),
         Route("/ui/memories/{memory_id}", memory_detail),
         Route("/ui/graph", graph_page),
         Route("/ui/graph.json", graph_json),
@@ -525,7 +712,10 @@ def ui_routes() -> list:
         Route("/ui/timeline.json", timeline_json),
         Route("/ui/agents", agents_page),
         Route("/ui/agents.json", agents_json),
+        Route("/ui/health", health_page),
         Route("/ui/health.json", health_json),
+        Route("/ui/config", config_page),
+        Route("/ui/config.json", config_json),
         Mount(
             "/ui/static",
             StaticFiles(directory=str(_UI_DIR / "static")),

--- a/agent_memory/ui/static/app.css
+++ b/agent_memory/ui/static/app.css
@@ -1367,6 +1367,89 @@ select.field {
 }
 
 /* ============================================================
+   PAGINATION
+   ============================================================ */
+.pager {
+  grid-column: 1 / -1;
+  display: flex; align-items: center; justify-content: center;
+  gap: 18px; padding: 28px 0 8px;
+  font-family: var(--f-mono); font-size: 10px;
+  letter-spacing: 0.22em; text-transform: uppercase;
+}
+.pager__btn {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: var(--f-mono); font-size: 10px;
+  letter-spacing: 0.25em; text-transform: uppercase;
+  color: var(--paper); background: transparent;
+  border: 1px solid var(--rule-strong); padding: 9px 16px;
+  cursor: pointer; text-decoration: none;
+  transition: border-color 0.15s, color 0.15s, background 0.15s;
+}
+.pager__btn:hover { border-color: var(--rust); color: var(--rust); }
+.pager__btn--disabled { color: var(--ghost); border-color: var(--rule); opacity: 0.4; cursor: default; pointer-events: none; }
+.pager__current { font-family: var(--f-mono); font-size: 11px; letter-spacing: 0.18em; color: var(--rust); }
+.pager__current b { font-weight: 400; font-size: 16px; }
+
+/* ============================================================
+   EXPORT BUTTONS
+   ============================================================ */
+.btn--secondary { border-color: var(--rule-strong); color: var(--ghost); }
+.btn--secondary:hover { border-color: var(--verdigris); color: var(--verdigris); }
+
+/* ============================================================
+   HEALTH DASHBOARD
+   ============================================================ */
+.health-area { padding: 0 40px 80px; }
+.health-banner {
+  display: flex; align-items: center; gap: 12px;
+  padding: 16px 24px; margin: 24px 0;
+  font-family: var(--f-mono); font-size: 12px;
+  letter-spacing: 0.32em; text-transform: uppercase;
+  border: 1px solid var(--rule);
+}
+.health-banner--ok { border-left: 4px solid var(--verdigris); color: var(--verdigris); }
+.health-banner--error { border-left: 4px solid var(--rust); color: var(--rust); }
+.health-dot { display: inline-block; width: 10px; height: 10px; border-radius: 50%; flex-shrink: 0; }
+.health-dot--ok { background: var(--verdigris); box-shadow: 0 0 8px var(--verdigris); }
+.health-dot--error { background: var(--rust); box-shadow: 0 0 8px var(--rust); }
+.health-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 24px; }
+.health-empty, .health-loading { text-align: center; padding: 80px 20px; font-family: var(--f-display); font-style: italic; font-size: 20px; color: var(--ghost); font-variation-settings: "opsz" 144, "SOFT" 100; }
+@keyframes health-card-in { from { opacity: 0; transform: translateY(14px); } to { opacity: 1; transform: translateY(0); } }
+.health-card { background: var(--ink-raised); border: 1px solid var(--rule); border-left: 3px solid var(--layer-color, var(--ghost)); padding: 20px 24px; animation: health-card-in 0.45s cubic-bezier(.2,.8,.2,1) both; }
+.health-card__head { display: flex; align-items: center; gap: 14px; margin-bottom: 14px; padding-bottom: 12px; border-bottom: 1px dashed var(--rule); }
+.health-card__icon { width: 32px; height: 32px; display: flex; align-items: center; justify-content: center; border: 1.5px solid var(--layer-color, var(--ghost)); color: var(--layer-color, var(--ghost)); font-family: var(--f-mono); font-size: 14px; flex-shrink: 0; }
+.health-card__info { flex: 1; min-width: 0; }
+.health-card__name { font-family: var(--f-mono); font-size: 12px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--paper); }
+.health-card__check-name { font-family: var(--f-mono); font-size: 9px; letter-spacing: 0.12em; color: var(--ghost); margin-top: 2px; }
+.health-card__status { font-family: var(--f-mono); font-size: 10px; letter-spacing: 0.22em; text-transform: uppercase; color: var(--ghost); }
+.health-metrics { padding: 4px 0; }
+.health-metric { display: flex; justify-content: space-between; align-items: baseline; padding: 5px 0; border-bottom: 1px dashed var(--rule); }
+.health-metric__label { font-family: var(--f-mono); font-size: 9px; letter-spacing: 0.28em; text-transform: uppercase; color: var(--ghost); }
+.health-metric__value { font-family: var(--f-mono); font-size: 12px; letter-spacing: 0.04em; color: var(--paper); }
+.health-layers { display: flex; flex-wrap: wrap; gap: 4px; padding: 10px 0 4px; }
+.health-layer-tag { font-family: var(--f-mono); font-size: 9px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--paper); border: 1px solid var(--rule-strong); padding: 2px 8px; }
+.health-note { font-family: var(--f-mono); font-size: 10px; color: var(--ghost); padding: 8px 0 2px; font-style: italic; }
+.health-error { font-family: var(--f-mono); font-size: 10px; color: var(--rust); padding: 8px 0 2px; }
+.health-refresh-note { font-family: var(--f-mono); font-size: 9px; letter-spacing: 0.28em; text-transform: uppercase; color: var(--ghost); text-align: center; padding: 24px 0 0; opacity: 0.5; }
+@media (max-width: 960px) { .health-area { padding: 0 20px 80px; } .health-grid { grid-template-columns: 1fr; } }
+
+/* ============================================================
+   CONFIG VIEWER
+   ============================================================ */
+.cfg-area { min-height: 400px; }
+.cfg-loading { text-align: center; padding: 80px 20px; font-family: var(--f-display); font-style: italic; font-size: 20px; color: var(--ghost); font-variation-settings: "opsz" 144, "SOFT" 100; }
+.cfg-section-label { font-family: var(--f-mono); font-size: 10px; letter-spacing: 0.32em; text-transform: uppercase; color: var(--rust); margin: 28px 0 10px; padding-bottom: 6px; border-bottom: 1px solid var(--rule); }
+.cfg-section-label:first-child { margin-top: 0; }
+.cfg-kv { margin-bottom: 0; }
+.cfg-dot { display: inline-block; width: 8px; height: 8px; border-radius: 50%; margin-right: 6px; vertical-align: middle; }
+.cfg-dot--ok { background: var(--verdigris); }
+.cfg-dot--err { background: var(--rust); }
+.cfg-health-list { font-family: var(--f-mono); font-size: 10px; }
+.cfg-health-item { padding: 5px 0; border-bottom: 1px dashed var(--rule); color: var(--paper); display: flex; align-items: center; }
+.cfg-health-name { letter-spacing: 0.12em; }
+.cfg-health-err { color: var(--rust); font-size: 9px; margin-left: 8px; }
+
+/* ============================================================
    SELECTION
    ============================================================ */
 ::selection { background: var(--rust); color: var(--paper); }

--- a/agent_memory/ui/static/config.js
+++ b/agent_memory/ui/static/config.js
@@ -1,0 +1,209 @@
+// Memwright — Configuration Viewer
+// Fetches /ui/config.json and renders system parameters in the Forensic Archive style.
+
+(function () {
+  "use strict";
+
+  // ---- Helpers ----
+
+  function esc(str) {
+    var d = document.createElement("div");
+    d.textContent = str == null ? "" : String(str);
+    return d.innerHTML;
+  }
+
+  function fmtBytes(bytes) {
+    if (bytes == null) return "\u2014";
+    if (bytes < 1024) return bytes + " B";
+    if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + " KB";
+    return (bytes / (1024 * 1024)).toFixed(2) + " MB";
+  }
+
+  function kvRow(key, value) {
+    return (
+      '<dt>' + esc(key) + '</dt>' +
+      '<dd>' + (value != null ? esc(String(value)) : '<span style="color:var(--ghost)">\u2014</span>') + '</dd>'
+    );
+  }
+
+  function kvRowCode(key, value) {
+    return (
+      '<dt>' + esc(key) + '</dt>' +
+      '<dd><code>' + esc(String(value)) + '</code></dd>'
+    );
+  }
+
+  function sectionHeader(label) {
+    return '<div class="cfg-section-label">' + esc(label) + '</div>';
+  }
+
+  function statusDot(ok) {
+    if (ok) return '<span class="cfg-dot cfg-dot--ok"></span>';
+    return '<span class="cfg-dot cfg-dot--err"></span>';
+  }
+
+  // ---- Render ----
+
+  function render(data) {
+    var area = document.getElementById("cfg-area");
+    var html = "";
+
+    // -- Storage Backends --
+    html += sectionHeader("Storage Backends");
+    html += '<dl class="kv cfg-kv">';
+
+    var roles = data.role_assignments || {};
+    html += kvRow("Document Store", roles.document || "\u2014");
+    html += kvRow("Vector Store", roles.vector || "\u2014");
+    html += kvRow("Graph Store", roles.graph || "\u2014");
+
+    var backends = data.backends || [];
+    html += kvRow("Backend List", backends.join(", ") || "\u2014");
+    html += kvRowCode("Store Path", data.store_path || "\u2014");
+
+    // Backend file paths
+    var paths = data.store_paths || {};
+    if (paths.db_path) html += kvRowCode("SQLite Path", paths.db_path);
+    if (paths.graph_path) html += kvRowCode("Graph Path", paths.graph_path);
+    if (paths.db_size_bytes != null) html += kvRow("SQLite Size", fmtBytes(paths.db_size_bytes));
+
+    html += '</dl>';
+
+    // -- Embedding Provider --
+    html += sectionHeader("Embedding Provider");
+    html += '<dl class="kv cfg-kv">';
+
+    var emb = data.embedding || {};
+    html += kvRow("Provider", emb.provider || "local");
+    html += kvRow("Dimension", emb.dimension || "\u2014");
+    html += kvRow("Vector Count", emb.vector_count != null ? emb.vector_count : "\u2014");
+
+    html += '</dl>';
+
+    // -- Retrieval Pipeline --
+    html += sectionHeader("Retrieval Pipeline");
+    html += '<dl class="kv cfg-kv">';
+
+    var ret = data.retrieval || {};
+    html += kvRow("Fusion Mode", ret.fusion_mode || "rrf");
+    html += kvRow("RRF k", ret.rrf_k != null ? ret.rrf_k : 60);
+    html += kvRow("MMR Enabled", ret.enable_mmr != null ? ret.enable_mmr : true);
+    html += kvRowCode("MMR Lambda", ret.mmr_lambda != null ? ret.mmr_lambda : 0.7);
+    html += kvRow("Graph BFS Depth", ret.graph_bfs_depth != null ? ret.graph_bfs_depth : 2);
+    html += kvRow("Min Results", ret.min_results != null ? ret.min_results : 3);
+    html += kvRow("Default Token Budget", ret.default_token_budget || "\u2014");
+    html += kvRow("Confidence Gate", ret.confidence_gate != null ? ret.confidence_gate : 0.0);
+    html += kvRowCode("Confidence Decay Rate", ret.confidence_decay_rate != null ? ret.confidence_decay_rate : 0.001);
+    html += kvRowCode("Confidence Boost Rate", ret.confidence_boost_rate != null ? ret.confidence_boost_rate : 0.03);
+
+    var layers = ret.active_layers || [];
+    html += kvRow("Active Layers", layers.length + " / " + (ret.max_layers || 3));
+    html += kvRow("Layer Names", layers.join(" \u2192 ") || "\u2014");
+
+    html += '</dl>';
+
+    // -- Store Statistics --
+    html += sectionHeader("Store Statistics");
+    html += '<dl class="kv cfg-kv">';
+
+    var stats = data.stats || {};
+    html += kvRow("Total Memories", stats.total_memories != null ? stats.total_memories : "\u2014");
+    html += kvRow("Active", stats.active != null ? stats.active : stats.total_active || "\u2014");
+    html += kvRow("Superseded", stats.superseded != null ? stats.superseded : "\u2014");
+
+    var ns = stats.namespaces;
+    if (Array.isArray(ns)) {
+      html += kvRow("Namespaces", ns.join(", ") || "\u2014");
+    } else if (ns != null) {
+      html += kvRow("Namespaces", ns);
+    }
+
+    var categories = stats.categories;
+    if (Array.isArray(categories)) {
+      html += kvRow("Categories", categories.join(", ") || "\u2014");
+    } else if (categories != null) {
+      html += kvRow("Categories", categories);
+    }
+
+    // Graph stats
+    var graph = data.graph_stats || {};
+    if (graph.nodes != null) html += kvRow("Graph Nodes", graph.nodes);
+    if (graph.edges != null) html += kvRow("Graph Edges", graph.edges);
+
+    html += '</dl>';
+
+    // -- Backend Configs (if any) --
+    var bcfg = data.backend_configs || {};
+    var bcfgKeys = Object.keys(bcfg);
+    if (bcfgKeys.length > 0) {
+      html += sectionHeader("Backend Configuration");
+      html += '<dl class="kv cfg-kv">';
+      bcfgKeys.forEach(function (key) {
+        var val = bcfg[key];
+        if (typeof val === "object" && val !== null) {
+          html += kvRow(key, JSON.stringify(val));
+        } else {
+          html += kvRow(key, val);
+        }
+      });
+      html += '</dl>';
+    }
+
+    area.innerHTML = html;
+  }
+
+  function renderHealth(data) {
+    var statusEl = document.getElementById("cfg-health-status");
+    var checksEl = document.getElementById("cfg-health-checks");
+
+    var health = data.health || {};
+    var checks = health.checks || [];
+    var healthy = health.healthy !== false;
+
+    statusEl.innerHTML = healthy
+      ? '<span style="color:var(--verdigris)">OK</span>'
+      : '<span style="color:var(--rust)">DEGRADED</span>';
+
+    var html = '<div class="cfg-health-list">';
+    checks.forEach(function (c) {
+      var ok = c.status === "ok";
+      html += '<div class="cfg-health-item">';
+      html += statusDot(ok);
+      html += '<span class="cfg-health-name">' + esc(c.name) + '</span>';
+      if (!ok && c.error) {
+        html += '<span class="cfg-health-err">' + esc(c.error) + '</span>';
+      }
+      html += '</div>';
+    });
+    html += '</div>';
+    checksEl.innerHTML = html;
+  }
+
+  // ---- Fetch ----
+
+  function loadConfig() {
+    var area = document.getElementById("cfg-area");
+    area.innerHTML = '<div class="cfg-loading">Loading configuration\u2026</div>';
+
+    fetch("/ui/config.json")
+      .then(function (r) { return r.json(); })
+      .then(function (data) {
+        render(data);
+        renderHealth(data);
+      })
+      .catch(function (err) {
+        area.innerHTML =
+          '<div class="cfg-loading" style="color:var(--rust)">Failed to load configuration: ' +
+          esc(String(err)) + '</div>';
+      });
+  }
+
+  // ---- Init ----
+
+  document.addEventListener("DOMContentLoaded", function () {
+    loadConfig();
+
+    var btn = document.getElementById("cfg-refresh");
+    if (btn) btn.addEventListener("click", loadConfig);
+  });
+})();

--- a/agent_memory/ui/static/health.js
+++ b/agent_memory/ui/static/health.js
@@ -1,0 +1,152 @@
+/* health.js — Fetches /ui/health.json and renders the System Health dashboard. */
+
+(function () {
+  "use strict";
+
+  const REFRESH_MS = 30_000;
+  const area = document.getElementById("health-area");
+
+  /* ---- Helpers ---- */
+  function esc(s) {
+    if (s == null) return "";
+    const d = document.createElement("div");
+    d.textContent = String(s);
+    return d.innerHTML;
+  }
+
+  function fmtBytes(b) {
+    if (b == null) return "\u2014";
+    if (b < 1024) return b + " B";
+    if (b < 1024 * 1024) return (b / 1024).toFixed(1) + " KB";
+    return (b / (1024 * 1024)).toFixed(1) + " MB";
+  }
+
+  function fmtMs(v) {
+    if (v == null) return "\u2014";
+    return parseFloat(v).toFixed(1) + " ms";
+  }
+
+  function fmtNum(v) {
+    if (v == null) return "\u2014";
+    return Number(v).toLocaleString();
+  }
+
+  /* Map check name to a human-friendly label + accent color variable */
+  var COMPONENT_META = {
+    "Document Store":     { icon: "D", color: "var(--brass)",     shortName: "SQLiteStore" },
+    "Vector Store":       { icon: "V", color: "var(--verdigris)", shortName: "ChromaDB / Vector" },
+    "Graph Store":        { icon: "G", color: "var(--indigo)",    shortName: "NetworkX / Graph" },
+    "Retrieval Pipeline": { icon: "R", color: "var(--rust)",      shortName: "Retrieval Pipeline" },
+  };
+
+  /* ---- Build a single metric row ---- */
+  function metricRow(label, value) {
+    if (value == null || value === "") return "";
+    return (
+      '<div class="health-metric">' +
+        '<span class="health-metric__label">' + esc(label) + '</span>' +
+        '<span class="health-metric__value">' + esc(value) + '</span>' +
+      '</div>'
+    );
+  }
+
+  /* ---- Render one component card ---- */
+  function renderCard(check, idx) {
+    var meta = COMPONENT_META[check.name] || { icon: "?", color: "var(--ghost)", shortName: check.name };
+    var ok = check.status === "ok";
+    var dotClass = ok ? "health-dot--ok" : "health-dot--error";
+    var borderColor = ok ? meta.color : "var(--rust)";
+
+    var metrics = "";
+    metrics += metricRow("Latency", check.latency_ms != null ? fmtMs(check.latency_ms) : null);
+    metrics += metricRow("Records", check.memory_count != null ? fmtNum(check.memory_count) : null);
+    metrics += metricRow("DB Size", check.db_size_bytes != null ? fmtBytes(check.db_size_bytes) : null);
+    metrics += metricRow("Vectors", check.vector_count != null ? fmtNum(check.vector_count) : null);
+    metrics += metricRow("Nodes", check.nodes != null ? fmtNum(check.nodes) : null);
+    metrics += metricRow("Edges", check.edges != null ? fmtNum(check.edges) : null);
+    metrics += metricRow("Layers", check.active_layers != null
+      ? check.active_layers + " / " + (check.max_layers || "?")
+      : null);
+    metrics += metricRow("Embedding", check.embedding_provider);
+    metrics += metricRow("Graph File", check.graph_file);
+
+    /* Layer list (retrieval pipeline) */
+    var layerList = "";
+    if (check.layers && check.layers.length) {
+      layerList = '<div class="health-layers">';
+      for (var l = 0; l < check.layers.length; l++) {
+        layerList += '<span class="health-layer-tag">' + esc(check.layers[l]) + '</span>';
+      }
+      layerList += '</div>';
+    }
+
+    var noteHtml = check.note
+      ? '<div class="health-note">' + esc(check.note) + '</div>'
+      : "";
+
+    var errorHtml = check.error
+      ? '<div class="health-error">' + esc(check.error) + '</div>'
+      : "";
+
+    return (
+      '<div class="health-card" style="--layer-color:' + borderColor + ';animation-delay:' + (idx * 80) + 'ms">' +
+        '<div class="health-card__head">' +
+          '<div class="health-card__icon">' + esc(meta.icon) + '</div>' +
+          '<div class="health-card__info">' +
+            '<div class="health-card__name">' + esc(meta.shortName) + '</div>' +
+            '<div class="health-card__check-name">' + esc(check.name) + '</div>' +
+          '</div>' +
+          '<div class="health-dot ' + dotClass + '"></div>' +
+          '<div class="health-card__status">' + esc(check.status).toUpperCase() + '</div>' +
+        '</div>' +
+        (metrics ? '<div class="health-metrics">' + metrics + '</div>' : '') +
+        layerList +
+        noteHtml +
+        errorHtml +
+      '</div>'
+    );
+  }
+
+  /* ---- Render the full dashboard ---- */
+  function render(data) {
+    var healthy = data.healthy;
+    var checks = data.checks || [];
+
+    var bannerClass = healthy ? "health-banner--ok" : "health-banner--error";
+    var bannerText = healthy ? "ALL SYSTEMS OPERATIONAL" : "ISSUES DETECTED";
+    var bannerDot = healthy
+      ? '<span class="health-dot health-dot--ok"></span>'
+      : '<span class="health-dot health-dot--error"></span>';
+
+    var html = '';
+    html += '<div class="health-banner ' + bannerClass + '">' + bannerDot + bannerText + '</div>';
+    html += '<div class="health-grid">';
+    for (var i = 0; i < checks.length; i++) {
+      html += renderCard(checks[i], i);
+    }
+    if (checks.length === 0) {
+      html += '<div class="health-empty">No diagnostic checks returned.</div>';
+    }
+    html += '</div>';
+    html += '<div class="health-refresh-note">Auto-refreshes every 30 seconds</div>';
+
+    area.innerHTML = html;
+  }
+
+  /* ---- Fetch loop ---- */
+  function poll() {
+    fetch("/ui/health.json")
+      .then(function (r) { return r.json(); })
+      .then(function (data) { render(data); })
+      .catch(function (err) {
+        area.innerHTML =
+          '<div class="health-banner health-banner--error">' +
+            '<span class="health-dot health-dot--error"></span>FETCH ERROR' +
+          '</div>' +
+          '<div class="health-error" style="margin:24px 40px;">' + esc(err.message) + '</div>';
+      });
+  }
+
+  poll();
+  setInterval(poll, REFRESH_MS);
+})();

--- a/agent_memory/ui/templates/base.html
+++ b/agent_memory/ui/templates/base.html
@@ -23,12 +23,14 @@
       <a class="tab" href="/ui/recall" {% if request.url.path.startswith("/ui/recall") %}aria-current="page"{% endif %}>03 · Recall</a>
       <a class="tab" href="/ui/timeline" {% if request.url.path.startswith("/ui/timeline") %}aria-current="page"{% endif %}>04 · Timeline</a>
       <a class="tab" href="/ui/agents" {% if request.url.path.startswith("/ui/agents") %}aria-current="page"{% endif %}>05 · Agents</a>
+      <a class="tab" href="/ui/health" {% if request.url.path.startswith("/ui/health") %}aria-current="page"{% endif %}>06 · Health</a>
+      <a class="tab" href="/ui/config" {% if request.url.path.startswith("/ui/config") %}aria-current="page"{% endif %}>07 · Config</a>
     </nav>
 
     <div class="chrome__ident">
       <div><span class="dot"></span><b>NAMESPACE</b> {{ namespace_default }}</div>
       <div>STORE · {{ store_path }}</div>
-      <div>{{ stats.total_memories or 0 }} records · {{ stats.active or stats.total_active or 0 }} active</div>
+      <div>{{ stats.total_memories or 0 }} records · {{ stats.active or stats.total_active or 0 }} active <button class="theme-toggle" onclick="toggleTheme()" title="Toggle theme">&#9680;</button></div>
     </div>
   </header>
 
@@ -38,7 +40,7 @@
 
   <footer class="ticker">
     <div class="ticker__pulse" data-secs="0">Live · read-only</div>
-    <div>MEMWRIGHT v2 · DETERMINISTIC RETRIEVAL · NO LLM IN CRITICAL PATH</div>
+    <div class="ticker__mid">MEMWRIGHT v2 · DETERMINISTIC RETRIEVAL · NO LLM IN CRITICAL PATH</div>
     <div>{{ stats.total_memories or 0 }} · ON DISK</div>
   </footer>
 

--- a/agent_memory/ui/templates/memories/config.html
+++ b/agent_memory/ui/templates/memories/config.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+{% block title %}Configuration · Memwright{% endblock %}
+{% block content %}
+
+<section class="page-head">
+  <h1 class="page-head__title">Config /<br><em>System Parameters.</em></h1>
+  <div class="page-head__meta">
+    <div>read-only inspection</div>
+    <div>backend topology</div>
+    <div>retrieval tuning</div>
+  </div>
+</section>
+
+<section class="workspace">
+  <aside class="rail">
+    <div class="rail__section">
+      <div class="rail__label">Actions</div>
+      <button class="btn btn--primary" id="cfg-refresh">Refresh</button>
+    </div>
+
+    <div class="rail__section">
+      <div class="rail__label">Health <span id="cfg-health-status"></span></div>
+      <div id="cfg-health-checks"></div>
+    </div>
+  </aside>
+
+  <section class="cfg-area" id="cfg-area">
+    <div class="cfg-loading">Loading configuration&hellip;</div>
+  </section>
+</section>
+
+<script src="/ui/static/config.js"></script>
+
+{% endblock %}

--- a/agent_memory/ui/templates/memories/health.html
+++ b/agent_memory/ui/templates/memories/health.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+{% block title %}System Health · Memwright{% endblock %}
+{% block content %}
+
+<section class="page-head">
+  <h1 class="page-head__title">System<br><em>Health.</em></h1>
+  <div class="page-head__meta">
+    <div>Component Diagnostics</div>
+    <div>auto-refresh · 30s</div>
+    <div>read-only</div>
+  </div>
+</section>
+
+<section class="health-area" id="health-area">
+  <div class="health-loading">Polling component diagnostics&hellip;</div>
+</section>
+
+<script src="/ui/static/health.js"></script>
+
+{% endblock %}

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,0 +1,210 @@
+# Memwright Install Guide
+
+A step-by-step guide to installing and verifying Memwright across different topologies. Each chapter is a self-contained setup you can follow from scratch.
+
+**Chapters**
+
+| # | Topology | Backend | Network required |
+|---|----------|---------|------------------|
+| [01](#chapter-01--local-with-chromadb) | Local embedded | SQLite + ChromaDB + NetworkX | No (after first model download) |
+| [02](#chapter-02--sidecar-rest-api) | Sidecar REST API | Same as local | Localhost only |
+| [03](#chapter-03--cloud-managed) | Cloud managed | Postgres / ArangoDB / AWS / Azure / GCP | Yes |
+
+---
+
+## Chapter 01 — Local with ChromaDB
+
+**The zero-config path.** SQLite for documents, ChromaDB for vectors, NetworkX for the entity graph. Everything runs in-process. No Docker. No API keys. No external services.
+
+### Prerequisites
+
+- Python 3.10 or later
+- `pip`, `pipx`, or `poetry`
+
+That's it. All three backends are embedded and auto-provision on first use.
+
+### Step 1 — Install the package
+
+Choose one:
+
+```bash
+# Via pip (into current environment)
+pip install memwright
+
+# Via pipx (isolated CLI tool)
+pipx install memwright
+
+# Via poetry (project dependency)
+poetry add memwright
+```
+
+Verify the CLI is available:
+
+```bash
+memwright --help
+```
+
+### Step 2 — Create a store
+
+```python
+from agent_memory import AgentMemory
+
+mem = AgentMemory("~/.memwright")
+```
+
+On first call, Memwright:
+1. Creates the directory if it doesn't exist
+2. Provisions SQLite with WAL mode, 17 columns, 6 indexes
+3. Initializes ChromaDB with local `all-MiniLM-L6-v2` embeddings (384 dimensions, ~90 MB download on first use)
+4. Creates the NetworkX graph with JSON persistence
+
+No configuration file is needed. The defaults work.
+
+### Step 3 — Write your first memory
+
+```python
+mem.add(
+    "The order service uses event sourcing with a 30-day retention policy",
+    entity="order-service",
+    tags=["architecture", "decision"],
+)
+```
+
+This writes to all three stores in parallel:
+- **Document store** (SQLite) — content, tags, entity, timestamp, confidence
+- **Vector store** (ChromaDB) — 384-dimensional embedding of the content
+- **Graph store** (NetworkX) — entity node `order-service` + typed edges
+
+### Step 4 — Recall
+
+```python
+results = mem.recall("how is the order service structured?", budget=2000)
+for r in results:
+    print(f"[{r.score:.2f}] {r.memory.content}")
+```
+
+The 5-layer retrieval pipeline runs:
+1. **Tag match** — SQLite FTS finds memories tagged with relevant terms
+2. **Graph expansion** — BFS depth=2 finds related entities
+3. **Vector search** — cosine similarity on the query embedding
+4. **Fusion + Rank** — RRF (k=60) merges all candidates, applies PageRank and confidence decay
+5. **Diversity + Fit** — MMR (lambda=0.7) removes near-duplicates, greedy packs under the token budget
+
+### Step 5 — Run the doctor
+
+The doctor verifies all four components are healthy:
+
+```bash
+memwright doctor ~/.memwright
+```
+
+Expected output:
+
+```
+Memwright Doctor
+==================================================
+
+Overall: ALL HEALTHY
+
+  [OK] SQLiteStore (0.4ms, 1 memories, 40,960 bytes)
+  [OK] ChromaDB (1 vectors)
+  [OK] NetworkXGraph (1 nodes, 0 edges)
+  [OK] Retrieval Pipeline (3/3 layers)
+```
+
+All four checks must show `[OK]`. If vector or graph shows `[FAIL]`, the self-healing health check will attempt automatic recovery — run doctor again and check for the `^ recovered at health check` note.
+
+### Step 6 — Verify from the CLI
+
+```bash
+# Add a memory
+memwright add ~/.memwright "API rate limit is 1000 req/min" --tags api,limits
+
+# Recall
+memwright recall ~/.memwright "what are the rate limits?"
+
+# View timeline
+memwright timeline ~/.memwright --limit 10
+
+# Check stats
+memwright stats ~/.memwright
+```
+
+### What's on disk
+
+After setup, `~/.memwright/` contains:
+
+```
+~/.memwright/
+├── memory.db          # SQLite — source of truth (WAL mode)
+├── memory.db-wal      # SQLite write-ahead log
+├── chroma/            # ChromaDB persistent storage
+│   └── ...            # Embedding model cached here on first use
+└── graph.json         # NetworkX graph (entity nodes + edges)
+```
+
+Total disk footprint: ~90 MB (mostly the sentence-transformers model). The SQLite database itself starts at 40 KB.
+
+### Self-healing
+
+If ChromaDB or NetworkX fail at startup (e.g., corrupted model cache, missing graph file), Memwright degrades gracefully:
+
+- **Vector down** — retrieval falls back to tag match + graph expansion
+- **Graph down** — retrieval falls back to tag match + vector search
+- **Document store** is the only hard dependency
+
+When `health()` or `memwright doctor` is called, failed stores are automatically re-initialized. If recovery succeeds, the store is wired back into the retrieval pipeline without a restart.
+
+### Claude Code integration
+
+The fastest path for Claude Code users:
+
+```
+> install agent memory
+```
+
+This triggers the interactive wizard that configures:
+- MCP server scope (global or project)
+- Store path
+- Lifecycle hooks (session-start, post-tool-use, stop)
+- Namespace and token budget
+
+Or manually add to `~/.claude/.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "memory": {
+      "command": "memwright",
+      "args": ["mcp", "--store-path", "~/.memwright"]
+    }
+  }
+}
+```
+
+### Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `memwright: command not found` | Not on PATH | Use `pipx install memwright` or check `pip show memwright` |
+| ChromaDB shows `[FAIL]` | Model not downloaded | Run any `recall` — model downloads automatically on first embedding |
+| `safetensors` noise on startup | Rust model loader prints to stderr | Normal on first load; suppressed after warmup |
+| Doctor shows 0 vectors but N memories | Embedding failed for some memories | Re-add affected memories; check disk space for model cache |
+| Graph shows 0 nodes after adding memories | Entity extraction found nothing | Add memories with explicit `entity=` parameter |
+
+### Next steps
+
+- **Chapter 02** — Run the REST API as a sidecar for non-Python agents
+- **Chapter 03** — Switch to a cloud backend for shared multi-agent deployments
+
+---
+
+## Chapter 02 — Sidecar REST API
+
+*Coming soon.* Run `memwright api --store-path ~/.memwright --port 8080` to expose the same API over HTTP. Any language can use the memory layer.
+
+---
+
+## Chapter 03 — Cloud Managed
+
+*Coming soon.* PostgreSQL (pgvector + Apache AGE), ArangoDB, AWS, Azure, and GCP backends for shared multi-agent deployments.


### PR DESCRIPTION
## Summary
- Add Health Dashboard (06) and Config Viewer (07) pages with auto-refresh and full system parameter inspection
- Add pagination (60/page with HTMX), CSV/JSON export, and dark/light theme toggle with localStorage
- Complete mobile responsive CSS (960px tablet, 640px phone breakpoints)
- Add install guide (docs/INSTALL.md) — Chapter 01: Local with ChromaDB

## Test plan
- [ ] Visit /ui/health — verify 4 component cards with auto-refresh
- [ ] Visit /ui/config — verify backends, retrieval params, store stats
- [ ] Visit /ui/memories — verify pagination controls and page navigation
- [ ] Click Export JSON / Export CSV in sidebar — verify downloads
- [ ] Click theme toggle (◐) — verify dark/light switch persists on reload
- [ ] Resize browser to 960px and 640px — verify responsive layout
- [ ] Verify all 7 nav tabs render correctly