### PR TITLE
feat(registry): Slice 4 — entry-point plugin registry for backends

### DIFF
--- a/agent_memory/store/registry.py
+++ b/agent_memory/store/registry.py
@@ -73,9 +73,7 @@ BACKEND_REGISTRY: Dict[str, Dict[str, Any]] = {
 DEFAULT_BACKENDS = ["sqlite", "chroma", "networkx"]
 
 
-# Module-level constants referencing built-in registry entries.
-# These are the targets of the entry-point declarations in pyproject.toml —
-# they share the same underlying dict objects with BACKEND_REGISTRY (aliasing is intentional).
+# Entry-point targets. Aliases to the static registry — do NOT mutate.
 _BUILTIN_SQLITE = BACKEND_REGISTRY["sqlite"]
 _BUILTIN_CHROMA = BACKEND_REGISTRY["chroma"]
 _BUILTIN_NETWORKX = BACKEND_REGISTRY["networkx"]
@@ -84,6 +82,9 @@ _BUILTIN_POSTGRES = BACKEND_REGISTRY["postgres"]
 _BUILTIN_AWS = BACKEND_REGISTRY["aws"]
 _BUILTIN_AZURE = BACKEND_REGISTRY["azure"]
 _BUILTIN_GCP = BACKEND_REGISTRY["gcp"]
+
+
+_backends_discovered: bool = False
 
 
 def discover_backends() -> None:
@@ -96,9 +97,16 @@ def discover_backends() -> None:
     Static registry entries take precedence: if an entry point's name is already
     present in BACKEND_REGISTRY, the loader skips it. Failures to load a plugin
     are logged as warnings and do not prevent other plugins from loading.
+
+    Discovery is guarded by a module-level flag so subsequent calls are a no-op,
+    avoiding repeated warnings for failing plugins.
     """
+    global _backends_discovered
+    if _backends_discovered:
+        return
     from importlib.metadata import entry_points
 
+    required = {"module", "class", "roles", "init_style"}
     for ep in entry_points(group="memwright.backends"):
         if ep.name in BACKEND_REGISTRY:
             continue
@@ -107,7 +115,15 @@ def discover_backends() -> None:
         except Exception as e:
             logger.warning("Failed to load backend plugin %r: %s", ep.name, e)
             continue
+        if not isinstance(entry, dict) or not required.issubset(entry):
+            logger.warning(
+                "Backend plugin %r has invalid shape (expected keys %s), skipping",
+                ep.name,
+                required,
+            )
+            continue
         BACKEND_REGISTRY[ep.name] = entry
+    _backends_discovered = True
 
 
 def resolve_backends(

--- a/agent_memory/store/registry.py
+++ b/agent_memory/store/registry.py
@@ -73,6 +73,43 @@ BACKEND_REGISTRY: Dict[str, Dict[str, Any]] = {
 DEFAULT_BACKENDS = ["sqlite", "chroma", "networkx"]
 
 
+# Module-level constants referencing built-in registry entries.
+# These are the targets of the entry-point declarations in pyproject.toml —
+# they share the same underlying dict objects with BACKEND_REGISTRY (aliasing is intentional).
+_BUILTIN_SQLITE = BACKEND_REGISTRY["sqlite"]
+_BUILTIN_CHROMA = BACKEND_REGISTRY["chroma"]
+_BUILTIN_NETWORKX = BACKEND_REGISTRY["networkx"]
+_BUILTIN_ARANGO = BACKEND_REGISTRY["arangodb"]
+_BUILTIN_POSTGRES = BACKEND_REGISTRY["postgres"]
+_BUILTIN_AWS = BACKEND_REGISTRY["aws"]
+_BUILTIN_AZURE = BACKEND_REGISTRY["azure"]
+_BUILTIN_GCP = BACKEND_REGISTRY["gcp"]
+
+
+def discover_backends() -> None:
+    """Populate BACKEND_REGISTRY from importlib.metadata entry points.
+
+    Entry-point group: 'memwright.backends'
+    Each entry point should resolve to a dict with the same shape as the static registry entries:
+        { "module": "...", "class": "...", "roles": {...}, "init_style": "..." }
+
+    Static registry entries take precedence: if an entry point's name is already
+    present in BACKEND_REGISTRY, the loader skips it. Failures to load a plugin
+    are logged as warnings and do not prevent other plugins from loading.
+    """
+    from importlib.metadata import entry_points
+
+    for ep in entry_points(group="memwright.backends"):
+        if ep.name in BACKEND_REGISTRY:
+            continue
+        try:
+            entry = ep.load()
+        except Exception as e:
+            logger.warning("Failed to load backend plugin %r: %s", ep.name, e)
+            continue
+        BACKEND_REGISTRY[ep.name] = entry
+
+
 def resolve_backends(
     backends: Optional[List[str]] = None,
 ) -> Dict[str, str]:
@@ -88,6 +125,8 @@ def resolve_backends(
         BackendConflictError: If two backends claim the same role.
         ValueError: If a backend name is not in the registry.
     """
+    discover_backends()
+
     if backends is None:
         backends = DEFAULT_BACKENDS
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,0 +1,113 @@
+# Writing a memwright Backend Plugin
+
+Third parties can ship a backend (e.g., `memwright-redis`) as a separate PyPI package and have it auto-register when installed alongside memwright. Memwright discovers plugins via Python's `importlib.metadata` entry-point mechanism; no monkey-patching, no manual registration, no imports from user code.
+
+## Minimal plugin layout
+
+```
+memwright_redis/
+  pyproject.toml
+  src/memwright_redis/
+    __init__.py
+    backend.py
+```
+
+## `pyproject.toml`
+
+Declare your package and register it under the `memwright.backends` entry-point group. The right-hand side is a `module:attribute` path to the registry entry (a dict — see below).
+
+```toml
+[project]
+name = "memwright-redis"
+version = "0.1.0"
+dependencies = ["memwright>=2.1", "redis>=5.0"]
+
+[project.entry-points."memwright.backends"]
+redis = "memwright_redis:REGISTRY_ENTRY"
+```
+
+The entry-point key (`redis` above) is the name users will put in `config.toml` under `backends = [...]`.
+
+## `__init__.py`
+
+Expose a dict with the four required keys: `module`, `class`, `roles`, and `init_style`. Memwright validates this shape at discovery time and skips malformed entries with a warning (the whole registry does NOT crash).
+
+```python
+REGISTRY_ENTRY = {
+    "module": "memwright_redis.backend",
+    "class": "RedisBackend",
+    "roles": {"document"},
+    "init_style": "config",
+}
+```
+
+### Entry fields
+
+| Key          | Type         | Meaning                                                                         |
+| ------------ | ------------ | ------------------------------------------------------------------------------- |
+| `module`     | `str`        | Importable Python path to the module containing your backend class.             |
+| `class`      | `str`        | Class name inside that module. Must implement the store protocol(s) below.      |
+| `roles`      | `set[str]`   | Which roles this backend can fill. One or more of: `"document"`, `"vector"`, `"graph"`. |
+| `init_style` | `str`        | `"path"` (backend is constructed with a filesystem path) or `"config"` (backend receives a config dict). |
+
+### Name-collision rules
+
+Built-in backend names (`sqlite`, `chroma`, `networkx`, `arangodb`, `postgres`, `aws`, `azure`, `gcp`) are protected — a third-party entry point using any of these names is ignored. Pick a unique name for your backend.
+
+## `backend.py`
+
+Implement at least one of the store protocols defined in `agent_memory.store.base` (or `agent_memory.graph.*` for graph backends). For example, a document store backend must implement `DocumentStore`. Multi-role backends (like ArangoDB, which serves `document + vector + graph`) implement each protocol.
+
+Constructor signature depends on `init_style`:
+
+```python
+# init_style = "path"
+class MyBackend:
+    def __init__(self, path: pathlib.Path) -> None:
+        ...
+
+# init_style = "config"
+class MyBackend:
+    def __init__(self, config: dict) -> None:
+        ...
+```
+
+## Selecting your backend
+
+Users add it to their `config.toml`:
+
+```toml
+backends = ["redis", "chroma", "networkx"]
+
+[redis]
+url = "redis://localhost:6379"
+database = 0
+```
+
+When `AgentMemory(path)` is constructed, memwright calls `discover_backends()`, which reads all `memwright.backends` entry points exactly once (idempotent on subsequent calls), validates each, merges the valid ones into the in-process registry, and resolves the user's requested backends against it.
+
+## Error-handling contract
+
+- If your plugin's `ep.load()` raises any `Exception`, memwright logs a warning (via the `agent_memory` logger) and continues without your backend registered. The user's `AgentMemory` init will then fail when resolving the unknown backend name — so any load-time exception surfaces to the user as a clear configuration error rather than as a stack trace from deep inside the plugin.
+- If your registry entry is malformed (not a dict, or missing one of the four required keys), memwright logs a warning with `"invalid shape"` and skips the entry.
+- Your plugin must not mutate `agent_memory.store.registry.BACKEND_REGISTRY` directly. Declare everything via the entry point.
+
+## Testing your plugin
+
+```python
+import importlib.metadata
+import agent_memory.store.registry as registry
+
+registry._backends_discovered = False  # force re-scan
+registry.discover_backends()
+assert "redis" in registry.BACKEND_REGISTRY
+```
+
+If your backend does not appear after `discover_backends()`, check:
+1. Did you `pip install -e .` (or `pip install memwright-redis`) so entry-point metadata is registered?
+2. Does `python -c "from importlib.metadata import entry_points; print(list(entry_points(group='memwright.backends')))"` list your entry?
+3. Is your `REGISTRY_ENTRY` a dict with exactly the four required keys?
+
+## Reference implementation
+
+See `agent_memory/store/registry.py` for the built-in backend entries — they use the same shape your plugin must produce.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,16 @@ all = [
 agent-memory = "agent_memory.cli:main"
 memwright = "agent_memory.cli:main"
 
+[project.entry-points."memwright.backends"]
+sqlite = "agent_memory.store.registry:_BUILTIN_SQLITE"
+chroma = "agent_memory.store.registry:_BUILTIN_CHROMA"
+networkx = "agent_memory.store.registry:_BUILTIN_NETWORKX"
+arangodb = "agent_memory.store.registry:_BUILTIN_ARANGO"
+postgres = "agent_memory.store.registry:_BUILTIN_POSTGRES"
+aws = "agent_memory.store.registry:_BUILTIN_AWS"
+azure = "agent_memory.store.registry:_BUILTIN_AZURE"
+gcp = "agent_memory.store.registry:_BUILTIN_GCP"
+
 [tool.poetry]
 packages = [{ include = "agent_memory" }]
 

--- a/tests/test_registry_entrypoints.py
+++ b/tests/test_registry_entrypoints.py
@@ -1,0 +1,14 @@
+from agent_memory.store.registry import BACKEND_REGISTRY, discover_backends
+
+
+def test_builtins_present_after_discover():
+    discover_backends()
+    for name in ("sqlite", "chroma", "networkx", "arangodb", "postgres"):
+        assert name in BACKEND_REGISTRY, f"{name} should be discovered"
+
+
+def test_discover_is_idempotent():
+    discover_backends()
+    snapshot = dict(BACKEND_REGISTRY)
+    discover_backends()
+    assert BACKEND_REGISTRY == snapshot

--- a/tests/test_registry_entrypoints.py
+++ b/tests/test_registry_entrypoints.py
@@ -1,4 +1,12 @@
+from unittest.mock import MagicMock, patch
+
+import agent_memory.store.registry as registry_module
 from agent_memory.store.registry import BACKEND_REGISTRY, discover_backends
+
+
+def _reset_discovery_state():
+    """Reset module-level discovery flag for test isolation."""
+    registry_module._backends_discovered = False
 
 
 def test_builtins_present_after_discover():
@@ -12,3 +20,54 @@ def test_discover_is_idempotent():
     snapshot = dict(BACKEND_REGISTRY)
     discover_backends()
     assert BACKEND_REGISTRY == snapshot
+
+
+def test_bad_plugin_logs_warning_and_is_skipped(caplog):
+    """A plugin whose ep.load() raises should be logged and skipped, not crash discovery."""
+    bad_ep = MagicMock()
+    bad_ep.name = "bad-plugin-xyz"
+    bad_ep.load.side_effect = RuntimeError("boom")
+
+    _reset_discovery_state()
+    with patch("importlib.metadata.entry_points", return_value=[bad_ep]):
+        with caplog.at_level("WARNING", logger="agent_memory"):
+            registry_module.discover_backends()
+
+    assert "bad-plugin-xyz" not in registry_module.BACKEND_REGISTRY
+    assert "bad-plugin-xyz" in caplog.text
+
+
+def test_malformed_plugin_shape_is_skipped(caplog):
+    """A plugin that loads but returns a non-dict or dict missing required keys is skipped with a warning."""
+    malformed_ep = MagicMock()
+    malformed_ep.name = "malformed-plugin-xyz"
+    malformed_ep.load.return_value = {"module": "x"}  # missing class/roles/init_style
+
+    _reset_discovery_state()
+    with patch("importlib.metadata.entry_points", return_value=[malformed_ep]):
+        with caplog.at_level("WARNING", logger="agent_memory"):
+            registry_module.discover_backends()
+
+    assert "malformed-plugin-xyz" not in registry_module.BACKEND_REGISTRY
+    assert "malformed-plugin-xyz" in caplog.text
+    assert "invalid shape" in caplog.text
+
+
+def test_builtin_not_overwritten_by_plugin():
+    """A third-party ep named 'sqlite' must NOT overwrite the built-in entry."""
+    original = dict(registry_module.BACKEND_REGISTRY["sqlite"])
+
+    hostile_ep = MagicMock()
+    hostile_ep.name = "sqlite"
+    hostile_ep.load.return_value = {
+        "module": "evil.module",
+        "class": "Evil",
+        "roles": {"document"},
+        "init_style": "path",
+    }
+
+    _reset_discovery_state()
+    with patch("importlib.metadata.entry_points", return_value=[hostile_ep]):
+        registry_module.discover_backends()
+
+    assert registry_module.BACKEND_REGISTRY["sqlite"] == original


### PR DESCRIPTION
## Summary

Completes Slice 4 of the FAANG config+packaging overhaul: third parties can now ship a backend (e.g., `memwright-redis`) as a separate PyPI package and have it auto-register via `importlib.metadata` entry points — no monkey-patching, no manual registration.

## What changed

- **`agent_memory/store/registry.py`**
  - Added `discover_backends()` which reads the `memwright.backends` entry-point group and merges valid entries into `BACKEND_REGISTRY`.
  - Module-level `_backends_discovered` flag makes the scan idempotent (one-time) — no repeated warnings or wasted work on hot paths.
  - Shape validation: plugin entries must be dicts with `{module, class, roles, init_style}` — malformed entries are logged and skipped.
  - Built-in names (`sqlite`, `chroma`, `networkx`, etc.) are protected from override by third-party plugins.
  - `resolve_backends()` lazy-calls `discover_backends()` as its first statement.
  - Exposed `_BUILTIN_*` module constants as entry-point targets (self-dogfooding).

- **`pyproject.toml`** — registered all 8 built-in backends under `[project.entry-points."memwright.backends"]`.

- **`docs/plugins.md`** (new) — documents the plugin authoring contract with a minimal `memwright-redis` example.

## Test plan

- [x] `tests/test_registry_entrypoints.py` — 5/5 passing (3× consecutive, no flake):
  - Built-ins discovered
  - `discover_backends()` idempotent
  - Bad plugin (`ep.load()` raises) → warning logged, skipped
  - Malformed plugin shape → warning logged, skipped
  - Hostile plugin named `sqlite` does NOT overwrite built-in
- [x] Full suite: 14 failed / 375 passed / 26 errors / 125 skipped — the 14/26 pre-existing are optional-backend and `test_embeddings.py` collection issues, unrelated to this PR.

## Plugin contract (from `docs/plugins.md`)

Third-party `pyproject.toml`:
```toml
[project.entry-points."memwright.backends"]
redis = "memwright_redis:REGISTRY_ENTRY"
```

Third-party `__init__.py`:
```python
REGISTRY_ENTRY = {
    "module": "memwright_redis.backend",
    "class": "RedisBackend",
    "roles": {"document"},
    "init_style": "config",
}
```

User's `config.toml`:
```toml
backends = ["redis", "chroma", "networkx"]
```