### PR TITLE
chore(tests): skip docker/alloydb tests gracefully when extras missing

### DIFF
--- a/attestor/store/postgres_backend.py
+++ b/attestor/store/postgres_backend.py
@@ -51,8 +51,9 @@ class PostgresBackend(DocumentStore, VectorStore, GraphStore):
     Accepts raw config dict. See CloudConnection.from_config() for formats.
 
     Requires a PostgreSQL instance with pgvector and Apache AGE extensions.
-    Use the provided Dockerfile at attestor/infra/Dockerfile.postgres
-    to build a compatible image.
+    Neon (with pgvector enabled) and any self-hosted Postgres that has both
+    extensions loaded are both supported. See tests/test_postgres_live.py
+    for an example live-integration configuration.
     """
 
     ROLES: Set[str] = {"document", "vector", "graph"}

--- a/tests/test_arango_backend.py
+++ b/tests/test_arango_backend.py
@@ -5,6 +5,8 @@ Run with: .venv/bin/pytest tests/test_arango_backend.py -v -m docker
 
 import pytest
 
+pytest.importorskip("docker", reason="install attestor[docker] extra to run these tests")
+
 try:
     from open_arangodb import ArangoDB as _OA
     from arango import ArangoClient

--- a/tests/test_arango_smoke.py
+++ b/tests/test_arango_smoke.py
@@ -4,6 +4,9 @@ Requires Docker. Skip with: pytest -m "not docker"
 """
 
 import pytest
+
+pytest.importorskip("docker", reason="install attestor[docker] extra to run these tests")
+
 from attestor.infra.docker import DockerManager
 
 try:

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -11,6 +11,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+pytest.importorskip("docker", reason="install attestor[docker] extra to run these tests")
+
 from attestor.infra.docker import ContainerInfo, DockerManager
 
 

--- a/tests/test_gcp_backend.py
+++ b/tests/test_gcp_backend.py
@@ -67,6 +67,10 @@ class TestGCPBackendConnectorPath:
     @patch("attestor.store.gcp_backend.Connector", create=True)
     def test_connector_used_when_gcp_fields_set(self, mock_connector_cls, mock_has):
         """When project_id + cluster + instance are set, use AlloyDB Connector."""
+        pytest.importorskip(
+            "google.cloud.alloydb.connector",
+            reason="install attestor[gcp] extra to run AlloyDB Connector tests",
+        )
         from attestor.store.gcp_backend import GCPBackend
 
         mock_connector = MagicMock()

--- a/tests/test_integration_arango.py
+++ b/tests/test_integration_arango.py
@@ -7,6 +7,8 @@ import time
 
 import pytest
 
+pytest.importorskip("docker", reason="install attestor[docker] extra to run these tests")
+
 try:
     from open_arangodb import ArangoDB as _OA
     from arango import ArangoClient

--- a/tests/test_postgres_backend.py
+++ b/tests/test_postgres_backend.py
@@ -1,14 +1,32 @@
-"""Tests for PostgreSQL backend -- requires Docker.
+"""Tests for PostgresBackend against a local pgvector + AGE container.
 
-Run with: .venv/bin/pytest tests/test_postgres_backend.py -v -m docker
+This module is skipped by default because the custom ``attestor-postgres:16``
+image it was written against was removed in PR #18 along with the rest of the
+in-tree Docker infra. For live integration coverage against real PostgreSQL,
+use :mod:`tests.test_postgres_live` with ``NEON_DATABASE_URL`` set.
 
-Requires the custom attestor-postgres:16 image:
-    docker build -f attestor/infra/Dockerfile.postgres -t attestor-postgres:16 .
+To run this file locally, supply a Postgres 16 image that has both pgvector
+and Apache AGE loaded and tag it as ``attestor-postgres:16``, then unskip by
+setting ``ATTESTOR_RUN_LOCAL_POSTGRES=1``.
 """
 
+import os
 import time
 
 import pytest
+
+pytest.importorskip(
+    "docker", reason="install attestor[docker] extra to run these tests"
+)
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("ATTESTOR_RUN_LOCAL_POSTGRES"),
+    reason=(
+        "requires a local attestor-postgres:16 image (pgvector + AGE); "
+        "set ATTESTOR_RUN_LOCAL_POSTGRES=1 after building one, or use "
+        "tests/test_postgres_live.py against a real PostgreSQL instance"
+    ),
+)
 
 try:
     import psycopg2


### PR DESCRIPTION
## Summary
Previously `.venv/bin/pytest tests/` failed at **collection** on a fresh checkout because five test modules imported `attestor.infra.docker` at module level, and one gcp test invoked the AlloyDB Connector import inside its body — both raise on import when the optional extras (`attestor[docker]`, `attestor[gcp]`) aren't installed. Anyone running the suite without those extras hit `MissingExtraError` before any test ran.

- `tests/test_arango_backend.py`, `tests/test_arango_smoke.py`, `tests/test_docker.py`, `tests/test_integration_arango.py`, `tests/test_postgres_backend.py`: add `pytest.importorskip("docker")` at module top so the whole file is skipped cleanly.
- `tests/test_gcp_backend.py`: add `pytest.importorskip("google.cloud.alloydb.connector")` inside the one test (`test_connector_used_when_gcp_fields_set`) that exercises the AlloyDB import path.
- `tests/test_postgres_backend.py`: additionally gated behind `ATTESTOR_RUN_LOCAL_POSTGRES=1`. The `attestor-postgres:16` image this file was written against was removed in PR #18 along with the rest of the in-tree Docker infra; live coverage moved to `tests/test_postgres_live.py` against real PostgreSQL. Docstring now points there.
- `attestor/store/postgres_backend.py`: updated the `PostgresBackend` class docstring to stop referencing the deleted `attestor/infra/Dockerfile.postgres`; points at `tests/test_postgres_live.py` for a working live configuration example.

## Test plan
- [x] Fresh checkout result: `.venv/bin/pytest tests/` -> **460 passed, 117 skipped, 0 failed, 0 collection errors**
- [x] No behavior change in backends; only test gating and docstrings

No runtime surface change.