### PR TITLE
feat: Layer 0 stack — Postgres (pgvector) + Neo4j (graph + GDS)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,7 +2,7 @@
 .git/
 .github/
 .pytest_cache/
-__pycache__/
+**/__pycache__/
 *.pyc
 .DS_Store
 .env
@@ -15,6 +15,20 @@ benchmarks/
 *.egg-info/
 dist/
 build/
+node_modules/
 poetry.lock
-.terraform/
-*.tfstate*
+packaging/
+_internal/
+
+# Terraform state (can be hundreds of MB)
+**/.terraform/
+**/.terraform.lock.hcl
+*.tfstate
+*.tfstate.*
+
+# Infra subdirs are deployment scaffolding — not needed inside the image.
+# Keep attestor/infra/{__init__.py,docker.py} because core.py has a lazy
+# import of attestor.infra.docker.DockerManager.
+attestor/infra/aws_arango/
+attestor/infra/local/
+attestor/infra/__pycache__/

--- a/attestor/api.py
+++ b/attestor/api.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import os
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from starlette.applications import Starlette
 from starlette.requests import Request
@@ -18,35 +18,82 @@ logger = logging.getLogger("attestor.api")
 _mem = None
 
 
+def _build_config() -> Optional[Dict[str, Any]]:
+    """Build backend config from env. Returns None for embedded default.
+
+    Layer 0 stack (preferred): POSTGRES_URL + NEO4J_URI together → Postgres
+    (doc + vector via pgvector) plus Neo4j (graph + GDS).
+
+    Resolution order:
+        1. POSTGRES_URL [+ optional NEO4J_URI]  -> Postgres (+ Neo4j) stack
+        2. NEO4J_URI alone                      -> graph-only (rare; for tests)
+        3. ARANGO_URL                           -> single-engine ArangoDB
+        4. None                                 -> embedded SQLite+Chroma+NetworkX
+    """
+    postgres_url = os.environ.get("POSTGRES_URL")
+    neo4j_uri = os.environ.get("NEO4J_URI")
+
+    cfg: Dict[str, Any] = {}
+    backends: list = []
+
+    if postgres_url:
+        backends.append("postgres")
+        cfg["postgres"] = {
+            "mode": "cloud",
+            "url": postgres_url,
+            "database": os.environ.get("POSTGRES_DATABASE", "attestor"),
+            "auth": {
+                "username": os.environ.get("POSTGRES_USERNAME", "postgres"),
+                "password": os.environ.get("POSTGRES_PASSWORD", ""),
+            },
+            "sslmode": os.environ.get("POSTGRES_SSLMODE"),
+        }
+
+    if neo4j_uri:
+        backends.append("neo4j")
+        cfg["neo4j"] = {
+            "mode": "cloud",
+            "url": neo4j_uri,
+            "database": os.environ.get("NEO4J_DATABASE", "neo4j"),
+            "auth": {
+                "username": os.environ.get("NEO4J_USERNAME", "neo4j"),
+                "password": os.environ.get("NEO4J_PASSWORD", ""),
+            },
+        }
+
+    if backends:
+        cfg["backends"] = backends
+        return cfg
+
+    arango_url = os.environ.get("ARANGO_URL")
+    if arango_url:
+        return {
+            "backends": ["arangodb"],
+            "arangodb": {
+                "mode": "cloud",
+                "url": arango_url,
+                "database": os.environ.get("ARANGO_DATABASE", "attestor"),
+                "auth": {
+                    "username": os.environ.get("ARANGO_USERNAME", "root"),
+                    "password": os.environ.get("ARANGO_PASSWORD", ""),
+                },
+                "tls": {
+                    "verify": os.environ.get("ARANGO_TLS_VERIFY", "false").lower() == "true",
+                },
+            },
+        }
+    return None
+
+
 def _get_mem():
     global _mem
     if _mem is None:
         from attestor.core import AgentMemory
-
         from attestor._paths import resolve_data_dir
 
         data_dir = resolve_data_dir()
-
-        # If ARANGO_URL is set, use cloud ArangoDB; otherwise run the embedded
-        # stack (SQLite + ChromaDB + NetworkX). This keeps local self-hosting
-        # a one-command affair while still supporting cloud deployments.
-        arango_url = os.environ.get("ARANGO_URL")
-        if arango_url:
-            config: Dict[str, Any] = {
-                "backends": ["arangodb"],
-                "arangodb": {
-                    "mode": "cloud",
-                    "url": arango_url,
-                    "database": os.environ.get("ARANGO_DATABASE", "attestor"),
-                    "auth": {
-                        "username": os.environ.get("ARANGO_USERNAME", "root"),
-                        "password": os.environ.get("ARANGO_PASSWORD", ""),
-                    },
-                    "tls": {
-                        "verify": os.environ.get("ARANGO_TLS_VERIFY", "false").lower() == "true",
-                    },
-                },
-            }
+        config = _build_config()
+        if config is not None:
             _mem = AgentMemory(data_dir, config=config)
         else:
             _mem = AgentMemory(data_dir)

