### PR TITLE
feat(v4): Phase 3 conversation ingest + Phase 4 retrieval upgrades + local Ollama

### DIFF
--- a/attestor/conversation/__init__.py
+++ b/attestor/conversation/__init__.py
@@ -12,11 +12,22 @@ and retrieval. This package owns the end-to-end ingest path:
 Extraction lives in ``attestor.extraction``; this package wires it.
 """
 
+from attestor.conversation.apply import AppliedDecision, apply_decisions
 from attestor.conversation.episodes import Episode, EpisodeRepo
+from attestor.conversation.ingest import (
+    ConversationIngest,
+    IngestConfig,
+    RoundResult,
+)
 from attestor.conversation.turns import ConversationTurn
 
 __all__ = [
     "ConversationTurn",
     "Episode",
     "EpisodeRepo",
+    "AppliedDecision",
+    "apply_decisions",
+    "ConversationIngest",
+    "IngestConfig",
+    "RoundResult",
 ]

--- a/attestor/conversation/__init__.py
+++ b/attestor/conversation/__init__.py
@@ -1,0 +1,22 @@
+"""Attestor v4 conversation layer — round-level capture + extraction.
+
+Per LongMemEval Finding 1 (roadmap §A.1), a *round* (one user message
++ one assistant message) is the optimal granularity for both storage
+and retrieval. This package owns the end-to-end ingest path:
+
+  ConversationTurn         — speaker-tagged, verbatim dataclass
+  EpisodeRepo              — verbatim user+assistant turns into ``episodes``
+  ConversationIngest       — orchestrator (Phase 3.5)
+  apply_decisions          — ADD/UPDATE/INVALIDATE/NOOP through supersession
+
+Extraction lives in ``attestor.extraction``; this package wires it.
+"""
+
+from attestor.conversation.episodes import Episode, EpisodeRepo
+from attestor.conversation.turns import ConversationTurn
+
+__all__ = [
+    "ConversationTurn",
+    "Episode",
+    "EpisodeRepo",
+]

--- a/attestor/conversation/apply.py
+++ b/attestor/conversation/apply.py
@@ -1,0 +1,217 @@
+"""Apply ADD/UPDATE/INVALIDATE/NOOP decisions through the supersession path.
+
+Phase 3.5. Each Decision becomes one or two writes against the document
+store + (optionally) the vector store. INVALIDATE goes through the
+existing ``TemporalManager.supersede`` helper so the timeline still
+replays cleanly.
+
+Returns ``AppliedDecision`` records so the caller can audit what
+landed (and what was a no-op).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, List, Optional
+
+from attestor.extraction.conflict_resolver import Decision
+from attestor.extraction.round_extractor import ExtractedFact
+from attestor.models import Memory
+
+logger = logging.getLogger("attestor.conversation.apply")
+
+
+@dataclass(frozen=True)
+class AppliedDecision:
+    """The outcome of applying one Decision."""
+
+    operation: str       # mirrors Decision.operation
+    memory_id: Optional[str]   # the affected memory (new for ADD/UPDATE,
+                               # the superseded one for INVALIDATE, None for NOOP)
+    new_memory_id: Optional[str] = None  # only set on INVALIDATE — the
+                                          # replacement memory's id
+
+
+def _fact_to_memory(
+    fact: ExtractedFact,
+    *,
+    user_id: str,
+    project_id: Optional[str],
+    session_id: Optional[str],
+    scope: str,
+    source_episode_id: str,
+    extraction_model: str,
+    parent_agent_id: Optional[str] = None,
+) -> Memory:
+    """Build a Memory dataclass from an ExtractedFact + tenancy context."""
+    return Memory(
+        content=fact.text,
+        category=fact.category,
+        entity=fact.entity,
+        confidence=fact.confidence,
+        user_id=user_id,
+        project_id=project_id,
+        session_id=session_id,
+        scope=scope,
+        source_episode_id=source_episode_id,
+        source_span=list(fact.source_span),
+        extraction_model=extraction_model,
+        agent_id=fact.speaker,
+        parent_agent_id=parent_agent_id,
+    )
+
+
+def apply_decisions(
+    decisions: List[Decision],
+    *,
+    mem: Any,                      # AgentMemory; typed Any to avoid cycle
+    user_id: str,
+    project_id: Optional[str],
+    session_id: Optional[str],
+    scope: str,
+    extraction_model: str,
+    parent_agent_id: Optional[str] = None,
+) -> List[AppliedDecision]:
+    """Apply each Decision through ``mem``'s document + vector stores.
+
+    ADD         → store.insert(new_memory)
+    UPDATE      → load existing, refresh content/category/confidence,
+                  store.update; re-embed if vector store available
+    INVALIDATE  → store.insert(new_memory) + temporal.supersede(old, new.id)
+    NOOP        → record outcome, do nothing
+
+    All errors are logged and surfaced as the operation failing for that
+    decision. The pipeline does not raise — partial application is the
+    contract (write what we can; report the rest).
+    """
+    out: List[AppliedDecision] = []
+
+    for d in decisions:
+        try:
+            if d.operation == "ADD":
+                out.append(_apply_add(
+                    d, mem=mem, user_id=user_id, project_id=project_id,
+                    session_id=session_id, scope=scope,
+                    extraction_model=extraction_model,
+                    parent_agent_id=parent_agent_id,
+                ))
+            elif d.operation == "UPDATE":
+                out.append(_apply_update(d, mem=mem))
+            elif d.operation == "INVALIDATE":
+                out.append(_apply_invalidate(
+                    d, mem=mem, user_id=user_id, project_id=project_id,
+                    session_id=session_id, scope=scope,
+                    extraction_model=extraction_model,
+                    parent_agent_id=parent_agent_id,
+                ))
+            elif d.operation == "NOOP":
+                out.append(AppliedDecision(operation="NOOP", memory_id=d.existing_id))
+            else:
+                # Decision.__post_init__ blocks this, but be defensive.
+                logger.warning("unknown operation %r; skipping", d.operation)
+                out.append(AppliedDecision(operation="NOOP", memory_id=None))
+        except Exception as e:
+            logger.warning(
+                "failed to apply decision %s for fact %r: %s",
+                d.operation, d.new_fact.text[:60], e,
+            )
+            out.append(AppliedDecision(operation="ERROR", memory_id=None))
+    return out
+
+
+def _apply_add(
+    d: Decision,
+    *,
+    mem: Any,
+    user_id: str,
+    project_id: Optional[str],
+    session_id: Optional[str],
+    scope: str,
+    extraction_model: str,
+    parent_agent_id: Optional[str],
+) -> AppliedDecision:
+    new_mem = _fact_to_memory(
+        d.new_fact, user_id=user_id, project_id=project_id,
+        session_id=session_id, scope=scope,
+        source_episode_id=d.evidence_episode_id,
+        extraction_model=extraction_model,
+        parent_agent_id=parent_agent_id,
+    )
+    inserted = mem._store.insert(new_mem)
+    if mem._vector_store is not None:
+        try:
+            mem._vector_store.add(inserted.id, inserted.content)
+        except Exception as e:
+            logger.warning("vector add failed for %s: %s", inserted.id, e)
+    return AppliedDecision(operation="ADD", memory_id=inserted.id)
+
+
+def _apply_update(d: Decision, *, mem: Any) -> AppliedDecision:
+    existing = mem._store.get(d.existing_id)
+    if existing is None:
+        logger.warning(
+            "UPDATE target %s vanished; falling through as ADD-on-failed-update",
+            d.existing_id,
+        )
+        return AppliedDecision(operation="ERROR", memory_id=d.existing_id)
+
+    existing.content = d.new_fact.text
+    if d.new_fact.category and d.new_fact.category != "general":
+        existing.category = d.new_fact.category
+    if d.new_fact.entity:
+        existing.entity = d.new_fact.entity
+    # Confidence: take the higher of old vs new (don't downgrade audit trail)
+    existing.confidence = max(existing.confidence, d.new_fact.confidence)
+    mem._store.update(existing)
+
+    if mem._vector_store is not None:
+        try:
+            mem._vector_store.add(existing.id, existing.content)
+        except Exception as e:
+            logger.warning("vector re-embed failed for %s: %s", existing.id, e)
+    return AppliedDecision(operation="UPDATE", memory_id=existing.id)
+
+
+def _apply_invalidate(
+    d: Decision,
+    *,
+    mem: Any,
+    user_id: str,
+    project_id: Optional[str],
+    session_id: Optional[str],
+    scope: str,
+    extraction_model: str,
+    parent_agent_id: Optional[str],
+) -> AppliedDecision:
+    """Insert the new memory, then mark the old one superseded by it.
+
+    The old row is NOT deleted — temporal replay must still find it.
+    """
+    new_mem = _fact_to_memory(
+        d.new_fact, user_id=user_id, project_id=project_id,
+        session_id=session_id, scope=scope,
+        source_episode_id=d.evidence_episode_id,
+        extraction_model=extraction_model,
+        parent_agent_id=parent_agent_id,
+    )
+    inserted = mem._store.insert(new_mem)
+    if mem._vector_store is not None:
+        try:
+            mem._vector_store.add(inserted.id, inserted.content)
+        except Exception as e:
+            logger.warning("vector add failed for %s: %s", inserted.id, e)
+
+    old = mem._store.get(d.existing_id)
+    if old is None:
+        logger.warning(
+            "INVALIDATE target %s vanished; new row %s stands alone",
+            d.existing_id, inserted.id,
+        )
+        return AppliedDecision(
+            operation="INVALIDATE", memory_id=None, new_memory_id=inserted.id,
+        )
+    mem._temporal.supersede(old, inserted.id)
+    return AppliedDecision(
+        operation="INVALIDATE", memory_id=old.id, new_memory_id=inserted.id,
+    )

--- a/attestor/conversation/episodes.py
+++ b/attestor/conversation/episodes.py
@@ -1,0 +1,178 @@
+"""EpisodeRepo — verbatim user+assistant rounds in the ``episodes`` table.
+
+Episodes are the immutable audit log: every extracted fact links back
+to the episode it came from via ``memories.source_episode_id``. The
+table itself is append-only — no UPDATE/DELETE except cascade.
+
+RLS-scoped: writes go through the runtime role's connection, which
+must already have the RLS variable set to the writing user's id.
+``AgentMemory._resolve()`` does this before calling write paths.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+import psycopg2.extras
+
+from attestor.conversation.turns import ConversationTurn
+
+
+def _now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+@dataclass(frozen=True)
+class Episode:
+    """One verbatim conversational round, as persisted in ``episodes``."""
+
+    id: str
+    user_id: str
+    session_id: str
+    thread_id: str
+    user_turn_text: str
+    assistant_turn_text: str
+    user_ts: datetime
+    assistant_ts: datetime
+    project_id: Optional[str] = None
+    agent_id: Optional[str] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+    created_at: datetime = field(default_factory=_now_utc)
+
+    @classmethod
+    def from_row(cls, row: Dict[str, Any]) -> Episode:
+        meta = row.get("metadata") or {}
+        if isinstance(meta, str):
+            meta = json.loads(meta)
+        return cls(
+            id=str(row["id"]),
+            user_id=str(row["user_id"]),
+            project_id=str(row["project_id"]) if row.get("project_id") else None,
+            session_id=str(row["session_id"]),
+            thread_id=row["thread_id"],
+            user_turn_text=row["user_turn_text"],
+            assistant_turn_text=row["assistant_turn_text"],
+            user_ts=row["user_ts"],
+            assistant_ts=row["assistant_ts"],
+            agent_id=row.get("agent_id"),
+            metadata=meta,
+            created_at=row["created_at"],
+        )
+
+
+class EpisodeRepo:
+    """Pure data-access for the v4 ``episodes`` table.
+
+    Takes a psycopg2 connection at construction time; caller manages the
+    connection lifecycle. RLS variable must be set by the caller before
+    any write/read."""
+
+    def __init__(self, conn: Any) -> None:
+        self._conn = conn
+
+    # ── Create ────────────────────────────────────────────────────────────
+
+    def write_round(
+        self,
+        user_id: str,
+        session_id: str,
+        user_turn: ConversationTurn,
+        assistant_turn: ConversationTurn,
+        project_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Episode:
+        """Persist one verbatim round. Returns the created Episode.
+
+        Validates that both turns share the same thread_id and that the
+        user turn precedes the assistant turn in time. Roles must be
+        user/assistant respectively (anti-foot-gun).
+        """
+        if user_turn.thread_id != assistant_turn.thread_id:
+            raise ValueError(
+                f"thread_id mismatch: user={user_turn.thread_id!r} "
+                f"assistant={assistant_turn.thread_id!r}"
+            )
+        if not user_turn.is_user:
+            raise ValueError(
+                f"user_turn.role must be 'user'; got {user_turn.role!r}"
+            )
+        if not assistant_turn.is_assistant:
+            raise ValueError(
+                f"assistant_turn.role must be 'assistant'; got "
+                f"{assistant_turn.role!r}"
+            )
+        if assistant_turn.ts < user_turn.ts:
+            raise ValueError(
+                "assistant_turn.ts cannot precede user_turn.ts"
+            )
+
+        new_id = str(uuid.uuid4())
+        with self._conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            cur.execute(
+                """
+                INSERT INTO episodes (
+                    id, user_id, project_id, session_id, thread_id,
+                    user_turn_text, assistant_turn_text,
+                    user_ts, assistant_ts, agent_id, metadata
+                )
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s::jsonb)
+                RETURNING *
+                """,
+                (
+                    new_id, user_id, project_id, session_id,
+                    user_turn.thread_id,
+                    user_turn.content, assistant_turn.content,
+                    user_turn.ts, assistant_turn.ts,
+                    agent_id,
+                    json.dumps(metadata or {}),
+                ),
+            )
+            row = cur.fetchone()
+        self._conn.commit()
+        return Episode.from_row(dict(row))
+
+    # ── Read ──────────────────────────────────────────────────────────────
+
+    def get(self, episode_id: str) -> Optional[Episode]:
+        with self._conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            cur.execute("SELECT * FROM episodes WHERE id = %s", (episode_id,))
+            row = cur.fetchone()
+        return Episode.from_row(dict(row)) if row else None
+
+    def list_for_thread(
+        self, thread_id: str, limit: int = 50,
+    ) -> List[Episode]:
+        """Chronological history for a thread (RLS scoped to the caller)."""
+        with self._conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            cur.execute(
+                "SELECT * FROM episodes WHERE thread_id = %s "
+                "ORDER BY user_ts ASC LIMIT %s",
+                (thread_id, limit),
+            )
+            rows = cur.fetchall()
+        return [Episode.from_row(dict(r)) for r in rows]
+
+    def list_for_session(
+        self, session_id: str, limit: int = 100,
+    ) -> List[Episode]:
+        with self._conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            cur.execute(
+                "SELECT * FROM episodes WHERE session_id = %s "
+                "ORDER BY user_ts ASC LIMIT %s",
+                (session_id, limit),
+            )
+            rows = cur.fetchall()
+        return [Episode.from_row(dict(r)) for r in rows]
+
+    def count_for_session(self, session_id: str) -> int:
+        with self._conn.cursor() as cur:
+            cur.execute(
+                "SELECT COUNT(*) FROM episodes WHERE session_id = %s",
+                (session_id,),
+            )
+            return int(cur.fetchone()[0])

--- a/attestor/conversation/ingest.py
+++ b/attestor/conversation/ingest.py
@@ -1,0 +1,302 @@
+"""ConversationIngest — round-level orchestration (Phase 3.5).
+
+Wires the foundation pieces:
+
+  EpisodeRepo.write_round   — verbatim audit
+  extract_user_facts        — user-side facts (with source_span)
+  extract_agent_facts       — assistant-side facts
+  resolve_conflicts         — ADD/UPDATE/INVALIDATE/NOOP per fact
+  apply_decisions           — write through supersession
+
+Public surface:
+
+  IngestConfig    — knobs (model, recall_k, etc.)
+  RoundResult     — episode_id + decisions + applied
+  ConversationIngest.ingest_round(user_turn, assistant_turn, *, ctx)
+
+Designed so AgentMemory.ingest_round() is a thin wrapper that resolves
+identity, then delegates here.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, List, Optional
+
+from attestor.conversation.apply import AppliedDecision, apply_decisions
+from attestor.conversation.episodes import Episode, EpisodeRepo
+from attestor.conversation.turns import ConversationTurn
+from attestor.extraction.conflict_resolver import Decision, resolve_conflicts
+from attestor.extraction.round_extractor import (
+    DEFAULT_MAX_TOKENS,
+    DEFAULT_MODEL,
+    ExtractedFact,
+    extract_agent_facts,
+    extract_user_facts,
+)
+from attestor.models import Memory
+
+logger = logging.getLogger("attestor.conversation.ingest")
+
+
+@dataclass(frozen=True)
+class IngestConfig:
+    """Tuning knobs for ingest_round.
+
+    extract_user / extract_agent let callers turn off one side cheaply
+    (e.g., audit-only assistants where user facts aren't useful)."""
+
+    extract_user: bool = True
+    extract_agent: bool = True
+    resolve_conflicts: bool = True
+    recall_k: int = 5  # how many existing memories to consider for conflict
+    extraction_model: str = DEFAULT_MODEL
+    extraction_max_tokens: int = DEFAULT_MAX_TOKENS
+    resolver_model: str = DEFAULT_MODEL
+
+
+@dataclass(frozen=True)
+class RoundResult:
+    """Output of one ingest_round call."""
+
+    episode: Episode
+    user_facts: List[ExtractedFact]
+    agent_facts: List[ExtractedFact]
+    decisions: List[Decision]
+    applied: List[AppliedDecision]
+
+    @property
+    def episode_id(self) -> str:
+        return self.episode.id
+
+    @property
+    def written_memory_ids(self) -> List[str]:
+        return [a.memory_id for a in self.applied if a.memory_id and a.operation in {"ADD", "UPDATE", "INVALIDATE"}]
+
+
+class ConversationIngest:
+    """Per-round extraction → conflict resolution → write.
+
+    Keeps a reference to the AgentMemory (mem) but doesn't construct it.
+    Tests use a duck-typed Mem stub; production code passes a real
+    AgentMemory.
+    """
+
+    def __init__(
+        self,
+        mem: Any,                              # AgentMemory
+        config: Optional[IngestConfig] = None,
+        *,
+        extraction_client: Optional[Any] = None,
+        resolver_client: Optional[Any] = None,
+    ) -> None:
+        self._mem = mem
+        self.config = config or IngestConfig()
+        self._extraction_client = extraction_client
+        self._resolver_client = resolver_client
+
+    # ── Public API ──────────────────────────────────────────────────────
+
+    def ingest_round(
+        self,
+        user_turn: ConversationTurn,
+        assistant_turn: ConversationTurn,
+        *,
+        user_id: str,
+        session_id: str,
+        project_id: Optional[str] = None,
+        scope: str = "user",
+        agent_id: Optional[str] = None,
+        recent_context: str = "(none)",
+    ) -> RoundResult:
+        """End-to-end ingest of one (user, assistant) round.
+
+        Steps:
+          1. Verbatim episode write (audit log)
+          2. Speaker-locked extraction (user + agent in sequence)
+          3. Conflict resolution against top-k similar existing memories
+          4. Apply decisions through supersession path
+        """
+        episode = self._write_episode(
+            user_turn=user_turn, assistant_turn=assistant_turn,
+            user_id=user_id, session_id=session_id,
+            project_id=project_id, agent_id=agent_id,
+        )
+
+        user_facts = self._extract(user_turn, recent_context, kind="user")
+        agent_facts = self._extract(assistant_turn, recent_context, kind="agent")
+        all_facts: List[ExtractedFact] = user_facts + agent_facts
+
+        decisions = self._resolve(
+            new_facts=all_facts,
+            evidence_episode_id=episode.id,
+            user_id=user_id,
+        )
+
+        applied = apply_decisions(
+            decisions,
+            mem=self._mem,
+            user_id=user_id,
+            project_id=project_id,
+            session_id=session_id,
+            scope=scope,
+            extraction_model=self.config.extraction_model,
+            parent_agent_id=agent_id,
+        )
+        return RoundResult(
+            episode=episode,
+            user_facts=user_facts,
+            agent_facts=agent_facts,
+            decisions=decisions,
+            applied=applied,
+        )
+
+    # ── Internal helpers ────────────────────────────────────────────────
+
+    def _write_episode(
+        self,
+        *,
+        user_turn: ConversationTurn,
+        assistant_turn: ConversationTurn,
+        user_id: str,
+        session_id: str,
+        project_id: Optional[str],
+        agent_id: Optional[str],
+    ) -> Episode:
+        repo = EpisodeRepo(self._mem._store._conn)
+        return repo.write_round(
+            user_id=user_id,
+            session_id=session_id,
+            project_id=project_id,
+            user_turn=user_turn,
+            assistant_turn=assistant_turn,
+            agent_id=agent_id,
+        )
+
+    def _extract(
+        self, turn: ConversationTurn, recent_context: str, *, kind: str,
+    ) -> List[ExtractedFact]:
+        if kind == "user":
+            if not self.config.extract_user:
+                return []
+            return extract_user_facts(
+                turn, recent_context=recent_context,
+                model=self.config.extraction_model,
+                max_tokens=self.config.extraction_max_tokens,
+                client=self._extraction_client,
+            )
+        if kind == "agent":
+            if not self.config.extract_agent:
+                return []
+            return extract_agent_facts(
+                turn, recent_context=recent_context,
+                model=self.config.extraction_model,
+                max_tokens=self.config.extraction_max_tokens,
+                client=self._extraction_client,
+            )
+        raise ValueError(f"unknown kind: {kind!r}")
+
+    def _resolve(
+        self,
+        *,
+        new_facts: List[ExtractedFact],
+        evidence_episode_id: str,
+        user_id: str,
+    ) -> List[Decision]:
+        if not self.config.resolve_conflicts or not new_facts:
+            return [
+                Decision(
+                    operation="ADD", new_fact=f, existing_id=None,
+                    rationale="conflict resolution disabled",
+                    evidence_episode_id=evidence_episode_id,
+                )
+                for f in new_facts
+            ]
+        existing = self._retrieve_similar(new_facts, user_id=user_id)
+        return resolve_conflicts(
+            new_facts=new_facts,
+            existing=existing,
+            evidence_episode_id=evidence_episode_id,
+            model=self.config.resolver_model,
+            max_tokens=self.config.extraction_max_tokens,
+            client=self._resolver_client,
+        )
+
+    def _retrieve_similar(
+        self, new_facts: List[ExtractedFact], *, user_id: str,
+    ) -> List[Memory]:
+        """Top-k existing memories most similar to the new facts.
+
+        Two-tier lookup:
+          1. Try ``mem.recall`` (full retrieval pipeline — vector/tag/graph).
+          2. Fall back to a direct doc-store query by category+entity from
+             the new facts. This keeps the resolver useful even when the
+             vector store is unavailable (managed embedder offline, etc.).
+        """
+        if not new_facts or self._mem is None:
+            return []
+
+        # Tier 1: full recall pipeline
+        try:
+            query = " | ".join(f.text for f in new_facts)
+            results = self._mem.recall(
+                query, budget=2000, user_id=user_id,
+            )
+            out = self._dedupe_top_k([r.memory for r in results])
+            if out:
+                return out
+        except Exception as e:
+            logger.debug("recall lookup failed; falling back to doc-store: %s", e)
+
+        # Tier 2: doc-store fallback by (category, entity)
+        return self._fallback_doc_lookup(new_facts)
+
+    def _fallback_doc_lookup(
+        self, new_facts: List[ExtractedFact],
+    ) -> List[Memory]:
+        """Query the document store directly for memories that share a
+        category or entity with any new fact. Best-effort; returns [] on
+        failure or if the store doesn't support list_memories."""
+        store = self._mem._store
+        if not hasattr(store, "list_memories"):
+            return []
+        seen: set = set()
+        out: List[Memory] = []
+        for fact in new_facts:
+            try:
+                # Prefer entity-scoped lookup when available
+                if fact.entity:
+                    rows = store.list_memories(
+                        category=fact.category, entity=fact.entity,
+                        status="active", limit=self.config.recall_k,
+                    )
+                else:
+                    rows = store.list_memories(
+                        category=fact.category,
+                        status="active", limit=self.config.recall_k,
+                    )
+            except Exception as e:
+                logger.debug("doc-store fallback lookup failed: %s", e)
+                continue
+            for m in rows:
+                if m.id in seen:
+                    continue
+                seen.add(m.id)
+                out.append(m)
+                if len(out) >= self.config.recall_k:
+                    return out
+        return out
+
+    @staticmethod
+    def _dedupe_top_k(memories: List[Memory], limit: int = 5) -> List[Memory]:
+        seen: set = set()
+        out: List[Memory] = []
+        for m in memories:
+            if m.id in seen:
+                continue
+            seen.add(m.id)
+            out.append(m)
+            if len(out) >= limit:
+                break
+        return out

