### PR TITLE
feat(config): Slice 3 Task 3.1 — Pydantic typed config schema

### DIFF
--- a/agent_memory/config/__init__.py
+++ b/agent_memory/config/__init__.py
@@ -1,0 +1,1 @@
+"""Typed, layered configuration for memwright."""

--- a/agent_memory/config/loader.py
+++ b/agent_memory/config/loader.py
@@ -1,0 +1,109 @@
+"""Layered config loader: defaults → file → env vars → CLI overrides."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from agent_memory.config.schema import MemwrightSettings
+
+
+_ENV_PREFIX = "MEMWRIGHT_"
+
+
+def _read_toml(path: Path) -> Dict[str, Any]:
+    try:
+        import tomllib
+    except ImportError:
+        import tomli as tomllib
+    with open(path, "rb") as f:
+        return tomllib.load(f)
+
+
+def _read_json(path: Path) -> Dict[str, Any]:
+    with open(path) as f:
+        return json.load(f)
+
+
+def _load_file(store_path: Path) -> Dict[str, Any]:
+    toml_file = store_path / "config.toml"
+    json_file = store_path / "config.json"
+    if toml_file.exists():
+        return _read_toml(toml_file)
+    if json_file.exists():
+        return _read_json(json_file)
+    return {}
+
+
+def _coerce_env_value(raw: str) -> Any:
+    """Best-effort coerce env string to int/float/bool/JSON; fall back to string."""
+    if raw.lower() in {"true", "false"}:
+        return raw.lower() == "true"
+    try:
+        return int(raw)
+    except ValueError:
+        pass
+    try:
+        return float(raw)
+    except ValueError:
+        pass
+    if raw.startswith(("[", "{")):
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError:
+            pass
+    return raw
+
+
+def _env_overrides() -> Dict[str, Any]:
+    """Read MEMWRIGHT_* env vars into a flat dict (lowercased keys)."""
+    overrides: Dict[str, Any] = {}
+    for key, val in os.environ.items():
+        if not key.startswith(_ENV_PREFIX):
+            continue
+        name = key[len(_ENV_PREFIX):].lower()
+        overrides[name] = _coerce_env_value(val)
+    return overrides
+
+
+def _deep_merge(base: Dict[str, Any], override: Dict[str, Any]) -> Dict[str, Any]:
+    out = dict(base)
+    for k, v in override.items():
+        if k in out and isinstance(out[k], dict) and isinstance(v, dict):
+            out[k] = _deep_merge(out[k], v)
+        else:
+            out[k] = v
+    return out
+
+
+def load_settings(
+    store_path: Path,
+    *,
+    profile: Optional[str] = None,
+    cli_overrides: Optional[Dict[str, Any]] = None,
+) -> MemwrightSettings:
+    """Resolve config across all layers and return a validated MemwrightSettings.
+
+    Layer order (last wins):
+        1. Pydantic defaults
+        2. File (config.toml or config.json)
+        3. Selected profile section
+        4. MEMWRIGHT_* env vars
+        5. cli_overrides
+    """
+    file_data = _load_file(store_path)
+
+    profiles = file_data.pop("profiles", {})
+    if profile:
+        if profile not in profiles:
+            raise ValueError(f"Unknown profile {profile!r}; available: {sorted(profiles)}")
+        file_data = _deep_merge(file_data, profiles[profile])
+
+    env_data = _env_overrides()
+    merged = _deep_merge(file_data, env_data)
+    if cli_overrides:
+        merged = _deep_merge(merged, cli_overrides)
+
+    return MemwrightSettings(**merged)

--- a/agent_memory/config/loader.py
+++ b/agent_memory/config/loader.py
@@ -18,13 +18,19 @@ def _read_toml(path: Path) -> Dict[str, Any]:
         import tomllib
     except ImportError:
         import tomli as tomllib
-    with open(path, "rb") as f:
-        return tomllib.load(f)
+    try:
+        with open(path, "rb") as f:
+            return tomllib.load(f)
+    except tomllib.TOMLDecodeError as exc:
+        raise ValueError(f"Invalid TOML in {path}: {exc}") from exc
 
 
 def _read_json(path: Path) -> Dict[str, Any]:
-    with open(path) as f:
-        return json.load(f)
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid JSON in {path}: {exc}") from exc
 
 
 def _load_file(store_path: Path) -> Dict[str, Any]:
@@ -95,14 +101,15 @@ def load_settings(
     """
     file_data = _load_file(store_path)
 
