### PR TITLE
fix(ui): auto-load timeline, fix recording script

### DIFF
--- a/agent_memory/ui/static/timeline.js
+++ b/agent_memory/ui/static/timeline.js
@@ -238,4 +238,8 @@
       }
     });
   });
+
+  // Auto-load timeline with status=all on page ready
+  document.getElementById("tl-status").value = "all";
+  fetchTimeline();
 })();

--- a/agent_memory/ui/templates/memories/timeline.html
+++ b/agent_memory/ui/templates/memories/timeline.html
@@ -70,6 +70,6 @@
   </section>
 </section>
 
-<script src="/ui/static/timeline.js"></script>
+<script src="/ui/static/timeline.js?v=2"></script>
 
 {% endblock %}

--- a/docs/demo/record-demo.js
+++ b/docs/demo/record-demo.js
@@ -57,11 +57,16 @@ const { chromium } = require('playwright');
 
   // 07 — Timeline
   await page.goto(base + '/ui/timeline');
-  await page.waitForTimeout(2500);
+  await page.waitForTimeout(1000);
+  // Click Reconstruct to load timeline data (also auto-loads now)
+  const tlGo = page.locator('#tl-go');
+  if (await tlGo.count() > 0) await tlGo.click();
+  await page.waitForTimeout(3000);
 
   // 08 — Agents
   await page.goto(base + '/ui/agents');
-  await page.waitForTimeout(2500);
+  // Wait for agents data to auto-load
+  await page.waitForTimeout(3500);
 
   // 09 — Health
   await page.goto(base + '/ui/health');


### PR DESCRIPTION
## Summary
- Timeline page now auto-loads data on page ready instead of requiring manual "Reconstruct" click
- Recording script updated to interact with timeline (click Reconstruct) and agents (longer wait) pages
- Cache-busting query param added to timeline.js script tag

## Test plan
- [ ] Navigate to `/ui/timeline` — data loads automatically without clicking Reconstruct
- [ ] Reconstruct button still works for re-filtering
- [ ] Agents page loads data on page ready (unchanged, was already working)