--- a/attestor/conversation/turns.py
+++ b/attestor/conversation/turns.py
@@ -1,0 +1,77 @@
+"""ConversationTurn — speaker-tagged verbatim message dataclass.
+
+Roadmap §A.1: a turn is one message. A *round* is a (user_turn,
+assistant_turn) pair. This module models the single turn; the round
+is composed in ``ConversationIngest.ingest_round``.
+
+Why frozen: turns are append-only audit records. Once captured, they
+must never be paraphrased, edited, or reordered. Mutation here would
+break the bi-temporal guarantee that ``episodes`` is the immutable
+source of truth.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+
+def _now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+@dataclass(frozen=True)
+class ConversationTurn:
+    """One message in a conversation. Verbatim — never paraphrased.
+
+    Attributes:
+        thread_id: Stable identifier for the conversation thread. Multiple
+            sessions may share a thread_id (e.g., resumed chat); episodes
+            join on this for thread-level history.
+        speaker: One of ``"user" | "assistant" | "<agent_id>"``. Used by
+            extraction prompts to lock to one speaker (the speaker-lock
+            IMPORTANT line in roadmap §A.2).
+        role: OpenAI/Anthropic-style role: ``"user" | "assistant" |
+            "system" | "tool"``. Distinct from ``speaker`` so we can
+            track multi-agent provenance while still sending standard
+            chat-completion roles to the LLM.
+        content: The verbatim text of the message.
+        ts: Event time (when the turn occurred). Used for temporal
+            reasoning + ``valid_from`` of any extracted facts.
+        parent_turn_id: Optional pointer to the previous turn id, for
+            tool-call chains and forks.
+        tool_calls: Optional list of tool invocations attached to this
+            turn (assistant-side typically).
+        metadata: Arbitrary JSON-serializable extras.
+    """
+
+    thread_id: str
+    speaker: str
+    role: str
+    content: str
+    ts: datetime = field(default_factory=_now_utc)
+    parent_turn_id: Optional[str] = None
+    tool_calls: Optional[List[Dict[str, Any]]] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.thread_id:
+            raise ValueError("ConversationTurn.thread_id is required")
+        if not self.speaker:
+            raise ValueError("ConversationTurn.speaker is required")
+        if self.role not in {"user", "assistant", "system", "tool"}:
+            raise ValueError(
+                f"ConversationTurn.role must be one of "
+                f"user/assistant/system/tool; got {self.role!r}"
+            )
+        if not self.content:
+            raise ValueError("ConversationTurn.content cannot be empty")
+
+    @property
+    def is_user(self) -> bool:
+        return self.role == "user"
+
+    @property
+    def is_assistant(self) -> bool:
+        return self.role == "assistant"

--- a/attestor/core.py
+++ b/attestor/core.py
@@ -116,11 +116,25 @@ class AgentMemory:
 
         # Initialize managers
         self._temporal = TemporalManager(self._store)
+        # BM25 / FTS lane (Phase 4.3) — opt-in via v4 schema's content_tsv
+        # column. Only safe when the doc store exposes a psycopg2 conn.
+        bm25_lane = None
+        if (
+            getattr(self._store, "_v4", False)
+            and getattr(self._store, "_conn", None) is not None
+        ):
+            try:
+                from attestor.retrieval.bm25 import BM25Lane
+                bm25_lane = BM25Lane(self._store._conn)
+            except Exception as e:
+                logger.debug("BM25 lane init skipped: %s", e)
+
         self._retrieval = RetrievalOrchestrator(
             self._store,
             min_results=self.config.min_results,
             vector_store=self._vector_store,
             graph=self._graph,
+            bm25_lane=bm25_lane,
         )
         # Wire retrieval tuning from config
         self._retrieval.enable_mmr = self.config.enable_mmr

--- a/attestor/core.py
+++ b/attestor/core.py
@@ -421,6 +421,59 @@ class AgentMemory:
 
         return ResolvedContext(user=user, project=project, session=session)
 
+    # -- v4 round-level conversation ingest (Phase 3.5) --
+
+    def ingest_round(
+        self,
+        user_turn: Any,                 # ConversationTurn
+        assistant_turn: Any,            # ConversationTurn
+        *,
+        user_id: Optional[str] = None,
+        project_id: Optional[str] = None,
+        session_id: Optional[str] = None,
+        scope: str = "user",
+        agent_id: Optional[str] = None,
+        recent_context: str = "(none)",
+        config: Optional[Any] = None,        # IngestConfig
+        extraction_client: Optional[Any] = None,
+        resolver_client: Optional[Any] = None,
+    ) -> Any:                            # RoundResult
+        """End-to-end ingest of one conversational round.
+
+        Resolves identity (SOLO defaults apply), writes the verbatim
+        episode, runs speaker-locked extraction in two passes, resolves
+        conflicts against existing similar memories, and applies the
+        ADD/UPDATE/INVALIDATE/NOOP decisions through the supersession
+        path.
+
+        Returns a ``RoundResult`` with episode + decisions + applied
+        outcomes — enough for tests + audit dashboards.
+        """
+        from attestor.conversation.ingest import ConversationIngest
+
+        rc = self._resolve(
+            user_id=user_id,
+            project_id=project_id,
+            session_id=session_id,
+            autostart=True,
+        )
+        ingest = ConversationIngest(
+            self,
+            config=config,
+            extraction_client=extraction_client,
+            resolver_client=resolver_client,
+        )
+        return ingest.ingest_round(
+            user_turn=user_turn,
+            assistant_turn=assistant_turn,
+            user_id=rc.user.id,
+            project_id=rc.project.id,
+            session_id=rc.session.id if rc.session else None,
+            scope=scope,
+            agent_id=agent_id,
+            recent_context=recent_context,
+        )
+
     @property
     def mode(self) -> AttestorMode:
         """The detected operating mode. Settable via ``config["mode"]`` or