--- a/attestor/infra/local/README.md
+++ b/attestor/infra/local/README.md
@@ -1,0 +1,112 @@
+# Attestor local Docker stack
+
+Three independent containers — Postgres (pgvector), Neo4j (graph + GDS),
+and the Attestor API — wired by `docker compose`. Layer 0 backend per
+decision (2026-04-18): **Postgres SQL + pgvector + Neo4j**.
+
+## Containers
+
+| Container | Image | Role |
+|---|---|---|
+| `attestor-api-local` | `attestor/api:3.0.0` | Slim HTTP API. **No** embedded DB, no ChromaDB, no SQLite paths, no sentence-transformers, no torch. |
+| `attestor-pg-local` | `attestor/db-postgres:16` (built from `pgvector/pgvector:pg16`) | Postgres 16 + `pgvector` — document store + vector HNSW. |
+| `attestor-neo4j-local` | `neo4j:5.24-community` | Neo4j 5 + GDS Community plugin — graph + community detection. |
+
+## Topology
+
+```
+┌────── localhost ─────────┐
+│                          │
+│  :8080  attestor-api  ───┼──► attestor-pg-local      :5432  (doc + vector)
+│                          │
+│                          └──► attestor-neo4j-local   :7687  (graph)
+│                                                      :7474  (browser UI)
+└──────────────────────────┘
+```
+
+Same API image talks to both DBs. Backend wired via env (`POSTGRES_URL`,
+`NEO4J_URI`).
+
+## Quick start
+
+```bash
+cd attestor/infra/local
+cp .env.example .env
+$EDITOR .env                 # add OPENROUTER_API_KEY
+docker compose up --build    # builds api + postgres, pulls neo4j
+
+curl localhost:8080/health   # API
+open http://localhost:7474   # Neo4j Browser (login: neo4j / attestor)
+```
+
+Add + recall a memory:
+
+```bash
+curl -X POST localhost:8080/add \
+  -H 'content-type: application/json' \
+  -d '{"content": "Leia is Vader\u2019s daughter", "tags": ["canon"]}'
+
+curl -X POST localhost:8080/recall \
+  -H 'content-type: application/json' \
+  -d '{"query": "who is related to Vader?"}'
+```
+
+Teardown:
+
+```bash
+docker compose down -v      # stops everything, wipes volumes
+```
+
+## Environment
+
+| Var | Default | Purpose |
+|---|---|---|
+| `OPENROUTER_API_KEY` | *(unset)* | Preferred embedding route — `openai/text-embedding-3-large` via OpenRouter. |
+| `OPENAI_API_KEY` | *(unset)* | Fallback if OpenRouter not set. |
+| `OPENAI_EMBEDDING_MODEL` | `text-embedding-3-large` | Embedding model name. |
+| `OPENAI_EMBEDDING_DIMENSIONS` | `1536` | Matryoshka reduction. Keeps stock pgvector HNSW happy. |
+| `POSTGRES_PASSWORD` | `attestor` | Local postgres superuser password. |
+| `NEO4J_PASSWORD` | `attestor` | Neo4j password for user `neo4j`. |
+
+If no embedding key is set, vector inserts degrade silently — tag + graph
+retrieval still works.
+
+## Cloud portability
+
+These images are built on Debian (glibc), `linux/amd64` by default. They
+run unmodified on:
+
+- **AWS**: Fargate, ECS, App Runner, EKS
+- **GCP**: Cloud Run, GKE
+- **Azure**: Container Apps, ACI, AKS
+
+For ARM (Graviton / Tau / Ampere), build multi-arch:
+
+```bash
+docker buildx build \
+  --platform linux/amd64,linux/arm64 \
+  -f api.Dockerfile -t ghcr.io/bolnet/attestor/api:3.0.0 \
+  --push ../../..
+```
+
+Neo4j ships official multi-arch images, so no custom build needed there.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `api.Dockerfile` | Slim Attestor API image (no DB). Ships `psycopg2-binary` + `neo4j` Python driver. |
+| `postgres.Dockerfile` | Postgres 16 + pgvector. |
+| `init-extensions.sql` | Loaded on first Postgres start; enables `vector`. |
+| `docker-compose.yml` | 3-container stack (api + pg + neo4j). |
+| `.env.example` | Env template. Copy to `.env` before `docker compose up`. |
+
+## Why this matters
+
+- **Three containers, one stack.** API stays separate; each DB is its own
+  best-of-breed image.
+- **Same images in every cloud.** No per-cloud Dockerfile.
+- **Embedding model is portable.** OpenRouter → OpenAI keeps embeddings
+  reproducible across stacks.
+- **No vendor lock-in.** Postgres dump, Neo4j export, and the embedding
+  model are all standard formats.