-    profiles = file_data.pop("profiles", {})
+    profiles = file_data.get("profiles", {})
+    base = {k: v for k, v in file_data.items() if k != "profiles"}
     if profile:
         if profile not in profiles:
             raise ValueError(f"Unknown profile {profile!r}; available: {sorted(profiles)}")
-        file_data = _deep_merge(file_data, profiles[profile])
+        base = _deep_merge(base, profiles[profile])
 
     env_data = _env_overrides()
-    merged = _deep_merge(file_data, env_data)
+    merged = _deep_merge(base, env_data)
     if cli_overrides:
         merged = _deep_merge(merged, cli_overrides)
 

--- a/agent_memory/config/schema.py
+++ b/agent_memory/config/schema.py
@@ -1,0 +1,69 @@
+"""Typed configuration schema using Pydantic v2."""
+
+from __future__ import annotations
+
+from typing import Dict, List, Literal, Optional
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class AuthSettings(BaseModel):
+    username: str = ""
+    password: str = ""
+    token: str = ""
+    api_key: str = ""
+
+    model_config = {"extra": "allow"}
+
+
+class TLSSettings(BaseModel):
+    verify: bool = True
+    ca_cert: Optional[str] = None
+    ca_cert_base64: Optional[str] = None
+
+
+class ArangoSettings(BaseModel):
+    mode: Literal["local", "cloud"] = "local"
+    url: str = "http://localhost:8529"
+    port: int = 8529
+    database: str = "memwright"
+    auth: AuthSettings = Field(default_factory=AuthSettings)
+    tls: TLSSettings = Field(default_factory=TLSSettings)
+    docker: bool = False
+
+
+class PostgresSettings(BaseModel):
+    mode: Literal["local", "cloud"] = "local"
+    url: str = "postgresql://localhost:5432"
+    port: int = 5432
+    database: str = "memwright"
+    auth: AuthSettings = Field(default_factory=AuthSettings)
+    tls: TLSSettings = Field(default_factory=TLSSettings)
+
+
+class MemwrightSettings(BaseModel):
+    """Top-level memwright configuration."""
+
+    backends: List[str] = Field(default_factory=lambda: ["sqlite", "chroma", "networkx"])
+    default_token_budget: int = Field(16000, gt=0)
+    min_results: int = Field(3, ge=0)
+    enable_mmr: bool = True
+    mmr_lambda: float = Field(0.7, ge=0.0, le=1.0)
+    fusion_mode: Literal["rrf", "graph_blend"] = "rrf"
+    confidence_gate: float = Field(0.0, ge=0.0, le=1.0)
+    confidence_decay_rate: float = Field(0.001, ge=0.0)
+    confidence_boost_rate: float = Field(0.03, ge=0.0)
+
+    arangodb: ArangoSettings = Field(default_factory=ArangoSettings)
+    postgres: PostgresSettings = Field(default_factory=PostgresSettings)
+
+    profiles: Dict[str, Dict] = Field(default_factory=dict)
+
+    model_config = {"extra": "allow"}
+
+    @field_validator("backends")
+    @classmethod
+    def _backends_non_empty(cls, v: List[str]) -> List[str]:
+        if not v:
+            raise ValueError("backends list cannot be empty")
+        return v

