### PR TITLE
feat(packaging): Slice 2 — extras-based packaging with actionable import errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,19 +66,21 @@ Choose one method. The package name is `memwright` on PyPI.
 
 ```bash
 # Option A: uv (recommended on macOS)
-uv tool install memwright
+uv tool install "memwright[mcp]"
 
 # Option B: pipx
-pipx install memwright
+pipx install "memwright[mcp]"
 
 # Option C: pip (in a venv or with --user)
-pip install memwright
+pip install "memwright[mcp]"
 
 # Option D: poetry (add to an existing project)
-poetry add memwright
+poetry add "memwright[mcp]"
 ```
 
 > **First run downloads ~90MB** for the local embedding model (all-MiniLM-L6-v2). This happens once and is cached.
+
+> The `[mcp]` extra adds the MCP server (most users want this). Add backend extras like `[arangodb]`, `[postgres]`, `[aws]`, `[azure]`, `[gcp]`, or `[docker]` as needed — e.g. `pipx install "memwright[mcp,arangodb]"`. Use `[all]` to pull everything.
 
 ### Step 2: Connect to Claude Code
 

--- a/agent_memory/mcp/server.py
+++ b/agent_memory/mcp/server.py
@@ -7,6 +7,9 @@ import sys
 from typing import Any
 
 from agent_memory.core import AgentMemory
+from agent_memory.store._extras import require_extra
+
+require_extra("mcp", extra="mcp")
 
 
 def _build_handlers(mem: AgentMemory) -> dict:

--- a/agent_memory/store/_extras.py
+++ b/agent_memory/store/_extras.py
@@ -1,0 +1,29 @@
+"""Helper for gating optional backend imports with actionable error messages."""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+
+def require_extra(module_name: str, *, extra: str, package: str = "memwright") -> Any:
+    """Import a module, raising an actionable ImportError if it's missing.
+
+    Args:
+        module_name: The module to import (e.g., "arango").
+        extra: The pyproject.toml extras name (e.g., "arangodb").
+        package: The distribution name. Defaults to "memwright".
+
+    Returns:
+        The imported module.
+
+    Raises:
+        ImportError: With a message telling the user exactly which extras to install.
+    """
+    try:
+        return importlib.import_module(module_name)
+    except ImportError as e:
+        raise ImportError(
+            f"Missing dependency for backend {extra!r}: {module_name}. "
+            f"Install with: pip install '{package}[{extra}]'"
+        ) from e

--- a/agent_memory/store/arango_backend.py
+++ b/agent_memory/store/arango_backend.py
@@ -7,7 +7,10 @@ import re
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set
 
-from arango import ArangoClient
+from agent_memory.store._extras import require_extra
+
+_arango = require_extra("arango", extra="arangodb")
+ArangoClient = _arango.ArangoClient
 
 from agent_memory.models import Memory
 from agent_memory.store.base import DocumentStore, VectorStore, GraphStore

--- a/agent_memory/store/aws_backend.py
+++ b/agent_memory/store/aws_backend.py
@@ -67,7 +67,8 @@ class AWSBackend(DocumentStore, VectorStore, GraphStore):
         self._parse_config(config)
 
         # Lazy imports — fail only when actually used
-        import boto3
+        from agent_memory.store._extras import require_extra
+        boto3 = require_extra("boto3", extra="aws")
 
         self._session = boto3.Session(region_name=self._region)
 

--- a/agent_memory/store/azure_backend.py
+++ b/agent_memory/store/azure_backend.py
@@ -69,7 +69,10 @@ class AzureBackend(DocumentStore, VectorStore, GraphStore):
         self._database_name = config.get("cosmos_database", "memwright")
 
         # Lazy import azure.cosmos
-        from azure.cosmos import CosmosClient, PartitionKey
+        from agent_memory.store._extras import require_extra
+        _azure_cosmos = require_extra("azure.cosmos", extra="azure")
+        CosmosClient = _azure_cosmos.CosmosClient
+        PartitionKey = _azure_cosmos.PartitionKey
 
         self._PartitionKey = PartitionKey
 

--- a/agent_memory/store/gcp_backend.py
+++ b/agent_memory/store/gcp_backend.py
@@ -72,7 +72,9 @@ class GCPBackend(PostgresBackend):
         self, config: Dict[str, Any], gcp_fields: Dict[str, str]
     ) -> None:
         """Connect via AlloyDB Connector with IAM auth (ADC)."""
-        from google.cloud.alloydb.connector import Connector
+        from agent_memory.store._extras import require_extra
+        _alloydb = require_extra("google.cloud.alloydb.connector", extra="gcp")
+        Connector = _alloydb.Connector
 
         self._config = config
         self._connector = Connector()