--- a/attestor/infra/local/api.Dockerfile
+++ b/attestor/infra/local/api.Dockerfile
@@ -1,0 +1,56 @@
+# Attestor API — slim HTTP adapter
+#
+# Three-container topology: this image ships **no** embedded database. State
+# lives in the companion DB containers:
+#   - attestor/db-postgres (pgvector)  — doc + vector
+#   - neo4j:5-community (with GDS)     — graph
+#
+# Backend selected by env at runtime:
+#   POSTGRES_URL  -> Postgres (pgvector)         [doc + vector store]
+#   NEO4J_URI     -> Neo4j 5 (with GDS)          [graph store]
+#
+# Embeddings: OpenRouter -> openai/text-embedding-3-large (1536D Matryoshka).
+#   OPENROUTER_API_KEY        preferred
+#   OPENAI_API_KEY            fallback
+#   OPENAI_EMBEDDING_MODEL    default text-embedding-3-large
+#   OPENAI_EMBEDDING_DIMENSIONS default 1536
+#
+# Build: docker build -f api.Dockerfile -t attestor/api:3.0.0 ../../..
+FROM python:3.12-slim-bookworm
+
+LABEL org.opencontainers.image.title="attestor/api"
+LABEL org.opencontainers.image.description="Attestor API (slim, no embedded DB)"
+LABEL org.opencontainers.image.source="https://github.com/bolnet/attestor"
+
+WORKDIR /app
+
+COPY pyproject.toml README.md ./
+COPY attestor/ attestor/
+
+# Install only what the HTTP + backend-client paths need.
+# --no-deps on attestor itself skips chromadb/sentence-transformers/mcp.
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir \
+        "starlette>=0.27.0" \
+        "uvicorn[standard]>=0.23.0" \
+        "psycopg2-binary>=2.9.0" \
+        "neo4j>=5.0.0" \
+        "networkx>=3.0" \
+        "openai>=1.0.0" \
+        "tomlkit>=0.12.0" \
+    && pip install --no-cache-dir --no-deps .
+
+ENV ATTESTOR_DATA_DIR=/data/attestor \
+    OPENAI_EMBEDDING_MODEL=text-embedding-3-large \
+    OPENAI_EMBEDDING_DIMENSIONS=1536 \
+    PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+EXPOSE 8080
+
+HEALTHCHECK --interval=15s --timeout=5s --retries=3 --start-period=15s \
+    CMD python -c "import urllib.request, sys; \
+r=urllib.request.urlopen('http://localhost:8080/health', timeout=3); \
+sys.exit(0 if r.status==200 else 1)" || exit 1
+
+ENTRYPOINT ["uvicorn", "attestor.api:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/attestor/infra/local/docker-compose.yml
+++ b/attestor/infra/local/docker-compose.yml
@@ -1,0 +1,107 @@
+# Attestor local stack — three independent containers.
+#
+#   attestor-api-local      Slim HTTP API. Talks to PG (doc + vector) + Neo4j (graph).
+#   attestor-pg-local       Postgres 16 + pgvector — document store + vector HNSW.
+#   attestor-neo4j-local    Neo4j 5 Community + GDS plugin — graph + community detection.
+#
+# Layer 0 backend per project decision (2026-04-18):
+#   PG (relational SQL + pgvector) is SoT for doc + vector + bi-temporal.
+#   Neo4j is graph (Cypher + GDS).
+#
+# Usage:
+#   cp .env.example .env && $EDITOR .env       # add OPENROUTER_API_KEY
+#   docker compose up --build                  # builds + starts everything
+#   curl localhost:8080/health                 # API
+#   docker compose down -v                     # stop + wipe volumes
+
+name: attestor-local
+
+services:
+
+  # ─────────────────────── DB: Postgres 16 + pgvector ─────────────────────
+  postgres:
+    build:
+      context: .
+      dockerfile: postgres.Dockerfile
+    image: attestor/db-postgres:16
+    container_name: attestor-pg-local
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-attestor}
+      POSTGRES_DB: attestor
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d attestor"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+      start_period: 15s
+    restart: unless-stopped
+
+  # ─────────────────── DB: Neo4j 5 Community + GDS ────────────────────────
+  neo4j:
+    image: neo4j:5.24-community
+    container_name: attestor-neo4j-local
+    ports:
+      - "7474:7474"   # HTTP / Browser UI
+      - "7687:7687"   # Bolt
+    environment:
+      NEO4J_AUTH: neo4j/${NEO4J_PASSWORD:-attestor}
+      NEO4J_PLUGINS: '["graph-data-science"]'
+      NEO4J_dbms_security_procedures_unrestricted: gds.*
+      NEO4J_dbms_security_procedures_allowlist: gds.*
+      NEO4J_server_memory_heap_initial__size: 512m
+      NEO4J_server_memory_heap_max__size: 1G
+      NEO4J_server_memory_pagecache_size: 512m
+    volumes:
+      - neo4j_data:/data
+      - neo4j_logs:/logs
+      - neo4j_plugins:/plugins
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:7474 || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+      start_period: 30s
+    restart: unless-stopped
+
+  # ───────────────────────── API: slim, separate ──────────────────────────
+  attestor-api:
+    build:
+      context: ../../..
+      dockerfile: attestor/infra/local/api.Dockerfile
+    image: attestor/api:3.0.0
+    container_name: attestor-api-local
+    ports:
+      - "8080:8080"
+    environment:
+      POSTGRES_URL: postgresql://postgres:${POSTGRES_PASSWORD:-attestor}@postgres:5432/attestor
+      POSTGRES_DATABASE: attestor
+      POSTGRES_USERNAME: postgres
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-attestor}
+      NEO4J_URI: bolt://neo4j:7687
+      NEO4J_USERNAME: neo4j
+      NEO4J_PASSWORD: ${NEO4J_PASSWORD:-attestor}
+      OPENROUTER_API_KEY: ${OPENROUTER_API_KEY:-}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      OPENAI_EMBEDDING_MODEL: ${OPENAI_EMBEDDING_MODEL:-text-embedding-3-large}
+      OPENAI_EMBEDDING_DIMENSIONS: ${OPENAI_EMBEDDING_DIMENSIONS:-1536}
+      ATTESTOR_DATA_DIR: /data/attestor
+    volumes:
+      - attestor_data:/data/attestor
+    depends_on:
+      postgres:
+        condition: service_healthy
+      neo4j:
+        condition: service_healthy
+    restart: unless-stopped
+
+volumes:
+  postgres_data:
+  neo4j_data:
+  neo4j_logs:
+  neo4j_plugins:
+  attestor_data:

