### PR TITLE
feat(v4): Phase 5 — Track C temporal reasoning (as_of replay + TimeWindow)

### DIFF
--- a/attestor/core.py
+++ b/attestor/core.py
@@ -713,12 +713,19 @@ class AgentMemory:
         budget: Optional[int] = None,
         namespace: Optional[str] = None,
         user_id: Optional[str] = None,
+        as_of: Optional[datetime] = None,
+        time_window: Optional[Any] = None,    # TimeWindow
     ) -> List[RetrievalResult]:
         """Retrieve relevant memories for a query using 3-layer cascade.
 
         v4: when ``user_id`` is provided AND the backend is in v4 mode, the
         RLS variable is set on the connection so policies filter to this
-        user. v3 callers omit user_id — behavior unchanged."""
+        user. v3 callers omit user_id — behavior unchanged.
+
+        v4 + Phase 5.3 — bi-temporal:
+          as_of       — point-in-time replay (returns past belief)
+          time_window — event-time overlap pre-filter
+        Both pass through to the orchestrator and on to the lanes."""
         # v4: route through _resolve() so zero-config recall works in SOLO
         # mode. Recall doesn't autostart a session — read-only ops only need
         # user+project scope.
@@ -733,7 +740,14 @@ class AgentMemory:
 
         t0 = time.monotonic()
         token_budget = budget or self.config.default_token_budget
-        results = self._retrieval.recall(query, token_budget, namespace=namespace)
+        # Pass temporal kwargs only when present so legacy v3 orchestrator
+        # signatures aren't disturbed.
+        recall_kwargs: Dict[str, Any] = {"namespace": namespace}
+        if as_of is not None:
+            recall_kwargs["as_of"] = as_of
+        if time_window is not None:
+            recall_kwargs["time_window"] = time_window
+        results = self._retrieval.recall(query, token_budget, **recall_kwargs)
         total_ms = round((time.monotonic() - t0) * 1000, 2)
 
         # Track access for confidence decay/boost

--- a/attestor/retrieval/bm25.py
+++ b/attestor/retrieval/bm25.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger("attestor.retrieval.bm25")
@@ -53,31 +54,55 @@ class BM25Lane:
         limit: int = 20,
         min_rank: float = 0.0,
         active_only: bool = True,
+        as_of: Optional[datetime] = None,
+        time_window: Optional[Any] = None,
     ) -> List[BM25Hit]:
         """Return the top BM25-ranked memory ids for ``query``.
 
         RLS scopes the search automatically — the caller must already
         have set ``attestor.current_user_id`` on the connection.
 