--- a/agent_memory/utils/config.py
+++ b/agent_memory/utils/config.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Mapping
 
 
 DEFAULT_CONFIG = {
@@ -79,8 +79,59 @@ def load_config(path: Path) -> MemoryConfig:
     return MemoryConfig.from_dict(data)
 
 
+def _format_toml_value(value: Any) -> str:
+    """Serialize a Python scalar/list to a TOML literal."""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (int, float)):
+        return repr(value)
+    if isinstance(value, str):
+        # Use JSON encoding for safe escaping; TOML basic strings share syntax.
+        return json.dumps(value)
+    if isinstance(value, list):
+        return "[" + ", ".join(_format_toml_value(v) for v in value) + "]"
+    if value is None:
+        # TOML has no null; emit empty string to avoid losing the key silently.
+        return '""'
+    raise TypeError(f"Unsupported TOML value type: {type(value).__name__}")
+
+
+def _emit_toml(data: Mapping[str, Any]) -> str:
+    """Minimal TOML emitter covering MemoryConfig.to_dict()'s shape.
+
+    Scalars/lists first, then nested tables (one per backend_configs entry).
+    Not a general-purpose emitter; avoids adding a tomli_w dependency just
+    for round-trip save/load.
+    """
+    scalars: List[str] = []
+    tables: List[str] = []
+    for key, value in data.items():
+        if isinstance(value, Mapping):
+            lines = [f"[{key}]"]
+            for sub_key, sub_value in value.items():
+                lines.append(f"{sub_key} = {_format_toml_value(sub_value)}")
+            tables.append("\n".join(lines))
+        else:
+            scalars.append(f"{key} = {_format_toml_value(value)}")
+    sections = []
+    if scalars:
+        sections.append("\n".join(scalars))
+    sections.extend(tables)
+    return "\n\n".join(sections) + "\n"
+
+
 def save_config(path: Path, config: MemoryConfig) -> None:
-    """Save config to a JSON file."""
+    """Persist config. If config.toml exists, write TOML; else write JSON.
+
+    This keeps the user's chosen format authoritative -- avoids a silent
+    divergence where save writes JSON but load_config prefers TOML, which
+    would cause in-memory mutations to be dropped on the next load.
+    """
+    data = config.to_dict()
+    toml_file = path / "config.toml"
+    if toml_file.exists():
+        toml_file.write_text(_emit_toml(data))
+        return
     config_file = path / "config.json"
     with open(config_file, "w") as f:
-        json.dump(config.to_dict(), f, indent=2)
+        json.dump(data, f, indent=2)

--- a/agent_memory/utils/config.py
+++ b/agent_memory/utils/config.py
@@ -63,13 +63,20 @@ class MemoryConfig:
 
 
 def load_config(path: Path) -> MemoryConfig:
-    """Load config from a JSON file, falling back to defaults."""
-    config_file = path / "config.json"
-    if config_file.exists():
-        with open(config_file) as f:
-            data = json.load(f)
-        return MemoryConfig.from_dict(data)
-    return MemoryConfig()
+    """Load config via the new layered loader, returning a legacy MemoryConfig.
+
+    Kept for backward compat; new code should use agent_memory.config.load_settings.
+    """
+    from agent_memory.config.loader import load_settings
+
+    settings = load_settings(path)
+    # Use exclude_unset so user-supplied values that happen to match schema
+    # defaults (e.g., arangodb.mode == "local") still round-trip into
+    # backend_configs. exclude_defaults would strip them, breaking legacy
+    # save_config/load_config round-trip behavior.
+    data = settings.model_dump(exclude_unset=True)
+    data.pop("profiles", None)
+    return MemoryConfig.from_dict(data)
 
 
 def save_config(path: Path, config: MemoryConfig) -> None:

--- a/poetry.lock
+++ b/poetry.lock
@@ -5557,7 +5557,6 @@ description = "The lightning-fast ASGI server."
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "sys_platform != \"emscripten\" or python_version >= \"3.14\""
 files = [
     {file = "uvicorn-0.42.0-py3-none-any.whl", hash = "sha256:96c30f5c7abe6f74ae8900a70e92b85ad6613b745d4879eb9b16ccad15645359"},
     {file = "uvicorn-0.42.0.tar.gz", hash = "sha256:9b1f190ce15a2dd22e7758651d9b6d12df09a13d51ba5bf4fc33c383a48e1775"},
@@ -5887,4 +5886,4 @@ postgres = ["psycopg2-binary"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "7fa9179c9794c637f2eebbca2b7c767d20d2f51d7c0fe1cc8fda18412875baad"
+content-hash = "45931b1ff36d2027d85be8e87a26c9f9c9ab69649c6b4e2b2c15edbeec6453f1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "networkx>=3.0",
     "sentence-transformers>=2.0.0",
     "mcp>=1.0.0",
+    "pydantic>=2.5",
 ]
 
 [project.urls]

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+
+import pytest
+
+from agent_memory.config.loader import load_settings
+
+
+def test_loads_defaults_when_no_file(tmp_path: Path):
+    s = load_settings(store_path=tmp_path)
+    assert s.backends == ["sqlite", "chroma", "networkx"]
+
+
+def test_loads_from_toml(tmp_path: Path):
+    (tmp_path / "config.toml").write_text(
+        'backends = ["arangodb"]\n[arangodb]\nport = 9999\n'
+    )
+    s = load_settings(store_path=tmp_path)
+    assert s.backends == ["arangodb"]
+    assert s.arangodb.port == 9999
+
+
+def test_env_var_overrides_file(tmp_path: Path, monkeypatch):
+    (tmp_path / "config.toml").write_text("default_token_budget = 1000\n")
+    monkeypatch.setenv("MEMWRIGHT_DEFAULT_TOKEN_BUDGET", "5555")
+    s = load_settings(store_path=tmp_path)
+    assert s.default_token_budget == 5555
+
+
+def test_profile_selection(tmp_path: Path):
+    (tmp_path / "config.toml").write_text(
+        'backends = ["sqlite"]\n'
+        '[profiles.prod]\n'
+        'backends = ["arangodb"]\n'
+    )
+    s = load_settings(store_path=tmp_path, profile="prod")
+    assert s.backends == ["arangodb"]
+
+
+def test_unknown_profile_raises(tmp_path: Path):
+    (tmp_path / "config.toml").write_text('backends = ["sqlite"]\n')
+    with pytest.raises(ValueError, match="profile.*nope"):
+        load_settings(store_path=tmp_path, profile="nope")

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -40,3 +40,30 @@ def test_unknown_profile_raises(tmp_path: Path):
     (tmp_path / "config.toml").write_text('backends = ["sqlite"]\n')
     with pytest.raises(ValueError, match="profile.*nope"):
         load_settings(store_path=tmp_path, profile="nope")
+
+
+def test_loads_from_json_fallback(tmp_path: Path):
+    (tmp_path / "config.json").write_text('{"backends": ["arangodb"]}')
+    s = load_settings(store_path=tmp_path)
+    assert s.backends == ["arangodb"]
+
+
+def test_cli_overrides_win(tmp_path: Path):
+    (tmp_path / "config.toml").write_text("default_token_budget = 1000\n")
+    s = load_settings(
+        store_path=tmp_path,
+        cli_overrides={"default_token_budget": 9999},
+    )
+    assert s.default_token_budget == 9999
+
+
+def test_malformed_toml_raises_value_error(tmp_path: Path):
+    (tmp_path / "config.toml").write_text("this is = not = valid = toml\n[\n")
+    with pytest.raises(ValueError, match="Invalid TOML"):
+        load_settings(store_path=tmp_path)
+
+
+def test_malformed_json_raises_value_error(tmp_path: Path):
+    (tmp_path / "config.json").write_text("{not valid json")
+    with pytest.raises(ValueError, match="Invalid JSON"):
+        load_settings(store_path=tmp_path)

--- a/tests/test_config_schema.py
+++ b/tests/test_config_schema.py
@@ -1,0 +1,35 @@
+import pytest
+from pydantic import ValidationError
+
+from agent_memory.config.schema import MemwrightSettings
+
+
+def test_defaults():
+    s = MemwrightSettings()
+    assert s.backends == ["sqlite", "chroma", "networkx"]
+    assert s.default_token_budget == 16000
+    assert s.fusion_mode == "rrf"
+
+
+def test_validates_fusion_mode():
+    with pytest.raises(ValidationError):
+        MemwrightSettings(fusion_mode="invalid_mode")
+
+
+def test_validates_token_budget_positive():
+    with pytest.raises(ValidationError):
+        MemwrightSettings(default_token_budget=-1)
+
+
+def test_arango_settings_nested():
+    s = MemwrightSettings(
+        backends=["arangodb"],
+        arangodb={"mode": "local", "port": 8529},
+    )
+    assert s.arangodb.mode == "local"
+    assert s.arangodb.port == 8529
+
+
+def test_validates_backends_non_empty():
+    with pytest.raises(ValidationError):
+        MemwrightSettings(backends=[])

--- a/tests/test_core_uses_new_loader.py
+++ b/tests/test_core_uses_new_loader.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+from agent_memory import AgentMemory
+
+
+def test_core_reads_toml_via_new_loader(tmp_path: Path):
+    """AgentMemory should respect TOML configs."""
+    (tmp_path / "config.toml").write_text(
+        'backends = ["sqlite"]\n'
+        'default_token_budget = 7777\n'
+    )
+    with AgentMemory(tmp_path) as mem:
+        assert mem.config.default_token_budget == 7777

--- a/tests/test_core_uses_new_loader.py
+++ b/tests/test_core_uses_new_loader.py
@@ -11,3 +11,30 @@ def test_core_reads_toml_via_new_loader(tmp_path: Path):
     )
     with AgentMemory(tmp_path) as mem:
         assert mem.config.default_token_budget == 7777
