### PR TITLE
feat: latency instrumentation + ops log + budget explorer

### DIFF
--- a/agent_memory/core.py
+++ b/agent_memory/core.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import time
+from collections import deque
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Deque, Dict, List, Optional
 
 from agent_memory.models import Memory, RetrievalResult
 from agent_memory.retrieval.orchestrator import RetrievalOrchestrator
@@ -120,6 +122,9 @@ class AgentMemory:
         self._retrieval.confidence_decay_rate = self.config.confidence_decay_rate
         self._retrieval.confidence_boost_rate = self.config.confidence_boost_rate
 
+        # Operation ring buffer for latency observability
+        self._ops_log: Deque[Dict[str, Any]] = deque(maxlen=200)
+
     def close(self) -> None:
         """Close all database connections."""
         if self._vector_store:
@@ -182,6 +187,9 @@ class AgentMemory:
         metadata: Optional[Dict[str, Any]] = None,
     ) -> Memory:
         """Store a new memory, handling contradictions automatically."""
+        t_total = time.monotonic()
+        store_timings: Dict[str, float] = {}
+
         # Dedup: check for exact content match (scoped by namespace)
         chash = self._content_hash(content)
         if hasattr(self._store, "get_by_hash"):
@@ -206,7 +214,9 @@ class AgentMemory:
         contradictions = self._temporal.check_contradictions(memory)
 
         # Insert new memory first (so FK reference is valid)
+        t0 = time.monotonic()
         self._store.insert(memory)
+        store_timings["document_ms"] = round((time.monotonic() - t0) * 1000, 2)
 
         # Then supersede old contradicting memories
         for old in contradictions:
@@ -215,14 +225,18 @@ class AgentMemory:
         # Store in vector DB
         if self._vector_store:
             try:
+                t0 = time.monotonic()
                 self._vector_store.add(memory.id, content, namespace=namespace)
+                store_timings["vector_ms"] = round((time.monotonic() - t0) * 1000, 2)
             except Exception:
+                store_timings["vector_ms"] = -1  # failed
                 pass  # Non-fatal
 
         # Update entity graph
         if self._graph:
             try:
                 from agent_memory.graph.extractor import extract_entities_and_relations
+                t0 = time.monotonic()
                 nodes, edges = extract_entities_and_relations(
                     content, tags or [], entity, category,
                 )
@@ -239,8 +253,25 @@ class AgentMemory:
                         relation_type=edge.get("type", "related_to"),
                         metadata=edge.get("metadata"),
                     )
+                store_timings["graph_ms"] = round((time.monotonic() - t0) * 1000, 2)
             except Exception:
+                store_timings["graph_ms"] = -1  # failed
                 pass  # Non-fatal
+
+        total_ms = round((time.monotonic() - t_total) * 1000, 2)
+        store_timings["total_ms"] = total_ms
+
+        # Record in ops log
+        self._ops_log.append({
+            "op": "add",
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "latency_ms": total_ms,
+            "store_timings": store_timings,
+            "input": content[:120],
+            "result_count": 1,
+            "stores": [k.replace("_ms", "") for k, v in store_timings.items()
+                       if k != "total_ms" and v >= 0],
+        })
 
         return memory
 
@@ -293,8 +324,10 @@ class AgentMemory:
         namespace: Optional[str] = None,
     ) -> List[RetrievalResult]:
         """Retrieve relevant memories for a query using 3-layer cascade."""
+        t0 = time.monotonic()
         token_budget = budget or self.config.default_token_budget
         results = self._retrieval.recall(query, token_budget, namespace=namespace)
