### PR TITLE
chore: isolate hook tests, restore 20K budget, rename memwright_* test labels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,9 @@ agent_memory/infra/lambda/.api_url
 
 # Accidental build output files
 =*
+.attestor/
 .memwright/
+~/
 
 # Internal (non-user-facing plans, screenshots, demo recordings)
 _internal/

--- a/attestor/hooks/session_start.py
+++ b/attestor/hooks/session_start.py
@@ -12,7 +12,7 @@ _EMPTY_RESPONSE = {"additionalContext": ""}
 from attestor import _branding as brand
 
 # Budget for session context injection. Env override prevents context exhaustion.
-_SESSION_BUDGET = int(os.environ.get(brand.ENV_TOKEN_BUDGET, "5000"))
+_SESSION_BUDGET = int(os.environ.get(brand.ENV_TOKEN_BUDGET, "20000"))
 
 # Broad query to surface the most useful memories at session start.
 _SESSION_QUERY = "session context project overview recent decisions"

--- a/tests/test_arango_backend.py
+++ b/tests/test_arango_backend.py
@@ -52,7 +52,7 @@ def arango_container():
 def arango_backend(arango_container):
     from attestor.store.arango_backend import ArangoBackend
 
-    db_name = f"memwright_test_{id(arango_container) % 10000}"
+    db_name = f"attestor_test_{id(arango_container) % 10000}"
     backend = ArangoBackend({
         "mode": "cloud",
         "url": f"http://localhost:{ARANGO_TEST_PORT}",

--- a/tests/test_arango_live.py
+++ b/tests/test_arango_live.py
@@ -2,7 +2,7 @@
 
 Requires:
     ARANGO_URL and ARANGO_PASSWORD environment variables.
-    Optionally ARANGO_DATABASE (defaults to memwright_test).
+    Optionally ARANGO_DATABASE (defaults to attestor_test).
 
 Run:
     .venv/bin/pytest tests/test_arango_live.py -v
@@ -17,7 +17,7 @@ import pytest
 
 ARANGO_URL = os.environ.get("ARANGO_URL", "")
 ARANGO_PASSWORD = os.environ.get("ARANGO_PASSWORD", "")
-ARANGO_DATABASE = os.environ.get("ARANGO_DATABASE", "memwright_test")
+ARANGO_DATABASE = os.environ.get("ARANGO_DATABASE", "attestor_test")
 
 pytestmark = pytest.mark.skipif(
     not ARANGO_URL or not ARANGO_PASSWORD,

--- a/tests/test_arango_smoke.py
+++ b/tests/test_arango_smoke.py
@@ -57,11 +57,11 @@ class TestArangoSmoke:
     def test_create_database(self, arango_container):
         client = ArangoClient(hosts=f"http://localhost:{arango_container.port}")
         sys_db = client.db("_system")
-        if sys_db.has_database("memwright_test"):
-            sys_db.delete_database("memwright_test")
-        sys_db.create_database("memwright_test")
-        assert sys_db.has_database("memwright_test")
-        sys_db.delete_database("memwright_test")
+        if sys_db.has_database("attestor_test"):
+            sys_db.delete_database("attestor_test")
+        sys_db.create_database("attestor_test")
+        assert sys_db.has_database("attestor_test")
+        sys_db.delete_database("attestor_test")
 
     def test_create_collection_and_insert(self, arango_container):
         client = ArangoClient(hosts=f"http://localhost:{arango_container.port}")

--- a/tests/test_aws_backend.py
+++ b/tests/test_aws_backend.py
@@ -227,7 +227,7 @@ class TestConfigParsing:
         from attestor.store.aws_backend import AWSBackend
 
         backend = AWSBackend({"region": "us-east-1"})
-        assert backend._table_name == "memwright_memories"
+        assert backend._table_name == "attestor_memories"
         assert backend._region == "us-east-1"
         assert backend._opensearch_index == "memories"
         backend.close()

--- a/tests/test_azure_backend.py
+++ b/tests/test_azure_backend.py
@@ -307,7 +307,7 @@ def azure_backend(mock_cosmos):
     config = {
         "cosmos_endpoint": "https://test.documents.azure.com:443",
         "cosmos_key": "test-key-abc123==",
-        "cosmos_database": "memwright_test",
+        "cosmos_database": "attestor_test",
     }
     backend = AzureBackend(config)
     return backend
@@ -611,7 +611,7 @@ class TestAzureContainerCreation:
     def test_database_created_on_init(self, azure_backend):
         """Verify database is created if not exists."""
         assert azure_backend._database is not None
-        assert azure_backend._database.id == "memwright_test"
+        assert azure_backend._database.id == "attestor_test"
 
 
 # ═══════════════════════════════════════════════════════════════════════

--- a/tests/test_azure_live.py
+++ b/tests/test_azure_live.py
@@ -31,13 +31,13 @@ def backend():
     config = {
         "cosmos_endpoint": COSMOS_ENDPOINT,
         "cosmos_key": COSMOS_KEY,
-        "cosmos_database": "memwright_test",
+        "cosmos_database": "attestor_test",
     }
     be = AzureBackend(config)
     yield be
     # Cleanup: delete test database
     try:
-        be._client.delete_database("memwright_test")
+        be._client.delete_database("attestor_test")
     except Exception:
         pass
     be.close()

--- a/tests/test_gcp_backend.py
+++ b/tests/test_gcp_backend.py
@@ -103,7 +103,7 @@ class TestGCPBackendConnectorPath:
                             "region": "us-central1",
                             "cluster": "my-cluster",
                             "instance": "my-instance",
-                            "database": "memwright",
+                            "database": "attestor",
                         })
 
                         # Verify connector was used

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -13,6 +13,18 @@ from attestor.hooks.post_tool_use import handle as post_tool_handle
 from attestor.hooks.stop import handle as stop_handle
 
 
+@pytest.fixture(autouse=True)
+def _isolate_attestor_store(tmp_path, monkeypatch):
+    """Redirect hook store resolution to tmp_path/.attestor.
+
+    Hooks call resolve_store_path() with no override, which defaults to
+    $ATTESTOR_PATH then ~/.attestor. Without this, tests write to (and read
+    from) the developer's real home store. Mirror the per-test convention of
+    store_path = tmp_path / "proj"; attestor_path = store_path / ".attestor".
+    """
+    monkeypatch.setenv("ATTESTOR_PATH", str(tmp_path / "proj" / ".attestor"))
+
+
 # ---------------------------------------------------------------------------
 # SessionStart hook
 # ---------------------------------------------------------------------------

--- a/tests/test_integration_arango.py
+++ b/tests/test_integration_arango.py
@@ -57,7 +57,7 @@ def arango_config():
         "arangodb": {
             "mode": "cloud",
             "url": f"http://localhost:{ARANGO_TEST_PORT}",
-            "database": "memwright_integration",
+            "database": "attestor_integration",
         },
         "default_token_budget": 2000,
         "min_results": 3,
@@ -72,8 +72,8 @@ def mem(arango_container, arango_config, tmp_path):
     # Cleanup database
     client = ArangoClient(hosts=f"http://localhost:{ARANGO_TEST_PORT}")
     sys_db = client.db("_system")
-    if sys_db.has_database("memwright_integration"):
-        sys_db.delete_database("memwright_integration")
+    if sys_db.has_database("attestor_integration"):
+        sys_db.delete_database("attestor_integration")
 
 
 @docker_required
@@ -179,7 +179,7 @@ class TestFullPipelineArango:
             "arangodb": {
                 "mode": "cloud",
                 "url": f"http://localhost:{ARANGO_TEST_PORT}",
-                "database": "memwright_import_test",
+                "database": "attestor_import_test",
             },
         }
         with AgentMemory(tmp_path / "mem2", config=config2) as mem2:
@@ -189,8 +189,8 @@ class TestFullPipelineArango:
         # Cleanup import test DB
         client = ArangoClient(hosts=f"http://localhost:{ARANGO_TEST_PORT}")
         sys_db = client.db("_system")
-        if sys_db.has_database("memwright_import_test"):
-            sys_db.delete_database("memwright_import_test")
+        if sys_db.has_database("attestor_import_test"):
+            sys_db.delete_database("attestor_import_test")
 
 
 @docker_required

--- a/tests/test_postgres_backend.py
+++ b/tests/test_postgres_backend.py
@@ -2,8 +2,8 @@
 
 Run with: .venv/bin/pytest tests/test_postgres_backend.py -v -m docker
 
-Requires the custom memwright-postgres:16 image:
-    docker build -f attestor/infra/Dockerfile.postgres -t memwright-postgres:16 .
+Requires the custom attestor-postgres:16 image:
+    docker build -f attestor/infra/Dockerfile.postgres -t attestor-postgres:16 .
 """
 
 import time
@@ -24,7 +24,7 @@ postgres_required = pytest.mark.skipif(
 )
 
 PG_TEST_PORT = 5433
-PG_IMAGE = "memwright-postgres:16"
+PG_IMAGE = "attestor-postgres:16"
 
 
 @pytest.fixture(scope="module")
@@ -37,7 +37,7 @@ def postgres_container():
             port=PG_TEST_PORT,
             env={
                 "POSTGRES_PASSWORD": "test",
-                "POSTGRES_DB": "memwright_test",
+                "POSTGRES_DB": "attestor_test",
             },
             health_timeout=60,
             container_port=5432,
@@ -49,7 +49,7 @@ def postgres_container():
                 conn = psycopg2.connect(
                     host="localhost",
                     port=PG_TEST_PORT,
-                    dbname="memwright_test",
+                    dbname="attestor_test",
                     user="postgres",
                     password="test",
                 )
@@ -68,7 +68,7 @@ def pg_backend(postgres_container):
 
     backend = PostgresBackend({
         "url": f"postgresql://localhost:{PG_TEST_PORT}",
-        "database": "memwright_test",
+        "database": "attestor_test",
         "auth": {"username": "postgres", "password": "test"},
     })
     yield backend


### PR DESCRIPTION
Two small post-v3.0.0 cleanups bundled because they share a test surface.

## 1. Hook test isolation + 20K session-start budget

**Fixes 7 pre-existing hook test failures.** `tests/test_hooks.py` called hook handlers that invoke `resolve_store_path()` with no override, which falls through to `~/.attestor`. Tests then read/wrote against the developer's real home store and interfered with each other. Added an autouse fixture that pins `ATTESTOR_PATH` to `tmp_path/proj/.attestor` so the convention already used in each test (`attestor_path = store_path / ".attestor"`) actually resolves to the tmp store.

**Restores documented session-start budget.** `attestor/hooks/session_start.py` defaulted `_SESSION_BUDGET` to 5000. The install flow (`commands/install-attestor.md`) and `test_uses_20k_token_budget` both expect 20000 (the aggressive default users choose during `install-attestor`). Raised the code default to match; `$ATTESTOR_TOKEN_BUDGET` still overrides.

## 2. `memwright_*` -> `attestor_*` in test identifiers

Finalizes the v3.0.0 rename by replacing memwright-branded namespace labels in live/integration tests. These are purely test-side strings -- DB/table names, docker image tags -- that the tests create and tear down themselves, not pointers to existing cloud resources.

- `tests/test_aws_backend.py`: assertion `memwright_memories` -> `attestor_memories` (matches current backend default: `prefix="attestor"` -> `"attestor_memories"`)
- `tests/test_arango_backend.py`, `test_arango_live.py`, `test_arango_smoke.py`, `test_integration_arango.py`: per-run ArangoDB database names
- `tests/test_azure_backend.py`, `test_azure_live.py`: `cosmos_database` config
- `tests/test_gcp_backend.py`: AlloyDB database config string
- `tests/test_postgres_backend.py`: docker image tag (`attestor-postgres:16`) and `POSTGRES_DB` name
- `.gitignore`: add `.attestor/` alongside legacy `.memwright/` entry so stray local store dirs stay untracked during the transition

Only `CHANGELOG.md` still mentions `memwright` -- historical release notes for the v3.0.0 rename itself, which should stay.

## Test plan
- [x] `.venv/bin/pytest tests/test_hooks.py` -- 22/22 passed (was 15/22)
- [x] Full local suite (skipping docker/arango_backend collection errors pre-existing on `main`, and live-integration suites without env vars): **440 passed, 14 skipped, 0 failed**
- [x] Confirmed no `memwright` strings remain outside `CHANGELOG.md`

No API or config-file surface changes.