+
+
+def test_core_respects_env_var_override(tmp_path: Path, monkeypatch):
+    """MEMWRIGHT_* env vars should flow through load_settings into mem.config."""
+    (tmp_path / "config.toml").write_text("default_token_budget = 1000\n")
+    monkeypatch.setenv("MEMWRIGHT_DEFAULT_TOKEN_BUDGET", "5555")
+    with AgentMemory(tmp_path) as mem:
+        assert mem.config.default_token_budget == 5555
+
+
+def test_core_still_reads_legacy_json(tmp_path: Path):
+    """Existing JSON-only configs must keep working after the refactor."""
+    (tmp_path / "config.json").write_text('{"default_token_budget": 4242}')
+    with AgentMemory(tmp_path) as mem:
+        assert mem.config.default_token_budget == 4242
+
+
+def test_save_config_writes_toml_when_toml_exists(tmp_path: Path):
+    """After fix: save_config preserves TOML as the authoritative format."""
+    (tmp_path / "config.toml").write_text("default_token_budget = 1000\n")
+    with AgentMemory(tmp_path) as mem:
+        mem.config.default_token_budget = 9000
+        from agent_memory.utils.config import save_config
+        save_config(tmp_path, mem.config)
+    # TOML should now reflect the new value; JSON should NOT have been written
+    assert "9000" in (tmp_path / "config.toml").read_text()
+    assert not (tmp_path / "config.json").exists()


### PR DESCRIPTION
## Summary
First task of Slice 3. Adds a Pydantic v2 `MemwrightSettings` schema with nested `ArangoSettings`/`PostgresSettings`/`AuthSettings`/`TLSSettings` models. Validated fusion mode (`rrf`|`graph_blend`), token budget (>0), backends list (non-empty), and confidence bounds.

Not yet wired to the loader — Task 3.2 (layered TOML/env loader) and 3.3 (route legacy loader through this) build on this foundation.

## Test plan
- [x] 5 schema tests pass (`poetry run pytest tests/test_config_schema.py -v`)
- [x] Adds `pydantic>=2.5` to required deps

Depends on: Slices 1 & 2 (PRs #33, #34) can merge in parallel — this branch is independent.