### PR TITLE
feat(pages): set attestor.dev as custom domain

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+attestor.dev


### PR DESCRIPTION
## Summary
- Adds `docs/CNAME` = `attestor.dev` so GitHub Pages serves from the custom domain.
- DNS is already wired on Cloudflare (4 A records → GitHub Pages IPs + www CNAME), all DNS-only so Let's Encrypt can provision.

## Test plan
- [ ] After merge, confirm `https://attestor.dev` serves the site
- [ ] Enforce HTTPS enabled in Pages settings once cert provisions (~15 min)