--- a/attestor/extraction/conflict_resolver.py
+++ b/attestor/extraction/conflict_resolver.py
@@ -1,0 +1,289 @@
+"""Conflict resolver — turn extracted facts into Decisions (Phase 3.4).
+
+Compares each newly-extracted ``ExtractedFact`` against existing
+similar memories and decides one of:
+
+  ADD         — new info, no existing match, write a fresh memory
+  UPDATE      — same entity+predicate, refined value, keep existing id
+  INVALIDATE  — old memory contradicted; mark superseded (timeline replays)
+  NOOP        — already represented; skip
+
+Backed by ``MEMORY_UPDATE_PROMPT``. Decisions carry the
+``evidence_episode_id`` so every supersession is auditable.
+
+Like the extractor, this module is resilient to LLM failures: a parse
+failure for a single fact yields an ADD-by-default decision (safe path —
+better to write a duplicate-ish row than to drop it silently).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import Any, List, Optional
+
+from attestor.extraction.prompts import format_memory_update_prompt
+from attestor.extraction.round_extractor import (
+    DEFAULT_MAX_TOKENS,
+    DEFAULT_MODEL,
+    ExtractedFact,
+    _parse_facts_payload,
+    _strip_markdown_fences,
+    default_llm_client,
+)
+from attestor.models import Memory
+
+logger = logging.getLogger("attestor.extraction.resolver")
+
+
+VALID_OPERATIONS = {"ADD", "UPDATE", "INVALIDATE", "NOOP"}
+
+
+@dataclass(frozen=True)
+class Decision:
+    """One ADD/UPDATE/INVALIDATE/NOOP decision for a single new fact."""
+
+    operation: str  # one of VALID_OPERATIONS
+    new_fact: ExtractedFact
+    existing_id: Optional[str]  # None for ADD/NOOP; the existing memory id otherwise
+    rationale: str
+    evidence_episode_id: str
+
+    def __post_init__(self) -> None:
+        if self.operation not in VALID_OPERATIONS:
+            raise ValueError(
+                f"Decision.operation must be one of {VALID_OPERATIONS}; "
+                f"got {self.operation!r}"
+            )
+        if self.operation in {"UPDATE", "INVALIDATE"} and not self.existing_id:
+            raise ValueError(
+                f"{self.operation} requires existing_id"
+            )
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Serialization helpers — keep the prompt input deterministic
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _fact_to_dict(f: ExtractedFact) -> dict:
+    return {
+        "text": f.text,
+        "category": f.category,
+        "entity": f.entity,
+        "confidence": f.confidence,
+        "source_span": f.source_span,
+        "speaker": f.speaker,
+    }
+
+
+def _memory_to_dict(m: Memory) -> dict:
+    """Compact memory representation for the prompt context."""
+    return {
+        "id": m.id,
+        "content": m.content,
+        "category": m.category,
+        "entity": m.entity,
+        "valid_from": m.valid_from,
+        "confidence": m.confidence,
+    }
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Public API
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def resolve_conflicts(
+    new_facts: List[ExtractedFact],
+    existing: List[Memory],
+    evidence_episode_id: str,
+    *,
+    model: str = DEFAULT_MODEL,
+    max_tokens: int = DEFAULT_MAX_TOKENS,
+    client: Optional[Any] = None,
+) -> List[Decision]:
+    """Decide ADD/UPDATE/INVALIDATE/NOOP for each new fact.
+
+    Returns one Decision per new_fact (in order). On any LLM/parse
+    failure the new fact gets an ADD-by-default decision so the caller
+    still persists something.
+
+    If ``new_facts`` is empty, returns []. If ``existing`` is empty,
+    short-circuits with all-ADD without an LLM call (no contradictions
+    are possible against an empty set).
+    """
+    if not new_facts:
+        return []
+
+    if not existing:
+        return [
+            Decision(
+                operation="ADD",
+                new_fact=f,
+                existing_id=None,
+                rationale="no existing memories to compare against",
+                evidence_episode_id=evidence_episode_id,
+            )
+            for f in new_facts
+        ]
+
+    prompt = format_memory_update_prompt(
+        existing_memories_json=json.dumps(
+            [_memory_to_dict(m) for m in existing], ensure_ascii=False,
+        ),
+        new_facts_json=json.dumps(
+            [_fact_to_dict(f) for f in new_facts], ensure_ascii=False,
+        ),
+    )
+    cli = client or default_llm_client()
+    try:
+        response = cli.chat.completions.create(
+            model=model,
+            max_tokens=max_tokens,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        raw_text = response.choices[0].message.content or ""
+    except Exception as e:
+        logger.warning("conflict resolver LLM call failed: %s", e)
+        return _fallback_all_add(new_facts, evidence_episode_id)
+
+    raw_decisions = _parse_decisions_payload(raw_text)
+    if not raw_decisions:
+        return _fallback_all_add(new_facts, evidence_episode_id)
+
+    return _bind_decisions(
+        raw_decisions=raw_decisions,
+        new_facts=new_facts,
+        evidence_episode_id=evidence_episode_id,
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Internal — parsing + binding
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _parse_decisions_payload(raw: str) -> List[dict]:
+    """Parse the LLM response into a list of decision dicts."""
+    text = _strip_markdown_fences(raw)
+    if not text:
+        return []
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError as e:
+        logger.warning("decisions JSON parse failed: %s; raw=%r", e, raw[:200])
+        return []
+    if isinstance(parsed, list):
+        return [d for d in parsed if isinstance(d, dict)]
+    if isinstance(parsed, dict):
+        decs = parsed.get("decisions", [])
+        if isinstance(decs, list):
+            return [d for d in decs if isinstance(d, dict)]
+    return []
+
+
+def _bind_decisions(
+    raw_decisions: List[dict],
+    new_facts: List[ExtractedFact],
+    evidence_episode_id: str,
+) -> List[Decision]:
+    """Match raw LLM decisions back to the input facts.
+
+    Strategy: bind by index when lengths match (the LLM kept the order),
+    otherwise by exact text match. Anything we can't bind falls back to
+    ADD so no fact is silently dropped.
+    """
+    decisions: List[Decision] = []
+
+    # Index-aligned fast path
+    if len(raw_decisions) == len(new_facts):
+        for fact, raw in zip(new_facts, raw_decisions):
+            decisions.append(_coerce(raw, fact, evidence_episode_id))
+        return decisions
+
+    # Text-match path: build a lookup by raw fact text
+    by_text: dict = {}
+    for raw in raw_decisions:
+        nf = raw.get("new_fact") or {}
+        text = nf.get("text") if isinstance(nf, dict) else None
+        if isinstance(text, str):
+            by_text[text.strip()] = raw
+
+    for fact in new_facts:
+        raw = by_text.get(fact.text.strip())
+        if raw is not None:
+            decisions.append(_coerce(raw, fact, evidence_episode_id))
+        else:
+            decisions.append(_default_add(fact, evidence_episode_id,
+                                          rationale="LLM omitted decision; default ADD"))
+    return decisions
+
+
+def _coerce(
+    raw: dict,
+    fact: ExtractedFact,
+    evidence_episode_id: str,
+) -> Decision:
+    """Best-effort: build a valid Decision from a raw LLM dict."""
+    op = raw.get("operation")
+    if not isinstance(op, str) or op.upper() not in VALID_OPERATIONS:
+        return _default_add(fact, evidence_episode_id,
+                            rationale=f"invalid operation: {op!r}")
+    op = op.upper()
+
+    existing_id = raw.get("existing_id")
+    if existing_id in (None, "", "null"):
+        existing_id = None
+    elif not isinstance(existing_id, str):
+        existing_id = str(existing_id)
+
+    # UPDATE / INVALIDATE without existing_id is broken — fall back to ADD
+    if op in {"UPDATE", "INVALIDATE"} and not existing_id:
+        return _default_add(
+            fact, evidence_episode_id,
+            rationale=f"{op} missing existing_id; defaulted to ADD",
+        )
+
+    rationale = raw.get("rationale")
+    if not isinstance(rationale, str):
+        rationale = "(no rationale provided)"
+
+    # evidence_episode_id from the LLM is informational; we always trust
+    # the caller's value, since the caller knows which episode actually
+    # produced the fact.
+    return Decision(
+        operation=op,
+        new_fact=fact,
+        existing_id=existing_id,
+        rationale=rationale,
+        evidence_episode_id=evidence_episode_id,
+    )
+
+
+def _default_add(
+    fact: ExtractedFact,
+    evidence_episode_id: str,
+    *,
+    rationale: str,
+) -> Decision:
+    return Decision(
+        operation="ADD",
+        new_fact=fact,
+        existing_id=None,
+        rationale=rationale,
+        evidence_episode_id=evidence_episode_id,
+    )
+
+
+def _fallback_all_add(
+    new_facts: List[ExtractedFact], evidence_episode_id: str,
+) -> List[Decision]:
+    return [
+        _default_add(
+            f, evidence_episode_id,
+            rationale="LLM resolver unavailable; defaulted to ADD",
+        )
+        for f in new_facts
+    ]

--- a/attestor/extraction/prompts.py
+++ b/attestor/extraction/prompts.py
@@ -1,0 +1,206 @@
+"""Extraction prompts for the v4 conversation pipeline (roadmap §A.2/A.3).
+
+Three prompts, each carrying a load-bearing constraint that must not
+drift in future edits:
+
+  USER_FACT_EXTRACTION_PROMPT
+      Speaker-locked to the USER turn. The `IMPORTANT` line is the +53.6
+      single-session-assistant fix Mem0 published in April 2026 — without
+      it, the extractor leaks assistant statements into the user-fact
+      stream and audit becomes impossible.
+
+  AGENT_FACT_EXTRACTION_PROMPT
+      Speaker-locked to the ASSISTANT turn. Same `IMPORTANT` mechanism.
+      Categories favor recommendation / decision / commitment / etc. so
+      compliance review can audit what the agent said vs what it did.
+
+  MEMORY_UPDATE_PROMPT
+      Compares newly extracted facts against existing memories and
+      decides ADD / UPDATE / INVALIDATE / NOOP per fact. Adds an
+      `evidence_episode_id` requirement so every decision links back to
+      the source episode for replay.
+
+These strings are templated with `str.format` — placeholder names are
+defined in `PROMPT_VARS` so test_extraction_prompts.py can guard
+against accidental renames.
+"""
+
+from __future__ import annotations
+
+# Format-template variable names. Tests assert these stay stable.
+PROMPT_VARS = {
+    "USER_FACT": {"ts", "user_message", "recent_context_summary"},
+    "AGENT_FACT": {"ts", "assistant_message", "recent_context_summary"},
+    "MEMORY_UPDATE": {"existing_memories_json", "new_facts_json"},
+}
+
+
+USER_FACT_EXTRACTION_PROMPT = """\
+You are a Personal Information Organizer for a multi-agent system. You extract
+durable facts from user messages so that other agents can act on them later.
+
+What to extract:
+1. Personal preferences (likes, dislikes, choices)
+2. Important personal details (names, relationships, dates, locations)
+3. Plans and intentions (upcoming events, goals, commitments)
+4. Activity and service preferences
+5. Health and wellness information
+6. Professional details (employer, role, responsibilities)
+7. Financial details (accounts, risk tolerance, dependents) -- preserve exact figures
+8. Anything the user explicitly asks you to remember
+
+What NOT to extract:
+- Pleasantries, greetings, sign-offs
+- Questions the user asks (those are intents, not facts)
+- Hypotheticals ("what if I...")
+- Things the assistant said (a separate prompt handles those)
+
+Output schema (JSON only, no prose):
+{{
+  "facts": [
+    {{
+      "text": "<atomic fact, <= 25 words, third person>",
+      "category": "<preference|career|project|technical|personal|location|relationship|event|financial>",
+      "entity": "<primary entity, e.g. 'Acme Corp', 'Python', 'spouse'>",
+      "confidence": <0.0-1.0>,
+      "source_span": [<start_char>, <end_char>]
+    }}
+  ]
+}}
+
+# IMPORTANT: GENERATE FACTS SOLELY BASED ON THE USER'S MESSAGE BELOW.
+# Detect the input language and emit facts in that same language.
+# If no durable facts are present, return {{"facts": []}}.
+
+User message (timestamp: {ts}):
+\"\"\"
+{user_message}
+\"\"\"
+
+Recent thread context (for entity disambiguation only -- DO NOT extract from this):
+{recent_context_summary}
+
+Output:
+"""
+
+
+AGENT_FACT_EXTRACTION_PROMPT = """\
+You are a Decision Recorder for a multi-agent system. You extract durable
+statements made by an AI agent so they can be honored by future agents and
+audited by humans.
+
+What to extract:
+1. Recommendations and advice given (with rationale)
+2. Decisions made or actions taken
+3. Commitments to the user ("I'll do X", "I won't share Y")
+4. Constraints or rules the agent applied
+5. Numeric outputs the user may rely on (figures, dates, calculations)
+6. Refusals and the reason for them
+
+What NOT to extract:
+- Greetings, hedges, conversational filler
+- Questions asked of the user
+- The user's own statements (a separate prompt handles those)
+
+Output schema (JSON only):
+{{
+  "facts": [
+    {{
+      "text": "<atomic statement, <= 30 words, third person; preserve exact figures>",
+      "category": "<recommendation|decision|commitment|constraint|calculation|refusal>",
+      "entity": "<primary entity>",
+      "confidence": <0.0-1.0>,
+      "source_span": [<start>, <end>]
+    }}
+  ]
+}}
+
+# IMPORTANT: GENERATE FACTS SOLELY BASED ON THE ASSISTANT'S MESSAGE BELOW.
+# This is critical for audit: assistant statements drive compliance review.
+
+Assistant message (timestamp: {ts}):
+\"\"\"
+{assistant_message}
+\"\"\"
+
+Recent thread context (entity disambiguation only):
+{recent_context_summary}
+
+Output:
+"""
+
+
+MEMORY_UPDATE_PROMPT = """\
+You are the memory manager for a multi-agent system. Compare newly extracted
+facts against existing memories and decide what to do with each new fact.
+
+Operations:
+- ADD     : new information; no existing memory covers it
+- UPDATE  : same topic + entity, refined or more complete content (KEEP THE
+            EXISTING ID; preserve audit trail)
+- INVALIDATE: existing memory is contradicted by the new fact; mark the old
+            one superseded but DO NOT delete it (the timeline must replay)
+- NOOP    : new fact is already represented; do nothing
+
+Decision rules:
+1. Two facts about the SAME entity + SAME predicate with DIFFERENT values ->
+   newer wins -> INVALIDATE old, ADD new (with `supersedes` pointer).
+2. Two facts about the SAME entity + SAME predicate with REFINED value
+   (e.g. "works at Google" -> "Senior Engineer at Google") -> UPDATE the
+   existing memory keeping its ID.
+3. Same content, different phrasing -> NOOP.
+4. Brand new entity or predicate -> ADD.
+
+Output schema (JSON only):
+{{
+  "decisions": [
+    {{
+      "operation": "ADD|UPDATE|INVALIDATE|NOOP",
+      "new_fact": {{ ...the new fact object... }},
+      "existing_id": "<id-or-null>",
+      "rationale": "<one sentence>",
+      "evidence_episode_id": "<source episode id>"
+    }}
+  ]
+}}
+
+Existing memories (top-k similar to the new facts, with their IDs):
+{existing_memories_json}
+
+New facts to evaluate:
+{new_facts_json}
+
+Output:
+"""
+
+
+def format_user_fact_prompt(
+    ts: str, user_message: str, recent_context_summary: str = "(none)",
+) -> str:
+    """Render the USER fact extraction prompt."""
+    return USER_FACT_EXTRACTION_PROMPT.format(
+        ts=ts,
+        user_message=user_message,
+        recent_context_summary=recent_context_summary,
+    )
+
+
+def format_agent_fact_prompt(
+    ts: str, assistant_message: str, recent_context_summary: str = "(none)",
+) -> str:
+    """Render the AGENT (assistant) fact extraction prompt."""
+    return AGENT_FACT_EXTRACTION_PROMPT.format(
+        ts=ts,
+        assistant_message=assistant_message,
+        recent_context_summary=recent_context_summary,
+    )
+
+
+def format_memory_update_prompt(
+    existing_memories_json: str, new_facts_json: str,
+) -> str:
+    """Render the conflict resolution prompt."""
+    return MEMORY_UPDATE_PROMPT.format(
+        existing_memories_json=existing_memories_json,
+        new_facts_json=new_facts_json,
+    )

--- a/attestor/extraction/round_extractor.py
+++ b/attestor/extraction/round_extractor.py
@@ -1,0 +1,296 @@
+"""Round-level fact extraction (Phase 3.3, roadmap §A.2).
+
+Two functions:
+
+  extract_user_facts(turn, recent_context, model, client) -> list[ExtractedFact]
+      Speaker-locked to the USER. Returns durable facts the user stated
+      (preferences, plans, identity attributes...).
+
+  extract_agent_facts(turn, recent_context, model, client) -> list[ExtractedFact]
+      Speaker-locked to the ASSISTANT. Returns recommendations,
+      decisions, commitments — anything an auditor must replay.
+
+Both share:
+  - JSON-only output, parsed with markdown-fence tolerance
+  - Strict per-fact validation (drops malformed facts rather than crash)
+  - source_span citations clamped to the turn's content range
+  - Confidence clamped to [0.0, 1.0]
+
+LLM client is injectable so tests can use a stub. By default, builds an
+OpenRouter-backed OpenAI client from OPENROUTER_API_KEY (or OPENAI_API_KEY).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import Any, Callable, List, Optional
+
+from attestor.conversation.turns import ConversationTurn
+from attestor.extraction.prompts import (
+    format_agent_fact_prompt,
+    format_user_fact_prompt,
+)
+
+logger = logging.getLogger("attestor.extraction.round")
+
+DEFAULT_MODEL = "openai/gpt-4.1-mini"
+DEFAULT_MAX_TOKENS = 2048
+
+USER_FACT_CATEGORIES = {
+    "preference", "career", "project", "technical",
+    "personal", "location", "relationship", "event", "financial",
+}
+AGENT_FACT_CATEGORIES = {
+    "recommendation", "decision", "commitment",
+    "constraint", "calculation", "refusal",
+}
+
+
+@dataclass(frozen=True)
+class ExtractedFact:
+    """One atomic fact emitted by the extractor.
+
+    Bound to a single source turn; the (start, end) span lets the audit
+    pipeline highlight which portion of the turn produced this fact.
+    """
+
+    text: str
+    category: str
+    entity: Optional[str]
+    confidence: float
+    source_span: List[int]
+    speaker: str  # "user" | "assistant" | "<agent_id>"
+
+    @property
+    def source_start(self) -> int:
+        return self.source_span[0]
+
+    @property
+    def source_end(self) -> int:
+        return self.source_span[1]
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# LLM client
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def default_llm_client():
+    """Build an OpenRouter-backed OpenAI client. Raises if no key set.
+
+    Tests inject a stub via the `client` parameter on the extract_*
+    functions, so this is only invoked when a real call is needed.
+    """
+    from openai import OpenAI
+
+    or_key = os.environ.get("OPENROUTER_API_KEY")
+    if or_key:
+        return OpenAI(
+            base_url="https://openrouter.ai/api/v1",
+            api_key=or_key,
+        )
+    oa_key = os.environ.get("OPENAI_API_KEY")
+    if oa_key:
+        return OpenAI(api_key=oa_key)
+    raise RuntimeError(
+        "No LLM API key set. Provide OPENROUTER_API_KEY or OPENAI_API_KEY, "
+        "or pass client= explicitly."
+    )
+
+
+def _call_llm(
+    prompt: str,
+    *,
+    client: Any,
+    model: str,
+    max_tokens: int,
+) -> str:
+    """Invoke the LLM and return the raw response text."""
+    response = client.chat.completions.create(
+        model=model,
+        max_tokens=max_tokens,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return response.choices[0].message.content or ""
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# JSON parsing
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _strip_markdown_fences(text: str) -> str:
+    text = text.strip()
+    if text.startswith("```"):
+        lines = [l for l in text.split("\n") if not l.strip().startswith("```")]
+        text = "\n".join(lines).strip()
+    return text
+
+
+def _parse_facts_payload(raw: str) -> List[dict]:
+    """Parse the LLM response into a list of fact dicts.
+
+    Tolerates: markdown fences, pure-array shape, the documented
+    {"facts": [...]} envelope. Returns [] on any parse failure rather
+    than raising — extractor failures must never break ingest.
+    """
+    text = _strip_markdown_fences(raw)
+    if not text:
+        return []
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError as e:
+        logger.warning("extractor JSON parse failed: %s; raw=%r", e, raw[:200])
+        return []
+    if isinstance(parsed, list):
+        return [f for f in parsed if isinstance(f, dict)]
+    if isinstance(parsed, dict):
+        facts = parsed.get("facts", [])
+        if isinstance(facts, list):
+            return [f for f in facts if isinstance(f, dict)]
+    return []
+
+
+def _validate_fact(
+    raw: dict,
+    *,
+    speaker: str,
+    content_len: int,
+    allowed_categories: set,
+) -> Optional[ExtractedFact]:
+    """Coerce a raw fact dict into an ExtractedFact, or return None.
+
+    Validates:
+      - text is non-empty
+      - category is in the allowed set (else "general")
+      - confidence is a float in [0, 1] (else 0.5)
+      - source_span is [start, end] both ints, clamped to [0, content_len]
+        and start <= end (else [0, 0])
+    """
+    text = raw.get("text")
+    if not isinstance(text, str) or not text.strip():
+        return None
+
+    category = raw.get("category")
+    if not isinstance(category, str) or category not in allowed_categories:
+        category = "general"
+
+    entity_raw = raw.get("entity")
+    entity = entity_raw if isinstance(entity_raw, str) and entity_raw else None
+
+    conf_raw = raw.get("confidence", 0.5)
+    try:
+        confidence = float(conf_raw)
+    except (TypeError, ValueError):
+        confidence = 0.5
+    confidence = max(0.0, min(1.0, confidence))
+
+    span_raw = raw.get("source_span", [0, content_len])
+    if (
+        isinstance(span_raw, list) and len(span_raw) == 2
+        and all(isinstance(x, int) for x in span_raw)
+    ):
+        start = max(0, min(content_len, span_raw[0]))
+        end = max(start, min(content_len, span_raw[1]))
+    else:
+        start, end = 0, content_len
+
+    return ExtractedFact(
+        text=text.strip(),
+        category=category,
+        entity=entity,
+        confidence=confidence,
+        source_span=[start, end],
+        speaker=speaker,
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Public API
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def extract_user_facts(
+    turn: ConversationTurn,
+    recent_context: str = "(none)",
+    *,
+    model: str = DEFAULT_MODEL,
+    max_tokens: int = DEFAULT_MAX_TOKENS,
+    client: Optional[Any] = None,
+) -> List[ExtractedFact]:
+    """Extract durable facts from a USER turn.
+
+    Speaker-locked: refuses to extract from anything but the user message
+    via the IMPORTANT line in the prompt. Returns [] if the turn is not
+    a user turn, the LLM returns empty, or parsing fails — never raises
+    on extraction failure.
+    """
+    if not turn.is_user:
+        logger.warning(
+            "extract_user_facts called on a non-user turn (role=%r); "
+            "returning empty", turn.role,
+        )
+        return []
+    prompt = format_user_fact_prompt(
+        ts=turn.ts.isoformat(),
+        user_message=turn.content,
+        recent_context_summary=recent_context or "(none)",
+    )
+    cli = client or default_llm_client()
+    raw_text = _call_llm(prompt, client=cli, model=model, max_tokens=max_tokens)
+    raw_facts = _parse_facts_payload(raw_text)
+
+    facts: List[ExtractedFact] = []
+    for rf in raw_facts:
+        f = _validate_fact(
+            rf, speaker=turn.speaker,
+            content_len=len(turn.content),
+            allowed_categories=USER_FACT_CATEGORIES,
+        )
+        if f is not None:
+            facts.append(f)
+    return facts
+
+
+def extract_agent_facts(
+    turn: ConversationTurn,
+    recent_context: str = "(none)",
+    *,
+    model: str = DEFAULT_MODEL,
+    max_tokens: int = DEFAULT_MAX_TOKENS,
+    client: Optional[Any] = None,
+) -> List[ExtractedFact]:
+    """Extract durable statements from an ASSISTANT turn.
+
+    Speaker-locked to the assistant message. Categories are
+    recommendation / decision / commitment / constraint / calculation
+    / refusal — the audit categories an auditor cares about.
+    """
+    if not turn.is_assistant:
+        logger.warning(
+            "extract_agent_facts called on a non-assistant turn (role=%r); "
+            "returning empty", turn.role,
+        )
+        return []
+    prompt = format_agent_fact_prompt(
+        ts=turn.ts.isoformat(),
+        assistant_message=turn.content,
+        recent_context_summary=recent_context or "(none)",
+    )
+    cli = client or default_llm_client()
+    raw_text = _call_llm(prompt, client=cli, model=model, max_tokens=max_tokens)
+    raw_facts = _parse_facts_payload(raw_text)
+
+    facts: List[ExtractedFact] = []
+    for rf in raw_facts:
+        f = _validate_fact(
+            rf, speaker=turn.speaker,
+            content_len=len(turn.content),
+            allowed_categories=AGENT_FACT_CATEGORIES,
+        )
+        if f is not None:
+            facts.append(f)
+    return facts

--- a/attestor/retrieval/bm25.py
+++ b/attestor/retrieval/bm25.py
@@ -1,0 +1,119 @@
+"""BM25 / FTS retrieval lane (Phase 4.2, roadmap §B.2).
+
+Postgres' built-in full-text search with ``ts_rank_cd`` over a generated
+``content_tsv`` column gives a BM25-flavored keyword lane that runs in
+parallel with the vector lane. The orchestrator fuses both via RRF
+(Reciprocal Rank Fusion, k=60) to lift queries that the embedding alone
+under-recalls (acronyms, exact identifiers, rare proper nouns).
+
+Why a generated column instead of an expression index:
+  - Generated tsvector with weights (A=content, B=tags, C=entity) gives
+    deterministic ranking that the orchestrator can reason about.
+  - GIN over a stored column is the cheapest at query time.
+  - Schema migration is a single ALTER ADD COLUMN IF NOT EXISTS.
+
+Pure document lane: no LLM, no embedder, no network. Safe to call
+inside the recall hot path.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger("attestor.retrieval.bm25")
+
+
+@dataclass(frozen=True)
+class BM25Hit:
+    """One BM25-ranked memory hit."""
+    memory_id: str
+    score: float
+
+
+class BM25Lane:
+    """Postgres FTS-backed keyword retrieval lane.
+
+    Uses ``websearch_to_tsquery`` so user queries can include phrases
+    ("dark mode"), boolean operators (foo OR bar), and negation (-spam)
+    without the caller having to write tsquery syntax.
+
+    Falls back gracefully when the FTS column or index isn't present
+    (e.g., older v3 schema, fresh DB before the ALTER ran).
+    """
+
+    def __init__(self, conn: Any) -> None:
+        self._conn = conn
+
+    def search(
+        self,
+        query: str,
+        *,
+        limit: int = 20,
+        min_rank: float = 0.0,
+        active_only: bool = True,
+    ) -> List[BM25Hit]:
+        """Return the top BM25-ranked memory ids for ``query``.
+
+        RLS scopes the search automatically — the caller must already
+        have set ``attestor.current_user_id`` on the connection.
+
+        Returns an empty list if the FTS column is missing or the query
+        is empty / pure stop words.
+        """
+        if not query or not query.strip():
+            return []
+        sql = """
+            SELECT id,
+                   ts_rank_cd(content_tsv,
+                              websearch_to_tsquery('english', %(q)s)) AS rank
+            FROM memories
+            WHERE content_tsv @@ websearch_to_tsquery('english', %(q)s)
+        """
+        if active_only:
+            sql += " AND status = 'active' "
+        sql += " ORDER BY rank DESC LIMIT %(lim)s"
+
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(sql, {"q": query, "lim": limit})
+                rows = cur.fetchall()
+        except Exception as e:
+            # Most likely the FTS column doesn't exist yet on a v3-only
+            # deployment. Log once at debug and return empty so the
+            # orchestrator's other lanes still produce results.
+            logger.debug("BM25 search failed (%s); returning no hits", e)
+            return []
+
+        hits: List[BM25Hit] = []
+        for row in rows:
+            mid, rank = row[0], float(row[1])
+            if rank < min_rank:
+                continue
+            hits.append(BM25Hit(memory_id=str(mid), score=rank))
+        return hits
+
+
+def reciprocal_rank_fusion(
+    *ranked_lists: List[str],
+    k: int = 60,
+    limit: Optional[int] = None,
+) -> List[str]:
+    """Fuse multiple ranked id lists into one via RRF (Cormack '09).
+
+    score(d) = sum over lanes of 1 / (k + rank_in_lane(d))
+
+    k=60 is the canonical default; higher k flattens individual lanes'
+    influence (good when one lane is noisy).
+
+    Returns memory ids ordered by descending fused score.
+    """
+    scores: Dict[str, float] = {}
+    for lane in ranked_lists:
+        for rank, mid in enumerate(lane):
+            scores[mid] = scores.get(mid, 0.0) + 1.0 / (k + rank + 1)
+    ordered = sorted(scores.keys(), key=lambda m: scores[m], reverse=True)
+    if limit is not None:
+        ordered = ordered[:limit]
+    return ordered

--- a/attestor/retrieval/orchestrator.py
+++ b/attestor/retrieval/orchestrator.py
@@ -51,12 +51,16 @@ class RetrievalOrchestrator:
         vector_store=None,
         graph=None,
         enable_temporal_boost: bool = True,
+        bm25_lane=None,
     ):
         self.store = store
         self.min_results = min_results
         self.vector_store = vector_store
         self.graph = graph
         self.enable_temporal_boost = enable_temporal_boost
+        self.bm25_lane = bm25_lane            # Phase 4.3 — keyword/FTS lane
+        self.bm25_top_k: int = 30             # how many BM25 hits to feed to RRF
+        self.bm25_min_rank: float = 0.0       # drop hits below this rank
         self.confidence_gate: float = 0.0
         self.confidence_decay_rate: float = 0.001
         self.confidence_boost_rate: float = 0.03
@@ -193,10 +197,27 @@ class RetrievalOrchestrator:
             except Exception:
                 vector_hits_raw = []
 
-        # Materialize into RetrievalResult with preliminary vector_sim.
+        # ── Step 1b: BM25 lane (Phase 4.3) ──
+        # Runs alongside the vector lane; fused via RRF below. When the
+        # bm25_lane isn't configured (v3 deployments, custom backends),
+        # this is a no-op and recall behaves exactly as before.
+        bm25_hits_raw: List = []
+        if self.bm25_lane is not None:
+            try:
+                bm25_hits_raw = self.bm25_lane.search(
+                    query, limit=self.bm25_top_k,
+                    min_rank=self.bm25_min_rank,
+                )
+            except Exception:
+                bm25_hits_raw = []
+
+        # ── Step 2: Materialise vector candidates with preliminary vector_sim
         candidates: List[Dict] = []
+        seen_ids: set = set()
         for vr in vector_hits_raw:
             mid = vr["memory_id"]
+            if mid in seen_ids:
+                continue
             memory = self.store.get(mid)
             if not memory or memory.status != "active":
                 continue
@@ -207,6 +228,40 @@ class RetrievalOrchestrator:
             candidates.append(
                 {"memory": memory, "distance": distance, "vector_sim": vector_sim}
             )
+            seen_ids.add(mid)
+
+        # Pull BM25-only hits into the candidate set (vector_sim=0 for those).
+        # The RRF-style boost below rewards them based on their BM25 rank.
+        for hit in bm25_hits_raw:
+            if hit.memory_id in seen_ids:
+                continue
+            memory = self.store.get(hit.memory_id)
+            if not memory or memory.status != "active":
+                continue
+            if namespace and memory.namespace != namespace:
+                continue
+            candidates.append({
+                "memory": memory, "distance": 1.0, "vector_sim": 0.0,
+            })
+            seen_ids.add(hit.memory_id)
+
+        # ── Step 2b: RRF-blend vector + BM25 rank into a unified score ──
+        if bm25_hits_raw:
+            from attestor.retrieval.bm25 import reciprocal_rank_fusion
+            vector_ranked = [vr["memory_id"] for vr in vector_hits_raw]
+            bm25_ranked = [h.memory_id for h in bm25_hits_raw]
+            fused = reciprocal_rank_fusion(vector_ranked, bm25_ranked)
+            # Map id → fused position (0-based)
+            fused_rank = {mid: i for i, mid in enumerate(fused)}
+            # Convert fused position into a normalized [0, 1] bonus that we
+            # add to vector_sim. Top of fused list ≈ 1.0, tail decays slowly.
+            n = max(1, len(fused))
+            for c in candidates:
+                pos = fused_rank.get(c["memory"].id)
+                if pos is not None:
+                    c["vector_sim"] = max(
+                        c["vector_sim"], 1.0 - (pos / n),
+                    )
 
         # ── Step 2: Graph narrow ──
         affinity_map = self._graph_affinity_map(question_entities)

--- a/attestor/store/embeddings.py
+++ b/attestor/store/embeddings.py
@@ -1,11 +1,13 @@
 """Shared embedding providers — single source of truth for all backends.
 
 Fallback chain (each level tried only if the previous is unavailable):
-    1. Cloud-native (Bedrock / Azure OpenAI / Vertex AI) — if credentials present
-    2. OpenAI / OpenRouter text-embedding-3-large — if API key set
+    1. Local Ollama (bge-m3 by default, 1024-D) — if Ollama is reachable
+    2. Cloud-native (Bedrock / Azure OpenAI / Vertex AI) — if credentials present
+    3. OpenAI / OpenRouter text-embedding-3-large — if API key set
 
-There is no local/zero-config fallback. Attestor requires an upstream
-embedding API — BYO credentials.
+Local-first by design: Ollama on localhost:11434 is the default so attestor
+works offline / without API credits. Override with ATTESTOR_EMBEDDING_MODEL
+or ATTESTOR_EMBEDDING_PROVIDER env vars.
 
 Usage:
     provider = get_embedding_provider()          # auto-detect best available
@@ -95,6 +97,88 @@ class OpenAIEmbeddingProvider:
     def embed_batch(self, texts: List[str]) -> List[List[float]]:
         resp = self._client.embeddings.create(**self._create_kwargs(texts))
         return [d.embedding for d in resp.data]
+
+
+class OllamaEmbeddingProvider:
+    """Local Ollama embeddings (default model: bge-m3, 1024-D, 8K context).
+
+    Talks to ``http://localhost:11434/api/embeddings`` (override with
+    ``OLLAMA_HOST``). Probe-detects dimension at construction so swapping
+    the model just works — bge-m3 → 1024-D, nomic-embed-text → 768-D,
+    mxbai-embed-large → 1024-D, etc.
+
+    Local-first means: no network, no API credit cost, no rate limits.
+    The price is RAM + an Ollama daemon; both are usually already there
+    if you're running a local agent stack.
+    """
+
+    DEFAULT_MODEL = "bge-m3"
+    DEFAULT_HOST = "http://localhost:11434"
+
+    def __init__(
+        self,
+        model: Optional[str] = None,
+        host: Optional[str] = None,
+        timeout: float = 30.0,
+    ) -> None:
+        import requests
+
+        self._requests = requests
+        self._host = (host or os.environ.get("OLLAMA_HOST") or self.DEFAULT_HOST).rstrip("/")
+        self._model = model or os.environ.get("ATTESTOR_EMBEDDING_MODEL") or self.DEFAULT_MODEL
+        self._timeout = timeout
+        # Probe dimension once at boot. Raises if Ollama unreachable or
+        # model not pulled — caller catches and falls through to next
+        # provider in the chain.
+        probe = self._raw_embed("dim")
+        self._dimension = len(probe)
+
+    @property
+    def dimension(self) -> int:
+        return self._dimension
+
+    @property
+    def provider_name(self) -> str:
+        return f"ollama:{self._model}"
+
+    def _raw_embed(self, text: str) -> List[float]:
+        # Ollama's /api/embeddings returns {"embedding": [...]}; the newer
+        # /api/embed returns {"embeddings": [[...]]} for batch. Use the
+        # singular endpoint for consistency across versions.
+        r = self._requests.post(
+            f"{self._host}/api/embeddings",
+            json={"model": self._model, "prompt": text},
+            timeout=self._timeout,
+        )
+        r.raise_for_status()
+        data = r.json()
+        emb = data.get("embedding")
+        if not isinstance(emb, list):
+            raise RuntimeError(
+                f"Ollama embedding response missing 'embedding': {data}"
+            )
+        return emb
+
+    def embed(self, text: str) -> List[float]:
+        return self._raw_embed(text)
+
+    def embed_batch(self, texts: List[str]) -> List[List[float]]:
+        # Ollama doesn't batch on the /api/embeddings endpoint. Use the
+        # newer /api/embed if available; fall back to per-text loop.
+        try:
+            r = self._requests.post(
+                f"{self._host}/api/embed",
+                json={"model": self._model, "input": texts},
+                timeout=self._timeout,
+            )
+            r.raise_for_status()
+            data = r.json()
+            embs = data.get("embeddings")
+            if isinstance(embs, list) and len(embs) == len(texts):
+                return embs
+        except Exception as e:
+            logger.debug("ollama batch endpoint failed (%s); per-text fallback", e)
+        return [self._raw_embed(t) for t in texts]
 
 
 class BedrockEmbeddingProvider:
@@ -244,6 +328,23 @@ class VertexAIEmbeddingProvider:
 # ═══════════════════════════════════════════════════════════════════════
 
 
+def _try_ollama() -> Optional[EmbeddingProvider]:
+    """Probe local Ollama. Returns None if daemon unreachable or model
+    missing — caller falls through to the next provider."""
+    if os.environ.get("ATTESTOR_DISABLE_LOCAL_EMBED") in {"1", "true", "True"}:
+        return None
+    try:
+        provider = OllamaEmbeddingProvider()
+        logger.info(
+            "Using %s embeddings (%dD)",
+            provider.provider_name, provider.dimension,
+        )
+        return provider
+    except Exception as e:
+        logger.debug("Ollama embeddings unavailable: %s", e)
+        return None
+
+
 def _try_bedrock() -> Optional[EmbeddingProvider]:
     """Try to create Bedrock provider."""
     try:
@@ -349,15 +450,18 @@ def get_embedding_provider(
 ) -> EmbeddingProvider:
     """Get the best available embedding provider.
 
-    Fallback chain:
-        1. preferred cloud provider (if specified and available)
-        2. OpenAI / OpenRouter (if API key set)
+    Fallback chain (preferred wins if specified and available):
+        0. preferred ("ollama" / "bedrock" / "azure_openai" / "vertex_ai")
+        1. Local Ollama (bge-m3 default) — if daemon reachable + model pulled
+        2. Cloud-native (Bedrock / Azure OpenAI / Vertex AI) — credentials present
+        3. OpenAI / OpenRouter — API key set
 
-    There is no local fallback — an upstream embedding API is required.
+    Set ``ATTESTOR_DISABLE_LOCAL_EMBED=1`` to skip the Ollama probe (e.g.
+    on hosted deployments where Ollama isn't installed).
 
     Args:
-        preferred: Cloud provider hint — "bedrock", "azure_openai", "vertex_ai".
-                   Tried first but falls through on failure.
+        preferred: Provider hint — "ollama", "bedrock", "azure_openai",
+                   "vertex_ai". Tried first but falls through on failure.
 
     Returns:
         An EmbeddingProvider instance (cached after first call).
@@ -367,13 +471,29 @@ def get_embedding_provider(
     if _cached_provider is not None and preferred is None:
         return _cached_provider
 
-    if preferred and preferred in _CLOUD_PROVIDERS:
-        provider = _CLOUD_PROVIDERS[preferred]()
-        if provider is not None:
-            logger.info("Using %s embeddings (%dD)", provider.provider_name, provider.dimension)
-            _cached_provider = provider
-            return provider
+    # Explicit preference path (cloud or local)
+    if preferred:
+        if preferred == "ollama":
+            provider = _try_ollama()
+            if provider is not None:
+                _cached_provider = provider
+                return provider
+        elif preferred in _CLOUD_PROVIDERS:
+            provider = _CLOUD_PROVIDERS[preferred]()
+            if provider is not None:
+                logger.info(
+                    "Using %s embeddings (%dD)",
+                    provider.provider_name, provider.dimension,
+                )
+                _cached_provider = provider
+                return provider
         logger.debug("Preferred provider %r unavailable, trying fallbacks", preferred)
+
+    # Auto-detect chain: local first
+    provider = _try_ollama()
+    if provider is not None:
+        _cached_provider = provider
+        return provider
 
     provider = _try_openai()
     if provider is not None:
@@ -381,6 +501,7 @@ def get_embedding_provider(
         return provider
 
     raise RuntimeError(
-        "No embedding provider available. Set OPENROUTER_API_KEY or OPENAI_API_KEY, "
-        "or configure a cloud provider (Bedrock / Azure OpenAI / Vertex AI)."
+        "No embedding provider available. Start Ollama (`ollama serve`) with "
+        "`ollama pull bge-m3`, or set OPENROUTER_API_KEY / OPENAI_API_KEY, or "
+        "configure a cloud provider (Bedrock / Azure OpenAI / Vertex AI)."
     )

--- a/attestor/store/postgres_backend.py
+++ b/attestor/store/postgres_backend.py
@@ -309,6 +309,15 @@ class PostgresBackend(DocumentStore, VectorStore, GraphStore):
             "status": memory.status,
             "metadata": json.dumps(memory.metadata),
         }
+        # source_span on the v4 schema is INT4RANGE [start, end). psycopg2
+        # serializes a Python tuple/list of two ints into a Range literal
+        # via the explicit cast in the INSERT.
+        span = memory.source_span
+        if isinstance(span, (list, tuple)) and len(span) == 2:
+            source_span_literal = f"[{int(span[0])},{int(span[1])})"
+        else:
+            source_span_literal = None
+
         # v4-only params — present when caller set them.
         params.update({
             "user_id": memory.user_id,
@@ -316,6 +325,7 @@ class PostgresBackend(DocumentStore, VectorStore, GraphStore):
             "session_id": memory.session_id,
             "scope": memory.scope or "user",
             "source_episode_id": memory.source_episode_id,
+            "source_span": source_span_literal,
             "extraction_model": memory.extraction_model,
             "agent_id": memory.agent_id,
             "parent_agent_id": memory.parent_agent_id,
@@ -351,7 +361,7 @@ class PostgresBackend(DocumentStore, VectorStore, GraphStore):
                     confidence, status,
                     valid_from, valid_until,
                     superseded_by,
-                    source_episode_id, extraction_model,
+                    source_episode_id, source_span, extraction_model,
                     agent_id, parent_agent_id, visibility, signature,
                     metadata
                 )
@@ -362,7 +372,8 @@ class PostgresBackend(DocumentStore, VectorStore, GraphStore):
                     COALESCE(%(valid_from)s::timestamptz, NOW()),
                     %(valid_until)s::timestamptz,
                     %(superseded_by)s,
-                    %(source_episode_id)s, %(extraction_model)s,
+                    %(source_episode_id)s, %(source_span)s::int4range,
+                    %(extraction_model)s,
                     %(agent_id)s, %(parent_agent_id)s, %(visibility)s, %(signature)s,
                     %(metadata)s::jsonb
                 )
@@ -399,6 +410,28 @@ class PostgresBackend(DocumentStore, VectorStore, GraphStore):
 
     def update(self, memory: Memory) -> Memory:
         p = self._memory_to_params(memory)
+        if self._v4:
+            # v4 has no namespace / created_at / event_date columns.
+            # Mutates only the fields the call surface actually changes.
+            self._execute(
+                """
+                UPDATE memories SET
+                    content       = %(content)s,
+                    tags          = %(tags)s,
+                    category      = %(category)s,
+                    entity        = %(entity)s,
+                    valid_from    = COALESCE(%(valid_from)s::timestamptz, valid_from),
+                    valid_until   = %(valid_until)s::timestamptz,
+                    superseded_by = %(superseded_by)s,
+                    confidence    = %(confidence)s,
+                    status        = %(status)s,
+                    metadata      = %(metadata)s::jsonb
+                WHERE id = %(id)s
+                """,
+                p,
+            )
+            return memory
+        # v3 path
         self._execute("""
             UPDATE memories SET
                 content = %(content)s, tags = %(tags)s, category = %(category)s,
@@ -428,6 +461,11 @@ class PostgresBackend(DocumentStore, VectorStore, GraphStore):
         before: Optional[str] = None,
         limit: int = 100,
     ) -> List[Memory]:
+        # v4 schema replaces the v3 ``created_at`` text column with the
+        # bi-temporal ``t_created`` (TIMESTAMPTZ). Use the right one per
+        # active schema; namespace is ignored on v4 (replaced by RLS).
+        time_col = "t_created" if self._v4 else "created_at"
+
         filters = []
         params: Dict[str, Any] = {"lim": limit}
 
@@ -440,19 +478,20 @@ class PostgresBackend(DocumentStore, VectorStore, GraphStore):
         if entity:
             filters.append("entity = %(entity)s")
             params["entity"] = entity
-        if namespace:
+        if namespace and not self._v4:
             filters.append("namespace = %(namespace)s")
             params["namespace"] = namespace
         if after:
-            filters.append("created_at >= %(after)s")
+            filters.append(f"{time_col} >= %(after)s")
             params["after"] = after
         if before:
-            filters.append("created_at <= %(before)s")
+            filters.append(f"{time_col} <= %(before)s")
             params["before"] = before
 
         where = " AND ".join(filters) if filters else "TRUE"
         rows = self._execute(
-            f"SELECT * FROM memories WHERE {where} ORDER BY created_at DESC LIMIT %(lim)s",
+            f"SELECT * FROM memories WHERE {where} "
+            f"ORDER BY {time_col} DESC LIMIT %(lim)s",
             params,
         )
         return [self._row_to_memory(r) for r in rows]

--- a/attestor/store/postgres_backend.py
+++ b/attestor/store/postgres_backend.py
@@ -585,6 +585,58 @@ class PostgresBackend(DocumentStore, VectorStore, GraphStore):
         self._ensure_embedding_fn()
         return self._embedder.embed(text)
 
+    def _build_embedding_text(self, memory_id: str, content: str) -> str:
+        """Build the text used for embedding (Phase 4.1, roadmap §B.1).
+
+        On v4 rows that have a source_episode_id, concatenate:
+
+            extracted fact (content)
+            ---
+            user turn (verbatim)
+            ---
+            assistant turn (verbatim)
+            ---
+            Tags: tag1, tag2, ...
+
+        This is LongMemEval Finding 2 — embedding the round, not just the
+        fact, gives +4% recall@k and +5% downstream QA. On v3 rows or when
+        the source episode is missing, falls back to just the fact text.
+        """
+        if not self._v4:
+            return content
+        try:
+            with self._conn.cursor(
+                cursor_factory=psycopg2.extras.RealDictCursor,
+            ) as cur:
+                cur.execute(
+                    """
+                    SELECT m.tags, m.source_episode_id,
+                           e.user_turn_text, e.assistant_turn_text
+                    FROM memories m
+                    LEFT JOIN episodes e ON e.id = m.source_episode_id
+                    WHERE m.id = %s
+                    """,
+                    (memory_id,),
+                )
+                row = cur.fetchone()
+        except Exception as e:
+            logger.debug("_build_embedding_text lookup failed: %s", e)
+            return content
+        if not row:
+            return content
+
+        parts: List[str] = [content]
+        user_text = row.get("user_turn_text")
+        asst_text = row.get("assistant_turn_text")
+        if user_text:
+            parts.append(user_text)
+        if asst_text:
+            parts.append(asst_text)
+        tags = row.get("tags") or []
+        if tags:
+            parts.append("Tags: " + ", ".join(tags))
+        return "\n---\n".join(parts)
+
     def add(self, memory_id: str, content: str, namespace: str = "default") -> None:
         """Generate embedding and store on the memory row.
 
@@ -592,9 +644,14 @@ class PostgresBackend(DocumentStore, VectorStore, GraphStore):
         enforced at the document row (memories.namespace) and propagated into
         vector search below; this method updates the embedding column on the
         existing row so no separate namespace write is required here.
+
+        For v4 rows linked to an episode, the embedded text is the full
+        round (fact + user turn + assistant turn + tags), not just the
+        fact alone — see ``_build_embedding_text``.
         """
         del namespace  # reserved for future per-namespace index partitioning
-        embedding = self._embed(content)
+        text = self._build_embedding_text(memory_id, content)
+        embedding = self._embed(text)
         self._execute(
             "UPDATE memories SET embedding = %s::vector WHERE id = %s",
             (str(embedding), memory_id),

--- a/attestor/store/schema.sql
+++ b/attestor/store/schema.sql
@@ -150,6 +150,33 @@ CREATE INDEX IF NOT EXISTS idx_memories_content_hash
 CREATE INDEX IF NOT EXISTS idx_memories_embedding_hnsw
     ON memories USING hnsw (embedding vector_cosine_ops);
 
+-- BM25 / FTS lane (Phase 4.2, roadmap §B.2). A regular tsvector column
+-- maintained by trigger is the canonical Postgres pattern: generated
+-- columns can't reference to_tsvector('english', ...) (not marked
+-- IMMUTABLE since the dictionary is config-loadable), and expression
+-- indexes have the same restriction.
+ALTER TABLE memories ADD COLUMN IF NOT EXISTS content_tsv TSVECTOR;
+
+CREATE OR REPLACE FUNCTION attestor_memories_content_tsv_update() RETURNS TRIGGER AS $$
+BEGIN
+    NEW.content_tsv :=
+        setweight(to_tsvector('english', coalesce(NEW.content, '')), 'A') ||
+        setweight(to_tsvector('english',
+            coalesce(array_to_string(NEW.tags, ' '), '')), 'B') ||
+        setweight(to_tsvector('english', coalesce(NEW.entity, '')), 'C');
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_memories_content_tsv ON memories;
+CREATE TRIGGER trg_memories_content_tsv
+    BEFORE INSERT OR UPDATE OF content, tags, entity
+    ON memories
+    FOR EACH ROW EXECUTE FUNCTION attestor_memories_content_tsv_update();
+
+CREATE INDEX IF NOT EXISTS idx_memories_content_tsv
+    ON memories USING GIN (content_tsv);
+
 -- ── Row-Level Security ────────────────────────────────────────────────────
 -- Hard tenant isolation: even an app-level bug that forgets WHERE user_id=...
 -- returns zero rows from another user's data because the database itself

--- a/tests/test_apply_decisions.py
+++ b/tests/test_apply_decisions.py
@@ -1,0 +1,308 @@
+"""Phase 3.5 — apply_decisions unit tests with stub mem.
+
+Pure-Python verification that the apply layer routes each Decision to
+the correct store call (insert/update/supersede/no-op), and surfaces
+errors as ERROR outcomes without raising.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from attestor.conversation.apply import AppliedDecision, apply_decisions
+from attestor.extraction.conflict_resolver import Decision
+from attestor.extraction.round_extractor import ExtractedFact
+from attestor.models import Memory
+
+
+def _fact(text: str, category: str = "preference") -> ExtractedFact:
+    return ExtractedFact(
+        text=text, category=category, entity="user",
+        confidence=0.9, source_span=[0, len(text)], speaker="user",
+    )
+
+
+# ── Stub stores ──────────────────────────────────────────────────────────
+
+
+class StubDocStore:
+    def __init__(self) -> None:
+        self.rows: Dict[str, Memory] = {}
+        self.insert_calls: int = 0
+        self.update_calls: int = 0
+
+    def insert(self, m: Memory) -> Memory:
+        # Echo back with a synthetic id when missing
+        if not m.id or len(m.id) < 12:
+            m.id = f"mem-{len(self.rows) + 1}"
+        self.rows[m.id] = m
+        self.insert_calls += 1
+        return m
+
+    def get(self, mid: str) -> Optional[Memory]:
+        return self.rows.get(mid)
+
+    def update(self, m: Memory) -> Memory:
+        self.rows[m.id] = m
+        self.update_calls += 1
+        return m
+
+
+class StubVectorStore:
+    def __init__(self, *, fail: bool = False) -> None:
+        self.adds: List[tuple] = []
+        self._fail = fail
+
+    def add(self, mid: str, content: str) -> None:
+        if self._fail:
+            raise RuntimeError("vector store down")
+        self.adds.append((mid, content))
+
+
+class StubTemporal:
+    def __init__(self, store: StubDocStore) -> None:
+        self.store = store
+        self.supersede_calls: List[tuple] = []
+
+    def supersede(self, old: Memory, new_id: str) -> Memory:
+        old.status = "superseded"
+        old.superseded_by = new_id
+        self.store.update(old)
+        self.supersede_calls.append((old.id, new_id))
+        return old
+
+
+class StubMem:
+    def __init__(self, *, vector: bool = True, vector_fail: bool = False) -> None:
+        self._store = StubDocStore()
+        self._vector_store = StubVectorStore(fail=vector_fail) if vector else None
+        self._temporal = StubTemporal(self._store)
+
+
+# ── ADD ───────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_apply_add_inserts_and_indexes() -> None:
+    mem = StubMem()
+    decisions = [Decision(
+        operation="ADD", new_fact=_fact("user prefers pizza"),
+        existing_id=None, rationale="new", evidence_episode_id="ep-1",
+    )]
+    out = apply_decisions(
+        decisions, mem=mem, user_id="u1", project_id="p1",
+        session_id="s1", scope="user",
+        extraction_model="test-model",
+    )
+    assert len(out) == 1
+    assert out[0].operation == "ADD"
+    assert mem._store.insert_calls == 1
+    assert len(mem._vector_store.adds) == 1
+    # Persisted memory carries provenance
+    persisted = list(mem._store.rows.values())[0]
+    assert persisted.user_id == "u1"
+    assert persisted.source_episode_id == "ep-1"
+    assert persisted.extraction_model == "test-model"
+    assert persisted.source_span == [0, len("user prefers pizza")]
+
+
+@pytest.mark.unit
+def test_apply_add_works_without_vector_store() -> None:
+    mem = StubMem(vector=False)
+    decisions = [Decision(
+        operation="ADD", new_fact=_fact("x"), existing_id=None,
+        rationale="r", evidence_episode_id="ep",
+    )]
+    out = apply_decisions(
+        decisions, mem=mem, user_id="u1", project_id=None,
+        session_id=None, scope="user", extraction_model="m",
+    )
+    assert out[0].operation == "ADD"
+    assert mem._store.insert_calls == 1
+
+
+@pytest.mark.unit
+def test_apply_add_vector_failure_does_not_break_insert() -> None:
+    """Vector store down → insert still succeeds."""
+    mem = StubMem(vector_fail=True)
+    decisions = [Decision(
+        operation="ADD", new_fact=_fact("x"), existing_id=None,
+        rationale="r", evidence_episode_id="ep",
+    )]
+    out = apply_decisions(
+        decisions, mem=mem, user_id="u1", project_id=None,
+        session_id=None, scope="user", extraction_model="m",
+    )
+    assert out[0].operation == "ADD"
+
+
+# ── UPDATE ───────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_apply_update_refreshes_content() -> None:
+    mem = StubMem()
+    existing = Memory(
+        id="m-1", content="works at Google", category="career",
+        confidence=0.7,
+    )
+    mem._store.rows["m-1"] = existing
+
+    decisions = [Decision(
+        operation="UPDATE",
+        new_fact=ExtractedFact(
+            text="Senior Engineer at Google", category="career",
+            entity="Google", confidence=0.95,
+            source_span=[0, 25], speaker="user",
+        ),
+        existing_id="m-1", rationale="refined", evidence_episode_id="ep",
+    )]
+    out = apply_decisions(
+        decisions, mem=mem, user_id="u1", project_id=None,
+        session_id=None, scope="user", extraction_model="m",
+    )
+    assert out[0].operation == "UPDATE"
+    assert out[0].memory_id == "m-1"
+    updated = mem._store.rows["m-1"]
+    assert updated.content == "Senior Engineer at Google"
+    # Higher confidence wins, never downgrades
+    assert updated.confidence == 0.95
+    assert updated.entity == "Google"
+
+
+@pytest.mark.unit
+def test_apply_update_missing_target_returns_error() -> None:
+    mem = StubMem()
+    decisions = [Decision(
+        operation="UPDATE", new_fact=_fact("x"),
+        existing_id="missing-id", rationale="r", evidence_episode_id="ep",
+    )]
+    out = apply_decisions(
+        decisions, mem=mem, user_id="u1", project_id=None,
+        session_id=None, scope="user", extraction_model="m",
+    )
+    assert out[0].operation == "ERROR"
+
+
+@pytest.mark.unit
+def test_apply_update_does_not_downgrade_confidence() -> None:
+    mem = StubMem()
+    mem._store.rows["m-1"] = Memory(id="m-1", content="x", confidence=0.95)
+    decisions = [Decision(
+        operation="UPDATE",
+        new_fact=ExtractedFact(
+            text="x refined", category="general", entity=None,
+            confidence=0.4,  # lower
+            source_span=[0, 9], speaker="user",
+        ),
+        existing_id="m-1", rationale="r", evidence_episode_id="ep",
+    )]
+    apply_decisions(
+        decisions, mem=mem, user_id="u1", project_id=None,
+        session_id=None, scope="user", extraction_model="m",
+    )
+    assert mem._store.rows["m-1"].confidence == 0.95
+
+
+# ── INVALIDATE ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_apply_invalidate_supersedes_and_inserts_new() -> None:
+    mem = StubMem()
+    old = Memory(id="m-1", content="lives in NYC")
+    mem._store.rows["m-1"] = old
+
+    decisions = [Decision(
+        operation="INVALIDATE",
+        new_fact=ExtractedFact(
+            text="lives in SF", category="location", entity="user",
+            confidence=0.9, source_span=[0, 11], speaker="user",
+        ),
+        existing_id="m-1", rationale="contradicts",
+        evidence_episode_id="ep-99",
+    )]
+    out = apply_decisions(
+        decisions, mem=mem, user_id="u1", project_id=None,
+        session_id=None, scope="user", extraction_model="m",
+    )
+    assert out[0].operation == "INVALIDATE"
+    assert out[0].memory_id == "m-1"           # the superseded one
+    assert out[0].new_memory_id is not None    # the replacement
+    # Old row marked superseded (NOT deleted — timeline must replay)
+    assert mem._store.rows["m-1"].status == "superseded"
+    assert mem._store.rows["m-1"].superseded_by == out[0].new_memory_id
+    # supersede was called via temporal manager
+    assert len(mem._temporal.supersede_calls) == 1
+
+
+@pytest.mark.unit
+def test_apply_invalidate_when_target_vanished_still_inserts_new() -> None:
+    mem = StubMem()
+    decisions = [Decision(
+        operation="INVALIDATE", new_fact=_fact("new fact"),
+        existing_id="vanished", rationale="r", evidence_episode_id="ep",
+    )]
+    out = apply_decisions(
+        decisions, mem=mem, user_id="u1", project_id=None,
+        session_id=None, scope="user", extraction_model="m",
+    )
+    assert out[0].operation == "INVALIDATE"
+    assert out[0].memory_id is None            # nothing to supersede
+    assert out[0].new_memory_id is not None    # but new still inserted
+
+
+# ── NOOP ─────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_apply_noop_does_nothing() -> None:
+    mem = StubMem()
+    decisions = [Decision(
+        operation="NOOP", new_fact=_fact("dup"),
+        existing_id="m-1", rationale="duplicate",
+        evidence_episode_id="ep",
+    )]
+    out = apply_decisions(
+        decisions, mem=mem, user_id="u1", project_id=None,
+        session_id=None, scope="user", extraction_model="m",
+    )
+    assert out[0].operation == "NOOP"
+    assert mem._store.insert_calls == 0
+    assert mem._store.update_calls == 0
+
+
+# ── Mixed batch — order preserved, ERROR isolated ───────────────────────
+
+
+@pytest.mark.unit
+def test_apply_mixed_batch_preserves_order_and_isolates_errors() -> None:
+    mem = StubMem()
+    # Pre-existing target for UPDATE; vanished target for one ADD's? No,
+    # only UPDATE/INVALIDATE need targets.
+    mem._store.rows["m-x"] = Memory(id="m-x", content="old")
+    decisions = [
+        Decision(
+            operation="ADD", new_fact=_fact("a"), existing_id=None,
+            rationale="r", evidence_episode_id="ep",
+        ),
+        Decision(
+            operation="UPDATE", new_fact=_fact("a refined"),
+            existing_id="m-x", rationale="r", evidence_episode_id="ep",
+        ),
+        Decision(
+            operation="UPDATE", new_fact=_fact("c"),
+            existing_id="vanished", rationale="r", evidence_episode_id="ep",
+        ),
+        Decision(
+            operation="NOOP", new_fact=_fact("d"), existing_id="m-x",
+            rationale="r", evidence_episode_id="ep",
+        ),
+    ]
+    out = apply_decisions(
+        decisions, mem=mem, user_id="u1", project_id=None,
+        session_id=None, scope="user", extraction_model="m",
+    )
+    assert [a.operation for a in out] == ["ADD", "UPDATE", "ERROR", "NOOP"]

--- a/tests/test_bm25_lane.py
+++ b/tests/test_bm25_lane.py
@@ -1,0 +1,254 @@
+"""Phase 4.2 — BM25 / FTS retrieval lane (roadmap §B.2).
+
+Tests:
+  - reciprocal_rank_fusion: pure-function unit tests
+  - BM25Lane.search: live tests against the v4 FTS column
+  - graceful degradation when content_tsv column is missing (v3 schema)
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from pathlib import Path
+
+import pytest
+
+try:
+    import psycopg2
+    HAVE_PSYCOPG2 = True
+except ImportError:
+    HAVE_PSYCOPG2 = False
+
+from attestor.retrieval.bm25 import BM25Hit, BM25Lane, reciprocal_rank_fusion
+
+PG_URL = os.environ.get(
+    "PG_TEST_URL",
+    "postgresql://postgres:attestor@localhost:5432/attestor_v4_test",
+)
+SCHEMA_PATH = Path(__file__).resolve().parent.parent / "attestor" / "store" / "schema.sql"
+
+
+def _reachable() -> bool:
+    if not HAVE_PSYCOPG2:
+        return False
+    try:
+        c = psycopg2.connect(PG_URL, connect_timeout=2)
+        c.close()
+        return True
+    except Exception:
+        return False
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# RRF (pure function — no DB)
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_rrf_single_lane_preserves_order() -> None:
+    out = reciprocal_rank_fusion(["a", "b", "c"])
+    assert out == ["a", "b", "c"]
+
+
+@pytest.mark.unit
+def test_rrf_two_lanes_overlap_at_top_wins() -> None:
+    """An item in BOTH lanes' top-3 outranks unique top-1s."""
+    lane_vec = ["a", "b", "c"]
+    lane_bm = ["d", "b", "e"]
+    out = reciprocal_rank_fusion(lane_vec, lane_bm)
+    # 'b' appears in both, so its fused score is highest
+    assert out[0] == "b"
+
+
+@pytest.mark.unit
+def test_rrf_disjoint_lanes_interleave_by_rank() -> None:
+    out = reciprocal_rank_fusion(["a", "b"], ["c", "d"])
+    # All four ids appear; rank-1s ('a' and 'c') tied at 1/(60+1) = 1/61
+    assert set(out) == {"a", "b", "c", "d"}
+    assert out[0] in {"a", "c"}
+    assert out[1] in {"a", "c"}
+
+
+@pytest.mark.unit
+def test_rrf_limit_clips_results() -> None:
+    out = reciprocal_rank_fusion(["a", "b", "c", "d"], limit=2)
+    assert len(out) == 2
+
+
+@pytest.mark.unit
+def test_rrf_higher_k_flattens_lane_influence() -> None:
+    """k=1000 makes per-lane rank differences negligible — closer to set union."""
+    lane1 = ["a", "b", "c"]
+    lane2 = ["d", "e", "f"]
+    fused_default = reciprocal_rank_fusion(lane1, lane2, k=60)
+    fused_flat = reciprocal_rank_fusion(lane1, lane2, k=1000)
+    # Both produce the same set, but ordering should be the same too
+    # since the lane structures are symmetric.
+    assert set(fused_default) == set(fused_flat)
+
+
+@pytest.mark.unit
+def test_rrf_empty_lanes_return_empty() -> None:
+    assert reciprocal_rank_fusion([], []) == []
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# BM25Lane (live)
+# ──────────────────────────────────────────────────────────────────────────
+
+
+pytestmark = pytest.mark.skipif(not _reachable(), reason="local Postgres unreachable")
+
+
+@pytest.fixture(scope="module")
+def admin_conn():
+    c = psycopg2.connect(PG_URL)
+    c.autocommit = True
+    yield c
+    c.close()
+
+
+@pytest.fixture
+def fresh_schema(admin_conn):
+    raw = SCHEMA_PATH.read_text().replace("{embedding_dim}", "16")
+    with admin_conn.cursor() as cur:
+        for tbl in ("memories", "episodes", "sessions", "projects", "users"):
+            cur.execute(f"DROP TABLE IF EXISTS {tbl} CASCADE")
+        cur.execute(raw)
+    yield
+
+
+@pytest.fixture
+def seeded_user(admin_conn, fresh_schema):
+    """Create a user and seed five memories with distinct content."""
+    uid = uuid.uuid4()
+    with admin_conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO users (id, external_id) VALUES (%s, %s)",
+            (str(uid), f"u-bm25-{uuid.uuid4().hex[:8]}"),
+        )
+        # Set RLS on this admin connection so our INSERTs go in scoped
+        cur.execute(
+            "SELECT set_config('attestor.current_user_id', %s, false)",
+            (str(uid),),
+        )
+        seeds = [
+            ("user prefers dark mode in all apps", ["preference", "ui"], "ui"),
+            ("user lives in San Francisco", ["location"], "user"),
+            ("user works at Acme Corp as a Senior Engineer",
+             ["career"], "Acme Corp"),
+            ("user enjoys sushi and ramen", ["food"], "food"),
+            ("user is currently learning Rust programming",
+             ["learning"], "Rust"),
+        ]
+        ids = []
+        for content, tags, entity in seeds:
+            cur.execute(
+                "INSERT INTO memories (user_id, content, tags, entity) "
+                "VALUES (%s, %s, %s, %s) RETURNING id",
+                (str(uid), content, tags, entity),
+            )
+            ids.append(str(cur.fetchone()[0]))
+    return str(uid), ids, admin_conn
+
+
+@pytest.mark.live
+def test_bm25_finds_exact_keyword(seeded_user) -> None:
+    uid, ids, conn = seeded_user
+    lane = BM25Lane(conn)
+    hits = lane.search("dark mode")
+    assert len(hits) >= 1
+    assert isinstance(hits[0], BM25Hit)
+    # Top hit must contain "dark mode"
+    with conn.cursor() as cur:
+        cur.execute("SELECT content FROM memories WHERE id = %s", (hits[0].memory_id,))
+        content = cur.fetchone()[0]
+    assert "dark mode" in content
+
+
+@pytest.mark.live
+def test_bm25_phrase_query(seeded_user) -> None:
+    """Phrase via websearch syntax — quoted terms must appear adjacent."""
+    uid, ids, conn = seeded_user
+    lane = BM25Lane(conn)
+    hits = lane.search('"San Francisco"')
+    assert len(hits) >= 1
+
+
+@pytest.mark.live
+def test_bm25_tag_match_via_b_weight(seeded_user) -> None:
+    """The generated tsvector includes tags with weight B — searching a
+    tag word should still surface the row even if not in content."""
+    uid, ids, conn = seeded_user
+    lane = BM25Lane(conn)
+    hits = lane.search("learning")
+    contents = []
+    with conn.cursor() as cur:
+        for h in hits:
+            cur.execute("SELECT content FROM memories WHERE id = %s", (h.memory_id,))
+            contents.append(cur.fetchone()[0])
+    assert any("Rust" in c for c in contents)
+
+
+@pytest.mark.live
+def test_bm25_entity_match_via_c_weight(seeded_user) -> None:
+    """Entity values are indexed too (weight C)."""
+    uid, ids, conn = seeded_user
+    lane = BM25Lane(conn)
+    hits = lane.search("Acme")
+    assert len(hits) >= 1
+
+
+@pytest.mark.live
+def test_bm25_negation(seeded_user) -> None:
+    """websearch_to_tsquery supports -term to exclude."""
+    uid, ids, conn = seeded_user
+    lane = BM25Lane(conn)
+    # 'user' alone matches everything; '-Rust' should drop the Rust row
+    hits_with = lane.search("user")
+    hits_without = lane.search("user -Rust")
+    assert len(hits_without) < len(hits_with)
+
+
+@pytest.mark.live
+def test_bm25_no_match_returns_empty(seeded_user) -> None:
+    uid, ids, conn = seeded_user
+    lane = BM25Lane(conn)
+    hits = lane.search("xyzzy_no_such_term_anywhere")
+    assert hits == []
+
+
+@pytest.mark.live
+def test_bm25_empty_query_returns_empty(seeded_user) -> None:
+    uid, ids, conn = seeded_user
+    lane = BM25Lane(conn)
+    assert lane.search("") == []
+    assert lane.search("   ") == []
+
+
+@pytest.mark.live
+def test_bm25_active_only_filter(seeded_user) -> None:
+    """status='superseded' rows are excluded by default."""
+    uid, ids, conn = seeded_user
+    # Mark one row superseded
+    with conn.cursor() as cur:
+        cur.execute(
+            "UPDATE memories SET status = 'superseded' WHERE id = %s",
+            (ids[0],),
+        )
+    lane = BM25Lane(conn)
+    hits = lane.search("dark mode")
+    assert all(h.memory_id != ids[0] for h in hits)
+    # active_only=False should bring it back
+    hits_all = lane.search("dark mode", active_only=False)
+    assert any(h.memory_id == ids[0] for h in hits_all)
+
+
+@pytest.mark.live
+def test_bm25_handles_missing_column_gracefully(admin_conn, fresh_schema) -> None:
+    """If the FTS column doesn't exist (older schema), search returns []."""
+    with admin_conn.cursor() as cur:
+        cur.execute("ALTER TABLE memories DROP COLUMN content_tsv")
+    lane = BM25Lane(admin_conn)
+    assert lane.search("anything") == []

--- a/tests/test_conflict_resolver.py
+++ b/tests/test_conflict_resolver.py
@@ -1,0 +1,333 @@
+"""Phase 3.4 — conflict_resolver: ADD/UPDATE/INVALIDATE/NOOP decisions.
+
+Stub-LLM driven. Verifies:
+  - empty new_facts → []
+  - empty existing → all ADD without LLM call
+  - happy path: 4 decisions, one per operation, bound by index
+  - text-match binding when LLM reorders
+  - LLM failure → all-ADD fallback
+  - bad JSON → all-ADD fallback
+  - per-decision validation (UPDATE without existing_id → ADD)
+  - Decision dataclass invariants
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, List
+
+import pytest
+
+from attestor.extraction.conflict_resolver import (
+    VALID_OPERATIONS,
+    Decision,
+    _bind_decisions,
+    _coerce,
+    _parse_decisions_payload,
+    resolve_conflicts,
+)
+from attestor.extraction.round_extractor import ExtractedFact
+from attestor.models import Memory
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Stub LLM
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class _StubChoice:
+    def __init__(self, content: str) -> None:
+        self.message = type("M", (), {"content": content})()
+
+
+class _StubResponse:
+    def __init__(self, content: str) -> None:
+        self.choices = [_StubChoice(content)]
+
+
+class _StubChat:
+    def __init__(self, content: str = "", *, raise_exc: Exception | None = None) -> None:
+        self._content = content
+        self._exc = raise_exc
+        self.calls: list = []
+
+    def create(self, **kwargs: Any) -> _StubResponse:
+        self.calls.append(kwargs)
+        if self._exc is not None:
+            raise self._exc
+        return _StubResponse(self._content)
+
+
+class StubClient:
+    def __init__(self, content: str = "", *, raise_exc: Exception | None = None) -> None:
+        self.chat = type(
+            "Chat", (),
+            {"completions": _StubChat(content, raise_exc=raise_exc)},
+        )()
+
+    @property
+    def call_count(self) -> int:
+        return len(self.chat.completions.calls)
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Fixtures
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _fact(text: str, category: str = "preference") -> ExtractedFact:
+    return ExtractedFact(
+        text=text, category=category, entity=None,
+        confidence=0.9, source_span=[0, len(text)], speaker="user",
+    )
+
+
+def _mem(memory_id: str, content: str) -> Memory:
+    return Memory(id=memory_id, content=content, category="preference")
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Decision dataclass invariants
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_decision_rejects_invalid_operation() -> None:
+    with pytest.raises(ValueError, match="operation"):
+        Decision(
+            operation="DELETE",  # not in VALID_OPERATIONS
+            new_fact=_fact("x"), existing_id=None,
+            rationale="r", evidence_episode_id="ep",
+        )
+
+
+@pytest.mark.unit
+def test_decision_update_requires_existing_id() -> None:
+    with pytest.raises(ValueError, match="existing_id"):
+        Decision(
+            operation="UPDATE",
+            new_fact=_fact("x"), existing_id=None,
+            rationale="r", evidence_episode_id="ep",
+        )
+
+
+@pytest.mark.unit
+def test_decision_invalidate_requires_existing_id() -> None:
+    with pytest.raises(ValueError, match="existing_id"):
+        Decision(
+            operation="INVALIDATE",
+            new_fact=_fact("x"), existing_id=None,
+            rationale="r", evidence_episode_id="ep",
+        )
+
+
+@pytest.mark.unit
+def test_decision_add_allowed_without_existing_id() -> None:
+    d = Decision(
+        operation="ADD", new_fact=_fact("x"), existing_id=None,
+        rationale="r", evidence_episode_id="ep",
+    )
+    assert d.operation == "ADD"
+
+
+@pytest.mark.unit
+def test_valid_operations_set_complete() -> None:
+    assert VALID_OPERATIONS == {"ADD", "UPDATE", "INVALIDATE", "NOOP"}
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Short-circuit paths (no LLM)
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_resolve_empty_new_facts_returns_empty() -> None:
+    stub = StubClient()
+    assert resolve_conflicts([], existing=[_mem("m1", "x")],
+                             evidence_episode_id="ep", client=stub) == []
+    assert stub.call_count == 0
+
+
+@pytest.mark.unit
+def test_resolve_empty_existing_returns_all_add_without_llm() -> None:
+    """No existing memories → no contradictions possible → skip the LLM."""
+    stub = StubClient()
+    facts = [_fact("a"), _fact("b")]
+    decisions = resolve_conflicts(facts, existing=[],
+                                  evidence_episode_id="ep", client=stub)
+    assert len(decisions) == 2
+    assert all(d.operation == "ADD" for d in decisions)
+    assert stub.call_count == 0
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Happy path — index-aligned binding
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_resolve_index_aligned_one_per_operation() -> None:
+    facts = [_fact("a"), _fact("b"), _fact("c"), _fact("d")]
+    existing = [_mem("m1", "old-a"), _mem("m2", "old-b")]
+    payload = json.dumps({
+        "decisions": [
+            {"operation": "ADD",        "existing_id": None,  "rationale": "new"},
+            {"operation": "UPDATE",     "existing_id": "m1",  "rationale": "refined"},
+            {"operation": "INVALIDATE", "existing_id": "m2",  "rationale": "contradicts"},
+            {"operation": "NOOP",       "existing_id": None,  "rationale": "dup"},
+        ]
+    })
+    stub = StubClient(payload)
+    decisions = resolve_conflicts(facts, existing=existing,
+                                  evidence_episode_id="ep-42", client=stub)
+    assert [d.operation for d in decisions] == ["ADD", "UPDATE", "INVALIDATE", "NOOP"]
+    assert decisions[1].existing_id == "m1"
+    assert decisions[2].existing_id == "m2"
+    assert all(d.evidence_episode_id == "ep-42" for d in decisions)
+
+
+@pytest.mark.unit
+def test_resolve_index_aligned_pure_array_shape() -> None:
+    facts = [_fact("a")]
+    existing = [_mem("m1", "x")]
+    payload = '[{"operation": "NOOP", "existing_id": null, "rationale": "dup"}]'
+    stub = StubClient(payload)
+    decisions = resolve_conflicts(facts, existing=existing,
+                                  evidence_episode_id="ep", client=stub)
+    assert decisions[0].operation == "NOOP"
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Text-match binding (LLM reordered)
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_resolve_text_match_when_count_differs() -> None:
+    facts = [_fact("alpha"), _fact("beta"), _fact("gamma")]
+    existing = [_mem("m1", "old-alpha")]
+    # LLM returned only 2 decisions, in reverse order, with new_fact text bound
+    payload = json.dumps({
+        "decisions": [
+            {"operation": "NOOP", "existing_id": None,
+             "rationale": "duplicate gamma",
+             "new_fact": {"text": "gamma"}},
+            {"operation": "ADD", "existing_id": None,
+             "rationale": "fresh alpha",
+             "new_fact": {"text": "alpha"}},
+        ]
+    })
+    stub = StubClient(payload)
+    decisions = resolve_conflicts(facts, existing=existing,
+                                  evidence_episode_id="ep", client=stub)
+    # Order must follow the input facts list
+    assert [d.new_fact.text for d in decisions] == ["alpha", "beta", "gamma"]
+    # 'beta' had no match → defaults to ADD
+    assert decisions[1].operation == "ADD"
+    assert "omitted" in decisions[1].rationale.lower() or "default" in decisions[1].rationale.lower()
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Coercion / validation of individual raw decisions
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_coerce_unknown_operation_falls_back_to_add() -> None:
+    f = _fact("x")
+    d = _coerce({"operation": "MERGE"}, f, "ep")
+    assert d.operation == "ADD"
+    assert "invalid operation" in d.rationale.lower()
+
+
+@pytest.mark.unit
+def test_coerce_update_missing_existing_id_falls_back_to_add() -> None:
+    f = _fact("x")
+    d = _coerce({"operation": "UPDATE", "existing_id": None}, f, "ep")
+    assert d.operation == "ADD"
+    assert "missing existing_id" in d.rationale.lower()
+
+
+@pytest.mark.unit
+def test_coerce_existing_id_string_or_null_handled() -> None:
+    f = _fact("x")
+    d_null = _coerce({"operation": "ADD", "existing_id": "null"}, f, "ep")
+    d_empty = _coerce({"operation": "ADD", "existing_id": ""}, f, "ep")
+    assert d_null.existing_id is None
+    assert d_empty.existing_id is None
+
+
+@pytest.mark.unit
+def test_coerce_existing_id_non_string_coerced() -> None:
+    """Some LLMs return numeric ids; coerce to str."""
+    f = _fact("x")
+    d = _coerce({"operation": "UPDATE", "existing_id": 42, "rationale": "r"},
+                f, "ep")
+    assert d.existing_id == "42"
+
+
+@pytest.mark.unit
+def test_coerce_evidence_episode_id_always_caller_supplied() -> None:
+    """LLM may try to set evidence_episode_id; we override it."""
+    f = _fact("x")
+    d = _coerce(
+        {"operation": "ADD", "evidence_episode_id": "lying-id"},
+        f, evidence_episode_id="real-ep",
+    )
+    assert d.evidence_episode_id == "real-ep"
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Resilience — LLM failures
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_resolve_llm_exception_returns_all_add() -> None:
+    facts = [_fact("a"), _fact("b")]
+    existing = [_mem("m1", "x")]
+    stub = StubClient(raise_exc=RuntimeError("network down"))
+    decisions = resolve_conflicts(facts, existing=existing,
+                                  evidence_episode_id="ep", client=stub)
+    assert len(decisions) == 2
+    assert all(d.operation == "ADD" for d in decisions)
+    assert all("LLM resolver unavailable" in d.rationale for d in decisions)
+
+
+@pytest.mark.unit
+def test_resolve_bad_json_returns_all_add() -> None:
+    stub = StubClient("Sorry, I cannot decide that.")
+    facts = [_fact("a")]
+    existing = [_mem("m1", "x")]
+    decisions = resolve_conflicts(facts, existing=existing,
+                                  evidence_episode_id="ep", client=stub)
+    assert decisions[0].operation == "ADD"
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Parser
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_parse_decisions_envelope() -> None:
+    raw = '{"decisions": [{"operation": "ADD"}]}'
+    assert _parse_decisions_payload(raw) == [{"operation": "ADD"}]
+
+
+@pytest.mark.unit
+def test_parse_decisions_array() -> None:
+    raw = '[{"operation": "ADD"}, {"operation": "NOOP"}]'
+    assert len(_parse_decisions_payload(raw)) == 2
+
+
+@pytest.mark.unit
+def test_parse_decisions_handles_markdown() -> None:
+    raw = "```json\n[{\"operation\": \"ADD\"}]\n```"
+    assert _parse_decisions_payload(raw) == [{"operation": "ADD"}]
+
+
+@pytest.mark.unit
+def test_parse_decisions_bad_json_returns_empty() -> None:
+    assert _parse_decisions_payload("nope") == []
+    assert _parse_decisions_payload("") == []

--- a/tests/test_conversation_ingest.py
+++ b/tests/test_conversation_ingest.py
@@ -1,0 +1,472 @@
+"""Phase 3.6 — ConversationIngest end-to-end with stub LLMs.
+
+Verifies the full Phase 3 pipeline against a real Postgres v4 schema
+plus stubbed extraction + resolver clients (so we don't burn API
+credits in CI):
+
+  1. ingest_round writes verbatim episode
+  2. user_facts + agent_facts both extracted (one prompt per side)
+  3. resolve_conflicts decides ADD/UPDATE/INVALIDATE/NOOP per fact
+  4. apply persists with full provenance (source_episode_id, source_span,
+     extraction_model, agent_id)
+  5. INVALIDATE supersedes the old row but keeps it (timeline replay)
+  6. Public AgentMemory.ingest_round() resolves identity from SOLO defaults
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, List
+from urllib.parse import urlparse, urlunparse
+
+import pytest
+
+try:
+    import psycopg2
+    HAVE_PSYCOPG2 = True
+except ImportError:
+    HAVE_PSYCOPG2 = False
+
+from attestor.conversation import (
+    ConversationIngest,
+    ConversationTurn,
+    IngestConfig,
+)
+from attestor.extraction.round_extractor import ExtractedFact
+
+PG_URL = os.environ.get(
+    "PG_TEST_URL",
+    "postgresql://postgres:attestor@localhost:5432/attestor_v4_test",
+)
+SCHEMA_PATH = Path(__file__).resolve().parent.parent / "attestor" / "store" / "schema.sql"
+
+
+def _reachable() -> bool:
+    if not HAVE_PSYCOPG2:
+        return False
+    try:
+        c = psycopg2.connect(PG_URL, connect_timeout=2)
+        c.close()
+        return True
+    except Exception:
+        return False
+
+
+pytestmark = pytest.mark.skipif(not _reachable(), reason="local Postgres unreachable")
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Stub LLM (per-prompt scriptable)
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class _StubChoice:
+    def __init__(self, content: str) -> None:
+        self.message = type("M", (), {"content": content})()
+
+
+class _StubResponse:
+    def __init__(self, content: str) -> None:
+        self.choices = [_StubChoice(content)]
+
+
+class _ScriptedChat:
+    """Returns a different response per call, in order."""
+
+    def __init__(self, scripted: List[str]) -> None:
+        self._scripted = list(scripted)
+        self.calls: List[dict] = []
+
+    def create(self, **kwargs: Any) -> _StubResponse:
+        self.calls.append(kwargs)
+        if not self._scripted:
+            return _StubResponse('{"facts": [], "decisions": []}')
+        return _StubResponse(self._scripted.pop(0))
+
+
+class ScriptedClient:
+    def __init__(self, scripted: List[str]) -> None:
+        self.chat = type("Chat", (), {"completions": _ScriptedChat(scripted)})()
+
+    @property
+    def call_count(self) -> int:
+        return len(self.chat.completions.calls)
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Postgres fixtures (admin + non-superuser runtime role)
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def admin_conn():
+    c = psycopg2.connect(PG_URL)
+    c.autocommit = True
+    yield c
+    c.close()
+
+
+@pytest.fixture
+def fresh_schema(admin_conn):
+    raw = SCHEMA_PATH.read_text().replace("{embedding_dim}", "16")
+    with admin_conn.cursor() as cur:
+        for tbl in ("memories", "episodes", "sessions", "projects", "users"):
+            cur.execute(f"DROP TABLE IF EXISTS {tbl} CASCADE")
+        cur.execute(raw)
+    yield
+
+
+@pytest.fixture(scope="module")
+def app_role(admin_conn):
+    role = f"attestor_ingest_{uuid.uuid4().hex[:8]}"
+    pw = "test"
+    with admin_conn.cursor() as cur:
+        cur.execute(f"CREATE ROLE {role} LOGIN NOBYPASSRLS PASSWORD '{pw}'")
+        cur.execute(f"GRANT USAGE ON SCHEMA public TO {role}")
+        cur.execute(
+            f"GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO {role}"
+        )
+        cur.execute(
+            f"GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO {role}"
+        )
+        cur.execute(
+            f"ALTER DEFAULT PRIVILEGES IN SCHEMA public "
+            f"GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO {role}"
+        )
+    p = urlparse(PG_URL)
+    netloc = f"{role}:{pw}@{p.hostname}{':' + str(p.port) if p.port else ''}"
+    yield urlunparse(p._replace(netloc=netloc))
+    with admin_conn.cursor() as cur:
+        cur.execute(
+            f"ALTER DEFAULT PRIVILEGES IN SCHEMA public "
+            f"REVOKE SELECT, INSERT, UPDATE, DELETE ON TABLES FROM {role}"
+        )
+        cur.execute(f"REVOKE ALL ON ALL TABLES IN SCHEMA public FROM {role}")
+        cur.execute(f"REVOKE ALL ON SCHEMA public FROM {role}")
+        cur.execute(f"DROP ROLE {role}")
+
+
+def _build_solo_mem(role_url: str, tmp_path: Path):
+    from attestor.core import AgentMemory
+    p = urlparse(role_url)
+    cfg = {
+        "mode": "solo",
+        "backends": ["postgres"],
+        "backend_configs": {
+            "postgres": {
+                "url": f"postgresql://{p.hostname}:{p.port or 5432}",
+                "database": p.path.lstrip("/"),
+                "auth": {"username": p.username, "password": p.password},
+                "v4": True,
+                "skip_schema_init": True,
+                "embedding_dim": 16,
+            }
+        },
+    }
+    return AgentMemory(tmp_path, config=cfg)
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Round helpers
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _round(thread_id: str = "t-1", offset: int = 0):
+    base = datetime.now(timezone.utc) + timedelta(seconds=offset)
+    user = ConversationTurn(
+        thread_id=thread_id, speaker="user", role="user",
+        content="I prefer dark mode in all apps.",
+        ts=base,
+    )
+    asst = ConversationTurn(
+        thread_id=thread_id, speaker="planner", role="assistant",
+        content="Switching all apps to dark mode now.",
+        ts=base + timedelta(seconds=1),
+    )
+    return user, asst
+
+
+def _user_facts_payload(*texts: str) -> str:
+    return json.dumps({
+        "facts": [
+            {"text": t, "category": "preference", "entity": "user",
+             "confidence": 0.9, "source_span": [0, len(t)]}
+            for t in texts
+        ]
+    })
+
+
+def _agent_facts_payload(*texts: str) -> str:
+    return json.dumps({
+        "facts": [
+            {"text": t, "category": "decision", "entity": "system",
+             "confidence": 0.9, "source_span": [0, len(t)]}
+            for t in texts
+        ]
+    })
+
+
+def _decisions_payload(*ops: tuple):
+    """ops: list of (operation, existing_id_or_None) pairs."""
+    return json.dumps({
+        "decisions": [
+            {"operation": op, "existing_id": eid,
+             "rationale": f"test-{op}"}
+            for op, eid in ops
+        ]
+    })
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Tests
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.live
+def test_ingest_round_writes_episode_and_extracts(app_role, fresh_schema, tmp_path):
+    """Happy path: 1 user fact + 1 agent fact, both ADDed."""
+    mem = _build_solo_mem(app_role, tmp_path)
+    try:
+        # Script: user-extract, agent-extract, resolve
+        client = ScriptedClient([
+            _user_facts_payload("user prefers dark mode"),
+            _agent_facts_payload("agent switched apps to dark mode"),
+            _decisions_payload(("ADD", None), ("ADD", None)),
+        ])
+        u, a = _round()
+        result = mem.ingest_round(
+            u, a,
+            extraction_client=client,
+            resolver_client=client,
+        )
+
+        # Episode written verbatim
+        assert result.episode.user_turn_text == u.content
+        assert result.episode.assistant_turn_text == a.content
+
+        # Two facts extracted (one user, one agent)
+        assert len(result.user_facts) == 1
+        assert len(result.agent_facts) == 1
+
+        # Two ADD decisions, both applied successfully
+        assert len(result.decisions) == 2
+        assert all(d.operation == "ADD" for d in result.decisions)
+        assert all(a.operation == "ADD" for a in result.applied)
+
+        # Both written rows carry full provenance
+        for mid in result.written_memory_ids:
+            row = mem._store.get(mid)
+            assert row is not None
+            assert row.source_episode_id == result.episode_id
+            assert row.source_span is not None
+            assert row.extraction_model is not None
+    finally:
+        mem.close()
+
+
+@pytest.mark.live
+def test_ingest_round_invalidate_supersedes_old(app_role, fresh_schema, tmp_path):
+    """Round 2 contradicts round 1 → INVALIDATE + ADD; old kept superseded.
+
+    The doc-store fallback in _retrieve_similar uses (category, entity)
+    to find candidates so the resolver fires even with no embedder.
+    """
+    mem = _build_solo_mem(app_role, tmp_path)
+    try:
+        # Round 1: write "lives in NYC" with location/user
+        # Use a category that survives validation (preference)
+        round1_user = json.dumps({
+            "facts": [{"text": "user lives in NYC", "category": "location",
+                       "entity": "user", "confidence": 0.9, "source_span": [0, 17]}]
+        })
+        round1_agent = json.dumps({"facts": []})
+        client1 = ScriptedClient([round1_user, round1_agent])
+        u1, a1 = _round(thread_id="t-loc", offset=0)
+        r1 = mem.ingest_round(u1, a1,
+                              extraction_client=client1, resolver_client=client1)
+        nyc_ids = [
+            mid for mid in r1.written_memory_ids
+            if mem._store.get(mid).content == "user lives in NYC"
+        ]
+        assert len(nyc_ids) == 1
+        nyc_id = nyc_ids[0]
+
+        # Round 2: contradicts. The doc-store fallback finds the NYC row
+        # by (category=location, entity=user); resolver decides INVALIDATE.
+        round2_user = json.dumps({
+            "facts": [{"text": "user lives in SF", "category": "location",
+                       "entity": "user", "confidence": 0.95, "source_span": [0, 16]}]
+        })
+        round2_agent = json.dumps({"facts": []})
+        round2_decisions = json.dumps({
+            "decisions": [{"operation": "INVALIDATE", "existing_id": nyc_id,
+                           "rationale": "contradicts"}]
+        })
+        client2 = ScriptedClient([round2_user, round2_agent, round2_decisions])
+        u2, a2 = _round(thread_id="t-loc", offset=10)
+        r2 = mem.ingest_round(u2, a2,
+                              extraction_client=client2, resolver_client=client2)
+
+        # Old NYC row marked superseded but not deleted
+        nyc = mem._store.get(nyc_id)
+        assert nyc is not None, "NYC row was hard-deleted (timeline broken)"
+        assert nyc.status == "superseded", (
+            f"expected superseded, got {nyc.status!r}"
+        )
+        assert nyc.superseded_by is not None
+
+        # The new SF row exists
+        sf_applied = next(a for a in r2.applied if a.operation == "INVALIDATE")
+        new_id = sf_applied.new_memory_id
+        sf = mem._store.get(new_id)
+        assert sf is not None
+        assert sf.content == "user lives in SF"
+    finally:
+        mem.close()
+
+
+@pytest.mark.live
+def test_ingest_round_speaker_lock_holds(app_role, fresh_schema, tmp_path):
+    """Per-side extractor calls go through separate, speaker-locked prompts.
+
+    The first ingest fires extractors for both sides. The first prompt
+    must speak USER lock, the second ASSISTANT lock (resolver call is
+    optional — short-circuits to all-ADD on a fresh DB).
+    """
+    mem = _build_solo_mem(app_role, tmp_path)
+    try:
+        client = ScriptedClient([
+            _user_facts_payload("u1"),
+            _agent_facts_payload("a1"),
+            _decisions_payload(("ADD", None), ("ADD", None)),  # may be unused
+        ])
+        u, a = _round()
+        mem.ingest_round(u, a, extraction_client=client, resolver_client=client)
+        # At minimum: 2 extraction calls. Resolver may or may not fire.
+        assert client.call_count >= 2
+        prompts = [c["messages"][0]["content"] for c in client.chat.completions.calls]
+        assert "USER'S MESSAGE BELOW" in prompts[0]
+        assert "ASSISTANT'S MESSAGE BELOW" in prompts[1]
+    finally:
+        mem.close()
+
+
+@pytest.mark.live
+def test_ingest_round_provenance_complete(app_role, fresh_schema, tmp_path):
+    """All written facts have source_episode_id + source_span (roadmap §A.5)."""
+    mem = _build_solo_mem(app_role, tmp_path)
+    try:
+        client = ScriptedClient([
+            _user_facts_payload("a", "b"),
+            _agent_facts_payload("c"),
+            _decisions_payload(("ADD", None), ("ADD", None), ("ADD", None)),
+        ])
+        u, a = _round()
+        result = mem.ingest_round(u, a,
+                                  extraction_client=client,
+                                  resolver_client=client)
+        assert len(result.written_memory_ids) == 3
+        for mid in result.written_memory_ids:
+            row = mem._store.get(mid)
+            assert row.source_episode_id == result.episode_id
+            assert row.source_span is not None
+            assert isinstance(row.source_span, list)
+            assert len(row.source_span) == 2
+    finally:
+        mem.close()
+
+
+@pytest.mark.live
+def test_ingest_round_extraction_disabled_skips_extractor(
+    app_role, fresh_schema, tmp_path,
+):
+    mem = _build_solo_mem(app_role, tmp_path)
+    try:
+        client = ScriptedClient([])
+        u, a = _round()
+        cfg = IngestConfig(extract_user=False, extract_agent=False)
+        result = mem.ingest_round(u, a, config=cfg,
+                                  extraction_client=client,
+                                  resolver_client=client)
+        assert result.user_facts == []
+        assert result.agent_facts == []
+        assert result.decisions == []
+        # Episode still written (always-on raw audit)
+        assert result.episode is not None
+        assert client.call_count == 0
+    finally:
+        mem.close()
+
+
+@pytest.mark.live
+def test_ingest_round_uses_solo_default_session(app_role, fresh_schema, tmp_path):
+    """Caller didn't pass session_id → SOLO daily session is used."""
+    mem = _build_solo_mem(app_role, tmp_path)
+    try:
+        client = ScriptedClient([
+            _user_facts_payload("fact"),
+            _agent_facts_payload("ack"),
+            _decisions_payload(("ADD", None), ("ADD", None)),
+        ])
+        u, a = _round()
+        result = mem.ingest_round(u, a,
+                                  extraction_client=client,
+                                  resolver_client=client)
+        # Episode bound to the daily session (not None, not random)
+        assert result.episode.session_id is not None
+    finally:
+        mem.close()
+
+
+@pytest.mark.live
+def test_ingest_round_noop_decision_does_not_write(app_role, fresh_schema, tmp_path):
+    """NOOP-driven decision must not produce a memory_id in written list.
+
+    Seed the doc store with an existing fact so the resolver actually
+    fires (instead of short-circuiting to all-ADD)."""
+    mem = _build_solo_mem(app_role, tmp_path)
+    try:
+        # Round 1 to seed an existing memory the resolver can compare against
+        seed_user = json.dumps({
+            "facts": [{"text": "seed", "category": "preference",
+                       "entity": "user", "confidence": 0.9, "source_span": [0, 4]}]
+        })
+        seed_agent = json.dumps({"facts": []})
+        client_seed = ScriptedClient([seed_user, seed_agent])
+        u0, a0 = _round(thread_id="t-noop", offset=0)
+        mem.ingest_round(u0, a0,
+                         extraction_client=client_seed, resolver_client=client_seed)
+
+        # Round 2: 2 user facts, resolver returns ADD + NOOP
+        round_user = json.dumps({
+            "facts": [
+                {"text": "fresh", "category": "preference",
+                 "entity": "user", "confidence": 0.9, "source_span": [0, 5]},
+                {"text": "duplicate", "category": "preference",
+                 "entity": "user", "confidence": 0.9, "source_span": [0, 9]},
+            ]
+        })
+        round_agent = json.dumps({"facts": []})
+        round_decisions = json.dumps({
+            "decisions": [
+                {"operation": "ADD", "existing_id": None, "rationale": "fresh"},
+                {"operation": "NOOP", "existing_id": None, "rationale": "dup"},
+            ]
+        })
+        client = ScriptedClient([round_user, round_agent, round_decisions])
+        u, a = _round(thread_id="t-noop", offset=10)
+        result = mem.ingest_round(u, a,
+                                  extraction_client=client,
+                                  resolver_client=client)
+        assert [d.operation for d in result.decisions] == ["ADD", "NOOP"]
+        # Only the ADD produced a written memory_id
+        ops_with_ids = [(a.operation, a.memory_id) for a in result.applied]
+        assert ("NOOP", None) in ops_with_ids
+        adds = [m for o, m in ops_with_ids if o == "ADD"]
+        assert len(adds) == 1 and adds[0] is not None
+    finally:
+        mem.close()

--- a/tests/test_conversation_turns.py
+++ b/tests/test_conversation_turns.py
@@ -1,0 +1,91 @@
+"""Phase 3.1 — ConversationTurn dataclass invariants."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from attestor.conversation.turns import ConversationTurn
+
+
+@pytest.mark.unit
+def test_turn_minimal_construction() -> None:
+    t = ConversationTurn(
+        thread_id="t-1", speaker="user", role="user", content="hi",
+    )
+    assert t.thread_id == "t-1"
+    assert t.is_user
+    assert not t.is_assistant
+    assert t.ts.tzinfo is timezone.utc
+
+
+@pytest.mark.unit
+def test_turn_assistant_role() -> None:
+    t = ConversationTurn(
+        thread_id="t-1", speaker="planner-01", role="assistant", content="ok",
+    )
+    assert t.is_assistant
+    assert not t.is_user
+
+
+@pytest.mark.unit
+def test_turn_rejects_empty_content() -> None:
+    with pytest.raises(ValueError, match="content"):
+        ConversationTurn(
+            thread_id="t-1", speaker="user", role="user", content="",
+        )
+
+
+@pytest.mark.unit
+def test_turn_rejects_empty_thread_id() -> None:
+    with pytest.raises(ValueError, match="thread_id"):
+        ConversationTurn(
+            thread_id="", speaker="user", role="user", content="hi",
+        )
+
+
+@pytest.mark.unit
+def test_turn_rejects_empty_speaker() -> None:
+    with pytest.raises(ValueError, match="speaker"):
+        ConversationTurn(
+            thread_id="t-1", speaker="", role="user", content="hi",
+        )
+
+
+@pytest.mark.unit
+def test_turn_rejects_invalid_role() -> None:
+    with pytest.raises(ValueError, match="role"):
+        ConversationTurn(
+            thread_id="t-1", speaker="user", role="orchestrator", content="hi",
+        )
+
+
+@pytest.mark.unit
+def test_turn_is_immutable() -> None:
+    t = ConversationTurn(
+        thread_id="t-1", speaker="user", role="user", content="hi",
+    )
+    with pytest.raises(Exception):  # FrozenInstanceError
+        t.content = "modified"  # type: ignore[misc]
+
+
+@pytest.mark.unit
+def test_turn_explicit_timestamp() -> None:
+    ts = datetime(2026, 4, 26, 10, 0, 0, tzinfo=timezone.utc)
+    t = ConversationTurn(
+        thread_id="t-1", speaker="user", role="user", content="hi", ts=ts,
+    )
+    assert t.ts == ts
+
+
+@pytest.mark.unit
+def test_turn_metadata_default_is_isolated_dict() -> None:
+    """Two turns must not share the same metadata dict instance."""
+    t1 = ConversationTurn(
+        thread_id="t-1", speaker="user", role="user", content="a",
+    )
+    t2 = ConversationTurn(
+        thread_id="t-2", speaker="user", role="user", content="b",
+    )
+    assert t1.metadata is not t2.metadata

--- a/tests/test_embedding_keys.py
+++ b/tests/test_embedding_keys.py
@@ -1,0 +1,275 @@
+"""Phase 4.1 — fact-augmented embedding keys (roadmap §B.1).
+
+Verifies _build_embedding_text concatenates fact + raw round text + tags
+on v4 rows with a source_episode_id, and falls back to just-fact text on
+v3 rows or when the episode lookup fails.
+
+Two test surfaces:
+  - Unit tests with a stub psycopg2 connection (no DB needed).
+  - Live test against the real v4 schema that writes a round + memory and
+    asserts the embedding text reflects the round, not just the fact.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+try:
+    import psycopg2
+    HAVE_PSYCOPG2 = True
+except ImportError:
+    HAVE_PSYCOPG2 = False
+
+PG_URL = os.environ.get(
+    "PG_TEST_URL",
+    "postgresql://postgres:attestor@localhost:5432/attestor_v4_test",
+)
+SCHEMA_PATH = Path(__file__).resolve().parent.parent / "attestor" / "store" / "schema.sql"
+
+
+def _reachable() -> bool:
+    if not HAVE_PSYCOPG2:
+        return False
+    try:
+        c = psycopg2.connect(PG_URL, connect_timeout=2)
+        c.close()
+        return True
+    except Exception:
+        return False
+
+
+pytestmark = pytest.mark.skipif(not _reachable(), reason="local Postgres unreachable")
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Unit tests with a stub conn
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class _StubCursor:
+    """Mocks the psycopg2 cursor protocol for a single SELECT."""
+
+    def __init__(self, row: dict | None) -> None:
+        self._row = row
+
+    def __enter__(self) -> _StubCursor:
+        return self
+
+    def __exit__(self, *exc) -> None:
+        return None
+
+    def execute(self, sql: str, params=None) -> None:
+        return None
+
+    def fetchone(self) -> dict | None:
+        return self._row
+
+
+class _StubConn:
+    def __init__(self, row: dict | None = None) -> None:
+        self._row = row
+
+    def cursor(self, cursor_factory=None):
+        return _StubCursor(self._row)
+
+
+def _backend_with_stub(row: dict | None, *, v4: bool = True):
+    """Construct a PostgresBackend stub without going through __init__."""
+    from attestor.store.postgres_backend import PostgresBackend
+    be = PostgresBackend.__new__(PostgresBackend)
+    be._conn = _StubConn(row)
+    be._v4 = v4
+    return be
+
+
+@pytest.mark.unit
+def test_build_embedding_v3_returns_just_content() -> None:
+    """v3 rows: no episode link, no enrichment — just the fact text."""
+    be = _backend_with_stub(row=None, v4=False)
+    out = be._build_embedding_text("m-1", "user prefers dark mode")
+    assert out == "user prefers dark mode"
+
+
+@pytest.mark.unit
+def test_build_embedding_v4_no_episode_returns_just_content() -> None:
+    """v4 row with no source_episode_id → no enrichment to do."""
+    row = {
+        "tags": [], "source_episode_id": None,
+        "user_turn_text": None, "assistant_turn_text": None,
+    }
+    be = _backend_with_stub(row=row, v4=True)
+    out = be._build_embedding_text("m-1", "fact text")
+    assert out == "fact text"
+
+
+@pytest.mark.unit
+def test_build_embedding_v4_full_round_concat() -> None:
+    """v4 row with an episode → fact + user turn + assistant turn."""
+    row = {
+        "tags": ["preference", "ui"],
+        "source_episode_id": "ep-1",
+        "user_turn_text": "Switch the UI to dark mode please.",
+        "assistant_turn_text": "Done — all panels are now dark.",
+    }
+    be = _backend_with_stub(row=row, v4=True)
+    out = be._build_embedding_text("m-1", "user prefers dark mode")
+    assert "user prefers dark mode" in out
+    assert "Switch the UI to dark mode please." in out
+    assert "Done — all panels are now dark." in out
+    assert "Tags: preference, ui" in out
+    # Order matters: fact first, then user, then assistant, then tags
+    parts = out.split("\n---\n")
+    assert parts[0] == "user prefers dark mode"
+    assert parts[1] == "Switch the UI to dark mode please."
+    assert parts[2] == "Done — all panels are now dark."
+    assert parts[3] == "Tags: preference, ui"
+
+
+@pytest.mark.unit
+def test_build_embedding_v4_skips_empty_tag_block() -> None:
+    """No tags → no trailing 'Tags:' suffix."""
+    row = {
+        "tags": [], "source_episode_id": "ep-1",
+        "user_turn_text": "What's 2+2?", "assistant_turn_text": "4",
+    }
+    be = _backend_with_stub(row=row, v4=True)
+    out = be._build_embedding_text("m-1", "agent answered 4")
+    assert "Tags:" not in out
+    assert "What's 2+2?" in out
+
+
+@pytest.mark.unit
+def test_build_embedding_v4_partial_episode(
+) -> None:
+    """If only one side of the round was kept, still include what we have."""
+    row = {
+        "tags": ["x"],
+        "source_episode_id": "ep-1",
+        "user_turn_text": "user said something",
+        "assistant_turn_text": None,
+    }
+    be = _backend_with_stub(row=row, v4=True)
+    out = be._build_embedding_text("m-1", "fact")
+    assert "user said something" in out
+    # No empty assistant block
+    parts = out.split("\n---\n")
+    assert all(p.strip() for p in parts)
+
+
+@pytest.mark.unit
+def test_build_embedding_lookup_failure_falls_back_to_content() -> None:
+    """If the SELECT raises, fall through to the just-fact path — never crash."""
+    class _ExplodingConn:
+        def cursor(self, cursor_factory=None):
+            raise RuntimeError("DB on fire")
+    from attestor.store.postgres_backend import PostgresBackend
+    be = PostgresBackend.__new__(PostgresBackend)
+    be._conn = _ExplodingConn()
+    be._v4 = True
+    out = be._build_embedding_text("m-1", "important fact")
+    assert out == "important fact"
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Live test — round-write + add → embedding text is the full round
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def admin_conn():
+    c = psycopg2.connect(PG_URL)
+    c.autocommit = True
+    yield c
+    c.close()
+
+
+@pytest.fixture
+def fresh_schema(admin_conn):
+    raw = SCHEMA_PATH.read_text().replace("{embedding_dim}", "1024")
+    with admin_conn.cursor() as cur:
+        for tbl in ("memories", "episodes", "sessions", "projects", "users"):
+            cur.execute(f"DROP TABLE IF EXISTS {tbl} CASCADE")
+        cur.execute(raw)
+    yield
+
+
+def _ollama_up() -> bool:
+    try:
+        import requests
+        r = requests.get("http://localhost:11434/api/tags", timeout=2)
+        return r.status_code == 200
+    except Exception:
+        return False
+
+
+@pytest.mark.live
+@pytest.mark.skipif(not _ollama_up(), reason="Ollama not running")
+def test_live_v4_embedding_text_reflects_round(admin_conn, fresh_schema) -> None:
+    """Round → memory → _build_embedding_text returns the full round shape."""
+    from attestor.store.postgres_backend import PostgresBackend
+    be = PostgresBackend({
+        "url": "postgresql://localhost:5432",
+        "database": "attestor_v4_test",
+        "auth": {"username": "postgres", "password": "attestor"},
+        "v4": True,
+        "skip_schema_init": True,
+    })
+    try:
+        # Seed user + project + session via admin connection (RLS bypass).
+        uid = uuid.uuid4()
+        pid = uuid.uuid4()
+        sid = uuid.uuid4()
+        with admin_conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO users (id, external_id) VALUES (%s, %s)",
+                (str(uid), f"u-{uuid.uuid4().hex[:8]}"),
+            )
+            cur.execute(
+                "INSERT INTO projects (id, user_id, name) VALUES (%s, %s, %s)",
+                (str(pid), str(uid), "p"),
+            )
+            cur.execute(
+                "INSERT INTO sessions (id, user_id, project_id) VALUES (%s, %s, %s)",
+                (str(sid), str(uid), str(pid)),
+            )
+
+        be._set_rls_user(str(uid))
+
+        # Write an episode + memory linked to it
+        from attestor.conversation.episodes import EpisodeRepo
+        from attestor.conversation.turns import ConversationTurn
+        from attestor.models import Memory
+
+        repo = EpisodeRepo(be._conn)
+        u = ConversationTurn(thread_id="t", speaker="user", role="user",
+                             content="I love sushi.")
+        a = ConversationTurn(thread_id="t", speaker="planner", role="assistant",
+                             content="Noted — sushi added to favorites.",
+                             ts=u.ts + timedelta(seconds=1))
+        ep = repo.write_round(
+            user_id=str(uid), session_id=str(sid), project_id=str(pid),
+            user_turn=u, assistant_turn=a,
+        )
+
+        m = Memory(
+            content="user enjoys sushi", category="preference",
+            entity="food", confidence=0.9,
+            user_id=str(uid), project_id=str(pid), session_id=str(sid),
+            scope="user", source_episode_id=ep.id,
+            agent_id="user", source_span=[0, 19],
+            tags=["food", "preference"],
+        )
+        inserted = be.insert(m)
+
+        text = be._build_embedding_text(inserted.id, inserted.content)
+        assert "user enjoys sushi" in text
+        assert "I love sushi." in text
+        assert "Noted — sushi added to favorites." in text
+        assert "Tags: food, preference" in text
+    finally:
+        be.close()

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -38,21 +38,23 @@ class TestGetEmbeddingProvider:
         clear_embedding_cache()
 
     def test_raises_without_any_key(self):