+        Phase 5.2 — bi-temporal filters (roadmap §C.2/§C.3):
+          time_window → tstzrange(valid_from, valid_until) && tstzrange
+          as_of       → t_created/t_expired and valid_from/valid_until
+                        evaluated at that point in time
+
         Returns an empty list if the FTS column is missing or the query
         is empty / pure stop words.
         """
         if not query or not query.strip():
             return []
-        sql = """
-            SELECT id,
-                   ts_rank_cd(content_tsv,
-                              websearch_to_tsquery('english', %(q)s)) AS rank
-            FROM memories
-            WHERE content_tsv @@ websearch_to_tsquery('english', %(q)s)
-        """
+        params: Dict[str, Any] = {"q": query, "lim": limit}
+        where: List[str] = ["content_tsv @@ websearch_to_tsquery('english', %(q)s)"]
         if active_only:
-            sql += " AND status = 'active' "
-        sql += " ORDER BY rank DESC LIMIT %(lim)s"
+            where.append("status = 'active'")
+        if as_of is not None:
+            where.append(
+                "t_created <= %(as_of)s "
+                "AND COALESCE(t_expired, 'infinity'::timestamptz) > %(as_of)s "
+                "AND tstzrange(valid_from, "
+                "  COALESCE(valid_until, 'infinity'::timestamptz)) @> %(as_of)s::timestamptz"
+            )
+            params["as_of"] = as_of
+        if time_window is not None:
+            params["tw_start"] = getattr(time_window, "start", None)
+            params["tw_end"] = getattr(time_window, "end", None)
+            where.append(
+                "tstzrange(valid_from, "
+                "  COALESCE(valid_until, 'infinity'::timestamptz)) "
+                "&& tstzrange(%(tw_start)s::timestamptz, %(tw_end)s::timestamptz)"
+            )
+
+        sql = (
+            "SELECT id, "
+            "ts_rank_cd(content_tsv, websearch_to_tsquery('english', %(q)s)) AS rank "
+            "FROM memories WHERE " + " AND ".join(where) +
+            " ORDER BY rank DESC LIMIT %(lim)s"
+        )
 
         try:
             with self._conn.cursor() as cur:
-                cur.execute(sql, {"q": query, "lim": limit})
+                cur.execute(sql, params)
                 rows = cur.fetchall()
         except Exception as e:
             # Most likely the FTS column doesn't exist yet on a v3-only

--- a/attestor/retrieval/orchestrator.py
+++ b/attestor/retrieval/orchestrator.py
@@ -181,8 +181,21 @@ class RetrievalOrchestrator:
         query: str,
         token_budget: int = 2000,
         namespace: Optional[str] = None,
+        as_of: Optional[Any] = None,           # datetime; Phase 5.3
+        time_window: Optional[Any] = None,     # TimeWindow; Phase 5.3
     ) -> List[RetrievalResult]:
-        """Semantic-first recall with graph narrowing."""
+        """Semantic-first recall with graph narrowing.
+
+        Phase 5.3 — bi-temporal:
+          as_of       — replay past belief: see only memories the system
+                        BELIEVED were true at that timestamp
+          time_window — pre-filter by EVENT-time overlap (when the fact
+                        was true in the world)
+
+        Both kwargs are passed through to the vector + BM25 lanes; lanes
+        that don't support them ignore them silently. Behavior unchanged
+        when both are None.
+        """
         t_total = time.monotonic()
         question_entities = self._question_entities(query)
 
@@ -191,9 +204,17 @@ class RetrievalOrchestrator:
         results: List[RetrievalResult] = []
         if self.vector_store:
             try:
-                vector_hits_raw = self.vector_store.search(
-                    query, limit=VECTOR_TOP_K, namespace=namespace
-                )
+                # Newer v4 backends accept as_of/time_window; v3 backends
+                # don't — fall back to the legacy signature on TypeError.
+                try:
+                    vector_hits_raw = self.vector_store.search(
+                        query, limit=VECTOR_TOP_K, namespace=namespace,
+                        as_of=as_of, time_window=time_window,
+                    )
+                except TypeError:
+                    vector_hits_raw = self.vector_store.search(
+                        query, limit=VECTOR_TOP_K, namespace=namespace,
+                    )
             except Exception:
                 vector_hits_raw = []
 
@@ -207,11 +228,22 @@ class RetrievalOrchestrator:
                 bm25_hits_raw = self.bm25_lane.search(
                     query, limit=self.bm25_top_k,
                     min_rank=self.bm25_min_rank,
+                    as_of=as_of, time_window=time_window,
+                    # When replaying past belief OR slicing an event-time
+                    # window, superseded rows are valid answers; drop the
+                    # current-state filter.
+                    active_only=(as_of is None and time_window is None),
                 )
             except Exception:
                 bm25_hits_raw = []
 
         # ── Step 2: Materialise vector candidates with preliminary vector_sim
+        # status='active' is current-state filtering. When as_of is set,
+        # the lane SQL has already restricted by t_created/t_expired so a
+        # row that's now 'superseded' but was active at as_of must pass.
+        # When time_window is set, the lane filtered by event-time overlap;
+        # a fact that was true during the window may now be superseded too.
+        require_active = (as_of is None and time_window is None)
         candidates: List[Dict] = []
         seen_ids: set = set()
         for vr in vector_hits_raw:
@@ -219,7 +251,9 @@ class RetrievalOrchestrator:
             if mid in seen_ids:
                 continue
             memory = self.store.get(mid)
-            if not memory or memory.status != "active":
+            if not memory:
+                continue
+            if require_active and memory.status != "active":
                 continue
             if namespace and memory.namespace != namespace:
                 continue
@@ -236,7 +270,9 @@ class RetrievalOrchestrator:
             if hit.memory_id in seen_ids:
                 continue
             memory = self.store.get(hit.memory_id)
-            if not memory or memory.status != "active":
+            if not memory:
+                continue
+            if require_active and memory.status != "active":
                 continue
             if namespace and memory.namespace != namespace:
                 continue

--- a/attestor/retrieval/temporal_query.py
+++ b/attestor/retrieval/temporal_query.py
@@ -1,0 +1,218 @@
+"""Temporal query expansion (Phase 5.1, roadmap §C.1).
+
+Extracts a ``TimeWindow`` from a natural-language query so the
+retrieval pipeline can hard-filter by ``t_valid`` overlap before doing
+semantic search. Wu et al. Finding 3: +7-11% on the LongMemEval
+``temporal-reasoning`` category from running this single LLM call at
+query time.
+
+Examples:
+  "What did I say last Tuesday?"  → start=last_tuesday_00:00, end=last_tuesday_23:59
+  "Before I had kids"             → start=null, end=<earliest known kids date>
+  "Recent recommendations"         → start=now-30d, end=now
+  "What's my favorite color?"     → has_time_constraint=False (returns None)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+logger = logging.getLogger("attestor.retrieval.temporal_query")
+
+
+TIME_EXTRACTION_PROMPT = """\
+Extract a time window from this query, anchored to the reference time.
+Return JSON only.
+
+Reference time (now): {now}
+Query: "{query}"
+
+Output schema:
+{{
+  "has_time_constraint": <true|false>,
+  "start": "<ISO datetime or null>",
+  "end":   "<ISO datetime or null>",
+  "interpretation": "<one short sentence>"
+}}
+
+Examples:
+- "What did I say last Tuesday?" -> start=last_tuesday_00:00, end=last_tuesday_23:59
+- "Before I had kids" -> has_time_constraint=true, start=null, end=<earliest known kids date>
+- "What's my favorite color?" -> has_time_constraint=false
+- "Recent recommendations" -> start=now-30d, end=now
+
+Output:
+"""
+
+
+@dataclass(frozen=True)
+class TimeWindow:
+    """A time range over which to filter retrieval.
+
+    Either bound may be None (open-ended). ``has_time_constraint`` is
+    implicit: a TimeWindow object exists ⇒ the caller said yes.
+
+    `interpretation` is a short human-readable description from the LLM,
+    useful for debugging traces and audit logs.
+    """
+
+    start: Optional[datetime]
+    end: Optional[datetime]
+    interpretation: str = ""
+
+    def __post_init__(self) -> None:
+        # Allow strings on input — coerce to datetime
+        if isinstance(self.start, str):
+            object.__setattr__(self, "start", _parse_iso(self.start))
+        if isinstance(self.end, str):
+            object.__setattr__(self, "end", _parse_iso(self.end))
+        if self.start is not None and self.end is not None:
+            if self.start > self.end:
+                raise ValueError(
+                    f"TimeWindow start ({self.start}) > end ({self.end})"
+                )
+
+    @property
+    def is_open_ended(self) -> bool:
+        return self.start is None or self.end is None
+
+    @property
+    def is_unbounded(self) -> bool:
+        return self.start is None and self.end is None
+
+
+def _parse_iso(s: Optional[str]) -> Optional[datetime]:
+    """Best-effort ISO 8601 → datetime. Returns None on failure or 'null'."""
+    if s is None:
+        return None
+    if not isinstance(s, str):
+        return None
+    s = s.strip()
+    if not s or s.lower() in {"null", "none"}:
+        return None
+    # Strip trailing Z (Python datetime.fromisoformat accepts +00:00)
+    s2 = s.replace("Z", "+00:00") if s.endswith("Z") else s
+    try:
+        dt = datetime.fromisoformat(s2)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Expander
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _strip_markdown_fences(text: str) -> str:
+    text = text.strip()
+    if text.startswith("```"):
+        lines = [l for l in text.split("\n") if not l.strip().startswith("```")]
+        text = "\n".join(lines).strip()
+    return text
+
+
+class TemporalQueryExpander:
+    """Run an LLM to extract a TimeWindow from a query.
+
+    Designed to be cheap: small model, low max_tokens, JSON-only output.
+    Returns None when:
+      - the query has no time constraint
+      - the LLM call fails
+      - the response is unparseable
+
+    Returning None is safe: the orchestrator just skips the temporal
+    pre-filter and behaves like Phase 4.
+    """
+
+    def __init__(
+        self,
+        client: Optional[Any] = None,
+        *,
+        model: str = "openai/gpt-4o-mini",
+        max_tokens: int = 256,
+    ) -> None:
+        self._client = client
+        self._model = model
+        self._max_tokens = max_tokens
+
+    def expand(
+        self, query: str, now: Optional[datetime] = None,
+    ) -> Optional[TimeWindow]:
+        """Return a TimeWindow if the query has a time constraint, else None."""
+        if not query or not query.strip():
+            return None
+        ref_now = now or datetime.now(timezone.utc)
+        prompt = TIME_EXTRACTION_PROMPT.format(
+            now=ref_now.isoformat(), query=query,
+        )
+        client = self._client or _default_client()
+        if client is None:
+            return None
+        try:
+            response = client.chat.completions.create(
+                model=self._model,
+                max_tokens=self._max_tokens,
+                messages=[{"role": "user", "content": prompt}],
+            )
+            raw = response.choices[0].message.content or ""
+        except Exception as e:
+            logger.debug("temporal LLM call failed: %s", e)
+            return None
+        return _parse_window(raw)
+
+
+def _parse_window(raw: str) -> Optional[TimeWindow]:
+    """Parse a TIME_EXTRACTION_PROMPT response into a TimeWindow or None."""
+    text = _strip_markdown_fences(raw)
+    if not text:
+        return None
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError as e:
+        logger.debug("temporal JSON parse failed: %s; raw=%r", e, raw[:200])
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    if not parsed.get("has_time_constraint"):
+        return None
+    start = _parse_iso(parsed.get("start"))
+    end = _parse_iso(parsed.get("end"))
+    # No bounds at all → not actually constrained
+    if start is None and end is None:
+        return None
+    interp = parsed.get("interpretation") or ""
+    if not isinstance(interp, str):
+        interp = ""
+    try:
+        return TimeWindow(start=start, end=end, interpretation=interp)
+    except ValueError as e:
+        # start > end, etc. — treat as unconstrained
+        logger.debug("temporal window invalid: %s", e)
+        return None
+
+
+def _default_client() -> Optional[Any]:
+    """Build the same OpenAI/OpenRouter client the extractor uses.
+
+    Returns None if no key set — the expander then no-ops gracefully.
+    """
+    try:
+        from openai import OpenAI
+    except ImportError:
+        return None
+    or_key = os.environ.get("OPENROUTER_API_KEY")
+    if or_key:
+        return OpenAI(base_url="https://openrouter.ai/api/v1", api_key=or_key)
+    oa_key = os.environ.get("OPENAI_API_KEY")
+    if oa_key:
+        return OpenAI(api_key=oa_key)
+    return None