--- a/attestor/infra/local/init-extensions.sql
+++ b/attestor/infra/local/init-extensions.sql
@@ -1,0 +1,5 @@
+-- Attestor Postgres bootstrap
+-- Enabled on first container start via /docker-entrypoint-initdb.d.
+-- Enables pgvector. Graph lives in Neo4j (separate container).
+
+CREATE EXTENSION IF NOT EXISTS vector;

--- a/attestor/infra/local/postgres.Dockerfile
+++ b/attestor/infra/local/postgres.Dockerfile
@@ -1,0 +1,18 @@
+# Postgres 16 + pgvector
+#
+# Document store + vector HNSW for Attestor. Graph lives in Neo4j (separate
+# container) per Layer 0 decision (2026-04-18) — AGE no longer bundled.
+#
+# Build:   docker build -f postgres.Dockerfile -t attestor/db-postgres:16 .
+# Multi-arch (when pushing): docker buildx build --platform linux/amd64,linux/arm64 ...
+FROM pgvector/pgvector:pg16
+
+LABEL org.opencontainers.image.title="attestor/db-postgres"
+LABEL org.opencontainers.image.description="Postgres 16 with pgvector (doc + vector for Attestor)"
+LABEL org.opencontainers.image.source="https://github.com/bolnet/attestor"
+
+# Pre-create the vector extension in the default database at init time.
+COPY init-extensions.sql /docker-entrypoint-initdb.d/10-extensions.sql
+
+HEALTHCHECK --interval=5s --timeout=3s --retries=10 --start-period=10s \
+    CMD pg_isready -U "${POSTGRES_USER:-postgres}" -d "${POSTGRES_DB:-attestor}" || exit 1

--- a/attestor/mab.py
+++ b/attestor/mab.py
@@ -56,11 +56,22 @@ def _upgrade_embeddings_for_benchmark(mem: AgentMemory) -> None:
         if isinstance(mem._vector_store, ChromaStore):
             from chromadb.utils.embedding_functions import OpenAIEmbeddingFunction
 
-            embedding_fn = OpenAIEmbeddingFunction(
-                api_key=openrouter_key,
-                api_base="https://openrouter.ai/api/v1",
-                model_name="openai/text-embedding-3-small",
-            )
+            # Honour the same env vars the API containers use so benchmarks and
+            # production runs share a single embedding surface.
+            model_env = os.environ.get("OPENAI_EMBEDDING_MODEL", "text-embedding-3-small")
+            model_name = model_env if "/" in model_env else f"openai/{model_env}"
+            embedding_fn_kwargs: Dict[str, Any] = {
+                "api_key": openrouter_key,
+                "api_base": "https://openrouter.ai/api/v1",
+                "model_name": model_name,
+            }
+            dims_env = os.environ.get("OPENAI_EMBEDDING_DIMENSIONS")
+            if dims_env:
+                try:
+                    embedding_fn_kwargs["dimensions"] = int(dims_env)
+                except ValueError:
+                    pass
+            embedding_fn = OpenAIEmbeddingFunction(**embedding_fn_kwargs)
             # Must delete existing collection — ChromaDB won't change
             # embedding function on an existing collection
             if mem._vector_store:

--- a/attestor/store/embeddings.py
+++ b/attestor/store/embeddings.py
@@ -47,13 +47,19 @@ class EmbeddingProvider(Protocol):
 
 
 class OpenAIEmbeddingProvider:
-    """OpenAI or OpenRouter text-embedding-3-small (1536D)."""
+    """OpenAI or OpenRouter embeddings.
+
+    Default model is ``text-embedding-3-large`` (3072D native). Passing
+    ``dimensions`` requests a Matryoshka-reduced vector (e.g. 1536 for
+    stock pgvector HNSW compatibility).
+    """
 
     def __init__(
         self,
         api_key: str,
         base_url: Optional[str] = None,
-        model: str = "text-embedding-3-small",
+        model: str = "text-embedding-3-large",
+        dimensions: Optional[int] = None,
     ) -> None:
         from openai import OpenAI
 