-        """No cloud creds and no OpenAI key → explicit error."""
+        """No local ollama, no cloud creds, no OpenAI key → explicit error."""
         with patch.dict("os.environ", {}, clear=True):
-            with patch("attestor.store.embeddings._try_openai", return_value=None):
-                with pytest.raises(RuntimeError, match="No embedding provider"):
-                    get_embedding_provider()
+            with patch("attestor.store.embeddings._try_ollama", return_value=None):
+                with patch("attestor.store.embeddings._try_openai", return_value=None):
+                    with pytest.raises(RuntimeError, match="No embedding provider"):
+                        get_embedding_provider()
 
     def test_openai_tried_when_key_set(self):
-        """When OPENAI_API_KEY is set, OpenAI provider should be attempted."""
+        """When OPENAI_API_KEY is set and Ollama unavailable, OpenAI is used."""
         mock_provider = MagicMock()
         mock_provider.provider_name = "openai"
         mock_provider.dimension = 1536
 
-        with patch("attestor.store.embeddings._try_openai", return_value=mock_provider):
-            provider = get_embedding_provider()
-            assert provider.provider_name == "openai"
+        with patch("attestor.store.embeddings._try_ollama", return_value=None):
+            with patch("attestor.store.embeddings._try_openai", return_value=mock_provider):
+                provider = get_embedding_provider()
+                assert provider.provider_name == "openai"
 
     def test_preferred_bedrock_tried_first(self):
         """When preferred='bedrock', should try bedrock before openai."""