--- a/agent_memory/store/postgres_backend.py
+++ b/agent_memory/store/postgres_backend.py
@@ -7,8 +7,10 @@ import logging
 import re
 from typing import Any, Dict, List, Optional, Set
 
-import psycopg2
-import psycopg2.extras
+from agent_memory.store._extras import require_extra
+
+psycopg2 = require_extra("psycopg2", extra="postgres")
+require_extra("psycopg2.extras", extra="postgres")  # side-effect import
 
 from agent_memory.models import Memory
 from agent_memory.store.base import DocumentStore, VectorStore, GraphStore

--- a/poetry.lock
+++ b/poetry.lock
@@ -304,10 +304,10 @@ files = [
 name = "cffi"
 version = "2.0.0"
 description = "Foreign Function Interface for Python calling C code."
-optional = false
+optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "platform_python_implementation != \"PyPy\""
+markers = "platform_python_implementation != \"PyPy\" and (extra == \"gcp\" or extra == \"all\" or extra == \"mcp\" or extra == \"azure\")"
 files = [
     {file = "cffi-2.0.0-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:0cf2d91ecc3fcc0625c2c530fe004f82c110405f101548512cce44322fa8ac44"},
     {file = "cffi-2.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f73b96c41e3b2adedc34a7356e64c8eb96e03a3782b535e043a986276ce12a49"},
@@ -739,9 +739,10 @@ toml = ["tomli ; python_full_version <= \"3.11.0a6\""]
 name = "cryptography"
 version = "46.0.5"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
-optional = false
+optional = true
 python-versions = "!=3.9.0,!=3.9.1,>=3.8"
 groups = ["main"]
+markers = "extra == \"gcp\" or extra == \"all\" or extra == \"mcp\" or extra == \"azure\""
 files = [
     {file = "cryptography-46.0.5-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:351695ada9ea9618b3500b490ad54c739860883df6c1f555e088eaf25b1bbaad"},
     {file = "cryptography-46.0.5-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c18ff11e86df2e28854939acde2d003f7984f721eba450b56a200ad90eeb0e6b"},
@@ -920,6 +921,30 @@ files = [
     {file = "distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2"},
     {file = "distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed"},
 ]
+
+[[package]]
+name = "docker"
+version = "7.1.0"
+description = "A Python library for the Docker Engine API."
+optional = true
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "extra == \"docker\" or extra == \"all\""
+files = [
+    {file = "docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0"},
+    {file = "docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c"},
+]
+
+[package.dependencies]
+pywin32 = {version = ">=304", markers = "sys_platform == \"win32\""}
+requests = ">=2.26.0"
+urllib3 = ">=1.26.0"
+
+[package.extras]
+dev = ["coverage (==7.2.7)", "pytest (==7.4.2)", "pytest-cov (==4.1.0)", "pytest-timeout (==2.1.0)", "ruff (==0.1.8)"]
+docs = ["myst-parser (==0.18.0)", "sphinx (==5.1.1)"]
+ssh = ["paramiko (>=2.4.3)"]
+websockets = ["websocket-client (>=1.3.0)"]
 
 [[package]]
 name = "docstring-parser"
@@ -1674,9 +1699,10 @@ zstd = ["zstandard (>=0.18.0)"]
 name = "httpx-sse"
 version = "0.4.3"
 description = "Consume Server-Sent Event (SSE) messages with HTTPX."
-optional = false
+optional = true
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "extra == \"mcp\" or extra == \"all\""
 files = [
     {file = "httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc"},
     {file = "httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d"},
@@ -2164,9 +2190,10 @@ files = [
 name = "mcp"
 version = "1.26.0"
 description = "Model Context Protocol SDK"
-optional = false
+optional = true
 python-versions = ">=3.10"
 groups = ["main"]
+markers = "extra == \"mcp\" or extra == \"all\""
 files = [
     {file = "mcp-1.26.0-py3-none-any.whl", hash = "sha256:904a21c33c25aa98ddbeb47273033c435e595bbacfdb177f4bd87f6dceebe1ca"},
     {file = "mcp-1.26.0.tar.gz", hash = "sha256:db6e2ef491eecc1a0d93711a76f28dec2e05999f93afd48795da1c1137142c66"},
@@ -3785,10 +3812,10 @@ files = [
 name = "pycparser"
 version = "3.0"
 description = "C parser in Python"
-optional = false
+optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "platform_python_implementation != \"PyPy\" and implementation_name != \"PyPy\""
+markers = "platform_python_implementation != \"PyPy\" and implementation_name != \"PyPy\" and (extra == \"gcp\" or extra == \"all\" or extra == \"mcp\" or extra == \"azure\")"
 files = [
     {file = "pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992"},
     {file = "pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29"},
@@ -3993,9 +4020,10 @@ windows-terminal = ["colorama (>=0.4.6)"]
 name = "pyjwt"
 version = "2.12.1"
 description = "JSON Web Token implementation in Python"
-optional = false
+optional = true
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "extra == \"mcp\" or extra == \"all\" or extra == \"azure\" or extra == \"arangodb\""
 files = [
     {file = "pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c"},
     {file = "pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b"},
@@ -4139,9 +4167,10 @@ cli = ["click (>=5.0)"]
 name = "python-multipart"
 version = "0.0.22"
 description = "A streaming multipart parser for Python"
-optional = false
+optional = true
 python-versions = ">=3.10"
 groups = ["main"]
+markers = "extra == \"mcp\" or extra == \"all\""
 files = [
     {file = "python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155"},
     {file = "python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58"},
@@ -4151,10 +4180,10 @@ files = [
 name = "pywin32"
 version = "311"
 description = "Python for Window Extensions"
-optional = false
+optional = true
 python-versions = "*"
 groups = ["main"]
-markers = "sys_platform == \"win32\""
+markers = "(extra == \"mcp\" or extra == \"all\" or extra == \"docker\") and sys_platform == \"win32\""
 files = [
     {file = "pywin32-311-cp310-cp310-win32.whl", hash = "sha256:d03ff496d2a0cd4a5893504789d4a15399133fe82517455e78bad62efbb7f0a3"},
     {file = "pywin32-311-cp310-cp310-win_amd64.whl", hash = "sha256:797c2772017851984b97180b0bebe4b620bb86328e8a884bb626156295a63b3b"},
@@ -5049,9 +5078,10 @@ files = [
 name = "sse-starlette"
 version = "3.3.3"
 description = "SSE plugin for Starlette"
-optional = false
+optional = true
 python-versions = ">=3.10"
 groups = ["main"]
+markers = "extra == \"mcp\" or extra == \"all\""
 files = [
     {file = "sse_starlette-3.3.3-py3-none-any.whl", hash = "sha256:c5abb5082a1cc1c6294d89c5290c46b5f67808cfdb612b7ec27e8ba061c22e8d"},
     {file = "sse_starlette-3.3.3.tar.gz", hash = "sha256:72a95d7575fd5129bd0ae15275ac6432bb35ac542fdebb82889c24bb9f3f4049"},
@@ -5071,9 +5101,10 @@ uvicorn = ["uvicorn (>=0.34.0)"]
 name = "starlette"
 version = "1.0.0"
 description = "The little ASGI library that shines."
-optional = false
+optional = true
 python-versions = ">=3.10"
 groups = ["main"]
+markers = "extra == \"mcp\" or extra == \"all\" or extra == \"lambda\""
 files = [
     {file = "starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b"},
     {file = "starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149"},
@@ -5557,7 +5588,6 @@ description = "The lightning-fast ASGI server."
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "sys_platform != \"emscripten\" or python_version >= \"3.14\""
 files = [
     {file = "uvicorn-0.42.0-py3-none-any.whl", hash = "sha256:96c30f5c7abe6f74ae8900a70e92b85ad6613b745d4879eb9b16ccad15645359"},
     {file = "uvicorn-0.42.0.tar.gz", hash = "sha256:9b1f190ce15a2dd22e7758651d9b6d12df09a13d51ba5bf4fc33c383a48e1775"},
@@ -5874,17 +5904,19 @@ test = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more_it
 type = ["pytest-mypy"]
 
 [extras]
-all = ["azure-cosmos", "azure-identity", "azure-search-documents", "boto3", "google-cloud-aiplatform", "google-cloud-firestore", "openai", "psycopg2-binary", "python-arango"]
+all = ["azure-cosmos", "azure-identity", "azure-search-documents", "boto3", "docker", "google-cloud-aiplatform", "google-cloud-firestore", "mcp", "openai", "psycopg2-binary", "python-arango"]
 arangodb = ["python-arango"]
 aws = ["boto3"]
 azure = ["azure-cosmos", "azure-identity", "azure-search-documents"]
 cloud-embeddings = ["openai"]
+docker = ["docker"]
 extraction = ["openai"]
 gcp = ["google-cloud-aiplatform", "google-cloud-firestore"]
 lambda = ["mangum", "starlette"]
+mcp = ["mcp"]
 postgres = ["psycopg2-binary"]
 
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "7fa9179c9794c637f2eebbca2b7c767d20d2f51d7c0fe1cc8fda18412875baad"
+content-hash = "837874b3a3596da23b47251fc09162d89a7f8fef4a021f4e1fffbed6980d1e91"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ dependencies = [
     "chromadb>=0.4.0",
     "networkx>=3.0",
     "sentence-transformers>=2.0.0",
-    "mcp>=1.0.0",
 ]
 
 [project.urls]
@@ -33,6 +32,8 @@ Repository = "https://github.com/bolnet/agent-memory"
 Issues = "https://github.com/bolnet/agent-memory/issues"
 
 [project.optional-dependencies]
+mcp = ["mcp>=1.0.0"]
+docker = ["docker>=7.0"]
 extraction = ["openai>=1.0.0"]
 arangodb = ["python-arango>=8.0.0"]
 postgres = ["psycopg2-binary>=2.9.0"]
@@ -42,6 +43,8 @@ gcp = ["google-cloud-firestore>=2.11.0", "google-cloud-aiplatform>=1.38.0"]
 cloud-embeddings = ["openai>=1.0.0"]
 lambda = ["mangum>=0.17.0", "starlette>=0.27.0"]
 all = [
+    "mcp>=1.0.0",
+    "docker>=7.0",
     "openai>=1.0.0",
     "python-arango>=8.0.0",
     "psycopg2-binary>=2.9.0",

--- a/tests/test_extras.py
+++ b/tests/test_extras.py
@@ -1,0 +1,26 @@
+"""Tests for the require_extra helper."""
+
+import pytest
+
+from agent_memory.store._extras import require_extra
+
+
+def test_require_extra_passes_when_present():
+    """Test that require_extra successfully imports an available module."""
+    # Import json which is always available in the stdlib
+    module = require_extra("json", extra="test", package="memwright")
+    assert module is not None
+
+
+def test_require_extra_raises_helpful_error():
+    """Test that require_extra raises an ImportError with actionable message."""
+    with pytest.raises(ImportError) as exc_info:
+        require_extra(
+            "definitely_not_a_module_xyz",
+            extra="arangodb",
+            package="memwright"
+        )
+
+    error_message = str(exc_info.value)
+    assert "memwright[arangodb]" in error_message
+    assert "pip install" in error_message

--- a/tests/test_registry_gating.py
+++ b/tests/test_registry_gating.py
@@ -1,0 +1,34 @@
+import builtins
+import sys
+import pytest
+from unittest.mock import patch
+
+
+def _patch_missing(names_to_fail):
+    real_import = builtins.__import__
+    def fake_import(name, *args, **kwargs):
+        if name in names_to_fail or any(name.startswith(n + ".") for n in names_to_fail):
+            raise ImportError(f"No module named {name!r}")
+        return real_import(name, *args, **kwargs)
+    return fake_import
+
+
+def test_arango_missing_raises_actionable_error():
+    """When python-arango is missing, re-import surfaces memwright[arangodb] hint."""
+    sys.modules.pop("agent_memory.store.arango_backend", None)
+    sys.modules.pop("arango", None)
+    with patch("builtins.__import__", _patch_missing({"arango"})):
+        with pytest.raises(ImportError) as exc_info:
+            import agent_memory.store.arango_backend  # noqa: F401
+    assert "memwright[arangodb]" in str(exc_info.value)
+
+
+def test_postgres_missing_raises_actionable_error():
+    """When psycopg2 is missing, re-import surfaces memwright[postgres] hint."""
+    sys.modules.pop("agent_memory.store.postgres_backend", None)
+    sys.modules.pop("psycopg2", None)
+    sys.modules.pop("psycopg2.extras", None)
+    with patch("builtins.__import__", _patch_missing({"psycopg2"})):
+        with pytest.raises(ImportError) as exc_info:
+            import agent_memory.store.postgres_backend  # noqa: F401
+    assert "memwright[postgres]" in str(exc_info.value)


### PR DESCRIPTION
## Summary

Second slice of the FAANG overhaul. Users who try a backend without its extra now get `pip install 'memwright[arangodb]'` instead of `ImportError: No module named 'arango'`. MCP and Docker are now optional extras — core install is lean.

- **`require_extra` helper** (`agent_memory/store/_extras.py`) — wraps `importlib.import_module` and converts `ImportError` into an actionable message naming the pip install command.
- **Gated cloud backends** — `arango_backend.py` and `postgres_backend.py` use top-level gating; `aws_backend.py`, `azure_backend.py`, and `gcp_backend.py` wrap their existing lazy imports so `memwright --help` never crashes for users without cloud extras.
- **`[mcp]` and `[docker]` extras** — moved `mcp` out of required dependencies; added `[docker]` for optional Docker auto-start (stub for Slice 6).
- **MCP server gate** — `require_extra('mcp', extra='mcp')` at top of `agent_memory/mcp/server.py`, so running `memwright mcp` without the extra produces a clean hint.

## Test plan
- [x] `poetry run pytest tests/test_extras.py tests/test_registry_gating.py -v` → **4 passed**
- [x] MCP server still imports when `mcp` is installed
- [x] Full test suite: 374 passed (no regressions; 14 pre-existing failures unrelated to this work)
- [x] README install examples updated to `pipx install 'memwright[mcp]'`

## Depends on
Slice 1 (PR #33) can merge independently. This branch was cut from main, not from Slice 1.