+        total_ms = round((time.monotonic() - t0) * 1000, 2)
 
         # Track access for confidence decay/boost
         real_ids = [
@@ -307,6 +340,22 @@ class AgentMemory:
                 self._store.increment_access(real_ids)
             except Exception:
                 pass  # Non-fatal
+
+        # Record in ops log
+        stores = ["document"]
+        if self._vector_store:
+            stores.append("vector")
+        if self._graph:
+            stores.append("graph")
+        self._ops_log.append({
+            "op": "recall",
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "latency_ms": total_ms,
+            "input": query[:120],
+            "result_count": len(results),
+            "budget": token_budget,
+            "stores": stores,
+        })
 
         return results
 
@@ -457,6 +506,11 @@ class AgentMemory:
         """Permanently remove archived memories."""
         return self._store.compact()
 
+    @property
+    def ops_log(self) -> List[Dict[str, Any]]:
+        """Return a snapshot of the operation ring buffer (most recent last)."""
+        return list(self._ops_log)
+
     def stats(self) -> Dict[str, Any]:
         """Get store statistics."""
         return self._store.stats()
@@ -520,7 +574,7 @@ class AgentMemory:
         Checks: SQLite, ChromaDB, NetworkX Graph, Retrieval Pipeline.
         No Docker checks. No external API checks.
         """
-        import time
+        t0_health = time.monotonic()
 
         # Attempt recovery of failed stores before reporting
         recovery: Dict[str, str] = {}
@@ -565,8 +619,13 @@ class AgentMemory:
                 vec_name = type(self._vector_store).__name__
                 # Skip if same instance as document store (multi-role backend)
                 if self._vector_store is not self._store:
+                    t0 = time.monotonic()
                     vector_count = self._vector_store.count()
-                    vec_details: Dict[str, Any] = {"vector_count": vector_count}
+                    vec_latency = round((time.monotonic() - t0) * 1000, 1)
+                    vec_details: Dict[str, Any] = {
+                        "vector_count": vector_count,
+                        "latency_ms": vec_latency,
+                    }
                     if hasattr(self._vector_store, "provider"):
                         vec_details["embedding_provider"] = self._vector_store.provider
                     if "vector" in recovery:
@@ -587,14 +646,17 @@ class AgentMemory:
         if self._graph:
             try:
                 graph_name = type(self._graph).__name__
+                t0 = time.monotonic()
                 graph_stats = (
                     self._graph.graph_stats()
                     if hasattr(self._graph, "graph_stats")
                     else self._graph.stats()
                 )
+                graph_latency = round((time.monotonic() - t0) * 1000, 1)
                 graph_details: Dict[str, Any] = {
                     "nodes": graph_stats["nodes"],
                     "edges": graph_stats["edges"],
+                    "latency_ms": graph_latency,
                 }
                 # Skip if same instance as document store (multi-role backend)
                 if self._graph is not self._store:
@@ -622,6 +684,35 @@ class AgentMemory:
             layers.append("vector_similarity")
         _check("Retrieval Pipeline", "ok",
                active_layers=len(layers), max_layers=3, layers=layers)
+
+        health_ms = round((time.monotonic() - t0_health) * 1000, 2)
+
+        # Include ops log summary in health report
+        report["ops_log_size"] = len(self._ops_log)
+        if self._ops_log:
+            latencies = [op["latency_ms"] for op in self._ops_log]
+            latencies_sorted = sorted(latencies)
+            n = len(latencies_sorted)
+            report["latency_percentiles"] = {
+                "p50": latencies_sorted[n // 2] if n else 0,
+                "p95": latencies_sorted[int(n * 0.95)] if n else 0,
+                "p99": latencies_sorted[int(n * 0.99)] if n else 0,
+            }
+            report["latency_sparkline"] = [
+                op["latency_ms"] for op in list(self._ops_log)[-50:]
+            ]
+
+        # Record health check itself in ops log
+        self._ops_log.append({
+            "op": "health",
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "latency_ms": health_ms,
+            "input": "health check",
+            "result_count": len(report["checks"]),
+            "stores": ["document"]
+                + (["vector"] if self._vector_store else [])
+                + (["graph"] if self._graph else []),
+        })
 
         return report
 

--- a/agent_memory/retrieval/orchestrator.py
+++ b/agent_memory/retrieval/orchestrator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from typing import Dict, List, Optional
 
 from agent_memory.models import Memory, RetrievalResult
@@ -305,8 +306,10 @@ class RetrievalOrchestrator:
             ]
 
         all_results: List[RetrievalResult] = []
+        t_total = time.monotonic()
 
         # Layer 1: Tag match
+        t_layer = time.monotonic()
         tags = extract_tags(query)
         tag_results: List[RetrievalResult] = []
         if tags:
@@ -321,10 +324,12 @@ class RetrievalOrchestrator:
             "description": "FTS on extracted tags",
             "tags": tags,
             "count": len(tag_results),
+            "latency_ms": round((time.monotonic() - t_layer) * 1000, 2),
             "results": _snap(tag_results),
         })
 
         # Layer 2: Graph expansion
+        t_layer = time.monotonic()
         graph_results: List[RetrievalResult] = []
         expanded_queries = []
         graph_context_triples: List[str] = []
@@ -382,10 +387,12 @@ class RetrievalOrchestrator:
             "expanded_entities": expanded_queries[:8],
             "triples": len(graph_context_triples),
             "count": len(graph_results),
+            "latency_ms": round((time.monotonic() - t_layer) * 1000, 2),
             "results": _snap(graph_results),
         })
 
         # Layer 3: Vector search
+        t_layer = time.monotonic()
         vector_results: List[RetrievalResult] = []
         if self.vector_store:
             try:
@@ -417,10 +424,12 @@ class RetrievalOrchestrator:
             "name": "Vector Search",
             "description": "Cosine similarity via ChromaDB",
             "count": len(vector_results),
+            "latency_ms": round((time.monotonic() - t_layer) * 1000, 2),
             "results": _snap(vector_results),
         })
 
         # Layer 4: Fusion + Rank (RRF or graph blend)
+        t_layer = time.monotonic()
         if self.fusion_mode == "graph_blend" and self.graph and len(all_results) >= 3:
             fused = self._graph_blend(all_results)
         else:
@@ -434,10 +443,12 @@ class RetrievalOrchestrator:
             "description": f"RRF k=60, temporal boost, entity boost" if self.fusion_mode == "rrf" else "Graph blend + temporal + entity boost",
             "fusion_mode": self.fusion_mode,
             "count": len(fused),
+            "latency_ms": round((time.monotonic() - t_layer) * 1000, 2),
             "results": _snap(fused),
         })
 
         # Layer 5: Diversity + Fit (MMR + token budget)
+        t_layer = time.monotonic()
         if self.enable_mmr:
             fused = mmr_rerank(fused, lambda_param=self.mmr_lambda)
         fused = confidence_decay_boost(
@@ -454,13 +465,17 @@ class RetrievalOrchestrator:
             "mmr_enabled": self.enable_mmr,
             "budget": token_budget,
             "count": len(final),
+            "latency_ms": round((time.monotonic() - t_layer) * 1000, 2),
             "results": _snap(final),
         })
+
+        total_ms = round((time.monotonic() - t_total) * 1000, 2)
 
         return {
             "query": query,
             "namespace": namespace,
             "token_budget": token_budget,
+            "total_latency_ms": total_ms,
             "layers": layers,
             "final_count": len(final),
             "config": {

--- a/agent_memory/ui/app.py
+++ b/agent_memory/ui/app.py
@@ -694,6 +694,51 @@ async def config_json(request: Request) -> JSONResponse:
     return JSONResponse(result)
 
 
+async def ops_page(request: Request) -> HTMLResponse:
+    """Operations Log — flight recorder of recent add/recall/health calls."""
+    mem = _get_mem(request)
+    ctx = {"request": request, **_common_context(request, mem)}
+    return _TEMPLATES.TemplateResponse(request, "memories/ops.html", ctx)
+
+
+async def ops_json(request: Request) -> JSONResponse:
+    """Return the ops ring buffer as JSON (most recent last)."""
+    mem = _get_mem(request)
+    return JSONResponse({"ops": mem.ops_log})
+
+
+async def budget_explore_json(request: Request) -> JSONResponse:
+    """Run the same query at multiple budgets, return latency + count."""
+    import time as _time
+
+    mem = _get_mem(request)
+    query = request.query_params.get("q", "").strip()
+    if not query:
+        return JSONResponse({"error": "q is required"}, status_code=400)
+
+    namespace = request.query_params.get("namespace") or None
+    retrieval = getattr(mem, "_retrieval", None)
+    if retrieval is None:
+        return JSONResponse({"error": "No retrieval orchestrator"}, status_code=500)
+
+    budgets = [500, 1000, 2000, 5000, 10000]
+    results = []
+    for b in budgets:
+        t0 = _time.monotonic()
+        trace = retrieval.recall_debug(query, token_budget=b, namespace=namespace)
+        ms = round((_time.monotonic() - t0) * 1000, 2)
+        results.append({
+            "budget": b,
+            "latency_ms": ms,
+            "result_count": trace["final_count"],
+            "layers": [
+                {"name": l["name"], "count": l["count"], "latency_ms": l.get("latency_ms", 0)}
+                for l in trace.get("layers", [])
+            ],
+        })
+    return JSONResponse({"query": query, "budgets": results})
+
+
 def ui_routes() -> list:
     """Return absolute UI routes — can be appended to any Starlette app."""
     return [
@@ -716,6 +761,9 @@ def ui_routes() -> list:
         Route("/ui/health.json", health_json),
         Route("/ui/config", config_page),
         Route("/ui/config.json", config_json),
+        Route("/ui/ops", ops_page),
+        Route("/ui/ops.json", ops_json),
+        Route("/ui/recall/budget-explore.json", budget_explore_json),
         Mount(
             "/ui/static",
             StaticFiles(directory=str(_UI_DIR / "static")),

--- a/agent_memory/ui/static/app.css
+++ b/agent_memory/ui/static/app.css
@@ -1601,3 +1601,274 @@ select.field {
 }
 
 ::selection { background: var(--rust); color: var(--paper); }
+
+/* ============================================================
+   RECALL: LATENCY BADGES
+   ============================================================ */
+.recall-diagram__ms {
+  font-family: var(--f-mono);
+  font-size: 11px;
+  color: var(--brass);
+  margin-top: 4px;
+  opacity: 0.85;
+}
+.recall-layer__ms {
+  font-family: var(--f-mono);
+  font-size: 12px;
+  color: var(--brass);
+  margin-left: auto;
+  padding: 2px 8px;
+  border: 1px solid var(--ghost);
+  border-radius: 2px;
+  white-space: nowrap;
+}
+
+/* ============================================================
+   BUDGET EXPLORER
+   ============================================================ */
+.budget-explore-area { margin-top: 24px; }
+.budget-chart {
+  border: 1px solid var(--ghost);
+  padding: 20px 24px;
+  margin-top: 16px;
+}
+.budget-chart__title {
+  font-family: var(--f-display);
+  font-size: 14px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--ghost);
+  margin-bottom: 16px;
+}
+.budget-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+.budget-row__label {
+  font-family: var(--f-mono);
+  font-size: 13px;
+  min-width: 60px;
+  text-align: right;
+  color: var(--ghost);
+}
+.budget-row__bars {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+.budget-row__bar {
+  height: 18px;
+  display: flex;
+  align-items: center;
+  padding: 0 8px;
+  font-family: var(--f-mono);
+  font-size: 11px;
+  color: var(--paper);
+  min-width: 60px;
+  transition: width 0.4s ease;
+}
+.budget-row__bar--ms { border-radius: 0; }
+.budget-row__bar--count {
+  background: var(--verdigris);
+  border-radius: 0;
+}
+.budget-row__bar span {
+  white-space: nowrap;
+}
+
+/* ============================================================
+   OPS LOG
+   ============================================================ */
+.ops-area { padding: 0 40px; }
+.ops-empty {
+  padding: 60px 20px;
+  text-align: center;
+  font-family: var(--f-display);
+  font-style: italic;
+  color: var(--ghost);
+}
+.ops-loading { @extend .ops-empty; }
+.ops-summary {
+  display: flex;
+  gap: 24px;
+  flex-wrap: wrap;
+  padding: 20px 0;
+  border-bottom: 1px solid var(--ghost);
+  margin-bottom: 16px;
+}
+.ops-stat {
+  text-align: center;
+  min-width: 80px;
+}
+.ops-stat__val {
+  font-family: var(--f-mono);
+  font-size: 20px;
+  color: var(--ink);
+}
+.ops-stat__label {
+  font-family: var(--f-display);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--ghost);
+}
+.ops-sparkline-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 0 16px;
+}
+.ops-sparkline-label {
+  font-family: var(--f-display);
+  font-size: 11px;
+  text-transform: uppercase;
+  color: var(--ghost);
+  white-space: nowrap;
+}
+.ops-spark {
+  width: 100%;
+  max-width: 600px;
+  height: 40px;
+}
+.ops-table-wrap { overflow-x: auto; }
+.ops-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--f-mono);
+  font-size: 12px;
+}
+.ops-table th {
+  text-align: left;
+  font-family: var(--f-display);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--ghost);
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--ghost);
+}
+.ops-table td {
+  padding: 5px 8px;
+  border-bottom: 1px solid color-mix(in srgb, var(--ghost) 30%, transparent);
+  vertical-align: middle;
+}
+.ops-table tbody tr:hover {
+  background: color-mix(in srgb, var(--ghost) 8%, transparent);
+}
+.ops-td--ts {
+  white-space: nowrap;
+  color: var(--ghost);
+  font-size: 11px;
+}
+.ops-td--ms {
+  white-space: nowrap;
+  text-align: right;
+  min-width: 70px;
+}
+.ops-td--bar { width: 100px; }
+.ops-bar {
+  height: 8px;
+  border-radius: 0;
+  transition: width 0.3s ease;
+}
+.ops-td--input {
+  max-width: 260px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 11px;
+  color: var(--ink);
+}
+.ops-td--stores {
+  font-size: 10px;
+  color: var(--ghost);
+}
+.ops-badge {
+  display: inline-block;
+  padding: 1px 6px;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  border: 1px solid var(--ghost);
+}
+.ops-op--recall { color: var(--verdigris); border-color: var(--verdigris); }
+.ops-op--add { color: var(--brass); border-color: var(--brass); }
+.ops-op--health { color: var(--ghost); }
+.ops-refresh-note {
+  text-align: center;
+  font-family: var(--f-display);
+  font-size: 11px;
+  color: var(--ghost);
+  padding: 16px 0;
+}
+
+/* ============================================================
+   HEALTH: LATENCY PANEL (PERCENTILES + SPARKLINE)
+   ============================================================ */
+.health-latency-panel {
+  border: 1px solid var(--ghost);
+  padding: 20px 24px;
+  margin: 0 40px 24px;
+}
+.health-latency-panel__title {
+  font-family: var(--f-display);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--ghost);
+  margin-bottom: 12px;
+}
+.health-pctl-row {
+  display: flex;
+  gap: 32px;
+  flex-wrap: wrap;
+  margin-bottom: 12px;
+}
+.health-pctl { text-align: center; }
+.health-pctl__val {
+  display: block;
+  font-family: var(--f-mono);
+  font-size: 18px;
+  color: var(--ink);
+}
+.health-pctl__label {
+  font-family: var(--f-display);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--ghost);
+}
+.health-spark-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.health-spark-label {
+  font-family: var(--f-display);
+  font-size: 11px;
+  text-transform: uppercase;
+  color: var(--ghost);
+  white-space: nowrap;
+}
+.health-spark {
+  width: 100%;
+  max-width: 500px;
+  height: 36px;
+}
+
+/* ============================================================
+   RESPONSIVE: OPS + BUDGET
+   ============================================================ */
+@media (max-width: 640px) {
+  .ops-area { padding: 0 16px; }
+  .ops-summary { gap: 12px; }
+  .ops-stat__val { font-size: 16px; }
+  .ops-td--input { max-width: 120px; }
+  .ops-td--bar { display: none; }
+  .health-latency-panel { margin: 0 16px 16px; }
+  .health-pctl-row { gap: 16px; }
+  .budget-chart { padding: 12px 16px; }
+}

--- a/agent_memory/ui/static/health.js
+++ b/agent_memory/ui/static/health.js
@@ -107,6 +107,19 @@
     );
   }
 
+  /* ---- Sparkline SVG ---- */
+  function sparklineSvg(latencies, width, height) {
+    if (!latencies || latencies.length < 2) return "";
+    var max = Math.max.apply(null, latencies) || 1;
+    var step = width / (latencies.length - 1);
+    var points = latencies.map(function (v, i) {
+      return (i * step).toFixed(1) + "," + (height - (v / max) * (height - 2)).toFixed(1);
+    }).join(" ");
+    return '<svg class="health-spark" viewBox="0 0 ' + width + ' ' + height + '" preserveAspectRatio="none">' +
+      '<polyline points="' + points + '" fill="none" stroke="var(--rust)" stroke-width="1.5"/>' +
+      '</svg>';
+  }
+
   /* ---- Render the full dashboard ---- */
   function render(data) {
     var healthy = data.healthy;
@@ -120,6 +133,30 @@
 
     var html = '';
     html += '<div class="health-banner ' + bannerClass + '">' + bannerDot + bannerText + '</div>';
+
+    /* Latency percentiles + sparkline (from ops ring buffer) */
+    var pctl = data.latency_percentiles;
+    var spark = data.latency_sparkline;
+    if (pctl || (spark && spark.length >= 2)) {
+      html += '<div class="health-latency-panel">';
+      html += '<div class="health-latency-panel__title">Operation Latency</div>';
+      if (pctl) {
+        html += '<div class="health-pctl-row">';
+        html += '<div class="health-pctl"><span class="health-pctl__val">' + fmtMs(pctl.p50) + '</span><span class="health-pctl__label">P50</span></div>';
+        html += '<div class="health-pctl"><span class="health-pctl__val">' + fmtMs(pctl.p95) + '</span><span class="health-pctl__label">P95</span></div>';
+        html += '<div class="health-pctl"><span class="health-pctl__val">' + fmtMs(pctl.p99) + '</span><span class="health-pctl__label">P99</span></div>';
+        html += '<div class="health-pctl"><span class="health-pctl__val">' + fmtNum(data.ops_log_size) + '</span><span class="health-pctl__label">Ops</span></div>';
+        html += '</div>';
+      }
+      if (spark && spark.length >= 2) {
+        html += '<div class="health-spark-row">';
+        html += '<span class="health-spark-label">Last ' + spark.length + ' ops</span>';
+        html += sparklineSvg(spark, 500, 36);
+        html += '</div>';
+      }
+      html += '</div>';
+    }
+
     html += '<div class="health-grid">';
     for (var i = 0; i < checks.length; i++) {
       html += renderCard(checks[i], i);

--- a/agent_memory/ui/static/ops.js
+++ b/agent_memory/ui/static/ops.js
@@ -1,0 +1,132 @@
+/* ops.js — Operations Log flight recorder with auto-refresh. */
+
+(function () {
+  "use strict";
+
+  var REFRESH_MS = 5000;
+  var area = document.getElementById("ops-area");
+
+  function esc(s) {
+    if (s == null) return "";
+    var d = document.createElement("div");
+    d.textContent = String(s);
+    return d.innerHTML;
+  }
+
+  function fmtMs(v) {
+    if (v == null) return "\u2014";
+    var n = parseFloat(v);
+    if (n < 1) return n.toFixed(3) + " ms";
+    if (n < 100) return n.toFixed(1) + " ms";
+    return Math.round(n) + " ms";
+  }
+
+  function fmtTs(iso) {
+    if (!iso) return "\u2014";
+    try {
+      var d = new Date(iso);
+      return d.toLocaleTimeString(undefined, { hour12: false }) + "." +
+        String(d.getMilliseconds()).padStart(3, "0");
+    } catch (_) {
+      return iso;
+    }
+  }
+
+  /* Latency bar — max 200ms = full width, clamped */
+  function latencyBar(ms) {
+    var pct = Math.min(100, (ms / 200) * 100);
+    var color = ms < 10 ? "var(--verdigris)" : ms < 50 ? "var(--brass)" : "var(--rust)";
+    return '<div class="ops-bar" style="width:' + pct + '%;background:' + color + '"></div>';
+  }
+
+  /* Sparkline SVG from latency array */
+  function sparklineSvg(latencies, width, height) {
+    if (!latencies || latencies.length < 2) return "";
+    var max = Math.max.apply(null, latencies) || 1;
+    var step = width / (latencies.length - 1);
+    var points = latencies.map(function (v, i) {
+      return (i * step).toFixed(1) + "," + (height - (v / max) * (height - 2)).toFixed(1);
+    }).join(" ");
+    return '<svg class="ops-spark" viewBox="0 0 ' + width + ' ' + height + '" preserveAspectRatio="none">' +
+      '<polyline points="' + points + '" fill="none" stroke="var(--rust)" stroke-width="1.5"/>' +
+      '</svg>';
+  }
+
+  function render(data) {
+    var ops = data.ops || [];
+
+    if (ops.length === 0) {
+      area.innerHTML = '<div class="ops-empty">No operations recorded yet. Add memories or run recalls to populate the flight recorder.</div>';
+      return;
+    }
+
+    /* Summary stats */
+    var recallOps = ops.filter(function (o) { return o.op === "recall"; });
+    var addOps = ops.filter(function (o) { return o.op === "add"; });
+    var latencies = ops.map(function (o) { return o.latency_ms; });
+    var sorted = latencies.slice().sort(function (a, b) { return a - b; });
+    var n = sorted.length;
+    var p50 = sorted[Math.floor(n * 0.5)] || 0;
+    var p95 = sorted[Math.floor(n * 0.95)] || 0;
+    var p99 = sorted[Math.floor(n * 0.99)] || 0;
+
+    var html = "";
+
+    /* Summary row */
+    html += '<div class="ops-summary">';
+    html += '<div class="ops-stat"><div class="ops-stat__val">' + ops.length + '</div><div class="ops-stat__label">Total Ops</div></div>';
+    html += '<div class="ops-stat"><div class="ops-stat__val">' + recallOps.length + '</div><div class="ops-stat__label">Recalls</div></div>';
+    html += '<div class="ops-stat"><div class="ops-stat__val">' + addOps.length + '</div><div class="ops-stat__label">Adds</div></div>';
+    html += '<div class="ops-stat"><div class="ops-stat__val">' + fmtMs(p50) + '</div><div class="ops-stat__label">P50</div></div>';
+    html += '<div class="ops-stat"><div class="ops-stat__val">' + fmtMs(p95) + '</div><div class="ops-stat__label">P95</div></div>';
+    html += '<div class="ops-stat"><div class="ops-stat__val">' + fmtMs(p99) + '</div><div class="ops-stat__label">P99</div></div>';
+    html += '</div>';
+
+    /* Sparkline */
+    var last50 = latencies.slice(-50);
+    if (last50.length >= 2) {
+      html += '<div class="ops-sparkline-row">';
+      html += '<span class="ops-sparkline-label">Last ' + last50.length + ' ops</span>';
+      html += sparklineSvg(last50, 600, 40);
+      html += '</div>';
+    }
+
+    /* Table */
+    html += '<div class="ops-table-wrap">';
+    html += '<table class="ops-table">';
+    html += '<thead><tr><th>Time</th><th>Op</th><th>Latency</th><th></th><th>Input</th><th>Results</th><th>Stores</th></tr></thead>';
+    html += '<tbody>';
+
+    /* Show most recent first */
+    for (var i = ops.length - 1; i >= 0; i--) {
+      var op = ops[i];
+      var opClass = "ops-op--" + (op.op || "unknown");
+      html += '<tr>';
+      html += '<td class="ops-td--ts">' + esc(fmtTs(op.ts)) + '</td>';
+      html += '<td><span class="ops-badge ' + opClass + '">' + esc(op.op) + '</span></td>';
+      html += '<td class="ops-td--ms">' + fmtMs(op.latency_ms) + '</td>';
+      html += '<td class="ops-td--bar">' + latencyBar(op.latency_ms) + '</td>';
+      html += '<td class="ops-td--input">' + esc(op.input || "") + '</td>';
+      html += '<td>' + (op.result_count != null ? op.result_count : "\u2014") + '</td>';
+      html += '<td class="ops-td--stores">' + (op.stores || []).join(", ") + '</td>';
+      html += '</tr>';
+    }
+
+    html += '</tbody></table></div>';
+    html += '<div class="ops-refresh-note">Auto-refreshes every 5 seconds</div>';
+
+    area.innerHTML = html;
+  }
+
+  function poll() {
+    fetch("/ui/ops.json")
+      .then(function (r) { return r.json(); })
+      .then(function (data) { render(data); })
+      .catch(function (err) {
+        area.innerHTML = '<div class="ops-empty">Fetch error: ' + esc(err.message) + '</div>';
+      });
+  }
+
+  poll();
+  setInterval(poll, REFRESH_MS);
+})();

--- a/agent_memory/ui/static/recall.js
+++ b/agent_memory/ui/static/recall.js
@@ -66,24 +66,32 @@
         html += `<div class="recall-diagram__arrow" style="animation-delay:${arrowDelay}ms">&rarr;</div>`;
       }
 
+      const msLabel = layer.latency_ms != null
+        ? `<div class="recall-diagram__ms">${parseFloat(layer.latency_ms).toFixed(1)} ms</div>`
+        : "";
+
       html += `
         <div class="recall-diagram__step" style="--layer-color:${color}; animation-delay:${stepDelay}ms">
           <div class="recall-diagram__num">Layer ${i + 1}</div>
           <div class="recall-diagram__name">${esc(layer.name)}</div>
           <div class="recall-diagram__count">${layer.count}</div>
           <div class="recall-diagram__count-label">results</div>
+          ${msLabel}
         </div>
       `;
     });
 
-    // Summary line: total input candidates -> final output
+    // Summary line: total input candidates -> final output + total latency
     const firstCount = layers.length > 0 ? layers[0].count : 0;
     const lastCount = layers.length > 0 ? layers[layers.length - 1].count : 0;
+    const totalMs = data.total_latency_ms != null
+      ? ` in <span class="recall-diagram__summary-count">${parseFloat(data.total_latency_ms).toFixed(1)} ms</span>`
+      : "";
     html += `
       <div class="recall-diagram__summary">
         <span class="recall-diagram__summary-count">${firstCount}</span> candidates entered
         &rarr;
-        <span class="recall-diagram__summary-count">${lastCount}</span> results delivered
+        <span class="recall-diagram__summary-count">${lastCount}</span> results delivered${totalMs}
       </div>
     `;
 
@@ -135,6 +143,7 @@
               <div class="recall-layer__name">Layer ${i + 1} · ${esc(layer.name)}</div>
               <div class="recall-layer__desc">${esc(layer.description)}</div>
             </div>
+            ${layer.latency_ms != null ? `<div class="recall-layer__ms">${parseFloat(layer.latency_ms).toFixed(1)} ms</div>` : ""}
             <div class="recall-layer__count">${layer.count}</div>
           </div>
       `;
@@ -220,4 +229,75 @@
       executeRecall();
     }
   });
+
+  // Budget-vs-latency explorer
+  async function budgetExplore() {
+    const query = document.getElementById("recall-query").value.trim();
+    if (!query) return;
+    const ns = document.getElementById("recall-ns").value.trim() || "";
+    const btn = document.getElementById("budget-explore-btn");
+    const container = document.getElementById("budget-explore-area");
+    if (!container) return;
+
+    btn.disabled = true;
+    btn.textContent = "Running\u2026";
+    container.innerHTML = '<div class="recall-loading">Running 5 budget variants\u2026</div>';
+
+    try {
+      const params = new URLSearchParams({ q: query });
+      if (ns) params.set("namespace", ns);
+      const res = await fetch("/ui/recall/budget-explore.json?" + params);
+      const data = await res.json();
+      if (data.error) {
+        container.innerHTML = `<div class="recall-empty">${esc(data.error)}</div>`;
+        return;
+      }
+      renderBudgetChart(data, container);
+    } catch (e) {
+      container.innerHTML = `<div class="recall-empty">Error: ${esc(e.message)}</div>`;
+    } finally {
+      btn.disabled = false;
+      btn.textContent = "Budget Explorer";
+    }
+  }
+
+  function renderBudgetChart(data, container) {
+    const budgets = data.budgets || [];
+    if (!budgets.length) { container.innerHTML = ""; return; }
+
+    const maxMs = Math.max.apply(null, budgets.map(b => b.latency_ms)) || 1;
+    const maxCount = Math.max.apply(null, budgets.map(b => b.result_count)) || 1;
+
+    let html = '<div class="budget-chart">';
+    html += '<div class="budget-chart__title">Budget vs Latency &amp; Results</div>';
+    html += '<div class="budget-chart__bars">';
+
+    budgets.forEach((b) => {
+      const msPct = Math.min(100, (b.latency_ms / maxMs) * 100);
+      const countPct = Math.min(100, (b.result_count / maxCount) * 100);
+      const msColor = b.latency_ms < 10 ? "var(--verdigris)" : b.latency_ms < 50 ? "var(--brass)" : "var(--rust)";
+      html += `
+        <div class="budget-row">
+          <div class="budget-row__label">${b.budget.toLocaleString()}</div>
+          <div class="budget-row__bars">
+            <div class="budget-row__bar budget-row__bar--ms" style="width:${msPct}%;background:${msColor}">
+              <span>${b.latency_ms.toFixed(1)} ms</span>
+            </div>
+            <div class="budget-row__bar budget-row__bar--count" style="width:${countPct}%">
+              <span>${b.result_count} results</span>
+            </div>
+          </div>
+        </div>
+      `;
+    });
+
+    html += '</div></div>';
+    container.innerHTML = html;
+  }
+
+  // Wire up budget explore button if present
+  const budgetBtn = document.getElementById("budget-explore-btn");
+  if (budgetBtn) {
+    budgetBtn.addEventListener("click", budgetExplore);
+  }
 })();

--- a/agent_memory/ui/templates/base.html
+++ b/agent_memory/ui/templates/base.html
@@ -25,6 +25,7 @@
       <a class="tab" href="/ui/agents" {% if request.url.path.startswith("/ui/agents") %}aria-current="page"{% endif %}>05 · Agents</a>
       <a class="tab" href="/ui/health" {% if request.url.path.startswith("/ui/health") %}aria-current="page"{% endif %}>06 · Health</a>
       <a class="tab" href="/ui/config" {% if request.url.path.startswith("/ui/config") %}aria-current="page"{% endif %}>07 · Config</a>
+      <a class="tab" href="/ui/ops" {% if request.url.path.startswith("/ui/ops") %}aria-current="page"{% endif %}>08 · Ops</a>
     </nav>
 
     <div class="chrome__ident">

--- a/agent_memory/ui/templates/memories/ops.html
+++ b/agent_memory/ui/templates/memories/ops.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+{% block title %}Operations Log · Memwright{% endblock %}
+{% block content %}
+
+<section class="page-head">
+  <h1 class="page-head__title">Operations<br><em>Log.</em></h1>
+  <div class="page-head__meta">
+    <div>Flight Recorder</div>
+    <div>last 200 operations</div>
+    <div>auto-refresh · 5s</div>
+  </div>
+</section>
+
+<section class="ops-area" id="ops-area">
+  <div class="ops-loading">Loading operations log&hellip;</div>
+</section>
+
+<script src="/ui/static/ops.js"></script>
+
+{% endblock %}

--- a/agent_memory/ui/templates/memories/recall.html
+++ b/agent_memory/ui/templates/memories/recall.html
@@ -35,12 +35,18 @@
       </div>
     </form>
 
+    <div class="rail__section">
+      <button class="btn btn--secondary" type="button" id="budget-explore-btn">Budget Explorer</button>
+    </div>
+
     <div class="rail__section" id="recall-config"></div>
   </aside>
 
   <section class="recall-area" id="recall-area">
     <div class="recall-empty">Enter a query and execute to replay the 5-layer retrieval cascade.</div>
   </section>
+
+  <section class="budget-explore-area" id="budget-explore-area"></section>
 </section>
 
 <script src="/ui/static/recall.js"></script>


### PR DESCRIPTION
## Summary
- **Per-layer timing** in recall pipeline — each of 5 layers reports `latency_ms` alongside count, shown as badges in the pipeline diagram and per-layer detail cards
- **Operation ring buffer** (deque maxlen=200) tracks every add/recall/health call — new **08 · Ops** page with flight recorder table, sparkline, P50/P95/P99 stats, auto-refresh every 5s
- **Per-store timing in add()** — measures SQLite, ChromaDB, NetworkX independently; makes the ChromaDB model-reload bottleneck immediately visible
- **Health dashboard upgraded** — latency percentiles panel + sparkline from ops buffer; all 3 stores now report latency_ms (previously only document store)
- **Budget-vs-latency explorer** — runs same query at 5 budget levels (500–10,000), renders comparison bar chart on recall page
- 706 lines across 10 files, 23 routes total

## Test plan
- [ ] Run recall query on /ui/recall — verify ms badges appear on all 5 pipeline steps + total in summary
- [ ] Click "Budget Explorer" — verify 5-budget chart renders with latency + result count bars
- [ ] Visit /ui/ops — verify flight recorder table populates with health/recall/add entries
- [ ] Visit /ui/health — verify Operation Latency panel shows P50/P95/P99 + sparkline after several ops
- [ ] Check health.json — verify all 3 store checks include latency_ms
- [ ] Run `pytest tests/ -q` — verify 384 tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)