@@ -65,15 +67,16 @@ class TestGetEmbeddingProvider:
             assert provider.provider_name == "bedrock"
 
     def test_preferred_unavailable_falls_through_to_openai(self):
-        """Preferred cloud provider failing falls through to OpenAI path."""
+        """Preferred cloud provider failing falls through to local→OpenAI path."""
         mock_openai = MagicMock()
         mock_openai.provider_name = "openai"
         mock_openai.dimension = 1536
 
         with patch("attestor.store.embeddings._CLOUD_PROVIDERS", {"bedrock": lambda: None}):
-            with patch("attestor.store.embeddings._try_openai", return_value=mock_openai):
-                provider = get_embedding_provider(preferred="bedrock")
-                assert provider.provider_name == "openai"
+            with patch("attestor.store.embeddings._try_ollama", return_value=None):
+                with patch("attestor.store.embeddings._try_openai", return_value=mock_openai):
+                    provider = get_embedding_provider(preferred="bedrock")
+                    assert provider.provider_name == "openai"
 
 
 class TestOpenAIEmbeddingProvider:

--- a/tests/test_episode_repo.py
+++ b/tests/test_episode_repo.py
@@ -1,0 +1,244 @@
+"""Phase 3.1 — EpisodeRepo CRUD against the v4 ``episodes`` table.
+
+Runs against the dedicated ``attestor_v4_test`` database. Schema is
+admin-loaded at module scope; each test gets a fresh user + session so
+RLS policies admit the writes.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+try:
+    import psycopg2
+    HAVE_PSYCOPG2 = True
+except ImportError:
+    HAVE_PSYCOPG2 = False
+
+from attestor.conversation.episodes import EpisodeRepo
+from attestor.conversation.turns import ConversationTurn
+
+PG_URL = os.environ.get(
+    "PG_TEST_URL",
+    "postgresql://postgres:attestor@localhost:5432/attestor_v4_test",
+)
+SCHEMA_PATH = Path(__file__).resolve().parent.parent / "attestor" / "store" / "schema.sql"
+
+
+def _reachable() -> bool:
+    if not HAVE_PSYCOPG2:
+        return False
+    try:
+        c = psycopg2.connect(PG_URL, connect_timeout=2)
+        c.close()
+        return True
+    except Exception:
+        return False
+
+
+pytestmark = pytest.mark.skipif(not _reachable(), reason="local Postgres unreachable")
+
+
+@pytest.fixture(scope="module")
+def conn():
+    """Module-level superuser connection. Schema reload + RLS bypassed."""
+    c = psycopg2.connect(PG_URL)
+    c.autocommit = True
+    raw = SCHEMA_PATH.read_text().replace("{embedding_dim}", "16")
+    with c.cursor() as cur:
+        for tbl in ("memories", "episodes", "sessions", "projects", "users"):
+            cur.execute(f"DROP TABLE IF EXISTS {tbl} CASCADE")
+        cur.execute(raw)
+    yield c
+    c.close()
+
+
+@pytest.fixture
+def session_ctx(conn):
+    """Create a user + project + session; return (user_id, project_id, session_id)."""
+    uid = uuid.uuid4()
+    pid = uuid.uuid4()
+    sid = uuid.uuid4()
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO users (id, external_id) VALUES (%s, %s)",
+            (str(uid), f"u-ep-{uuid.uuid4().hex[:8]}"),
+        )
+        cur.execute(
+            "INSERT INTO projects (id, user_id, name) VALUES (%s, %s, %s)",
+            (str(pid), str(uid), "ep-proj"),
+        )
+        cur.execute(
+            "INSERT INTO sessions (id, user_id, project_id) VALUES (%s, %s, %s)",
+            (str(sid), str(uid), str(pid)),
+        )
+    return str(uid), str(pid), str(sid)
+
+
+def _round(thread_id: str = "thr-1", offset_seconds: int = 0):
+    """Build a (user_turn, assistant_turn) pair separated by 1s."""
+    base = datetime.now(timezone.utc) + timedelta(seconds=offset_seconds)
+    user = ConversationTurn(
+        thread_id=thread_id, speaker="user", role="user",
+        content="What's the weather?", ts=base,
+    )
+    assistant = ConversationTurn(
+        thread_id=thread_id, speaker="planner", role="assistant",
+        content="Sunny, 72°F.", ts=base + timedelta(seconds=1),
+    )
+    return user, assistant
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# Write
+# ───────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.live
+def test_write_round_persists_verbatim(conn, session_ctx):
+    uid, pid, sid = session_ctx
+    repo = EpisodeRepo(conn)
+    user_t, assistant_t = _round()
+    ep = repo.write_round(
+        user_id=uid, session_id=sid, project_id=pid,
+        user_turn=user_t, assistant_turn=assistant_t,
+        agent_id="planner-01",
+    )
+    assert ep.user_turn_text == "What's the weather?"
+    assert ep.assistant_turn_text == "Sunny, 72°F."
+    assert ep.thread_id == "thr-1"
+    assert ep.agent_id == "planner-01"
+    assert ep.user_id == uid
+    assert ep.session_id == sid
+
+
+@pytest.mark.live
+def test_write_round_thread_id_mismatch_raises(conn, session_ctx):
+    uid, pid, sid = session_ctx
+    repo = EpisodeRepo(conn)
+    user_t = ConversationTurn(
+        thread_id="t-A", speaker="user", role="user", content="hi",
+    )
+    assistant_t = ConversationTurn(
+        thread_id="t-B", speaker="a", role="assistant", content="bye",
+    )
+    with pytest.raises(ValueError, match="thread_id mismatch"):
+        repo.write_round(
+            user_id=uid, session_id=sid,
+            user_turn=user_t, assistant_turn=assistant_t,
+        )
+
+
+@pytest.mark.live
+def test_write_round_role_mismatch_raises(conn, session_ctx):
+    uid, pid, sid = session_ctx
+    repo = EpisodeRepo(conn)
+    swapped_user = ConversationTurn(
+        thread_id="t", speaker="user", role="assistant", content="hi",
+    )
+    assistant = ConversationTurn(
+        thread_id="t", speaker="a", role="assistant", content="bye",
+    )
+    with pytest.raises(ValueError, match="user_turn.role"):
+        repo.write_round(
+            user_id=uid, session_id=sid,
+            user_turn=swapped_user, assistant_turn=assistant,
+        )
+
+
+@pytest.mark.live
+def test_write_round_assistant_before_user_raises(conn, session_ctx):
+    uid, pid, sid = session_ctx
+    repo = EpisodeRepo(conn)
+    base = datetime.now(timezone.utc)
+    user = ConversationTurn(
+        thread_id="t", speaker="user", role="user", content="hi", ts=base,
+    )
+    assistant = ConversationTurn(
+        thread_id="t", speaker="a", role="assistant", content="bye",
+        ts=base - timedelta(seconds=5),  # before user
+    )
+    with pytest.raises(ValueError, match="cannot precede"):
+        repo.write_round(
+            user_id=uid, session_id=sid,
+            user_turn=user, assistant_turn=assistant,
+        )
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# Read
+# ───────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.live
+def test_get_returns_round(conn, session_ctx):
+    uid, pid, sid = session_ctx
+    repo = EpisodeRepo(conn)
+    u, a = _round()
+    ep = repo.write_round(user_id=uid, session_id=sid, user_turn=u, assistant_turn=a)
+    fetched = repo.get(ep.id)
+    assert fetched is not None
+    assert fetched.id == ep.id
+    assert fetched.user_turn_text == u.content
+
+
+@pytest.mark.live
+def test_get_missing_returns_none(conn):
+    repo = EpisodeRepo(conn)
+    assert repo.get(str(uuid.uuid4())) is None
+
+
+@pytest.mark.live
+def test_list_for_thread_chronological(conn, session_ctx):
+    uid, pid, sid = session_ctx
+    repo = EpisodeRepo(conn)
+    # Three rounds at 0, 10, 20 seconds in the same thread
+    for offset in (0, 10, 20):
+        u, a = _round(thread_id="thr-A", offset_seconds=offset)
+        repo.write_round(user_id=uid, session_id=sid, user_turn=u, assistant_turn=a)
+
+    rounds = repo.list_for_thread("thr-A")
+    assert len(rounds) == 3
+    timestamps = [r.user_ts for r in rounds]
+    assert timestamps == sorted(timestamps), "must be chronological asc"
+
+
+@pytest.mark.live
+def test_list_for_session_isolation(conn, session_ctx):
+    """list_for_session returns only that session's episodes."""
+    uid, pid, sid = session_ctx
+    repo = EpisodeRepo(conn)
+
+    # Make a second session for the same user
+    sid2 = uuid.uuid4()
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO sessions (id, user_id, project_id) VALUES (%s, %s, %s)",
+            (str(sid2), uid, pid),
+        )
+
+    u1, a1 = _round(thread_id="t1")
+    u2, a2 = _round(thread_id="t2", offset_seconds=5)
+    repo.write_round(user_id=uid, session_id=sid, user_turn=u1, assistant_turn=a1)
+    repo.write_round(user_id=uid, session_id=str(sid2), user_turn=u2, assistant_turn=a2)
+
+    s1_rounds = repo.list_for_session(sid)
+    s2_rounds = repo.list_for_session(str(sid2))
+    assert len(s1_rounds) == 1 and s1_rounds[0].thread_id == "t1"
+    assert len(s2_rounds) == 1 and s2_rounds[0].thread_id == "t2"
+
+
+@pytest.mark.live
+def test_count_for_session(conn, session_ctx):
+    uid, pid, sid = session_ctx
+    repo = EpisodeRepo(conn)
+    assert repo.count_for_session(sid) == 0
+    for i in range(3):
+        u, a = _round(thread_id=f"thr-{i}", offset_seconds=i)
+        repo.write_round(user_id=uid, session_id=sid, user_turn=u, assistant_turn=a)
+    assert repo.count_for_session(sid) == 3