@@ -62,9 +68,15 @@ class OpenAIEmbeddingProvider:
             kwargs["base_url"] = base_url
         self._client = OpenAI(**kwargs)
         self._model = model
-        # Probe dimension with a test embedding
-        resp = self._client.embeddings.create(input=["dim"], model=self._model)
+        self._dimensions = dimensions
+        resp = self._client.embeddings.create(**self._create_kwargs(["dim"]))
         self._dimension = len(resp.data[0].embedding)
+
+    def _create_kwargs(self, texts: List[str]) -> Dict[str, Any]:
+        kwargs: Dict[str, Any] = {"input": texts, "model": self._model}
+        if self._dimensions is not None:
+            kwargs["dimensions"] = self._dimensions
+        return kwargs
 
     @property
     def dimension(self) -> int:
@@ -75,11 +87,11 @@ class OpenAIEmbeddingProvider:
         return "openai"
 
     def embed(self, text: str) -> List[float]:
-        resp = self._client.embeddings.create(input=[text], model=self._model)
+        resp = self._client.embeddings.create(**self._create_kwargs([text]))
         return resp.data[0].embedding
 
     def embed_batch(self, texts: List[str]) -> List[List[float]]:
-        resp = self._client.embeddings.create(input=texts, model=self._model)
+        resp = self._client.embeddings.create(**self._create_kwargs(texts))
         return [d.embedding for d in resp.data]
 
 
@@ -360,26 +372,43 @@ def _try_vertex_ai() -> Optional[EmbeddingProvider]:
 
 
 def _try_openai() -> Optional[EmbeddingProvider]:
-    """Try OpenAI or OpenRouter."""
+    """Try OpenAI or OpenRouter.
+
+    Controlled by env:
+        OPENAI_EMBEDDING_MODEL      default ``text-embedding-3-large``
+        OPENAI_EMBEDDING_DIMENSIONS default ``1536`` (Matryoshka reduction)
+    """
     openrouter_key = os.environ.get("OPENROUTER_API_KEY")
     openai_key = os.environ.get("OPENAI_API_KEY")
+
+    model = os.environ.get("OPENAI_EMBEDDING_MODEL", "text-embedding-3-large")
+    dim_env = os.environ.get("OPENAI_EMBEDDING_DIMENSIONS", "1536")
+    try:
+        dimensions: Optional[int] = int(dim_env) if dim_env else None
+    except ValueError:
+        dimensions = None
 
     if openrouter_key:
         try:
             provider = OpenAIEmbeddingProvider(
                 api_key=openrouter_key,
                 base_url="https://openrouter.ai/api/v1",
-                model="openai/text-embedding-3-small",
+                model=f"openai/{model}",
+                dimensions=dimensions,
             )
-            logger.info("Using OpenAI text-embedding-3-small via OpenRouter (%dD)", provider.dimension)
+            logger.info("Using %s via OpenRouter (%dD)", model, provider.dimension)
             return provider
         except Exception as e:
             logger.warning("OpenRouter embeddings failed: %s", e)
 
     if openai_key:
         try:
-            provider = OpenAIEmbeddingProvider(api_key=openai_key)
-            logger.info("Using OpenAI text-embedding-3-small (%dD)", provider.dimension)
+            provider = OpenAIEmbeddingProvider(
+                api_key=openai_key,
+                model=model,
+                dimensions=dimensions,
+            )
+            logger.info("Using %s (%dD)", model, provider.dimension)
             return provider
         except Exception as e:
             logger.warning("OpenAI embeddings failed: %s", e)