--- a/attestor/store/postgres_backend.py
+++ b/attestor/store/postgres_backend.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import re
+from datetime import datetime
 from typing import Any, Dict, List, Optional, Set
 
 import psycopg2
@@ -662,24 +663,64 @@ class PostgresBackend(DocumentStore, VectorStore, GraphStore):
         query_text: str,
         limit: int = 20,
         namespace: Optional[str] = None,
+        as_of: Optional[datetime] = None,
+        time_window: Optional[Any] = None,    # TimeWindow (avoid import cycle)
     ) -> List[Dict[str, Any]]:
-        """Vector similarity search using pgvector cosine distance."""
+        """Vector similarity search using pgvector cosine distance.
+
+        v4 + Phase 5.2 — bi-temporal filters (roadmap §C.2/§C.3):
+
+          time_window  → tstzrange(valid_from, valid_until) && tstzrange(start, end)
+                         pre-filters by EVENT-time overlap (when the fact
+                         was true in the world)
+
+          as_of        → t_created <= as_of AND t_expired > as_of
+                         AND tstzrange(valid_from, valid_until) @> as_of
+                         filters by TRANSACTION-time AND event-time:
+                         "what did the system believe was true on date X"
+
+        Both filters are additive; passing both narrows further. v3
+        callers omit them — search behaves exactly as before.
+        """
         query_vec = self._embed(query_text)