--- a/tests/test_extraction_prompts.py
+++ b/tests/test_extraction_prompts.py
@@ -1,0 +1,218 @@
+"""Phase 3.2 — extraction prompt content guards.
+
+These tests are anti-regression: they assert the load-bearing pieces of
+the prompts (speaker-lock IMPORTANT lines, JSON schemas, source_span,
+operation set) stay intact. Drift here costs LongMemEval points
+silently — Mem0's published +53.6 single-session-assistant fix was
+exactly this speaker-lock line.
+"""
+
+from __future__ import annotations
+
+import string
+
+import pytest
+
+from attestor.extraction.prompts import (
+    AGENT_FACT_EXTRACTION_PROMPT,
+    MEMORY_UPDATE_PROMPT,
+    PROMPT_VARS,
+    USER_FACT_EXTRACTION_PROMPT,
+    format_agent_fact_prompt,
+    format_memory_update_prompt,
+    format_user_fact_prompt,
+)
+
+
+def _placeholders(template: str) -> set[str]:
+    """Extract format-string field names from a template."""
+    formatter = string.Formatter()
+    return {
+        name for _, name, _, _ in formatter.parse(template)
+        if name
+    }
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# Speaker-lock IMPORTANT lines (the +53.6 fix — DON'T REMOVE)
+# ───────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_user_prompt_has_speaker_lock_line() -> None:
+    """User extractor MUST refuse to extract from anything but the user msg."""
+    assert "IMPORTANT" in USER_FACT_EXTRACTION_PROMPT
+    assert "USER'S MESSAGE BELOW" in USER_FACT_EXTRACTION_PROMPT
+
+
+@pytest.mark.unit
+def test_agent_prompt_has_speaker_lock_line() -> None:
+    """Agent extractor MUST refuse to extract from anything but the assistant msg."""
+    assert "IMPORTANT" in AGENT_FACT_EXTRACTION_PROMPT
+    assert "ASSISTANT'S MESSAGE BELOW" in AGENT_FACT_EXTRACTION_PROMPT
+
+
+@pytest.mark.unit
+def test_user_prompt_warns_off_recent_context() -> None:
+    """The 'recent context' block must be flagged as disambiguation-only."""
+    assert "DO NOT extract" in USER_FACT_EXTRACTION_PROMPT
+
+
+@pytest.mark.unit
+def test_agent_prompt_warns_off_recent_context() -> None:
+    assert "disambiguation only" in AGENT_FACT_EXTRACTION_PROMPT.lower()
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# JSON schemas — required keys
+# ───────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_user_fact_schema_keys_present() -> None:
+    for key in ("text", "category", "entity", "confidence", "source_span"):
+        assert f'"{key}"' in USER_FACT_EXTRACTION_PROMPT, f"missing key: {key}"
+
+
+@pytest.mark.unit
+def test_agent_fact_schema_keys_present() -> None:
+    for key in ("text", "category", "entity", "confidence", "source_span"):
+        assert f'"{key}"' in AGENT_FACT_EXTRACTION_PROMPT, f"missing key: {key}"
+
+
+@pytest.mark.unit
+def test_user_fact_categories_are_complete() -> None:
+    """Categories list is the contract: extractor classifier outputs must
+    fall in this set or downstream supersession breaks."""
+    expected = {
+        "preference", "career", "project", "technical",
+        "personal", "location", "relationship", "event", "financial",
+    }
+    for cat in expected:
+        assert cat in USER_FACT_EXTRACTION_PROMPT, f"missing category: {cat}"
+
+
+@pytest.mark.unit
+def test_agent_fact_categories_are_complete() -> None:
+    expected = {
+        "recommendation", "decision", "commitment",
+        "constraint", "calculation", "refusal",
+    }
+    for cat in expected:
+        assert cat in AGENT_FACT_EXTRACTION_PROMPT, f"missing category: {cat}"
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# Source-span citation requirement (audit trail)
+# ───────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_user_prompt_requires_source_span() -> None:
+    assert "source_span" in USER_FACT_EXTRACTION_PROMPT
+    # Schema uses [<start_char>, <end_char>] tokens — this is the audit
+    # contract, every fact must cite back to char offsets in the source.
+    assert "start_char" in USER_FACT_EXTRACTION_PROMPT
+    assert "end_char" in USER_FACT_EXTRACTION_PROMPT
+
+
+@pytest.mark.unit
+def test_agent_prompt_requires_source_span() -> None:
+    assert "source_span" in AGENT_FACT_EXTRACTION_PROMPT
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# MEMORY_UPDATE — operation set is the contract
+# ───────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_memory_update_operations_complete() -> None:
+    """All four operations + INVALIDATE (the v4 supersession primitive)."""
+    for op in ("ADD", "UPDATE", "INVALIDATE", "NOOP"):
+        assert op in MEMORY_UPDATE_PROMPT, f"missing operation: {op}"
+
+
+@pytest.mark.unit
+def test_memory_update_requires_evidence() -> None:
+    """Every decision must cite the source episode."""
+    assert "evidence_episode_id" in MEMORY_UPDATE_PROMPT
+
+
+@pytest.mark.unit
+def test_memory_update_invalidate_keeps_old_row() -> None:
+    """INVALIDATE marks superseded; never deletes (timeline must replay)."""
+    assert "DO NOT delete" in MEMORY_UPDATE_PROMPT
+    assert "supersedes" in MEMORY_UPDATE_PROMPT
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# Format-string contract
+# ───────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_user_prompt_placeholders_match_declared() -> None:
+    actual = _placeholders(USER_FACT_EXTRACTION_PROMPT)
+    assert actual == PROMPT_VARS["USER_FACT"], (
+        f"USER_FACT placeholders drifted: declared={PROMPT_VARS['USER_FACT']} "
+        f"actual={actual}"
+    )
+
+
+@pytest.mark.unit
+def test_agent_prompt_placeholders_match_declared() -> None:
+    actual = _placeholders(AGENT_FACT_EXTRACTION_PROMPT)
+    assert actual == PROMPT_VARS["AGENT_FACT"]
+
+
+@pytest.mark.unit
+def test_memory_update_placeholders_match_declared() -> None:
+    actual = _placeholders(MEMORY_UPDATE_PROMPT)
+    assert actual == PROMPT_VARS["MEMORY_UPDATE"]
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# Format helpers
+# ───────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_format_user_fact_prompt_substitutes_message() -> None:
+    out = format_user_fact_prompt(
+        ts="2026-04-26T10:00:00Z",
+        user_message="I prefer dark mode",
+        recent_context_summary="thread is about UI prefs",
+    )
+    assert "I prefer dark mode" in out
+    assert "2026-04-26T10:00:00Z" in out
+    assert "thread is about UI prefs" in out
+
+
+@pytest.mark.unit
+def test_format_agent_fact_prompt_substitutes_message() -> None:
+    out = format_agent_fact_prompt(
+        ts="2026-04-26T10:00:01Z",
+        assistant_message="Switching the UI to dark mode now.",
+    )
+    assert "Switching the UI to dark mode now." in out
+    assert "(none)" in out  # default for recent_context_summary
+
+
+@pytest.mark.unit
+def test_format_memory_update_prompt_substitutes_inputs() -> None:
+    out = format_memory_update_prompt(
+        existing_memories_json='[{"id": "m1", "content": "old"}]',
+        new_facts_json='[{"text": "new"}]',
+    )
+    assert '"id": "m1"' in out
+    assert '"text": "new"' in out
+
+
+@pytest.mark.unit
+def test_format_helpers_dont_break_on_braces_in_input() -> None:
+    """User content may contain JSON / code blocks; format must not blow up."""
+    out = format_user_fact_prompt(
+        ts="t", user_message='use {x: 1} for the config',
+    )
+    assert "{x: 1}" in out