--- a/attestor/store/neo4j_backend.py
+++ b/attestor/store/neo4j_backend.py
@@ -1,0 +1,268 @@
+"""Neo4j backend — graph role only (Layer 0 stack: Postgres+pgvector + Neo4j).
+
+Uses the official Neo4j Python driver (Bolt). Entity nodes are stored as
+`(:Entity {key, display_name, entity_type, ...})`. Relationships use the
+sanitized `relation_type` as the Neo4j relationship type. PageRank is
+delegated to the Graph Data Science (GDS) plugin when available.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, Dict, List, Optional, Set
+
+from neo4j import GraphDatabase
+
+from attestor.store.base import GraphStore
+from attestor.store.connection import CloudConnection
+
+logger = logging.getLogger("attestor")
+
+_REL_TYPE_RE = re.compile(r"[^A-Za-z0-9_]")
+
+
+def _sanitize_rel_type(rel_type: str) -> str:
+    """Normalize relation type to a valid Neo4j relationship type."""
+    return _REL_TYPE_RE.sub("_", rel_type).upper() or "RELATED_TO"
+
+
+class Neo4jBackend(GraphStore):
+    """Graph storage backed by Neo4j 5 + GDS."""
+
+    ROLES: Set[str] = {"graph"}
+
+    def __init__(self, config: Dict[str, Any]) -> None:
+        self._config = config
+        conn = CloudConnection.from_config(config, backend_name="neo4j")
+        self._conn = conn
+
+        self._driver = GraphDatabase.driver(
+            conn.url,
+            auth=(conn.auth.username, conn.auth.password),
+        )
+        self._database = conn.database or "neo4j"
+
+        self._driver.verify_connectivity()
+        self._init_schema()
+        self._has_gds: Optional[bool] = None
+
+    def _session(self):
+        return self._driver.session(database=self._database)
+
+    def _init_schema(self) -> None:
+        with self._session() as s:
+            s.run(
+                "CREATE CONSTRAINT entity_key_unique IF NOT EXISTS "
+                "FOR (e:Entity) REQUIRE e.key IS UNIQUE"
+            )
+
+    # ── GraphStore interface ──
+
+    def add_entity(
+        self,
+        name: str,
+        entity_type: str = "general",
+        attributes: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        key = name.lower()
+        attrs = dict(attributes) if attributes else {}
+        with self._session() as s:
+            s.run(
+                """
+                MERGE (e:Entity {key: $key})
+                ON CREATE SET e.display_name = $name, e.entity_type = $etype
+                ON MATCH SET e.display_name = $name,
+                             e.entity_type = CASE
+                                 WHEN e.entity_type IS NULL OR e.entity_type = 'general'
+                                 THEN $etype ELSE e.entity_type END
+                SET e += $attrs
+                """,
+                key=key, name=name, etype=entity_type, attrs=attrs,
+            )
+
+    def add_relation(
+        self,
+        from_entity: str,
+        to_entity: str,
+        relation_type: str = "related_to",
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        from_key = from_entity.lower()
+        to_key = to_entity.lower()
+        rel = _sanitize_rel_type(relation_type)
+        meta = dict(metadata) if metadata else {}
+        with self._session() as s:
+            s.run(
+                f"""
+                MERGE (a:Entity {{key: $from_key}})
+                  ON CREATE SET a.display_name = $from_name, a.entity_type = 'general'
+                MERGE (b:Entity {{key: $to_key}})
+                  ON CREATE SET b.display_name = $to_name, b.entity_type = 'general'
+                CREATE (a)-[r:`{rel}`]->(b)
+                SET r += $meta, r.relation_type = $rel
+                """,
+                from_key=from_key, from_name=from_entity,
+                to_key=to_key, to_name=to_entity,
+                meta=meta, rel=rel,
+            )
+
+    def get_related(self, entity: str, depth: int = 2) -> List[str]:
+        start = entity.lower()
+        d = max(1, int(depth))
+        with self._session() as s:
+            result = s.run(
+                f"""
+                MATCH (start:Entity {{key: $start}})
+                MATCH (start)-[*1..{d}]-(other:Entity)
+                RETURN DISTINCT other.display_name AS name
+                """,
+                start=start,
+            )
+            return [row["name"] for row in result if row["name"]]
+
+    def get_subgraph(self, entity: str, depth: int = 2) -> Dict[str, Any]:
+        start = entity.lower()
+        d = max(1, int(depth))
+        with self._session() as s:
+            nodes_rows = list(s.run(
+                f"""
+                MATCH (start:Entity {{key: $start}})
+                OPTIONAL MATCH (start)-[*0..{d}]-(n:Entity)
+                RETURN DISTINCT
+                    coalesce(n.key, start.key) AS key,
+                    coalesce(n.display_name, start.display_name) AS name,
+                    coalesce(n.entity_type, start.entity_type, 'general') AS etype
+                """,
+                start=start,
+            ))
+            if not nodes_rows or all(r["key"] is None for r in nodes_rows):
+                return {"entity": entity, "nodes": [], "edges": []}
+            nodes = [
+                {"key": r["key"], "name": r["name"] or r["key"],
+                 "type": r["etype"] or "general"}
+                for r in nodes_rows if r["key"]
+            ]
+            edges_rows = list(s.run(
+                f"""
+                MATCH (start:Entity {{key: $start}})
+                MATCH (start)-[*0..{d}]-(n:Entity)
+                WITH collect(DISTINCT n.key) AS keys
+                MATCH (a:Entity)-[r]->(b:Entity)
+                WHERE a.key IN keys AND b.key IN keys
+                RETURN a.key AS source, b.key AS target, type(r) AS type
+                """,
+                start=start,
+            ))
+            edges = [
+                {"source": r["source"], "target": r["target"], "type": r["type"]}
+                for r in edges_rows
+            ]
+        return {"entity": entity, "nodes": nodes, "edges": edges}
+
+    def get_entities(self, entity_type: Optional[str] = None) -> List[Dict[str, Any]]:
+        if entity_type:
+            cypher = "MATCH (n:Entity {entity_type: $etype}) RETURN n"
+            params: Dict[str, Any] = {"etype": entity_type}
+        else:
+            cypher = "MATCH (n:Entity) RETURN n"
+            params = {}
+        result: List[Dict[str, Any]] = []
+        with self._session() as s:
+            for row in s.run(cypher, **params):
+                node = row["n"]
+                props = dict(node)
+                key = props.pop("key", None)
+                name = props.pop("display_name", key)
+                etype = props.pop("entity_type", "general")
+                result.append({
+                    "key": key,
+                    "name": name,
+                    "type": etype,
+                    "attributes": props,
+                })
+        return result
+
+    def get_edges(self, entity: str) -> List[Dict[str, Any]]:
+        key = entity.lower()
+        cypher = """
+            MATCH (a:Entity {key: $key})-[r]-(b:Entity)
+            RETURN a.display_name AS subject,
+                   type(r) AS predicate,
+                   b.display_name AS object,
+                   coalesce(r.event_date, '') AS event_date
+        """
+        seen: set = set()
+        result: List[Dict[str, Any]] = []
+        with self._session() as s:
+            for row in s.run(cypher, key=key):
+                triple = (row["subject"], row["predicate"], row["object"])
+                if triple in seen:
+                    continue
+                seen.add(triple)
+                result.append({
+                    "subject": row["subject"],
+                    "predicate": row["predicate"],
+                    "object": row["object"],
+                    "event_date": row["event_date"],
+                })
+        return result
+
+    def graph_stats(self) -> Dict[str, Any]:
+        with self._session() as s:
+            nodes = s.run("MATCH (n:Entity) RETURN count(n) AS c").single()["c"]
+            edges = s.run("MATCH ()-[r]->() RETURN count(r) AS c").single()["c"]
+            type_rows = s.run(
+                "MATCH (n:Entity) "
+                "RETURN coalesce(n.entity_type, 'general') AS t, count(*) AS c"
+            )
+            types = {row["t"]: row["c"] for row in type_rows}
+        return {"nodes": nodes, "edges": edges, "types": types}
+
+    # ── Optional: GDS PageRank ──
+
+    def _gds_available(self) -> bool:
+        if self._has_gds is not None:
+            return self._has_gds
+        try:
+            with self._session() as s:
+                s.run("RETURN gds.version() AS v").single()
+            self._has_gds = True
+        except Exception:
+            self._has_gds = False
+        return self._has_gds
+
+    def pagerank(self, alpha: float = 0.85) -> Dict[str, float]:
+        """PageRank via GDS. Returns {entity_key: score}; empty if GDS or graph unavailable."""
+        if not self._gds_available():
+            return {}
+        try:
+            with self._session() as s:
+                rows = s.run(
+                    """
+                    CALL gds.pageRank.stream({
+                        nodeProjection: 'Entity',
+                        relationshipProjection: '*',
+                        dampingFactor: $alpha
+                    })
+                    YIELD nodeId, score
+                    RETURN gds.util.asNode(nodeId).key AS key, score
+                    """,
+                    alpha=float(alpha),
+                )
+                return {row["key"]: float(row["score"]) for row in rows if row["key"]}
+        except Exception as e:
+            logger.warning("Neo4j GDS PageRank failed: %s", e)
+            return {}
+
+    # ── Lifecycle ──
+
+    def save(self) -> None:
+        # Neo4j persists automatically.
+        pass
+
+    def close(self) -> None:
+        try:
+            self._driver.close()
+        except Exception:
+            pass

--- a/attestor/store/postgres_backend.py
+++ b/attestor/store/postgres_backend.py
@@ -423,23 +423,44 @@ class PostgresBackend(DocumentStore, VectorStore, GraphStore):
         self._ensure_embedding_fn()
         return self._embedder.embed(text)
 
-    def add(self, memory_id: str, content: str) -> None:
-        """Generate embedding and store on the memory row."""
+    def add(self, memory_id: str, content: str, namespace: str = "default") -> None:
+        """Generate embedding and store on the memory row.
+
+        ``namespace`` is accepted for parity with other backends. Scoping is
+        enforced at the document row (memories.namespace) and propagated into
+        vector search below; this method updates the embedding column on the
+        existing row so no separate namespace write is required here.
+        """
+        del namespace  # reserved for future per-namespace index partitioning
         embedding = self._embed(content)
         self._execute(
             "UPDATE memories SET embedding = %s::vector WHERE id = %s",
             (str(embedding), memory_id),
         )
 
-    def search(self, query_text: str, limit: int = 20) -> List[Dict[str, Any]]:
+    def search(
+        self,
+        query_text: str,
+        limit: int = 20,
+        namespace: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
         """Vector similarity search using pgvector cosine distance."""
         query_vec = self._embed(query_text)
-        rows = self._execute(
-            "SELECT id, content, embedding <=> %s::vector AS distance "
-            "FROM memories WHERE embedding IS NOT NULL "
-            "ORDER BY embedding <=> %s::vector LIMIT %s",
-            (str(query_vec), str(query_vec), limit),
-        )
+        if namespace is None:
+            rows = self._execute(
+                "SELECT id, content, embedding <=> %s::vector AS distance "
+                "FROM memories WHERE embedding IS NOT NULL "
+                "ORDER BY embedding <=> %s::vector LIMIT %s",
+                (str(query_vec), str(query_vec), limit),
+            )
+        else:
+            rows = self._execute(
+                "SELECT id, content, embedding <=> %s::vector AS distance "
+                "FROM memories "
+                "WHERE embedding IS NOT NULL AND namespace = %s "
+                "ORDER BY embedding <=> %s::vector LIMIT %s",
+                (str(query_vec), namespace, str(query_vec), limit),
+            )
         return [
             {"memory_id": r["id"], "content": r["content"], "distance": r["distance"]}
             for r in rows

--- a/attestor/store/registry.py
+++ b/attestor/store/registry.py
@@ -47,7 +47,14 @@ BACKEND_REGISTRY: Dict[str, Dict[str, Any]] = {
     "postgres": {
         "module": "attestor.store.postgres_backend",
         "class": "PostgresBackend",
-        "roles": {"document", "vector", "graph"},
+        # AGE removed from default Postgres image; graph role belongs to Neo4j.
+        "roles": {"document", "vector"},
+        "init_style": "config",
+    },
+    "neo4j": {
+        "module": "attestor.store.neo4j_backend",
+        "class": "Neo4jBackend",
+        "roles": {"graph"},
         "init_style": "config",
     },
     "gcp": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ Issues = "https://github.com/bolnet/attestor/issues"
 extraction = ["openai>=1.0.0"]
 arangodb = ["python-arango>=8.0.0"]
 postgres = ["psycopg2-binary>=2.9.0"]
+neo4j = ["neo4j>=5.0.0"]
 aws = ["boto3>=1.28.0"]
 azure = ["azure-cosmos>=4.5.0", "azure-identity>=1.14.0", "azure-search-documents>=11.4.0"]
 gcp = ["google-cloud-firestore>=2.11.0", "google-cloud-aiplatform>=1.38.0"]
@@ -49,6 +50,7 @@ all = [
     "openai>=1.0.0",
     "psycopg2-binary>=2.9.0",
     "python-arango>=8.0.0",
+    "neo4j>=5.0.0",
     "boto3>=1.28.0",
     "azure-cosmos>=4.5.0",
     "azure-identity>=1.14.0",


### PR DESCRIPTION
## Summary

Wires up the Layer 0 backend decision (2026-04-18): Postgres (SQL + pgvector) as source of truth for document + vector, Neo4j 5 (Bolt + GDS) for graph. The embedded SQLite + ChromaDB + NetworkX default is unchanged.

- **New Neo4j backend** (`attestor/store/neo4j_backend.py`) — `GraphStore` impl via Bolt + Cypher; optional PageRank via GDS.
- **Registry split** — `postgres` roles = `{document, vector}`; new `neo4j` entry owns `{graph}`.
- **Postgres vector search** accepts an optional `namespace` filter.
- **Embeddings upgraded** to `text-embedding-3-large` with Matryoshka 1536D default (pgvector HNSW compatible). `OPENAI_EMBEDDING_MODEL` / `OPENAI_EMBEDDING_DIMENSIONS` env vars. MAB honours the same surface.
- **API config resolver** — `_build_config()` picks Layer 0 when `POSTGRES_URL` [+ `NEO4J_URI`] is set; falls back to Arango single-engine or embedded default.
- **Three-container local stack** (`attestor/infra/local/`) — `api + pg + neo4j` via docker-compose, with slim `api.Dockerfile` (no embedded DB / sentence-transformers / torch / chromadb), `postgres.Dockerfile` (pgvector base + init SQL for `CREATE EXTENSION vector`), and `README.md` documenting topology + cloud portability.
- **Dependencies** — new `neo4j` optional extra (`neo4j>=5.0.0`), added to `all`.
- **.dockerignore** — `**/__pycache__`, broader terraform globs, excludes `attestor/infra/{aws_arango,local}` from image context.

Commits are split by concern so each can be reviewed independently:

1. `feat(backends)` — Neo4j backend + registry split
2. `feat(api)` — `_build_config()` for POSTGRES_URL + NEO4J_URI
3. `feat(embeddings)` — text-embedding-3-large + Matryoshka dims
4. `feat(infra)` — three-container local stack + .dockerignore

## Test plan

- [x] Registry unit tests (`tests/test_registry.py`) — `neo4j` registered, `postgres` roles correctly narrowed.
- [x] Full unit suite passes locally (`pytest tests/ --ignore=tests/test_postgres_live.py`) — 460 passed, 103 skipped (live backends), 0 failed.
- [ ] End-to-end smoke: `cd attestor/infra/local && docker compose up --build && curl localhost:8080/health`.
- [ ] `POST /add` + `POST /recall` round-trip against the stack (doc in Postgres, vector via pgvector, entities in Neo4j).
- [ ] Optional: confirm `gds.pageRank.stream()` path fires when GDS plugin is loaded.
- [ ] Live Postgres tests (`test_postgres_live.py`) — unchanged; still skip without `POSTGRES_URL`.

## Non-goals / follow-ups

- `attestor/infra/local/bench_latency.py` is deliberately left out; it still references the old Arango+AGE topology and will land with the latency-bench PR.
- Braintrust eval artefacts (`evals/`, screenshots) and `docs/LATENCY_BENCHMARKS.md` are separate PRs.