-        if namespace is None:
-            rows = self._execute(
-                "SELECT id, content, embedding <=> %s::vector AS distance "
-                "FROM memories WHERE embedding IS NOT NULL "
-                "ORDER BY embedding <=> %s::vector LIMIT %s",
-                (str(query_vec), str(query_vec), limit),
-            )
-        else:
-            rows = self._execute(
-                "SELECT id, content, embedding <=> %s::vector AS distance "
-                "FROM memories "
-                "WHERE embedding IS NOT NULL AND namespace = %s "
-                "ORDER BY embedding <=> %s::vector LIMIT %s",
-                (str(query_vec), namespace, str(query_vec), limit),
-            )
+        params: List[Any] = [str(query_vec)]
+        where: List[str] = ["embedding IS NOT NULL"]
+
+        if namespace is not None and not self._v4:
+            where.append("namespace = %s")
+            params.append(namespace)
+
+        if self._v4:
+            # Bi-temporal filters only meaningful on v4 schema
+            if as_of is not None:
+                where.append(
+                    "t_created <= %s "
+                    "AND COALESCE(t_expired, 'infinity'::timestamptz) > %s "
+                    "AND tstzrange(valid_from, "
+                    "  COALESCE(valid_until, 'infinity'::timestamptz)) @> %s::timestamptz"
+                )
+                params.extend([as_of, as_of, as_of])
+            if time_window is not None:
+                tw_start = getattr(time_window, "start", None)
+                tw_end = getattr(time_window, "end", None)
+                # tstzrange(NULL, NULL) is "any time" — Postgres treats
+                # NULL bounds as -infinity / infinity inside the range
+                # constructor, which is what we want for open-ended windows.
+                where.append(
+                    "tstzrange(valid_from, "
+                    "  COALESCE(valid_until, 'infinity'::timestamptz)) "
+                    "&& tstzrange(%s::timestamptz, %s::timestamptz)"
+                )
+                params.extend([tw_start, tw_end])
+
+        sql = (
+            "SELECT id, content, embedding <=> %s::vector AS distance "
+            "FROM memories WHERE " + " AND ".join(where) +
+            " ORDER BY embedding <=> %s::vector LIMIT %s"
+        )
+        params.append(str(query_vec))
+        params.append(limit)
+        rows = self._execute(sql, params)
         return [
             {"memory_id": r["id"], "content": r["content"], "distance": r["distance"]}
             for r in rows

--- a/tests/test_as_of_replay.py
+++ b/tests/test_as_of_replay.py
@@ -1,0 +1,296 @@
+"""Phase 5.2 — bi-temporal as_of replay (roadmap §C.3/§C.4).
+
+Verifies the canonical regulator/auditor case:
+  "What did the system BELIEVE was true on date X?"
+
+Pattern:
+  1. Insert a memory with t_created = T0
+  2. Insert a contradicting memory at T1 (T1 > T0); supersede the first
+  3. Search at as_of=T0     → see only the original
+  4. Search at as_of=T1     → see only the new
+  5. Search with no as_of   → see only the new (current state)
+
+Also covers TimeWindow filtering by valid_from/valid_until overlap
+(event-time, distinct from transaction-time).
+
+Tests run with admin (BYPASSRLS) so we can manipulate t_created /
+t_expired directly to simulate historical state.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+try:
+    import psycopg2
+    HAVE_PSYCOPG2 = True
+except ImportError:
+    HAVE_PSYCOPG2 = False
+
+PG_URL = os.environ.get(
+    "PG_TEST_URL",
+    "postgresql://postgres:attestor@localhost:5432/attestor_v4_test",
+)
+SCHEMA_PATH = Path(__file__).resolve().parent.parent / "attestor" / "store" / "schema.sql"
+
+
+def _reachable() -> bool:
+    if not HAVE_PSYCOPG2:
+        return False
+    try:
+        c = psycopg2.connect(PG_URL, connect_timeout=2)
+        c.close()
+        return True
+    except Exception:
+        return False
+
+
+def _ollama_up() -> bool:
+    try:
+        import requests
+        r = requests.get("http://localhost:11434/api/tags", timeout=2)
+        return r.status_code == 200
+    except Exception:
+        return False
+
+
+pytestmark = pytest.mark.skipif(
+    not (_reachable() and _ollama_up()),
+    reason="local Postgres or Ollama unreachable",
+)
+
+
+@pytest.fixture(scope="module")
+def admin_conn():
+    c = psycopg2.connect(PG_URL)
+    c.autocommit = True
+    yield c
+    c.close()
+
+
+@pytest.fixture
+def fresh_schema(admin_conn):
+    raw = SCHEMA_PATH.read_text().replace("{embedding_dim}", "1024")
+    with admin_conn.cursor() as cur:
+        for tbl in ("memories", "episodes", "sessions", "projects", "users"):
+            cur.execute(f"DROP TABLE IF EXISTS {tbl} CASCADE")
+        cur.execute(raw)
+    yield
+
+
+@pytest.fixture
+def backend(fresh_schema):
+    from attestor.store.postgres_backend import PostgresBackend
+    be = PostgresBackend({
+        "url": "postgresql://localhost:5432",
+        "database": "attestor_v4_test",
+        "auth": {"username": "postgres", "password": "attestor"},
+        "v4": True,
+        "skip_schema_init": True,
+    })
+    yield be
+    be.close()
+
+
+@pytest.fixture
+def two_facts_one_supersedes(admin_conn, backend):
+    """Insert user + two memories: 'lives in NYC' (T0) → 'lives in SF' (T1).
+    The NYC row is marked superseded with t_expired = T1."""
+    uid = uuid.uuid4()
+    with admin_conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO users (id, external_id) VALUES (%s, %s)",
+            (str(uid), f"u-asof-{uuid.uuid4().hex[:8]}"),
+        )
+    backend._set_rls_user(str(uid))
+
+    t0 = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    t1 = datetime(2026, 4, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+    # Insert via backend.insert (so embedding is generated) then patch
+    # t_created/t_expired/valid_from to the historical values we want.
+    from attestor.models import Memory
+    nyc = backend.insert(Memory(
+        content="user lives in NYC", category="location", entity="user",
+        user_id=str(uid), scope="user",
+    ))
+    backend.add(nyc.id, "user lives in NYC")
+    sf = backend.insert(Memory(
+        content="user lives in SF", category="location", entity="user",
+        user_id=str(uid), scope="user",
+    ))
+    backend.add(sf.id, "user lives in SF")
+
+    nyc_id = nyc.id
+    sf_id = sf.id
+    with admin_conn.cursor() as cur:
+        # Backdate NYC: created at T0, expired at T1
+        cur.execute(
+            "UPDATE memories SET valid_from=%s, t_created=%s, "
+            "valid_until=%s, t_expired=%s, "
+            "status='superseded', superseded_by=%s WHERE id=%s",
+            (t0, t0, t1, t1, str(sf_id), str(nyc_id)),
+        )
+        # SF: created at T1
+        cur.execute(
+            "UPDATE memories SET valid_from=%s, t_created=%s WHERE id=%s",
+            (t1, t1, str(sf_id)),
+        )
+
+    return {
+        "user_id": str(uid),
+        "nyc_id": str(nyc_id),
+        "sf_id": str(sf_id),
+        "t0": t0,
+        "t1": t1,
+    }
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# search() with as_of
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.live
+def test_search_no_as_of_returns_current_state_only(backend, two_facts_one_supersedes):
+    """No as_of, status='active' filter → only the current SF row."""
+    s = two_facts_one_supersedes
+    # search() in postgres_backend doesn't apply status filter — that's
+    # the orchestrator's job. Here we verify the bi-temporal filter on
+    # its own: with as_of=NOW, both rows are still in the index but the
+    # NYC row's t_expired is T1 (past), so the policy excludes it.
+    hits = backend.search("lives in", limit=20, as_of=datetime.now(timezone.utc))
+    ids = {h["memory_id"] for h in hits}
+    # NYC has t_expired=T1 in the past → excluded. SF has no t_expired → included.
+    assert s["sf_id"] in ids
+    assert s["nyc_id"] not in ids
+
+
+@pytest.mark.live
+def test_search_as_of_t0_returns_old_belief(backend, two_facts_one_supersedes):
+    """At T0 the system only knew about NYC; SF didn't exist yet."""
+    s = two_facts_one_supersedes
+    # Query just BEFORE T1, AFTER T0 → only NYC
+    midpoint = s["t0"] + timedelta(days=30)
+    hits = backend.search("lives in", limit=20, as_of=midpoint)
+    ids = {h["memory_id"] for h in hits}
+    assert s["nyc_id"] in ids, "NYC must be visible at as_of in [T0, T1)"
+    assert s["sf_id"] not in ids, "SF wasn't created until T1"
+
+
+@pytest.mark.live
+def test_search_as_of_t1_sees_sf(backend, two_facts_one_supersedes):
+    """At T1 (transaction-time of supersession), SF replaces NYC.
+
+    Both rows have valid_from = T0 / T1. At as_of=T1+epsilon:
+      - NYC: t_created=T0 ≤ T1+ε, t_expired=T1 > T1+ε? No (T1 == T1+ε if ε=0;
+        we need strict >). So this is exclusive. To be safe, query at T1 + 1s.
+    """
+    s = two_facts_one_supersedes
+    just_after_t1 = s["t1"] + timedelta(seconds=1)
+    hits = backend.search("lives in", limit=20, as_of=just_after_t1)
+    ids = {h["memory_id"] for h in hits}
+    assert s["sf_id"] in ids
+    assert s["nyc_id"] not in ids
+
+
+@pytest.mark.live
+def test_search_as_of_before_anything_returns_empty(backend, two_facts_one_supersedes):
+    """Query at as_of < any t_created → no rows known."""
+    s = two_facts_one_supersedes
+    way_back = s["t0"] - timedelta(days=365)
+    hits = backend.search("lives in", limit=20, as_of=way_back)
+    ids = {h["memory_id"] for h in hits}
+    assert s["nyc_id"] not in ids
+    assert s["sf_id"] not in ids
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# search() with TimeWindow (event-time overlap)
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.live
+def test_search_time_window_filters_by_valid_from(backend, two_facts_one_supersedes):
+    """time_window narrowing the search to before T0 returns nothing."""
+    from attestor.retrieval.temporal_query import TimeWindow
+    s = two_facts_one_supersedes
+    tw = TimeWindow(
+        start=s["t0"] - timedelta(days=365),
+        end=s["t0"] - timedelta(days=1),
+    )
+    hits = backend.search("lives in", limit=20, time_window=tw)
+    assert hits == []
+
+
+@pytest.mark.live
+def test_search_time_window_overlapping_returns_match(backend, two_facts_one_supersedes):
+    """time_window covering T0 picks up the NYC row (whose validity range
+    is [T0, T1)). The SF row has valid_from=T1, outside this window."""
+    from attestor.retrieval.temporal_query import TimeWindow
+    s = two_facts_one_supersedes
+    tw = TimeWindow(
+        start=s["t0"] + timedelta(days=10),
+        end=s["t0"] + timedelta(days=20),
+    )
+    hits = backend.search("lives in", limit=20, time_window=tw)
+    ids = {h["memory_id"] for h in hits}
+    assert s["nyc_id"] in ids
+    assert s["sf_id"] not in ids
+
+
+@pytest.mark.live
+def test_search_time_window_open_ended_end(backend, two_facts_one_supersedes):
+    """end=None → 'from start onward' overlap. Should pick up both rows
+    since both have valid_from after start."""
+    from attestor.retrieval.temporal_query import TimeWindow
+    s = two_facts_one_supersedes
+    tw = TimeWindow(start=s["t0"] - timedelta(days=1), end=None)
+    hits = backend.search("lives in", limit=20, time_window=tw)
+    ids = {h["memory_id"] for h in hits}
+    assert s["nyc_id"] in ids
+    assert s["sf_id"] in ids
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# v3 backward compat — without as_of/time_window, behaves like before
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.live
+def test_search_v3_compat_no_temporal_args(backend, two_facts_one_supersedes):
+    """No as_of, no time_window → see all rows that have an embedding."""
+    s = two_facts_one_supersedes
+    hits = backend.search("lives in", limit=20)
+    ids = {h["memory_id"] for h in hits}
+    # Both rows are present because we don't filter by status here
+    assert {s["nyc_id"], s["sf_id"]}.issubset(ids)
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# BM25 lane respects the same filters
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.live
+def test_bm25_as_of_replay(admin_conn, two_facts_one_supersedes):
+    from attestor.retrieval.bm25 import BM25Lane
+    s = two_facts_one_supersedes
+    lane = BM25Lane(admin_conn)
+
+    # No as_of → both visible
+    hits_now = lane.search("lives", active_only=False)
+    ids_now = {h.memory_id for h in hits_now}
+    assert {s["nyc_id"], s["sf_id"]}.issubset(ids_now)
+
+    # as_of = T0 + 30d (between T0 and T1) → only NYC
+    midpoint = s["t0"] + timedelta(days=30)
+    hits_past = lane.search("lives", active_only=False, as_of=midpoint)
+    ids_past = {h.memory_id for h in hits_past}
+    assert s["nyc_id"] in ids_past
+    assert s["sf_id"] not in ids_past

--- a/tests/test_recall_as_of.py
+++ b/tests/test_recall_as_of.py
@@ -1,0 +1,203 @@
+"""Phase 5.3 — AgentMemory.recall() as_of + time_window end-to-end.
+
+Top-level integration: builds a SOLO AgentMemory, ingests a contradictory
+pair via direct insert + admin backdating, then verifies recall(as_of=)
+and recall(time_window=) return the right past/window snapshot.
+
+This is the canonical regulator/audit case from the README:
+  "What did the system know on date X?"
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from urllib.parse import urlparse
+
+import pytest
+
+try:
+    import psycopg2
+    HAVE_PSYCOPG2 = True
+except ImportError:
+    HAVE_PSYCOPG2 = False
+
+PG_URL = os.environ.get(
+    "PG_TEST_URL",
+    "postgresql://postgres:attestor@localhost:5432/attestor_v4_test",
+)
+SCHEMA_PATH = Path(__file__).resolve().parent.parent / "attestor" / "store" / "schema.sql"
+
+
+def _reachable() -> bool:
+    if not HAVE_PSYCOPG2:
+        return False
+    try:
+        c = psycopg2.connect(PG_URL, connect_timeout=2)
+        c.close()
+        return True
+    except Exception:
+        return False
+
+
+def _ollama_up() -> bool:
+    try:
+        import requests
+        r = requests.get("http://localhost:11434/api/tags", timeout=2)
+        return r.status_code == 200
+    except Exception:
+        return False
+
+
+pytestmark = pytest.mark.skipif(
+    not (_reachable() and _ollama_up()),
+    reason="local Postgres or Ollama unreachable",
+)
+
+
+@pytest.fixture(scope="module")
+def admin_conn():
+    c = psycopg2.connect(PG_URL)
+    c.autocommit = True
+    yield c
+    c.close()
+
+
+@pytest.fixture
+def fresh_schema(admin_conn):
+    raw = SCHEMA_PATH.read_text().replace("{embedding_dim}", "1024")
+    with admin_conn.cursor() as cur:
+        for tbl in ("memories", "episodes", "sessions", "projects", "users"):
+            cur.execute(f"DROP TABLE IF EXISTS {tbl} CASCADE")
+        cur.execute(raw)
+    yield
+
+
+def _build_solo_mem(tmp_path: Path):
+    from attestor.core import AgentMemory
+    cfg = {
+        "mode": "solo",
+        "backends": ["postgres"],
+        "backend_configs": {
+            "postgres": {
+                "url": "postgresql://localhost:5432",
+                "database": "attestor_v4_test",
+                "auth": {"username": "postgres", "password": "attestor"},
+                "v4": True,
+                "skip_schema_init": True,
+            }
+        },
+    }
+    return AgentMemory(tmp_path, config=cfg)
+
+
+@pytest.fixture
+def two_facts_supersede(admin_conn, fresh_schema, tmp_path):
+    """Singleton SOLO user, two memories: NYC@T0 superseded by SF@T1."""
+    mem = _build_solo_mem(tmp_path)
+    uid = mem.default_user.id
+    t0 = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    t1 = datetime(2026, 4, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+    nyc = mem.add(
+        content="user lives in NYC", category="location", entity="user",
+    )
+    sf = mem.add(
+        content="user lives in SF", category="location", entity="user",
+    )
+    # Backdate via admin so we control the timestamps exactly
+    with admin_conn.cursor() as cur:
+        cur.execute(
+            "UPDATE memories SET valid_from=%s, t_created=%s, "
+            "valid_until=%s, t_expired=%s, "
+            "status='superseded', superseded_by=%s WHERE id=%s",
+            (t0, t0, t1, t1, sf.id, nyc.id),
+        )
+        cur.execute(
+            "UPDATE memories SET valid_from=%s, t_created=%s WHERE id=%s",
+            (t1, t1, sf.id),
+        )
+
+    yield {
+        "mem": mem, "uid": uid, "nyc_id": nyc.id, "sf_id": sf.id,
+        "t0": t0, "t1": t1,
+    }
+    mem.close()
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Public API as_of round-trip
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.live
+def test_recall_no_as_of_returns_current_only(two_facts_supersede):
+    s = two_facts_supersede
+    results = s["mem"].recall("where does the user live?")
+    contents = [r.memory.content for r in results
+                if r.memory.category != "graph_relation"]
+    assert any("SF" in c for c in contents), f"missing SF in {contents}"
+    assert not any("NYC" in c for c in contents), (
+        f"NYC leaked into current recall: {contents}"
+    )
+
+
+@pytest.mark.live
+def test_recall_as_of_t0_returns_old_belief(two_facts_supersede):
+    """Replay the past: at T0+30d, only the NYC row was known."""
+    s = two_facts_supersede
+    midpoint = s["t0"] + timedelta(days=30)
+    results = s["mem"].recall(
+        "where does the user live?", as_of=midpoint,
+    )
+    contents = [r.memory.content for r in results
+                if r.memory.category != "graph_relation"]
+    assert any("NYC" in c for c in contents), (
+        f"NYC must be visible at as_of=T0+30d: got {contents}"
+    )
+    assert not any("SF" in c for c in contents), (
+        f"SF didn't exist at T0+30d: got {contents}"
+    )
+
+
+@pytest.mark.live
+def test_recall_as_of_after_t1_sees_sf(two_facts_supersede):
+    s = two_facts_supersede
+    just_after = s["t1"] + timedelta(seconds=1)
+    results = s["mem"].recall(
+        "where does the user live?", as_of=just_after,
+    )
+    contents = [r.memory.content for r in results
+                if r.memory.category != "graph_relation"]
+    assert any("SF" in c for c in contents)
+    assert not any("NYC" in c for c in contents)
+
+
+@pytest.mark.live
+def test_recall_time_window_event_time(two_facts_supersede):
+    """time_window narrows by valid_from/valid_until overlap."""
+    from attestor.retrieval.temporal_query import TimeWindow
+    s = two_facts_supersede
+    # Window covers NYC's validity (T0..T1) but not SF's (T1..)
+    tw = TimeWindow(
+        start=s["t0"] + timedelta(days=10),
+        end=s["t0"] + timedelta(days=20),
+    )
+    results = s["mem"].recall(
+        "where does the user live?", time_window=tw,
+    )
+    contents = [r.memory.content for r in results
+                if r.memory.category != "graph_relation"]
+    assert any("NYC" in c for c in contents)
+    assert not any("SF" in c for c in contents)
+
+
+@pytest.mark.live
+def test_recall_as_of_signature_backward_compat(two_facts_supersede):
+    """Calling recall without as_of/time_window must work unchanged."""
+    s = two_facts_supersede
+    results = s["mem"].recall("where", budget=2000)
+    # Just verify no TypeError + we get a list
+    assert isinstance(results, list)

--- a/tests/test_temporal_query.py
+++ b/tests/test_temporal_query.py
@@ -1,0 +1,294 @@
+"""Phase 5.1 — TemporalQueryExpander + TimeWindow tests.
+
+Stub LLM throughout — these are unit tests for parsing + dataclass
+invariants, not LLM behaviour validation.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from typing import Any, List
+
+import pytest
+
+from attestor.retrieval.temporal_query import (
+    TIME_EXTRACTION_PROMPT,
+    TemporalQueryExpander,
+    TimeWindow,
+    _parse_iso,
+    _parse_window,
+)
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Stub LLM
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class _StubChoice:
+    def __init__(self, c: str) -> None:
+        self.message = type("M", (), {"content": c})()
+
+
+class _StubResponse:
+    def __init__(self, c: str) -> None:
+        self.choices = [_StubChoice(c)]
+
+
+class _StubChat:
+    def __init__(self, payload: str = "", *, exc: Exception | None = None) -> None:
+        self._payload = payload
+        self._exc = exc
+        self.calls: list = []
+
+    def create(self, **kw: Any) -> _StubResponse:
+        self.calls.append(kw)
+        if self._exc is not None:
+            raise self._exc
+        return _StubResponse(self._payload)
+
+
+class StubClient:
+    def __init__(self, payload: str = "", *, exc: Exception | None = None) -> None:
+        self.chat = type("Chat", (), {"completions": _StubChat(payload, exc=exc)})()
+
+    @property
+    def call_count(self) -> int:
+        return len(self.chat.completions.calls)
+
+    @property
+    def last_prompt(self) -> str:
+        msgs = self.chat.completions.calls[-1]["messages"]
+        return msgs[0]["content"]
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# TimeWindow dataclass
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_timewindow_accepts_iso_strings() -> None:
+    tw = TimeWindow(start="2026-04-26T00:00:00Z", end="2026-04-26T23:59:59Z")
+    assert tw.start.year == 2026 and tw.start.month == 4
+    assert tw.end.tzinfo is timezone.utc
+
+
+@pytest.mark.unit
+def test_timewindow_accepts_datetimes() -> None:
+    a = datetime(2026, 4, 26, tzinfo=timezone.utc)
+    b = datetime(2026, 4, 27, tzinfo=timezone.utc)
+    tw = TimeWindow(start=a, end=b)
+    assert tw.start == a
+    assert tw.end == b
+
+
+@pytest.mark.unit
+def test_timewindow_open_ended_start() -> None:
+    tw = TimeWindow(start=None, end=datetime(2026, 1, 1, tzinfo=timezone.utc))
+    assert tw.is_open_ended
+    assert not tw.is_unbounded
+
+
+@pytest.mark.unit
+def test_timewindow_open_ended_end() -> None:
+    tw = TimeWindow(start=datetime(2026, 1, 1, tzinfo=timezone.utc), end=None)
+    assert tw.is_open_ended
+
+
+@pytest.mark.unit
+def test_timewindow_rejects_inverted_range() -> None:
+    a = datetime(2026, 4, 26, tzinfo=timezone.utc)
+    b = a + timedelta(days=-1)  # b < a
+    with pytest.raises(ValueError, match="start.*end"):
+        TimeWindow(start=a, end=b)
+
+
+@pytest.mark.unit
+def test_timewindow_naive_datetime_gets_utc() -> None:
+    tw = TimeWindow(start="2026-04-26T00:00:00", end="2026-04-26T23:59:59")
+    assert tw.start.tzinfo is timezone.utc
+    assert tw.end.tzinfo is timezone.utc
+
+
+@pytest.mark.unit
+def test_parse_iso_handles_z_suffix() -> None:
+    dt = _parse_iso("2026-04-26T10:00:00Z")
+    assert dt is not None
+    assert dt.tzinfo is not None
+    assert dt.hour == 10
+
+
+@pytest.mark.unit
+def test_parse_iso_returns_none_on_garbage() -> None:
+    assert _parse_iso(None) is None
+    assert _parse_iso("") is None
+    assert _parse_iso("null") is None
+    assert _parse_iso("not a date") is None
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# _parse_window — LLM payload → TimeWindow
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_parse_window_no_constraint_returns_none() -> None:
+    raw = json.dumps({
+        "has_time_constraint": False,
+        "start": None, "end": None, "interpretation": "no time",
+    })
+    assert _parse_window(raw) is None
+
+
+@pytest.mark.unit
+def test_parse_window_full_range() -> None:
+    raw = json.dumps({
+        "has_time_constraint": True,
+        "start": "2026-04-21T00:00:00Z",
+        "end": "2026-04-21T23:59:59Z",
+        "interpretation": "last Tuesday",
+    })
+    tw = _parse_window(raw)
+    assert tw is not None
+    assert tw.start.day == 21
+    assert tw.interpretation == "last Tuesday"
+
+
+@pytest.mark.unit
+def test_parse_window_open_end_only() -> None:
+    """'Before I had kids' → start=null, end=<date>"""
+    raw = json.dumps({
+        "has_time_constraint": True,
+        "start": None,
+        "end": "2020-01-01T00:00:00Z",
+        "interpretation": "before kids",
+    })
+    tw = _parse_window(raw)
+    assert tw is not None
+    assert tw.start is None
+    assert tw.end.year == 2020
+
+
+@pytest.mark.unit
+def test_parse_window_both_null_returns_none() -> None:
+    """has_time_constraint=true but no actual bounds → unhelpful, treat as None."""
+    raw = json.dumps({
+        "has_time_constraint": True,
+        "start": None, "end": None,
+    })
+    assert _parse_window(raw) is None
+
+
+@pytest.mark.unit
+def test_parse_window_handles_markdown_fence() -> None:
+    raw = (
+        "```json\n"
+        + json.dumps({"has_time_constraint": True,
+                      "start": "2026-04-21T00:00:00Z", "end": None})
+        + "\n```"
+    )
+    tw = _parse_window(raw)
+    assert tw is not None
+    assert tw.start.day == 21
+
+
+@pytest.mark.unit
+def test_parse_window_bad_json_returns_none() -> None:
+    assert _parse_window("not json") is None
+    assert _parse_window("") is None
+    assert _parse_window("[]") is None  # array, not object
+
+
+@pytest.mark.unit
+def test_parse_window_inverted_range_returns_none() -> None:
+    """If LLM hallucinates start > end, drop the window rather than crash."""
+    raw = json.dumps({
+        "has_time_constraint": True,
+        "start": "2026-05-01T00:00:00Z",
+        "end": "2026-04-01T00:00:00Z",
+    })
+    assert _parse_window(raw) is None
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Expander.expand — end-to-end with stub LLM
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_expand_happy_path() -> None:
+    payload = json.dumps({
+        "has_time_constraint": True,
+        "start": "2026-04-21T00:00:00Z",
+        "end": "2026-04-21T23:59:59Z",
+        "interpretation": "last Tuesday",
+    })
+    stub = StubClient(payload)
+    exp = TemporalQueryExpander(client=stub)
+    tw = exp.expand("what did I say last Tuesday?")
+    assert tw is not None
+    assert tw.start.day == 21
+    assert "last Tuesday" in tw.interpretation
+
+
+@pytest.mark.unit
+def test_expand_empty_query_skips_llm() -> None:
+    stub = StubClient(payload="should not be called")
+    exp = TemporalQueryExpander(client=stub)
+    assert exp.expand("") is None
+    assert exp.expand("   ") is None
+    assert stub.call_count == 0
+
+
+@pytest.mark.unit
+def test_expand_no_constraint_returns_none() -> None:
+    payload = json.dumps({
+        "has_time_constraint": False,
+        "start": None, "end": None,
+        "interpretation": "no time",
+    })
+    stub = StubClient(payload)
+    exp = TemporalQueryExpander(client=stub)
+    assert exp.expand("what's my favorite color?") is None
+
+
+@pytest.mark.unit
+def test_expand_llm_error_returns_none() -> None:
+    stub = StubClient(exc=RuntimeError("api down"))
+    exp = TemporalQueryExpander(client=stub)
+    assert exp.expand("any time-sensitive question") is None
+
+
+@pytest.mark.unit
+def test_expand_passes_now_into_prompt() -> None:
+    """The reference time must reach the prompt — caller controls 'now'."""
+    payload = json.dumps({"has_time_constraint": False})
+    stub = StubClient(payload)
+    exp = TemporalQueryExpander(client=stub)
+    fixed_now = datetime(2026, 4, 26, 10, 0, 0, tzinfo=timezone.utc)
+    exp.expand("recent stuff", now=fixed_now)
+    assert "2026-04-26T10:00:00" in stub.last_prompt
+
+
+@pytest.mark.unit
+def test_expand_default_now_is_current_utc() -> None:
+    """No now passed → uses datetime.now(UTC). Just check the call works."""
+    payload = json.dumps({"has_time_constraint": False})
+    stub = StubClient(payload)
+    exp = TemporalQueryExpander(client=stub)
+    exp.expand("anything")
+    assert stub.call_count == 1
+
+
+@pytest.mark.unit
+def test_prompt_template_includes_examples() -> None:
+    """Examples in the prompt are load-bearing for accuracy — don't drift."""
+    assert "last Tuesday" in TIME_EXTRACTION_PROMPT
+    assert "Before I had kids" in TIME_EXTRACTION_PROMPT
+    assert "favorite color" in TIME_EXTRACTION_PROMPT
+    assert "Recent" in TIME_EXTRACTION_PROMPT
+    # Schema fields
+    assert "has_time_constraint" in TIME_EXTRACTION_PROMPT
+    assert "interpretation" in TIME_EXTRACTION_PROMPT


### PR DESCRIPTION
## Summary

- **Phase 5.1** — \`TimeWindow\` dataclass + \`TemporalQueryExpander\` with \`TIME_EXTRACTION_PROMPT\` (small-LLM call extracts a query-time window; 4 anchor examples from roadmap §C.1).
- **Phase 5.2** — bi-temporal SQL filters wired into the vector lane (\`PostgresBackend.search\`) and BM25 lane (\`BM25Lane.search\`): \`as_of\` (transaction-time replay via \`t_created\`/\`t_expired\` + \`tstzrange @> as_of\`) and \`time_window\` (event-time overlap via \`tstzrange && tstzrange\`).
- **Phase 5.3** — \`as_of\` and \`time_window\` promoted to the public API on \`AgentMemory.recall()\` and \`RetrievalOrchestrator.recall()\`. Status='active' filter + BM25 \`active_only\` are dropped when either kwarg is set so superseded rows return correctly for past-belief queries.

The canonical regulator/audit case from the README now works end-to-end:
\`\`\`python
mem.recall("where does the user live?")                       # → \"SF\" (current)
mem.recall("where does the user live?", as_of=last_january)   # → \"NYC\" (past belief)
mem.recall("where does the user live?", time_window=window)   # → event-time slice
\`\`\`

## Test plan

- [x] 592 unit tests pass; 232 skipped (env-gated cloud)
- [x] 22 \`TemporalQueryExpander\` / \`TimeWindow\` unit tests (parsing, validation, prompt content guards)
- [x] 9 \`as_of\` replay tests against live Postgres (NYC@T0 → SF@T1 supersession round-trip)
- [x] 5 public-API tests — \`AgentMemory.recall\` returns past belief at \`as_of=T0+30d\`, current state with no kwargs
- [x] BM25 lane respects \`as_of\` (regression: fusion can't leak old rows back into recall)
- [x] v3/v4 backward compat — temporal kwargs are no-ops on v3 schemas
- [ ] LongMemEval \`temporal-reasoning\` ≥ 75% (out of scope for this PR; needs a harness run)