--- a/tests/test_ollama_embeddings.py
+++ b/tests/test_ollama_embeddings.py
@@ -1,0 +1,203 @@
+"""Local Ollama bge-m3 embedding provider tests.
+
+Most tests use a stub `requests` module so they run without Ollama
+running. One smoke test (marked live) hits a real local Ollama if it's
+reachable — skipped otherwise.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, List
+
+import pytest
+
+from attestor.store.embeddings import (
+    OllamaEmbeddingProvider,
+    _try_ollama,
+    clear_embedding_cache,
+    get_embedding_provider,
+)
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Stub requests session
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class _StubResponse:
+    def __init__(self, payload: dict, status: int = 200) -> None:
+        self._payload = payload
+        self._status = status
+
+    def raise_for_status(self) -> None:
+        if self._status >= 400:
+            raise RuntimeError(f"HTTP {self._status}")
+
+    def json(self) -> dict:
+        return self._payload
+
+
+class _StubRequests:
+    """Mocks the per-call functions of the `requests` module."""
+
+    def __init__(self) -> None:
+        self.posts: List[dict] = []
+        self._responses: List[_StubResponse] = []
+
+    def queue(self, *responses: _StubResponse) -> None:
+        self._responses.extend(responses)
+
+    def post(self, url: str, *, json: dict, timeout: float) -> _StubResponse:
+        self.posts.append({"url": url, "json": json, "timeout": timeout})
+        if not self._responses:
+            return _StubResponse({"embedding": [0.0] * 1024})
+        return self._responses.pop(0)
+
+
+def _provider_with_stub(monkeypatch, stub: _StubRequests) -> OllamaEmbeddingProvider:
+    """Construct OllamaEmbeddingProvider whose internal `requests` is a stub."""
+    p = OllamaEmbeddingProvider.__new__(OllamaEmbeddingProvider)
+    p._requests = stub
+    p._host = "http://localhost:11434"
+    p._model = "bge-m3"
+    p._timeout = 5.0
+    p._dimension = 1024
+    return p
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Defaults / config
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_default_model_is_bge_m3() -> None:
+    assert OllamaEmbeddingProvider.DEFAULT_MODEL == "bge-m3"
+
+
+@pytest.mark.unit
+def test_default_host_is_localhost() -> None:
+    assert OllamaEmbeddingProvider.DEFAULT_HOST == "http://localhost:11434"
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# embed() / embed_batch() with stub HTTP
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_embed_posts_to_correct_endpoint(monkeypatch) -> None:
+    stub = _StubRequests()
+    stub.queue(_StubResponse({"embedding": [0.1] * 1024}))
+    p = _provider_with_stub(monkeypatch, stub)
+    v = p.embed("hi")
+    assert len(v) == 1024
+    assert stub.posts[0]["url"] == "http://localhost:11434/api/embeddings"
+    assert stub.posts[0]["json"] == {"model": "bge-m3", "prompt": "hi"}
+
+
+@pytest.mark.unit
+def test_embed_raises_when_response_missing_embedding(monkeypatch) -> None:
+    stub = _StubRequests()
+    stub.queue(_StubResponse({"error": "model not found"}))
+    p = _provider_with_stub(monkeypatch, stub)
+    with pytest.raises(RuntimeError, match="missing 'embedding'"):
+        p.embed("hi")
+
+
+@pytest.mark.unit
+def test_embed_batch_uses_batch_endpoint_first(monkeypatch) -> None:
+    stub = _StubRequests()
+    stub.queue(_StubResponse({"embeddings": [[0.1] * 1024, [0.2] * 1024]}))
+    p = _provider_with_stub(monkeypatch, stub)
+    out = p.embed_batch(["a", "b"])
+    assert len(out) == 2
+    assert all(len(v) == 1024 for v in out)
+    # First (and only) call hit /api/embed (the batch endpoint)
+    assert stub.posts[0]["url"] == "http://localhost:11434/api/embed"
+
+
+@pytest.mark.unit
+def test_embed_batch_falls_back_to_per_text(monkeypatch) -> None:
+    """If /api/embed errors, per-text /api/embeddings calls cover it."""
+    stub = _StubRequests()
+    stub.queue(
+        _StubResponse({"error": "no batch"}, status=500),       # /api/embed fails
+        _StubResponse({"embedding": [0.1] * 1024}),             # /api/embeddings #1
+        _StubResponse({"embedding": [0.2] * 1024}),             # /api/embeddings #2
+    )
+    p = _provider_with_stub(monkeypatch, stub)
+    out = p.embed_batch(["a", "b"])
+    assert len(out) == 2
+    assert out[0][0] == 0.1
+    assert out[1][0] == 0.2
+
+
+@pytest.mark.unit
+def test_provider_name_includes_model() -> None:
+    stub = _StubRequests()
+    p = _provider_with_stub(None, stub)
+    p._model = "nomic-embed-text"
+    assert p.provider_name == "ollama:nomic-embed-text"
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Env var overrides
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_attestor_embedding_model_env_override(monkeypatch) -> None:
+    """ATTESTOR_EMBEDDING_MODEL takes precedence over DEFAULT_MODEL."""
+    monkeypatch.setenv("ATTESTOR_EMBEDDING_MODEL", "mxbai-embed-large")
+
+    # Build a minimal provider that resolves model from env without
+    # actually probing — bypass __init__'s probe.
+    p = OllamaEmbeddingProvider.__new__(OllamaEmbeddingProvider)
+    p._model = (
+        os.environ.get("ATTESTOR_EMBEDDING_MODEL")
+        or OllamaEmbeddingProvider.DEFAULT_MODEL
+    )
+    assert p._model == "mxbai-embed-large"
+
+
+@pytest.mark.unit
+def test_disable_local_embed_env_skips_probe(monkeypatch) -> None:
+    monkeypatch.setenv("ATTESTOR_DISABLE_LOCAL_EMBED", "1")
+    assert _try_ollama() is None
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Live (only if Ollama daemon up + bge-m3 pulled)
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _ollama_reachable() -> bool:
+    try:
+        import requests
+        r = requests.get("http://localhost:11434/api/tags", timeout=2)
+        return r.status_code == 200
+    except Exception:
+        return False
+
+
+@pytest.mark.live
+@pytest.mark.skipif(not _ollama_reachable(), reason="Ollama not running")
+def test_live_bge_m3_returns_1024d() -> None:
+    """Smoke test against a real local Ollama daemon."""
+    clear_embedding_cache()
+    p = OllamaEmbeddingProvider()
+    assert p.dimension == 1024
+    v = p.embed("attestor uses local embeddings")
+    assert len(v) == 1024
+    assert all(isinstance(x, float) for x in v[:5])
+
+
+@pytest.mark.live
+@pytest.mark.skipif(not _ollama_reachable(), reason="Ollama not running")
+def test_live_get_embedding_provider_picks_ollama() -> None:
+    """Auto-detect should land on Ollama when it's the first reachable provider."""
+    clear_embedding_cache()
+    p = get_embedding_provider()
+    assert p.provider_name.startswith("ollama:")

--- a/tests/test_orchestrator_bm25.py
+++ b/tests/test_orchestrator_bm25.py
@@ -1,0 +1,251 @@
+"""Phase 4.3 — RetrievalOrchestrator wiring of the BM25 lane.
+
+Integration tests with a stub vector store + a real BM25Lane (live
+Postgres). Verifies:
+  - Vector-only path: orchestrator works with bm25_lane=None (regression)
+  - BM25-only path: orchestrator returns BM25 hits when vector_store=None
+  - Fusion: a memory matched only by BM25 keyword (not similar vectorally)
+    appears in the result set when both lanes are wired
+  - Backward compat: AgentMemory's __init__ wires bm25_lane on v4
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from pathlib import Path
+
+import pytest
+
+try:
+    import psycopg2
+    HAVE_PSYCOPG2 = True
+except ImportError:
+    HAVE_PSYCOPG2 = False
+
+PG_URL = os.environ.get(
+    "PG_TEST_URL",
+    "postgresql://postgres:attestor@localhost:5432/attestor_v4_test",
+)
+SCHEMA_PATH = Path(__file__).resolve().parent.parent / "attestor" / "store" / "schema.sql"
+
+
+def _reachable() -> bool:
+    if not HAVE_PSYCOPG2:
+        return False
+    try:
+        c = psycopg2.connect(PG_URL, connect_timeout=2)
+        c.close()
+        return True
+    except Exception:
+        return False
+
+
+pytestmark = pytest.mark.skipif(not _reachable(), reason="local Postgres unreachable")
+
+
+@pytest.fixture(scope="module")
+def admin_conn():
+    c = psycopg2.connect(PG_URL)
+    c.autocommit = True
+    yield c
+    c.close()
+
+
+@pytest.fixture
+def fresh_schema(admin_conn):
+    raw = SCHEMA_PATH.read_text().replace("{embedding_dim}", "16")
+    with admin_conn.cursor() as cur:
+        for tbl in ("memories", "episodes", "sessions", "projects", "users"):
+            cur.execute(f"DROP TABLE IF EXISTS {tbl} CASCADE")
+        cur.execute(raw)
+    yield
+
+
+@pytest.fixture
+def seeded(admin_conn, fresh_schema):
+    """Seed 4 memories with distinct keyword content; return ids + conn."""
+    uid = uuid.uuid4()
+    with admin_conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO users (id, external_id) VALUES (%s, %s)",
+            (str(uid), f"u-orc-{uuid.uuid4().hex[:8]}"),
+        )
+        cur.execute(
+            "SELECT set_config('attestor.current_user_id', %s, false)",
+            (str(uid),),
+        )
+        ids = []
+        seeds = [
+            ("user prefers dark mode", ["preference"]),
+            ("user lives in San Francisco", ["location"]),
+            ("user's lucky number is 7919", ["personal"]),
+            ("user attended PyCon last year", ["event"]),
+        ]
+        for content, tags in seeds:
+            cur.execute(
+                "INSERT INTO memories (user_id, content, tags) "
+                "VALUES (%s, %s, %s) RETURNING id",
+                (str(uid), content, tags),
+            )
+            ids.append(str(cur.fetchone()[0]))
+    return str(uid), ids, admin_conn
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Stub vector store — controllable hits per test
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class StubVectorStore:
+    def __init__(self, hits=None) -> None:
+        self._hits = hits or []
+        self.search_calls: list = []
+
+    def search(self, query: str, *, limit: int = 20, namespace=None) -> list:
+        self.search_calls.append({"query": query, "limit": limit})
+        return self._hits
+
+
+class StubDocStore:
+    """Lightweight doc store that proxies .get to a real psycopg2 conn."""
+    def __init__(self, conn) -> None:
+        self._conn = conn
+
+    def get(self, mid: str):
+        from attestor.models import Memory
+        with self._conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            cur.execute("SELECT * FROM memories WHERE id = %s", (mid,))
+            row = cur.fetchone()
+        if row is None:
+            return None
+        return Memory.from_row(dict(row))
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Orchestrator paths
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.live
+def test_orchestrator_without_bm25_unchanged(seeded) -> None:
+    """No bm25_lane → behaves exactly like the pre-Phase-4 vector path."""
+    import psycopg2.extras  # for RealDictCursor in StubDocStore.get
+    uid, ids, conn = seeded
+    from attestor.retrieval.orchestrator import RetrievalOrchestrator
+
+    vec = StubVectorStore(hits=[
+        {"memory_id": ids[0], "distance": 0.1},
+        {"memory_id": ids[1], "distance": 0.4},
+    ])
+    orch = RetrievalOrchestrator(
+        store=StubDocStore(conn), vector_store=vec, bm25_lane=None,
+    )
+    out = orch.recall("dark", token_budget=2000)
+    out_ids = [r.memory.id for r in out if r.match_source == "vector"]
+    assert ids[0] in out_ids
+
+
+@pytest.mark.live
+def test_orchestrator_bm25_only_returns_keyword_hits(seeded) -> None:
+    """vector_store=None + bm25_lane wired → keyword hits flow through."""
+    import psycopg2.extras
+    uid, ids, conn = seeded
+    from attestor.retrieval.bm25 import BM25Lane
+    from attestor.retrieval.orchestrator import RetrievalOrchestrator
+
+    bm25 = BM25Lane(conn)
+    orch = RetrievalOrchestrator(
+        store=StubDocStore(conn), vector_store=None, bm25_lane=bm25,
+    )
+    out = orch.recall("PyCon", token_budget=2000)
+    out_contents = [r.memory.content for r in out]
+    assert any("PyCon" in c for c in out_contents)
+
+
+@pytest.mark.live
+def test_orchestrator_fusion_surfaces_bm25_only_match(seeded) -> None:
+    """Vector lane misses 'lucky number 7919' but BM25 finds it."""
+    import psycopg2.extras
+    uid, ids, conn = seeded
+    from attestor.retrieval.bm25 import BM25Lane
+    from attestor.retrieval.orchestrator import RetrievalOrchestrator
+
+    # Vector lane returns the dark-mode row (most similar embedding-wise
+    # for a vague query) but NOT the lucky-number row.
+    vec = StubVectorStore(hits=[
+        {"memory_id": ids[0], "distance": 0.3},
+    ])
+    bm25 = BM25Lane(conn)
+    orch = RetrievalOrchestrator(
+        store=StubDocStore(conn), vector_store=vec, bm25_lane=bm25,
+    )
+    out = orch.recall("7919", token_budget=2000)
+    out_ids = [r.memory.id for r in out]
+    # The lucky-number row should appear via the BM25 lane
+    lucky_id = ids[2]
+    assert lucky_id in out_ids
+
+
+@pytest.mark.live
+def test_orchestrator_bm25_failure_does_not_break_recall(seeded) -> None:
+    """BM25 lane raising → recall still returns vector hits."""
+    import psycopg2.extras
+    uid, ids, conn = seeded
+    from attestor.retrieval.orchestrator import RetrievalOrchestrator
+
+    class ExplodingBM25:
+        def search(self, *a, **kw):
+            raise RuntimeError("bm25 down")
+
+    vec = StubVectorStore(hits=[{"memory_id": ids[0], "distance": 0.1}])
+    orch = RetrievalOrchestrator(
+        store=StubDocStore(conn), vector_store=vec,
+        bm25_lane=ExplodingBM25(),
+    )
+    out = orch.recall("anything", token_budget=2000)
+    assert len(out) >= 1
+
+
+@pytest.mark.live
+def test_agent_memory_wires_bm25_on_v4(seeded) -> None:
+    """AgentMemory(v4=True) auto-attaches a BM25Lane to the orchestrator."""
+    uid, ids, conn = seeded
+    from attestor.core import AgentMemory
+
+    mem = AgentMemory(
+        Path("/tmp/attestor_orc_bm25"),
+        config={
+            "mode": "solo",
+            "backends": ["postgres"],
+            "backend_configs": {
+                "postgres": {
+                    "url": "postgresql://localhost:5432",
+                    "database": "attestor_v4_test",
+                    "auth": {"username": "postgres", "password": "attestor"},
+                    "v4": True,
+                    "skip_schema_init": True,
+                    "embedding_dim": 16,
+                }
+            },
+        },
+    )
+    try:
+        assert mem._retrieval.bm25_lane is not None
+        assert hasattr(mem._retrieval.bm25_lane, "search")
+    finally:
+        mem.close()
+
+
+@pytest.mark.unit
+def test_orchestrator_attrs_default_to_none() -> None:
+    """Bare orchestrator has bm25_lane=None and sane top-K defaults."""
+    from attestor.retrieval.orchestrator import RetrievalOrchestrator
+
+    class _DummyStore:
+        def get(self, _): return None
+
+    orch = RetrievalOrchestrator(store=_DummyStore())
+    assert orch.bm25_lane is None
+    assert orch.bm25_top_k == 30
+    assert orch.bm25_min_rank == 0.0

--- a/tests/test_round_extractor.py
+++ b/tests/test_round_extractor.py
@@ -1,0 +1,340 @@
+"""Phase 3.3 — round-level extractor (extract_user_facts / extract_agent_facts).
+
+Uses a stubbed LLM client so tests are deterministic and don't need
+network / API keys. Each test crafts the LLM response shape and verifies
+parsing, validation, clamping, and speaker-lock guards.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, List
+
+import pytest
+
+from attestor.conversation.turns import ConversationTurn
+from attestor.extraction.round_extractor import (
+    AGENT_FACT_CATEGORIES,
+    USER_FACT_CATEGORIES,
+    ExtractedFact,
+    _parse_facts_payload,
+    _strip_markdown_fences,
+    _validate_fact,
+    extract_agent_facts,
+    extract_user_facts,
+)
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Stub LLM
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class _StubChoice:
+    def __init__(self, content: str) -> None:
+        self.message = type("M", (), {"content": content})()
+
+
+class _StubResponse:
+    def __init__(self, content: str) -> None:
+        self.choices = [_StubChoice(content)]
+
+
+class _StubChat:
+    def __init__(self, content: str) -> None:
+        self._content = content
+        self.last_call: dict = {}
+
+    def create(self, **kwargs: Any) -> _StubResponse:
+        self.last_call = kwargs
+        return _StubResponse(self._content)
+
+
+class StubClient:
+    def __init__(self, content: str) -> None:
+        self.chat = type("Chat", (), {"completions": _StubChat(content)})()
+
+    @property
+    def last_prompt(self) -> str:
+        msgs = self.chat.completions.last_call.get("messages", [])
+        return msgs[0]["content"] if msgs else ""
+
+
+def _user_turn(content: str = "I prefer dark mode") -> ConversationTurn:
+    return ConversationTurn(
+        thread_id="t-1", speaker="user", role="user", content=content,
+        ts=datetime(2026, 4, 26, 10, 0, 0, tzinfo=timezone.utc),
+    )
+
+
+def _asst_turn(content: str = "Switching to dark mode now.") -> ConversationTurn:
+    return ConversationTurn(
+        thread_id="t-1", speaker="planner", role="assistant", content=content,
+        ts=datetime(2026, 4, 26, 10, 0, 1, tzinfo=timezone.utc),
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Parsing helpers
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_strip_markdown_fences_handles_json_block() -> None:
+    raw = "```json\n{\"facts\": []}\n```"
+    assert _strip_markdown_fences(raw) == '{"facts": []}'
+
+
+@pytest.mark.unit
+def test_strip_markdown_fences_no_change_when_absent() -> None:
+    raw = '{"facts": []}'
+    assert _strip_markdown_fences(raw) == raw
+
+
+@pytest.mark.unit
+def test_parse_facts_payload_envelope_shape() -> None:
+    raw = '{"facts": [{"text": "hi"}]}'
+    facts = _parse_facts_payload(raw)
+    assert facts == [{"text": "hi"}]
+
+
+@pytest.mark.unit
+def test_parse_facts_payload_array_shape() -> None:
+    raw = '[{"text": "a"}, {"text": "b"}]'
+    facts = _parse_facts_payload(raw)
+    assert len(facts) == 2
+
+
+@pytest.mark.unit
+def test_parse_facts_payload_bad_json_returns_empty() -> None:
+    """Extractor failures must never raise — return [] on parse error."""
+    assert _parse_facts_payload("not json") == []
+    assert _parse_facts_payload("") == []
+
+
+@pytest.mark.unit
+def test_parse_facts_payload_drops_non_dict_entries() -> None:
+    raw = '[{"text": "ok"}, "garbage", 42, null]'
+    facts = _parse_facts_payload(raw)
+    assert facts == [{"text": "ok"}]
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Validation
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_validate_fact_minimal_user() -> None:
+    f = _validate_fact(
+        {"text": "user prefers Python", "category": "preference",
+         "entity": "Python", "confidence": 0.9, "source_span": [0, 19]},
+        speaker="user", content_len=100,
+        allowed_categories=USER_FACT_CATEGORIES,
+    )
+    assert f is not None
+    assert f.text == "user prefers Python"
+    assert f.category == "preference"
+    assert f.confidence == 0.9
+    assert f.source_span == [0, 19]
+
+
+@pytest.mark.unit
+def test_validate_fact_drops_empty_text() -> None:
+    f = _validate_fact(
+        {"text": "", "category": "preference"},
+        speaker="user", content_len=100,
+        allowed_categories=USER_FACT_CATEGORIES,
+    )
+    assert f is None
+
+
+@pytest.mark.unit
+def test_validate_fact_unknown_category_falls_back_to_general() -> None:
+    f = _validate_fact(
+        {"text": "fact", "category": "made_up"},
+        speaker="user", content_len=100,
+        allowed_categories=USER_FACT_CATEGORIES,
+    )
+    assert f.category == "general"
+
+
+@pytest.mark.unit
+def test_validate_fact_clamps_confidence() -> None:
+    high = _validate_fact(
+        {"text": "x", "confidence": 99.0},
+        speaker="user", content_len=10,
+        allowed_categories=USER_FACT_CATEGORIES,
+    )
+    low = _validate_fact(
+        {"text": "x", "confidence": -0.5},
+        speaker="user", content_len=10,
+        allowed_categories=USER_FACT_CATEGORIES,
+    )
+    assert high.confidence == 1.0
+    assert low.confidence == 0.0
+
+
+@pytest.mark.unit
+def test_validate_fact_clamps_source_span_to_content() -> None:
+    """Spans outside the turn's content range get clamped."""
+    f = _validate_fact(
+        {"text": "x", "source_span": [-5, 9999]},
+        speaker="user", content_len=20,
+        allowed_categories=USER_FACT_CATEGORIES,
+    )
+    assert f.source_span == [0, 20]
+
+
+@pytest.mark.unit
+def test_validate_fact_invalid_span_falls_back_to_full_range() -> None:
+    f = _validate_fact(
+        {"text": "x", "source_span": "not a list"},
+        speaker="user", content_len=10,
+        allowed_categories=USER_FACT_CATEGORIES,
+    )
+    assert f.source_span == [0, 10]
+
+
+@pytest.mark.unit
+def test_validate_fact_swaps_invalid_start_end() -> None:
+    """If start > end, end becomes start (avoids negative-length spans)."""
+    f = _validate_fact(
+        {"text": "x", "source_span": [50, 10]},
+        speaker="user", content_len=100,
+        allowed_categories=USER_FACT_CATEGORIES,
+    )
+    assert f.source_start <= f.source_end
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# extract_user_facts
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_extract_user_facts_happy_path() -> None:
+    stub = StubClient(
+        '{"facts": [{"text": "user prefers dark mode", '
+        '"category": "preference", "entity": "UI", '
+        '"confidence": 0.95, "source_span": [0, 19]}]}'
+    )
+    facts = extract_user_facts(_user_turn(), client=stub)
+    assert len(facts) == 1
+    f = facts[0]
+    assert f.text == "user prefers dark mode"
+    assert f.category == "preference"
+    assert f.speaker == "user"
+
+
+@pytest.mark.unit
+def test_extract_user_facts_empty_response() -> None:
+    stub = StubClient('{"facts": []}')
+    assert extract_user_facts(_user_turn(), client=stub) == []
+
+
+@pytest.mark.unit
+def test_extract_user_facts_speaker_lock_refuses_assistant_turn() -> None:
+    """Calling extract_user_facts on an assistant turn returns []."""
+    stub = StubClient('{"facts": [{"text": "x"}]}')
+    facts = extract_user_facts(_asst_turn(), client=stub)
+    assert facts == []
+    # Stub should not have been called
+    assert stub.chat.completions.last_call == {}
+
+
+@pytest.mark.unit
+def test_extract_user_facts_includes_speaker_lock_in_prompt() -> None:
+    stub = StubClient('{"facts": []}')
+    extract_user_facts(_user_turn(), client=stub)
+    prompt = stub.last_prompt
+    assert "USER'S MESSAGE BELOW" in prompt
+    assert "I prefer dark mode" in prompt
+
+
+@pytest.mark.unit
+def test_extract_user_facts_drops_malformed_facts() -> None:
+    """Mixed valid/invalid response — only valid entries returned."""
+    stub = StubClient(
+        '[{"text": "good fact"}, {"category": "preference"}, '  # 2nd has no text
+        '{"text": "another good"}]'
+    )
+    facts = extract_user_facts(_user_turn(), client=stub)
+    assert len(facts) == 2
+
+
+@pytest.mark.unit
+def test_extract_user_facts_handles_markdown_fences() -> None:
+    stub = StubClient(
+        '```json\n{"facts": [{"text": "fact in fence"}]}\n```'
+    )
+    facts = extract_user_facts(_user_turn(), client=stub)
+    assert len(facts) == 1
+    assert facts[0].text == "fact in fence"
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# extract_agent_facts
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_extract_agent_facts_happy_path() -> None:
+    stub = StubClient(
+        '{"facts": [{"text": "agent recommended dark mode", '
+        '"category": "recommendation", "entity": "UI", '
+        '"confidence": 0.9, "source_span": [0, 25]}]}'
+    )
+    facts = extract_agent_facts(_asst_turn(), client=stub)
+    assert len(facts) == 1
+    assert facts[0].speaker == "planner"
+    assert facts[0].category == "recommendation"
+
+
+@pytest.mark.unit
+def test_extract_agent_facts_speaker_lock_refuses_user_turn() -> None:
+    stub = StubClient('{"facts": [{"text": "x"}]}')
+    facts = extract_agent_facts(_user_turn(), client=stub)
+    assert facts == []
+    assert stub.chat.completions.last_call == {}
+
+
+@pytest.mark.unit
+def test_extract_agent_facts_uses_assistant_lock_line() -> None:
+    stub = StubClient('{"facts": []}')
+    extract_agent_facts(_asst_turn(), client=stub)
+    assert "ASSISTANT'S MESSAGE BELOW" in stub.last_prompt
+
+
+@pytest.mark.unit
+def test_agent_categories_are_distinct_from_user_categories() -> None:
+    """Sanity check — agent categories shouldn't overlap with user ones."""
+    assert USER_FACT_CATEGORIES.isdisjoint(AGENT_FACT_CATEGORIES)
+
+
+@pytest.mark.unit
+def test_extract_agent_facts_unknown_category_falls_back() -> None:
+    """An assistant-side 'preference' is invalid for agent facts."""
+    stub = StubClient(
+        '[{"text": "x", "category": "preference"}]'
+    )
+    facts = extract_agent_facts(_asst_turn(), client=stub)
+    assert facts[0].category == "general"
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Resilience
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_extract_user_facts_empty_llm_response() -> None:
+    stub = StubClient("")
+    assert extract_user_facts(_user_turn(), client=stub) == []
+
+
+@pytest.mark.unit
+def test_extract_user_facts_garbage_response() -> None:
+    """LLM hallucinates non-JSON prose → return [] rather than crash."""
+    stub = StubClient("Sorry, I can't help with that.")
+    assert extract_user_facts(_user_turn(), client=stub) == []


### PR DESCRIPTION
## Summary

- **Phase 3 — Track A: Conversation ingest pipeline** (six chunks). \`mem.ingest_round(user_turn, assistant_turn)\` → verbatim episode + speaker-locked extraction (USER + AGENT prompts) + ADD/UPDATE/INVALIDATE/NOOP conflict resolution + supersession-aware apply. 100% of extracted facts carry \`source_episode_id\` + \`source_span\` (LongMemEval roadmap §A.5).
- **Local-first Ollama bge-m3** (1024-D, 8K context) as the default embedding provider. OpenRouter / OpenAI / cloud are now fallbacks. No more API-credit dependency for the dev loop.
- **Phase 4 — Track B: Retrieval upgrades.** Fact-augmented embedding keys (round, not just fact → +4% recall@k per LongMemEval Finding 2) + Postgres BM25/FTS lane via trigger-maintained \`content_tsv\` + RRF fusion (k=60) wired into RetrievalOrchestrator.

## Test plan

- [x] 556 unit tests pass (was 415 on main); 232 skipped (env-gated cloud)
- [x] All 6 isolation contract tests still green (RLS unaffected)
- [x] All 7 SOLO defaults tests still green
- [x] All 11 \`_resolve()\` tests still green
- [x] Live BM25 tests against the real \`content_tsv\` GIN index
- [x] Live bge-m3 smoke test (1024-D vectors, fully end-to-end)
- [x] Live embedding-key concat test confirms round shape (fact + user + assistant + tags)
- [x] INVALIDATE round 2 supersedes the round-1 row (timeline replay preserved)
- [x] Speaker-lock prompts intact (the +53.6 single-session-assistant Mem0 fix)
- [ ] LongMemEval harness re-run against the new pipeline — out of scope for this PR