### PR TITLE
feat(v4): Phase 6 Chain-of-Note reading + Phase 7 sleep-time consolidation

### DIFF
--- a/attestor/consolidation/__init__.py
+++ b/attestor/consolidation/__init__.py
@@ -1,0 +1,19 @@
+"""Sleep-time consolidation (Phase 7, roadmap §E).
+
+Background worker that drains the per-episode consolidation queue,
+re-extracts with a stronger model, and produces three artifacts:
+
+  1. Refined facts via the existing ADD/UPDATE/INVALIDATE/NOOP path
+  2. Session-level summaries (rolled into thread metadata)
+  3. Cross-thread reflection memories (stable preferences, contradictions
+     for human review)
+
+Public surface:
+  ConsolidationQueue   — enqueue/dequeue/mark_done/mark_failed
+  SleepTimeConsolidator— per-episode worker
+  ReflectionEngine     — cross-thread synthesis (Phase 7.3)
+"""
+
+from attestor.consolidation.queue import ConsolidationQueue, QueuedEpisode
+
+__all__ = ["ConsolidationQueue", "QueuedEpisode"]

--- a/attestor/consolidation/__init__.py
+++ b/attestor/consolidation/__init__.py
@@ -19,10 +19,24 @@ from attestor.consolidation.consolidator import (
     SleepTimeConsolidator,
 )
 from attestor.consolidation.queue import ConsolidationQueue, QueuedEpisode
+from attestor.consolidation.reflection import (
+    REFLECTION_PROMPT,
+    ChangedBelief,
+    Contradiction,
+    ReflectionEngine,
+    ReflectionResult,
+    StablePattern,
+)
 
 __all__ = [
     "ConsolidationQueue",
     "QueuedEpisode",
     "ConsolidationResult",
     "SleepTimeConsolidator",
+    "REFLECTION_PROMPT",
+    "ReflectionEngine",
+    "ReflectionResult",
+    "StablePattern",
+    "ChangedBelief",
+    "Contradiction",
 ]

--- a/attestor/consolidation/__init__.py
+++ b/attestor/consolidation/__init__.py
@@ -14,6 +14,15 @@ Public surface:
   ReflectionEngine     — cross-thread synthesis (Phase 7.3)
 """
 
+from attestor.consolidation.consolidator import (
+    ConsolidationResult,
+    SleepTimeConsolidator,
+)
 from attestor.consolidation.queue import ConsolidationQueue, QueuedEpisode
 
-__all__ = ["ConsolidationQueue", "QueuedEpisode"]
+__all__ = [
+    "ConsolidationQueue",
+    "QueuedEpisode",
+    "ConsolidationResult",
+    "SleepTimeConsolidator",
+]

--- a/attestor/consolidation/consolidator.py
+++ b/attestor/consolidation/consolidator.py
@@ -1,0 +1,228 @@
+"""SleepTimeConsolidator — per-episode background re-extraction (Phase 7.2).
+
+Drains the ConsolidationQueue and re-runs the conversation pipeline
+with a stronger model. Three artifacts per episode (roadmap §E.1):
+
+  1. Refined facts via the existing ADD/UPDATE/INVALIDATE/NOOP path
+     (with mode='consolidation' provenance)
+  2. Optional session summary when this episode closes a thread
+  3. Cross-thread reflection (Phase 7.3, hooked here but implemented
+     in attestor.consolidation.reflection)
+
+The consolidator is intentionally synchronous — the queue handles
+parallelism via SKIP LOCKED. ``run_once`` processes a batch and
+returns; ``run_forever`` is an asyncio loop for daemons.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from typing import Any, List, Optional
+
+from attestor.consolidation.queue import ConsolidationQueue, QueuedEpisode
+from attestor.conversation.apply import AppliedDecision, apply_decisions
+from attestor.conversation.turns import ConversationTurn
+from attestor.extraction.conflict_resolver import resolve_conflicts
+from attestor.extraction.round_extractor import (
+    DEFAULT_MAX_TOKENS,
+    DEFAULT_MODEL,
+    ExtractedFact,
+    extract_agent_facts,
+    extract_user_facts,
+)
+from attestor.models import Memory
+
+logger = logging.getLogger("attestor.consolidation.consolidator")
+
+# Production runs use a stronger reasoning model here than synchronous
+# extraction. claude-opus-4-7 is the recommended default per roadmap.
+DEFAULT_CONSOLIDATION_MODEL = "openai/gpt-4o"
+
+
+@dataclass(frozen=True)
+class ConsolidationResult:
+    """One episode consolidation outcome."""
+    episode_id: str
+    user_facts: List[ExtractedFact]
+    agent_facts: List[ExtractedFact]
+    applied: List[AppliedDecision]
+    error: Optional[str] = None
+
+    @property
+    def ok(self) -> bool:
+        return self.error is None
+
+    @property
+    def written_memory_ids(self) -> List[str]:
+        return [a.memory_id for a in self.applied
+                if a.memory_id and a.operation in {"ADD", "UPDATE", "INVALIDATE"}]
+
+
+class SleepTimeConsolidator:
+    """Per-episode worker that re-extracts with a stronger model.
+
+    Constructor takes an AgentMemory plus the consolidation model name.
+    For tests, inject ``extraction_client`` / ``resolver_client`` to use
+    stubs.
+
+    Idempotency: ConsolidationQueue.mark_done is called only after the
+    apply step succeeds. A crashed worker's row gets reclaimed after
+    queue_lock_seconds (default 600).
+    """
+
+    def __init__(
+        self,
+        mem: Any,                                  # AgentMemory
+        *,
+        model: str = DEFAULT_CONSOLIDATION_MODEL,
+        max_tokens: int = DEFAULT_MAX_TOKENS,
+        cadence_seconds: int = 300,
+        batch_size: int = 20,
+        extraction_client: Optional[Any] = None,
+        resolver_client: Optional[Any] = None,
+        queue: Optional[ConsolidationQueue] = None,
+    ) -> None:
+        self._mem = mem
+        self._model = model
+        self._max_tokens = max_tokens
+        self._cadence = cadence_seconds
+        self._batch_size = batch_size
+        self._extraction_client = extraction_client
+        self._resolver_client = resolver_client
+        # Allow injection so tests can use a custom queue connection
+        self._queue = queue or ConsolidationQueue(self._mem._store._conn)
+
+    # ── Public ──────────────────────────────────────────────────────────
+
+    def run_once(self, *, limit: Optional[int] = None) -> List[ConsolidationResult]:
+        """Drain one batch and return per-episode results."""
+        n = limit or self._batch_size
+        batch = self._queue.dequeue_batch(limit=n)
+        if not batch:
+            return []
+        return [self._consolidate_one(ep) for ep in batch]
+
+    async def run_forever(self) -> None:
+        """Daemon loop. Sleeps cadence_seconds when the queue is empty."""
+        while True:
+            results = self.run_once()
+            if not results:
+                await asyncio.sleep(self._cadence)
+                continue
+            ok = sum(1 for r in results if r.ok)
+            logger.info(
+                "consolidated %d/%d episodes (errors=%d)",
+                ok, len(results), len(results) - ok,
+            )
+
+    # ── Per-episode ─────────────────────────────────────────────────────
+
+    def _consolidate_one(self, ep: QueuedEpisode) -> ConsolidationResult:
+        # RLS scope: the consolidator must operate as the episode's user.
+        # The queue runs on an admin connection (BYPASSRLS); we explicitly
+        # set the var here so the apply step's writes/reads are scoped.
+        if hasattr(self._mem._store, "_set_rls_user"):
+            try:
+                self._mem._store._set_rls_user(ep.user_id)
+            except Exception as e:
+                self._queue.mark_failed(ep.id, f"set_rls_user failed: {e}")
+                return ConsolidationResult(
+                    episode_id=ep.id, user_facts=[], agent_facts=[],
+                    applied=[], error=f"rls: {e}",
+                )
+
+        try:
+            user_turn = ConversationTurn(
+                thread_id=ep.thread_id, speaker="user", role="user",
+                content=ep.user_turn_text, ts=ep.user_ts,
+            )
+            assistant_turn = ConversationTurn(
+                thread_id=ep.thread_id,
+                speaker=ep.agent_id or "assistant",
+                role="assistant",
+                content=ep.assistant_turn_text, ts=ep.assistant_ts,
+            )
+
+            user_facts = extract_user_facts(
+                user_turn, model=self._model,
+                max_tokens=self._max_tokens,
+                client=self._extraction_client,
+            )
+            agent_facts = extract_agent_facts(
+                assistant_turn, model=self._model,
+                max_tokens=self._max_tokens,
+                client=self._extraction_client,
+            )
+            all_facts = user_facts + agent_facts
+
+            existing = self._retrieve_similar(all_facts)
+            decisions = resolve_conflicts(
+                new_facts=all_facts,
+                existing=existing,
+                evidence_episode_id=ep.id,
+                model=self._model,
+                max_tokens=self._max_tokens,
+                client=self._resolver_client,
+            )
+
+            applied = apply_decisions(
+                decisions, mem=self._mem,
+                user_id=ep.user_id, project_id=ep.project_id,
+                session_id=ep.session_id, scope="user",
+                extraction_model=f"consolidation:{self._model}",
+                parent_agent_id=ep.agent_id,
+            )
+            self._queue.mark_done(ep.id)
+            return ConsolidationResult(
+                episode_id=ep.id,
+                user_facts=user_facts, agent_facts=agent_facts,
+                applied=applied,
+            )
+        except Exception as e:
+            logger.warning("consolidate %s failed: %s", ep.id, e)
+            self._queue.mark_failed(ep.id, str(e))
+            return ConsolidationResult(
+                episode_id=ep.id, user_facts=[], agent_facts=[],
+                applied=[], error=str(e),
+            )
+
+    # ── Helpers ────────────────────────────────────────────────────────
+
+    def _retrieve_similar(
+        self, new_facts: List[ExtractedFact],
+    ) -> List[Memory]:
+        """Reuse the same fallback logic as ConversationIngest — but
+        without going through mem.recall (which would require resolving
+        identity again). We just hit the doc store directly.
+        """
+        if not new_facts:
+            return []
+        store = getattr(self._mem, "_store", None)
+        if store is None or not hasattr(store, "list_memories"):
+            return []
+        seen: set = set()
+        out: List[Memory] = []
+        for fact in new_facts:
+            try:
+                if fact.entity:
+                    rows = store.list_memories(
+                        category=fact.category, entity=fact.entity,
+                        status="active", limit=5,
+                    )
+                else:
+                    rows = store.list_memories(
+                        category=fact.category, status="active", limit=5,
+                    )
+            except Exception as e:
+                logger.debug("similar-lookup failed: %s", e)
+                continue
+            for m in rows:
+                if m.id in seen:
+                    continue
+                seen.add(m.id)
+                out.append(m)
+                if len(out) >= 5:
+                    return out
+        return out

--- a/attestor/consolidation/queue.py
+++ b/attestor/consolidation/queue.py
@@ -1,0 +1,199 @@
+"""Episode consolidation queue (Phase 7.1, roadmap §E.1).
+
+Backed by the ``consolidation_state`` columns on the v4 ``episodes``
+table. State machine:
+
+    pending --(claim)--> processing --(done|failed)--> done|failed
+       ^                       |
+       +---(reclaim_stale)-----+
+
+``dequeue_batch`` claims rows atomically with FOR UPDATE SKIP LOCKED so
+multiple workers can run in parallel without coordination. A row that
+was claimed but never finished gets reclaimed after
+``queue_lock_seconds`` (default 600) so a crashed worker doesn't strand
+work forever.
+
+RLS scoping: this queue is operated by an admin-bypass connection in
+production (the worker isn't tied to a single user). For tests, an admin
+fixture sets the var to whatever user owns the rows.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+import psycopg2.extras
+
+logger = logging.getLogger("attestor.consolidation.queue")
+
+
+@dataclass(frozen=True)
+class QueuedEpisode:
+    """A row claimed from the queue. The worker holds the lease until
+    it calls ``mark_done`` or ``mark_failed``."""
+    id: str
+    user_id: str
+    session_id: str
+    thread_id: str
+    user_turn_text: str
+    assistant_turn_text: str
+    user_ts: datetime
+    assistant_ts: datetime
+    project_id: Optional[str] = None
+    agent_id: Optional[str] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_row(cls, row: Dict[str, Any]) -> QueuedEpisode:
+        meta = row.get("metadata") or {}
+        if isinstance(meta, str):
+            import json
+            meta = json.loads(meta)
+        return cls(
+            id=str(row["id"]),
+            user_id=str(row["user_id"]),
+            project_id=str(row["project_id"]) if row.get("project_id") else None,
+            session_id=str(row["session_id"]),
+            thread_id=row["thread_id"],
+            user_turn_text=row["user_turn_text"],
+            assistant_turn_text=row["assistant_turn_text"],
+            user_ts=row["user_ts"],
+            assistant_ts=row["assistant_ts"],
+            agent_id=row.get("agent_id"),
+            metadata=meta,
+        )
+
+
+class ConsolidationQueue:
+    """Pure data-access for the episode consolidation queue.
+
+    Takes a psycopg2 connection at construction; does not own its
+    lifecycle. Methods are short SQL transactions — no LLM calls, no
+    business logic.
+    """
+
+    def __init__(
+        self,
+        conn: Any,
+        *,
+        queue_lock_seconds: int = 600,
+    ) -> None:
+        self._conn = conn
+        self._lock_seconds = queue_lock_seconds
+
+    # ── Enqueue ──────────────────────────────────────────────────────────
+
+    def enqueue(self, episode_id: str) -> bool:
+        """Mark an episode as pending consolidation. Idempotent — a
+        row already pending or processing isn't reset.
+
+        Returns True if the row transitioned to pending (newly enqueued
+        or re-enqueued from done/failed); False if no change.
+        """
+        with self._conn.cursor() as cur:
+            cur.execute(
+                "UPDATE episodes "
+                "SET consolidation_state = 'pending', "
+                "    consolidation_claimed_at = NULL, "
+                "    consolidation_done_at = NULL, "
+                "    consolidation_error = NULL "
+                "WHERE id = %s "
+                "  AND consolidation_state IN ('done', 'failed')",
+                (episode_id,),
+            )
+            affected = cur.rowcount
+        self._conn.commit()
+        return affected > 0
+
+    # ── Dequeue ──────────────────────────────────────────────────────────
+
+    def dequeue_batch(self, limit: int = 20) -> List[QueuedEpisode]:
+        """Atomically claim up to ``limit`` pending rows. Other workers
+        skip locked rows so this is safe under concurrency.
+
+        Reclaim policy: rows stuck in 'processing' for longer than
+        ``queue_lock_seconds`` are also picked up — assumed crashed.
+        """
+        with self._conn.cursor(
+            cursor_factory=psycopg2.extras.RealDictCursor,
+        ) as cur:
+            cur.execute(
+                """
+                WITH claimed AS (
+                    SELECT id FROM episodes
+                    WHERE consolidation_state = 'pending'
+                       OR (consolidation_state = 'processing'
+                           AND consolidation_claimed_at < NOW() - INTERVAL '%s seconds')
+                    ORDER BY created_at ASC
+                    FOR UPDATE SKIP LOCKED
+                    LIMIT %s
+                )
+                UPDATE episodes e
+                SET consolidation_state = 'processing',
+                    consolidation_claimed_at = NOW()
+                FROM claimed
+                WHERE e.id = claimed.id
+                RETURNING e.*
+                """,
+                (self._lock_seconds, limit),
+            )
+            rows = cur.fetchall()
+        self._conn.commit()
+        return [QueuedEpisode.from_row(dict(r)) for r in rows]
+
+    # ── Lifecycle ────────────────────────────────────────────────────────
+
+    def mark_done(self, episode_id: str) -> None:
+        with self._conn.cursor() as cur:
+            cur.execute(
+                "UPDATE episodes SET consolidation_state = 'done', "
+                "consolidation_done_at = NOW(), consolidation_error = NULL "
+                "WHERE id = %s",
+                (episode_id,),
+            )
+        self._conn.commit()
+
+    def mark_failed(self, episode_id: str, error: str) -> None:
+        with self._conn.cursor() as cur:
+            cur.execute(
+                "UPDATE episodes SET consolidation_state = 'failed', "
+                "consolidation_done_at = NOW(), consolidation_error = %s "
+                "WHERE id = %s",
+                (error[:1000], episode_id),
+            )
+        self._conn.commit()
+
+    def release(self, episode_id: str) -> None:
+        """Drop a 'processing' lease back to 'pending' without marking
+        done/failed. Used when a worker shuts down cleanly mid-job."""
+        with self._conn.cursor() as cur:
+            cur.execute(
+                "UPDATE episodes SET consolidation_state = 'pending', "
+                "consolidation_claimed_at = NULL "
+                "WHERE id = %s AND consolidation_state = 'processing'",
+                (episode_id,),
+            )
+        self._conn.commit()
+
+    # ── Introspection ────────────────────────────────────────────────────
+
+    def stats(self) -> Dict[str, int]:
+        """Count rows by consolidation_state. Useful for dashboards."""
+        with self._conn.cursor() as cur:
+            cur.execute(
+                "SELECT consolidation_state, COUNT(*) FROM episodes "
+                "GROUP BY consolidation_state"
+            )
+            rows = cur.fetchall()
+        out: Dict[str, int] = {
+            "pending": 0, "processing": 0, "done": 0, "failed": 0,
+        }
+        for state, n in rows:
+            out[state] = int(n)
+        return out
+
+    def pending_count(self) -> int:
+        return self.stats()["pending"]

--- a/attestor/consolidation/reflection.py
+++ b/attestor/consolidation/reflection.py
@@ -1,0 +1,247 @@
+"""Cross-thread reflection (Phase 7.3, roadmap §E.2).
+
+Periodic synthesis over a user's recent facts. Produces:
+
+  - stable_preferences   — patterns appearing in 3+ episodes
+  - stable_constraints   — rules the user repeatedly invokes
+  - changed_beliefs      — preferences that have shifted (old → new)
+  - contradictions_for_review — same predicate, conflicting values, no
+                                clear winner; HUMAN REVIEW only — never
+                                auto-resolved (regulated chat systems)
+
+This is LangMem's procedural memory shape: turning observable behavior
+into explicit preferences the agent can rely on. Reflection runs after
+the per-episode consolidator and is much cheaper (one LLM call across
+N facts vs one per episode).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from attestor.extraction.round_extractor import (
+    DEFAULT_MAX_TOKENS,
+    DEFAULT_MODEL,
+    _strip_markdown_fences,
+)
+from attestor.models import Memory
+
+logger = logging.getLogger("attestor.consolidation.reflection")
+
+
+REFLECTION_PROMPT = """\
+You are a Senior Memory Curator reviewing facts collected across many
+conversations with the same user. Identify:
+
+1. STABLE PREFERENCES -- patterns appearing in 3+ episodes
+2. STABLE CONSTRAINTS -- rules the user repeatedly invokes
+3. CHANGED BELIEFS -- preferences that have shifted; mark old ones for INVALIDATE
+4. CONTRADICTIONS -- same predicate, conflicting values, no clear winner
+   (these must be flagged for HUMAN REVIEW; do NOT auto-resolve)
+
+Output schema (JSON only):
+{{
+  "stable_preferences": [
+    {{"text": "...", "evidence": ["mem_id1", "mem_id2", "mem_id3"], "confidence": 0.0-1.0}}
+  ],
+  "stable_constraints": [
+    {{"text": "...", "evidence": ["mem_id1", ...], "confidence": 0.0-1.0}}
+  ],
+  "changed_beliefs": [
+    {{"old": "mem_id", "new": "mem_id", "reason": "..."}}
+  ],
+  "contradictions_for_review": [
+    {{"facts": ["mem_id1", "mem_id2"], "rationale": "..."}}
+  ]
+}}
+
+# IMPORTANT: Do NOT auto-resolve contradictions. Flag them for human review.
+# Only emit a stable_preference if at least 3 distinct evidence ids support it.
+
+Facts to review (last 30 days, user_id {user_id}):
+{facts_json}
+
+Output:
+"""
+
+
+@dataclass(frozen=True)
+class StablePattern:
+    """A stable preference or constraint backed by evidence."""
+    text: str
+    evidence: List[str]
+    confidence: float
+
+
+@dataclass(frozen=True)
+class ChangedBelief:
+    """One belief that shifted: old memory_id → new memory_id."""
+    old: str
+    new: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class Contradiction:
+    """Same predicate, conflicting values — for human review only."""
+    facts: List[str]
+    rationale: str
+
+
+@dataclass(frozen=True)
+class ReflectionResult:
+    """Output of one reflect() call. Empty lists on LLM failure."""
+    stable_preferences: List[StablePattern] = field(default_factory=list)
+    stable_constraints: List[StablePattern] = field(default_factory=list)
+    changed_beliefs: List[ChangedBelief] = field(default_factory=list)
+    contradictions_for_review: List[Contradiction] = field(default_factory=list)
+    error: Optional[str] = None
+
+    @property
+    def total_patterns(self) -> int:
+        return len(self.stable_preferences) + len(self.stable_constraints)
+
+
+def _fact_to_dict(m: Memory) -> Dict[str, Any]:
+    return {
+        "id": m.id,
+        "content": m.content,
+        "category": m.category,
+        "entity": m.entity,
+        "valid_from": m.valid_from,
+        "confidence": m.confidence,
+        "source_episode_id": m.source_episode_id,
+    }
+
+
+def _parse_pattern_list(raw: Any) -> List[StablePattern]:
+    out: List[StablePattern] = []
+    if not isinstance(raw, list):
+        return out
+    for entry in raw:
+        if not isinstance(entry, dict):
+            continue
+        text = entry.get("text")
+        evidence = entry.get("evidence")
+        confidence = entry.get("confidence", 0.5)
+        if not isinstance(text, str) or not text.strip():
+            continue
+        if not isinstance(evidence, list):
+            continue
+        ev = [str(e) for e in evidence if e]
+        try:
+            conf = float(confidence)
+        except (TypeError, ValueError):
+            conf = 0.5
+        conf = max(0.0, min(1.0, conf))
+        out.append(StablePattern(
+            text=text.strip(), evidence=ev, confidence=conf,
+        ))
+    return out
+
+
+def _parse_changed_list(raw: Any) -> List[ChangedBelief]:
+    out: List[ChangedBelief] = []
+    if not isinstance(raw, list):
+        return out
+    for entry in raw:
+        if not isinstance(entry, dict):
+            continue
+        old = entry.get("old")
+        new = entry.get("new")
+        reason = entry.get("reason", "")
+        if not (isinstance(old, str) and isinstance(new, str)):
+            continue
+        out.append(ChangedBelief(
+            old=old, new=new, reason=reason if isinstance(reason, str) else "",
+        ))
+    return out
+
+
+def _parse_contradictions(raw: Any) -> List[Contradiction]:
+    out: List[Contradiction] = []
+    if not isinstance(raw, list):
+        return out
+    for entry in raw:
+        if not isinstance(entry, dict):
+            continue
+        facts = entry.get("facts")
+        rationale = entry.get("rationale", "")
+        if not isinstance(facts, list) or len(facts) < 2:
+            continue
+        out.append(Contradiction(
+            facts=[str(f) for f in facts if f],
+            rationale=rationale if isinstance(rationale, str) else "",
+        ))
+    return out
+
+
+class ReflectionEngine:
+    """Run REFLECTION_PROMPT over a list of facts.
+
+    The engine is stateless — pass facts in, get patterns out. The
+    consolidator decides when to run it (e.g., every N episodes).
+    """
+
+    def __init__(
+        self,
+        client: Optional[Any] = None,
+        *,
+        model: str = DEFAULT_MODEL,
+        max_tokens: int = DEFAULT_MAX_TOKENS,
+    ) -> None:
+        self._client = client
+        self._model = model
+        self._max_tokens = max_tokens
+
+    def reflect(
+        self, facts: List[Memory], *, user_id: str = "(unknown)",
+    ) -> ReflectionResult:
+        """Synthesize patterns from a fact set. Empty/error → empty result."""
+        if not facts:
+            return ReflectionResult()
+        if self._client is None:
+            return ReflectionResult(error="no llm client configured")
+
+        facts_json = json.dumps(
+            [_fact_to_dict(f) for f in facts], ensure_ascii=False,
+        )
+        prompt = REFLECTION_PROMPT.format(
+            user_id=user_id, facts_json=facts_json,
+        )
+        try:
+            response = self._client.chat.completions.create(
+                model=self._model,
+                max_tokens=self._max_tokens,
+                messages=[{"role": "user", "content": prompt}],
+            )
+            raw = response.choices[0].message.content or ""
+        except Exception as e:
+            logger.warning("reflection LLM call failed: %s", e)
+            return ReflectionResult(error=f"llm: {e}")
+
+        return _parse_response(raw)
+
+
+def _parse_response(raw: str) -> ReflectionResult:
+    text = _strip_markdown_fences(raw)
+    if not text:
+        return ReflectionResult()
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError as e:
+        logger.debug("reflection JSON parse failed: %s; raw=%r", e, raw[:200])
+        return ReflectionResult(error="bad json")
+    if not isinstance(parsed, dict):
+        return ReflectionResult(error="not an object")
+    return ReflectionResult(
+        stable_preferences=_parse_pattern_list(parsed.get("stable_preferences")),
+        stable_constraints=_parse_pattern_list(parsed.get("stable_constraints")),
+        changed_beliefs=_parse_changed_list(parsed.get("changed_beliefs")),
+        contradictions_for_review=_parse_contradictions(
+            parsed.get("contradictions_for_review")
+        ),
+    )

--- a/attestor/consolidation/session_end.py
+++ b/attestor/consolidation/session_end.py
@@ -1,0 +1,267 @@
+"""Session-end promotion (Phase 7.4, roadmap §E task list).
+
+When a session ends, decide what to do with each session-scoped memory:
+
+  KEEP_SESSION   — leave it scoped to the session (transient, low-value)
+  PROMOTE_PROJECT— widen scope to project (relevant beyond this chat)
+  PROMOTE_USER   — widen scope to user (cross-project preference)
+  DISCARD        — mark superseded (noise / one-off / hypothetical)
+
+The LLM emits the decision; the apply layer mutates ``memories.scope``
+(promotion) or status='superseded' (discard). Session-end consolidation
+can run synchronously (small sessions) or be queued for the worker.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from attestor.extraction.round_extractor import (
+    DEFAULT_MAX_TOKENS,
+    DEFAULT_MODEL,
+    _strip_markdown_fences,
+)
+from attestor.models import Memory
+
+logger = logging.getLogger("attestor.consolidation.session_end")
+
+
+VALID_PROMOTIONS = {"KEEP_SESSION", "PROMOTE_PROJECT", "PROMOTE_USER", "DISCARD"}
+
+
+SESSION_PROMOTION_PROMPT = """\
+You are reviewing memories captured during a single conversation session
+that just ended. For each memory, decide what to do with it:
+
+- KEEP_SESSION    : transient or low-value; relevant only inside this session
+- PROMOTE_PROJECT : useful across other sessions in this project
+- PROMOTE_USER    : a stable user preference / fact; useful across all projects
+- DISCARD         : noise, one-off, hypothetical — mark superseded (kept for audit)
+
+Decision rules:
+1. If the memory is a CONCRETE PREFERENCE that would still apply tomorrow
+   in any context (food, language, communication style) -> PROMOTE_USER.
+2. If the memory is project-specific knowledge (architecture decision,
+   API key, project conventions) -> PROMOTE_PROJECT.
+3. If the memory references "today", "this conversation", or only makes
+   sense inside this thread -> KEEP_SESSION.
+4. If the memory is hypothetical ("what if I"), incomplete, or contradicted
+   by a later memory in the same set -> DISCARD.
+
+Output schema (JSON only):
+{{
+  "decisions": [
+    {{
+      "memory_id": "<id>",
+      "operation": "KEEP_SESSION|PROMOTE_PROJECT|PROMOTE_USER|DISCARD",
+      "rationale": "<one short sentence>"
+    }}
+  ]
+}}
+
+Session memories ({memory_count} items):
+{memories_json}
+
+Output:
+"""
+
+
+@dataclass(frozen=True)
+class PromotionDecision:
+    """One operation per memory in the ended session."""
+    memory_id: str
+    operation: str   # one of VALID_PROMOTIONS
+    rationale: str
+
+    def __post_init__(self) -> None:
+        if self.operation not in VALID_PROMOTIONS:
+            raise ValueError(
+                f"PromotionDecision.operation must be one of {VALID_PROMOTIONS}; "
+                f"got {self.operation!r}"
+            )
+
+
+@dataclass(frozen=True)
+class AppliedPromotion:
+    """The outcome of one PromotionDecision."""
+    memory_id: str
+    operation: str
+    new_scope: Optional[str] = None  # set on PROMOTE_PROJECT/PROMOTE_USER
+    superseded: bool = False         # set on DISCARD
+    error: Optional[str] = None
+
+
+def _memory_to_dict(m: Memory) -> Dict[str, Any]:
+    return {
+        "id": m.id,
+        "content": m.content,
+        "category": m.category,
+        "entity": m.entity,
+        "valid_from": m.valid_from,
+        "confidence": m.confidence,
+    }
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Decide
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def decide_promotions(
+    memories: List[Memory],
+    *,
+    client: Optional[Any] = None,
+    model: str = DEFAULT_MODEL,
+    max_tokens: int = DEFAULT_MAX_TOKENS,
+) -> List[PromotionDecision]:
+    """Run SESSION_PROMOTION_PROMPT to classify each memory.
+
+    Empty memories → []. LLM error → all-KEEP_SESSION (safe default:
+    don't widen scope on uncertainty)."""
+    if not memories:
+        return []
+    if client is None:
+        return _all_keep(memories, "no llm client configured")
+
+    prompt = SESSION_PROMOTION_PROMPT.format(
+        memory_count=len(memories),
+        memories_json=json.dumps(
+            [_memory_to_dict(m) for m in memories], ensure_ascii=False,
+        ),
+    )
+    try:
+        response = client.chat.completions.create(
+            model=model, max_tokens=max_tokens,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        raw = response.choices[0].message.content or ""
+    except Exception as e:
+        logger.warning("promotion LLM call failed: %s", e)
+        return _all_keep(memories, f"llm error: {e}")
+
+    return _parse_decisions(raw, memories)
+
+
+def _all_keep(memories: List[Memory], reason: str) -> List[PromotionDecision]:
+    """Safe default — no scope change. Used when the LLM is unavailable."""
+    return [
+        PromotionDecision(
+            memory_id=m.id, operation="KEEP_SESSION", rationale=reason,
+        )
+        for m in memories
+    ]
+
+
+def _parse_decisions(
+    raw: str, memories: List[Memory],
+) -> List[PromotionDecision]:
+    text = _strip_markdown_fences(raw)
+    if not text:
+        return _all_keep(memories, "empty llm response")
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError as e:
+        logger.warning("promotion JSON parse failed: %s; raw=%r", e, raw[:200])
+        return _all_keep(memories, "bad json")
+
+    raw_decs: List = []
+    if isinstance(parsed, dict):
+        raw_decs = parsed.get("decisions", [])
+    elif isinstance(parsed, list):
+        raw_decs = parsed
+
+    by_id: Dict[str, dict] = {}
+    for d in raw_decs:
+        if not isinstance(d, dict):
+            continue
+        mid = d.get("memory_id")
+        if isinstance(mid, str):
+            by_id[mid] = d
+
+    out: List[PromotionDecision] = []
+    for m in memories:
+        d = by_id.get(m.id)
+        if d is None:
+            out.append(PromotionDecision(
+                memory_id=m.id, operation="KEEP_SESSION",
+                rationale="LLM omitted decision; default KEEP",
+            ))
+            continue
+        op = d.get("operation")
+        if not isinstance(op, str) or op not in VALID_PROMOTIONS:
+            out.append(PromotionDecision(
+                memory_id=m.id, operation="KEEP_SESSION",
+                rationale=f"invalid operation {op!r}; default KEEP",
+            ))
+            continue
+        rationale = d.get("rationale")
+        if not isinstance(rationale, str):
+            rationale = "(no rationale)"
+        out.append(PromotionDecision(
+            memory_id=m.id, operation=op, rationale=rationale,
+        ))
+    return out
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Apply
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def apply_promotions(
+    decisions: List[PromotionDecision],
+    *,
+    mem: Any,                # AgentMemory (uses _store + _temporal)
+) -> List[AppliedPromotion]:
+    """Mutate memories.scope (promotions) or mark superseded (discard).
+
+    KEEP_SESSION is a no-op outcome; included in the result list for
+    audit symmetry.
+    """
+    out: List[AppliedPromotion] = []
+    for d in decisions:
+        try:
+            if d.operation == "KEEP_SESSION":
+                out.append(AppliedPromotion(
+                    memory_id=d.memory_id, operation="KEEP_SESSION",
+                ))
+                continue
+            row = mem._store.get(d.memory_id)
+            if row is None:
+                out.append(AppliedPromotion(
+                    memory_id=d.memory_id, operation=d.operation,
+                    error="memory vanished",
+                ))
+                continue
+            if d.operation in {"PROMOTE_PROJECT", "PROMOTE_USER"}:
+                new_scope = "project" if d.operation == "PROMOTE_PROJECT" else "user"
+                row.scope = new_scope
+                mem._store.update(row)
+                out.append(AppliedPromotion(
+                    memory_id=d.memory_id, operation=d.operation,
+                    new_scope=new_scope,
+                ))
+            elif d.operation == "DISCARD":
+                # Mark superseded (timeline preserved). No replacement
+                # row — nothing to point to via superseded_by.
+                row.status = "superseded"
+                from datetime import datetime, timezone
+                row.valid_until = datetime.now(timezone.utc).isoformat()
+                mem._store.update(row)
+                out.append(AppliedPromotion(
+                    memory_id=d.memory_id, operation="DISCARD",
+                    superseded=True,
+                ))
+        except Exception as e:
+            logger.warning(
+                "apply_promotion %s for %s failed: %s",
+                d.operation, d.memory_id, e,
+            )
+            out.append(AppliedPromotion(
+                memory_id=d.memory_id, operation=d.operation,
+                error=str(e),
+            ))
+    return out

--- a/attestor/core.py
+++ b/attestor/core.py
@@ -786,10 +786,75 @@ class AgentMemory:
         budget: Optional[int] = None,
         namespace: Optional[str] = None,
     ) -> str:
-        """Recall and format as a context string for prompt injection."""
+        """Recall and format as a context string for prompt injection.
+
+        Legacy v3 surface — returns plain text. New code should prefer
+        ``recall_as_pack`` which returns a structured ``ContextPack``
+        with citations + Chain-of-Note prompt (Phase 6).
+        """
         token_budget = budget or self.config.default_token_budget
         return self._retrieval.recall_as_context(
             query, token_budget, namespace=namespace
+        )
+
+    def recall_as_pack(
+        self,
+        query: str,
+        budget: Optional[int] = None,
+        user_id: Optional[str] = None,
+        as_of: Optional[datetime] = None,
+        time_window: Optional[Any] = None,
+        chain_of_note_prompt: Optional[str] = None,
+    ):
+        """Recall as a structured ``ContextPack`` for Chain-of-Note agents.
+
+        The returned pack carries:
+          - memories sorted by score (orchestrator decides ranking)
+          - per-memory: id, content, validity window, confidence,
+            source_episode_id (for citation)
+          - default Chain-of-Note prompt with ABSTAIN clause
+
+        v4 + Phase 5 callers can pass ``as_of`` / ``time_window`` for
+        bi-temporal replay; the pack reflects the snapshot accordingly.
+
+        Phase 6.2 — roadmap §D.1.
+        """
+        from attestor.models import ContextPack, ContextPackEntry
+        from attestor.prompts.chain_of_note import DEFAULT_CHAIN_OF_NOTE_PROMPT
+
+        results = self.recall(
+            query, budget=budget, user_id=user_id,
+            as_of=as_of, time_window=time_window,
+        )
+        # Skip synthetic graph_relation rows — they aren't real memories
+        # and have no citation target.
+        real = [r for r in results if r.memory.category != "graph_relation"]
+        entries = [
+            ContextPackEntry(
+                id=r.memory.id,
+                content=r.memory.content,
+                category=r.memory.category,
+                entity=r.memory.entity,
+                valid_from=r.memory.valid_from,
+                valid_until=r.memory.valid_until,
+                confidence=r.memory.confidence,
+                source_episode_id=r.memory.source_episode_id,
+                score=r.score,
+            )
+            for r in real
+        ]
+        # Rough token-count estimate: ~4 chars/token
+        chars = sum(len(e.content) for e in entries)
+        token_count = chars // 4
+
+        return ContextPack(
+            query=query,
+            memories=entries,
+            as_of=as_of.isoformat() if as_of is not None else None,
+            token_count=token_count,
+            chain_of_note_prompt=(
+                chain_of_note_prompt or DEFAULT_CHAIN_OF_NOTE_PROMPT
+            ),
         )
 
     def search(

--- a/attestor/core.py
+++ b/attestor/core.py
@@ -488,6 +488,37 @@ class AgentMemory:
             recent_context=recent_context,
         )
 
+    # -- v4 sleep-time consolidation (Phase 7) --
+
+    def consolidate(
+        self,
+        *,
+        limit: int = 20,
+        model: Optional[str] = None,
+        extraction_client: Optional[Any] = None,
+        resolver_client: Optional[Any] = None,
+    ) -> List[Any]:
+        """Drain one batch from the consolidation queue in-process.
+
+        For long-running daemons use ``SleepTimeConsolidator.run_forever``
+        directly. This method is for tests and one-shot manual triggers
+        (e.g., ``attestor consolidate run``).
+
+        Returns a list of ``ConsolidationResult`` (one per processed
+        episode). Empty list when the queue is drained.
+        """
+        self._require_v4()
+        from attestor.consolidation import SleepTimeConsolidator
+        kwargs: Dict[str, Any] = {"batch_size": limit}
+        if model:
+            kwargs["model"] = model
+        if extraction_client is not None:
+            kwargs["extraction_client"] = extraction_client
+        if resolver_client is not None:
+            kwargs["resolver_client"] = resolver_client
+        cons = SleepTimeConsolidator(self, **kwargs)
+        return cons.run_once(limit=limit)
+
     @property
     def mode(self) -> AttestorMode:
         """The detected operating mode. Settable via ``config["mode"]`` or

--- a/attestor/identity/sessions.py
+++ b/attestor/identity/sessions.py
@@ -130,8 +130,13 @@ class SessionRepo:
         self._conn.commit()
 
     def end(self, session_id: str) -> Optional[Session]:
-        """Transition active/idle → ended. Caller should enqueue
-        consolidation after this (Phase 7)."""
+        """Transition active/idle → ended AND enqueue the session's
+        episodes for sleep-time consolidation (Phase 7.4).
+
+        Episodes that have already been consolidated (state='done') are
+        re-enqueued — ending a session is a strong "please re-look at
+        these with the stronger model" signal.
+        """
         with self._conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
             cur.execute(
                 "UPDATE sessions SET status = 'ended', ended_at = NOW() "
@@ -141,7 +146,28 @@ class SessionRepo:
             )
             row = cur.fetchone()
         self._conn.commit()
-        return Session.from_row(dict(row)) if row else None
+        if row is None:
+            return None
+        # Enqueue every episode in this session that's done/failed back
+        # into pending. Already-pending/processing rows are untouched.
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "UPDATE episodes "
+                    "SET consolidation_state = 'pending', "
+                    "    consolidation_claimed_at = NULL, "
+                    "    consolidation_done_at = NULL, "
+                    "    consolidation_error = NULL "
+                    "WHERE session_id = %s "
+                    "  AND consolidation_state IN ('done', 'failed')",
+                    (session_id,),
+                )
+            self._conn.commit()
+        except Exception:
+            # If the episodes table is older (no consolidation_state),
+            # silently skip — the lifecycle transition itself succeeded.
+            pass
+        return Session.from_row(dict(row))
 
     def archive(self, session_id: str) -> Optional[Session]:
         with self._conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:

--- a/attestor/models.py
+++ b/attestor/models.py
@@ -325,3 +325,83 @@ class RetrievalResult:
         return self.memory.content
 
 
+# ── ContextPack (Phase 6.1, roadmap §D.1) ────────────────────────────────
+
+
+@dataclass(frozen=True)
+class ContextPackEntry:
+    """One memory inside a ContextPack — citation-friendly view.
+
+    The agent's Chain-of-Note instructions cite by ``id`` (e.g. [mem_42]),
+    so the id MUST round-trip exactly. ``source_episode_id`` lets the
+    auditor reconstruct the verbatim round the fact came from.
+    """
+    id: str
+    content: str
+    category: str
+    entity: Optional[str]
+    valid_from: Optional[str]
+    valid_until: Optional[str]
+    confidence: float
+    source_episode_id: Optional[str]
+    score: float
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "content": self.content,
+            "category": self.category,
+            "entity": self.entity,
+            "valid_from": self.valid_from,
+            "valid_until": self.valid_until,
+            "confidence": self.confidence,
+            "source_episode_id": self.source_episode_id,
+            "score": self.score,
+        }
+
+
+@dataclass(frozen=True)
+class ContextPack:
+    """Structured retrieval envelope for Chain-of-Note consumption.
+
+    Returned by ``AgentMemory.recall_as_context``. The agent prepends
+    ``chain_of_note_prompt`` to its system prompt, then renders
+    ``memories`` (already sorted by score) into the {memories_json}
+    placeholder.
+
+    Why structured: the agent needs to cite ids, abstain when irrelevant,
+    and prefer the right validity window when memories conflict — all
+    impossible if recall_as_context returns plain text.
+    """
+    query: str
+    memories: List[ContextPackEntry]
+    as_of: Optional[str]
+    token_count: int
+    chain_of_note_prompt: str
+
+    @property
+    def memory_count(self) -> int:
+        return len(self.memories)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "query": self.query,
+            "memories": [m.to_dict() for m in self.memories],
+            "as_of": self.as_of,
+            "token_count": self.token_count,
+            "chain_of_note_prompt": self.chain_of_note_prompt,
+        }
+
+    def memories_json(self) -> str:
+        """Render the memories list as a JSON string suitable for the
+        {memories_json} placeholder in the Chain-of-Note prompt."""
+        return json.dumps([m.to_dict() for m in self.memories],
+                          ensure_ascii=False, indent=2)
+
+    def render_prompt(self) -> str:
+        """Return the Chain-of-Note prompt with memories interpolated."""
+        return self.chain_of_note_prompt.format(
+            memories_json=self.memories_json(),
+        )
+
+

--- a/attestor/prompts/__init__.py
+++ b/attestor/prompts/__init__.py
@@ -1,0 +1,9 @@
+"""Default prompt modules shipped with attestor.
+
+Currently:
+  chain_of_note — Chain-of-Note reading prompt for ContextPack consumers.
+"""
+
+from attestor.prompts.chain_of_note import DEFAULT_CHAIN_OF_NOTE_PROMPT
+
+__all__ = ["DEFAULT_CHAIN_OF_NOTE_PROMPT"]

--- a/attestor/prompts/chain_of_note.py
+++ b/attestor/prompts/chain_of_note.py
@@ -1,0 +1,41 @@
+"""Default Chain-of-Note reading prompt (Phase 6.1, roadmap §D.2).
+
+Agents should prepend this to their system prompt when consuming a
+``ContextPack`` from ``AgentMemory.recall_as_context``. Five steps:
+NOTES → SYNTHESIS → CITE → ABSTAIN → CONFLICT.
+
+The ABSTAIN clause is the load-bearing piece: AbstentionBench shows
+every frontier model defaults to confabulation when context is
+irrelevant unless explicitly instructed otherwise. With this clause,
+abstention rates jump dramatically — and that's exactly the
+LongMemEval ``abstention`` category Track D targets (≥80%).
+
+The {memories_json} placeholder is filled by ``ContextPack.render_prompt``.
+"""
+
+from __future__ import annotations
+
+DEFAULT_CHAIN_OF_NOTE_PROMPT = """\
+You have been given a set of retrieved memories. Before answering, do the following:
+
+1. NOTES: For each memory, write one line that says either:
+   - "memory:<id> -- relevant: <why and which part>"
+   - "memory:<id> -- irrelevant: <one-line reason>"
+
+2. SYNTHESIS: Combine only the relevant notes to form your answer. If the
+   memories' validity windows differ, prefer the one whose window covers the
+   user's question.
+
+3. CITE: When you state a fact derived from a memory, cite the memory ID in
+   square brackets, e.g. [mem_42].
+
+4. ABSTAIN: If no memory is relevant, say "I don't have that information"
+   and do not invent. This is correct behavior, not a failure.
+
+5. CONFLICT: If two memories contradict, prefer the one with the later
+   `valid_from`, or the higher confidence if dates tie. Note the conflict
+   in your answer if it would change the user's decision.
+
+Memories (sorted by relevance):
+{memories_json}
+"""

--- a/attestor/store/schema.sql
+++ b/attestor/store/schema.sql
@@ -75,12 +75,25 @@ CREATE TABLE IF NOT EXISTS episodes (
     assistant_ts        TIMESTAMPTZ NOT NULL,
     agent_id            VARCHAR(128),
     metadata            JSONB NOT NULL DEFAULT '{}'::jsonb,
-    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    -- Sleep-time consolidation queue (Phase 7.1):
+    --   pending     — never consolidated; queue picks these up
+    --   processing  — claimed by a worker; locked-out for queue_lock_seconds
+    --   done        — consolidator finished; refined facts written
+    --   failed      — consolidator hit a non-retryable error; consolidation_error has why
+    consolidation_state VARCHAR(32) NOT NULL DEFAULT 'pending',
+    consolidation_claimed_at TIMESTAMPTZ,
+    consolidation_done_at    TIMESTAMPTZ,
+    consolidation_error      TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_episodes_user_session_ts
     ON episodes (user_id, session_id, user_ts);
 CREATE INDEX IF NOT EXISTS idx_episodes_thread_ts
     ON episodes (thread_id, user_ts);
+-- Sleep-time queue: only the pending rows matter for the worker
+CREATE INDEX IF NOT EXISTS idx_episodes_consolidation_pending
+    ON episodes (created_at)
+    WHERE consolidation_state = 'pending';
 
 -- ── Memories — v4 native ──────────────────────────────────────────────────
 

--- a/tests/test_chain_of_note_prompt.py
+++ b/tests/test_chain_of_note_prompt.py
@@ -1,0 +1,72 @@
+"""Phase 6.1 — Chain-of-Note prompt content guards.
+
+Anti-regression on the load-bearing pieces (esp. ABSTAIN clause).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from attestor.prompts.chain_of_note import DEFAULT_CHAIN_OF_NOTE_PROMPT
+
+
+@pytest.mark.unit
+def test_prompt_has_five_numbered_steps() -> None:
+    for n in ("1.", "2.", "3.", "4.", "5."):
+        assert n in DEFAULT_CHAIN_OF_NOTE_PROMPT, f"missing step {n}"
+
+
+@pytest.mark.unit
+def test_prompt_has_notes_step() -> None:
+    assert "NOTES" in DEFAULT_CHAIN_OF_NOTE_PROMPT
+    assert "relevant" in DEFAULT_CHAIN_OF_NOTE_PROMPT.lower()
+    assert "irrelevant" in DEFAULT_CHAIN_OF_NOTE_PROMPT.lower()
+
+
+@pytest.mark.unit
+def test_prompt_has_synthesis_step() -> None:
+    assert "SYNTHESIS" in DEFAULT_CHAIN_OF_NOTE_PROMPT
+
+
+@pytest.mark.unit
+def test_prompt_has_cite_step() -> None:
+    """Cite by id in square brackets, e.g. [mem_42]."""
+    assert "CITE" in DEFAULT_CHAIN_OF_NOTE_PROMPT
+    assert "[mem_42]" in DEFAULT_CHAIN_OF_NOTE_PROMPT
+
+
+@pytest.mark.unit
+def test_prompt_has_abstain_clause() -> None:
+    """The +abstention fix from AbstentionBench — DON'T REMOVE."""
+    assert "ABSTAIN" in DEFAULT_CHAIN_OF_NOTE_PROMPT
+    assert "I don't have that information" in DEFAULT_CHAIN_OF_NOTE_PROMPT
+    assert "do not invent" in DEFAULT_CHAIN_OF_NOTE_PROMPT
+
+
+@pytest.mark.unit
+def test_prompt_has_conflict_resolution_step() -> None:
+    """Prefer later valid_from / higher confidence."""
+    assert "CONFLICT" in DEFAULT_CHAIN_OF_NOTE_PROMPT
+    assert "valid_from" in DEFAULT_CHAIN_OF_NOTE_PROMPT
+    assert "confidence" in DEFAULT_CHAIN_OF_NOTE_PROMPT
+
+
+@pytest.mark.unit
+def test_prompt_has_memories_placeholder() -> None:
+    """ContextPack.render_prompt fills this — must exist exactly once."""
+    assert DEFAULT_CHAIN_OF_NOTE_PROMPT.count("{memories_json}") == 1
+
+
+@pytest.mark.unit
+def test_prompt_renders_without_other_format_fields() -> None:
+    """No stray {placeholders} that would break str.format."""
+    rendered = DEFAULT_CHAIN_OF_NOTE_PROMPT.format(memories_json="[]")
+    assert rendered.count("{") == 0
+    assert "[]" in rendered
+
+
+@pytest.mark.unit
+def test_prompt_module_re_exports() -> None:
+    """Top-level attestor.prompts package exposes the constant."""
+    from attestor.prompts import DEFAULT_CHAIN_OF_NOTE_PROMPT as via_pkg
+    assert via_pkg is DEFAULT_CHAIN_OF_NOTE_PROMPT

--- a/tests/test_consolidation_queue.py
+++ b/tests/test_consolidation_queue.py
@@ -1,0 +1,316 @@
+"""Phase 7.1 — ConsolidationQueue: enqueue / claim / done / failed."""
+
+from __future__ import annotations
+
+import os
+import time
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+try:
+    import psycopg2
+    HAVE_PSYCOPG2 = True
+except ImportError:
+    HAVE_PSYCOPG2 = False
+
+PG_URL = os.environ.get(
+    "PG_TEST_URL",
+    "postgresql://postgres:attestor@localhost:5432/attestor_v4_test",
+)
+SCHEMA_PATH = Path(__file__).resolve().parent.parent / "attestor" / "store" / "schema.sql"
+
+
+def _reachable() -> bool:
+    if not HAVE_PSYCOPG2:
+        return False
+    try:
+        c = psycopg2.connect(PG_URL, connect_timeout=2)
+        c.close()
+        return True
+    except Exception:
+        return False
+
+
+pytestmark = pytest.mark.skipif(not _reachable(), reason="local Postgres unreachable")
+
+
+@pytest.fixture(scope="module")
+def admin_conn():
+    c = psycopg2.connect(PG_URL)
+    c.autocommit = True
+    yield c
+    c.close()
+
+
+@pytest.fixture
+def fresh_schema(admin_conn):
+    raw = SCHEMA_PATH.read_text().replace("{embedding_dim}", "16")
+    with admin_conn.cursor() as cur:
+        for tbl in ("memories", "episodes", "sessions", "projects", "users"):
+            cur.execute(f"DROP TABLE IF EXISTS {tbl} CASCADE")
+        cur.execute(raw)
+    yield
+
+
+@pytest.fixture
+def seeded_episodes(admin_conn, fresh_schema):
+    """Insert user + session + 5 episodes via raw SQL. Returns list of ids."""
+    uid = uuid.uuid4()
+    sid = uuid.uuid4()
+    with admin_conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO users (id, external_id) VALUES (%s, %s)",
+            (str(uid), f"u-q-{uuid.uuid4().hex[:8]}"),
+        )
+        cur.execute(
+            "INSERT INTO sessions (id, user_id) VALUES (%s, %s)",
+            (str(sid), str(uid)),
+        )
+    ids = []
+    base = datetime.now(timezone.utc)
+    for i in range(5):
+        eid = uuid.uuid4()
+        with admin_conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO episodes (id, user_id, session_id, thread_id, "
+                "user_turn_text, assistant_turn_text, user_ts, assistant_ts) "
+                "VALUES (%s, %s, %s, %s, %s, %s, %s, %s)",
+                (str(eid), str(uid), str(sid), f"thr-{i}",
+                 f"u-{i}", f"a-{i}",
+                 base + timedelta(seconds=i),
+                 base + timedelta(seconds=i + 1)),
+            )
+        ids.append(str(eid))
+    return ids
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Schema columns present
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.live
+def test_episodes_has_consolidation_columns(admin_conn, fresh_schema):
+    with admin_conn.cursor() as cur:
+        cur.execute(
+            "SELECT column_name FROM information_schema.columns "
+            "WHERE table_name='episodes' AND column_name LIKE 'consolidation_%'"
+        )
+        cols = {r[0] for r in cur.fetchall()}
+    expected = {"consolidation_state", "consolidation_claimed_at",
+                "consolidation_done_at", "consolidation_error"}
+    assert expected.issubset(cols), f"missing: {expected - cols}"
+
+
+@pytest.mark.live
+def test_pending_index_exists(admin_conn, fresh_schema):
+    with admin_conn.cursor() as cur:
+        cur.execute(
+            "SELECT indexname FROM pg_indexes "
+            "WHERE tablename='episodes' "
+            "AND indexname='idx_episodes_consolidation_pending'"
+        )
+        assert cur.fetchone() is not None
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Default state + dequeue
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.live
+def test_episodes_default_state_is_pending(admin_conn, seeded_episodes):
+    with admin_conn.cursor() as cur:
+        cur.execute(
+            "SELECT consolidation_state FROM episodes "
+            "WHERE id = ANY(%s::uuid[])",
+            (seeded_episodes,),
+        )
+        states = [r[0] for r in cur.fetchall()]
+    assert len(states) == 5
+    assert all(s == "pending" for s in states)
+
+
+@pytest.mark.live
+def test_dequeue_batch_claims_oldest_first(admin_conn, seeded_episodes):
+    from attestor.consolidation.queue import ConsolidationQueue
+    q = ConsolidationQueue(admin_conn)
+    batch = q.dequeue_batch(limit=3)
+    assert len(batch) == 3
+    # Episodes 0, 1, 2 (created earliest) should come first
+    assert [e.id for e in batch] == seeded_episodes[:3]
+
+
+@pytest.mark.live
+def test_dequeue_marks_processing_with_lease(admin_conn, seeded_episodes):
+    from attestor.consolidation.queue import ConsolidationQueue
+    q = ConsolidationQueue(admin_conn)
+    batch = q.dequeue_batch(limit=2)
+    with admin_conn.cursor() as cur:
+        cur.execute(
+            "SELECT consolidation_state, consolidation_claimed_at "
+            "FROM episodes WHERE id = ANY(%s::uuid[]) ORDER BY created_at",
+            ([e.id for e in batch],),
+        )
+        rows = cur.fetchall()
+    for state, claimed_at in rows:
+        assert state == "processing"
+        assert claimed_at is not None
+
+
+@pytest.mark.live
+def test_dequeue_skips_already_claimed(admin_conn, seeded_episodes):
+    """Two consecutive dequeues never return the same row."""
+    from attestor.consolidation.queue import ConsolidationQueue
+    q = ConsolidationQueue(admin_conn)
+    first = q.dequeue_batch(limit=2)
+    second = q.dequeue_batch(limit=2)
+    overlap = {e.id for e in first} & {e.id for e in second}
+    assert overlap == set(), f"queue handed out the same row twice: {overlap}"
+
+
+@pytest.mark.live
+def test_dequeue_returns_empty_when_drained(admin_conn, seeded_episodes):
+    from attestor.consolidation.queue import ConsolidationQueue
+    q = ConsolidationQueue(admin_conn)
+    q.dequeue_batch(limit=100)  # drain
+    assert q.dequeue_batch(limit=10) == []
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Lifecycle transitions
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.live
+def test_mark_done_transitions_state(admin_conn, seeded_episodes):
+    from attestor.consolidation.queue import ConsolidationQueue
+    q = ConsolidationQueue(admin_conn)
+    batch = q.dequeue_batch(limit=1)
+    q.mark_done(batch[0].id)
+    with admin_conn.cursor() as cur:
+        cur.execute(
+            "SELECT consolidation_state, consolidation_done_at "
+            "FROM episodes WHERE id = %s", (batch[0].id,),
+        )
+        state, done_at = cur.fetchone()
+    assert state == "done"
+    assert done_at is not None
+
+
+@pytest.mark.live
+def test_mark_failed_records_error(admin_conn, seeded_episodes):
+    from attestor.consolidation.queue import ConsolidationQueue
+    q = ConsolidationQueue(admin_conn)
+    batch = q.dequeue_batch(limit=1)
+    q.mark_failed(batch[0].id, "model returned bad JSON")
+    with admin_conn.cursor() as cur:
+        cur.execute(
+            "SELECT consolidation_state, consolidation_error "
+            "FROM episodes WHERE id = %s", (batch[0].id,),
+        )
+        state, err = cur.fetchone()
+    assert state == "failed"
+    assert err == "model returned bad JSON"
+
+
+@pytest.mark.live
+def test_mark_failed_truncates_long_error(admin_conn, seeded_episodes):
+    from attestor.consolidation.queue import ConsolidationQueue
+    q = ConsolidationQueue(admin_conn)
+    batch = q.dequeue_batch(limit=1)
+    long_err = "x" * 5000
+    q.mark_failed(batch[0].id, long_err)
+    with admin_conn.cursor() as cur:
+        cur.execute(
+            "SELECT consolidation_error FROM episodes WHERE id = %s",
+            (batch[0].id,),
+        )
+        err = cur.fetchone()[0]
+    assert len(err) == 1000
+
+
+@pytest.mark.live
+def test_release_returns_to_pending(admin_conn, seeded_episodes):
+    from attestor.consolidation.queue import ConsolidationQueue
+    q = ConsolidationQueue(admin_conn)
+    batch = q.dequeue_batch(limit=1)
+    q.release(batch[0].id)
+    with admin_conn.cursor() as cur:
+        cur.execute(
+            "SELECT consolidation_state FROM episodes WHERE id = %s",
+            (batch[0].id,),
+        )
+        assert cur.fetchone()[0] == "pending"
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Re-enqueue / stale lease reclaim
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.live
+def test_enqueue_resets_done_to_pending(admin_conn, seeded_episodes):
+    from attestor.consolidation.queue import ConsolidationQueue
+    q = ConsolidationQueue(admin_conn)
+    batch = q.dequeue_batch(limit=1)
+    q.mark_done(batch[0].id)
+    assert q.enqueue(batch[0].id) is True
+    with admin_conn.cursor() as cur:
+        cur.execute(
+            "SELECT consolidation_state FROM episodes WHERE id = %s",
+            (batch[0].id,),
+        )
+        assert cur.fetchone()[0] == "pending"
+
+
+@pytest.mark.live
+def test_enqueue_no_op_on_pending_or_processing(admin_conn, seeded_episodes):
+    """Re-enqueueing a row that's already pending must return False."""
+    from attestor.consolidation.queue import ConsolidationQueue
+    q = ConsolidationQueue(admin_conn)
+    assert q.enqueue(seeded_episodes[0]) is False  # already pending
+
+
+@pytest.mark.live
+def test_dequeue_reclaims_stale_processing_lease(admin_conn, seeded_episodes):
+    from attestor.consolidation.queue import ConsolidationQueue
+    q = ConsolidationQueue(admin_conn, queue_lock_seconds=1)
+    batch = q.dequeue_batch(limit=1)
+    eid = batch[0].id
+    # Sleep past the lock window
+    time.sleep(2)
+    # A second worker should reclaim the stale row
+    second = q.dequeue_batch(limit=1)
+    assert any(e.id == eid for e in second), (
+        "stale processing lease was not reclaimed"
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Stats
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.live
+def test_stats_counts_each_state(admin_conn, seeded_episodes):
+    from attestor.consolidation.queue import ConsolidationQueue
+    q = ConsolidationQueue(admin_conn)
+    # 5 pending initially
+    assert q.stats()["pending"] == 5
+
+    batch = q.dequeue_batch(limit=3)
+    s = q.stats()
+    assert s["pending"] == 2
+    assert s["processing"] == 3
+
+    q.mark_done(batch[0].id)
+    q.mark_failed(batch[1].id, "test")
+    s = q.stats()
+    assert s["done"] == 1
+    assert s["failed"] == 1
+    assert s["processing"] == 1
+    assert s["pending"] == 2

--- a/tests/test_consolidator.py
+++ b/tests/test_consolidator.py
@@ -1,0 +1,282 @@
+"""Phase 7.2 — SleepTimeConsolidator end-to-end with stubbed LLMs.
+
+Tests run against the live v4 schema. LLM calls go through scripted
+stubs so the tests are deterministic + don't burn local Ollama time.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, List
+
+import pytest
+
+try:
+    import psycopg2
+    HAVE_PSYCOPG2 = True
+except ImportError:
+    HAVE_PSYCOPG2 = False
+
+PG_URL = os.environ.get(
+    "PG_TEST_URL",
+    "postgresql://postgres:attestor@localhost:5432/attestor_v4_test",
+)
+SCHEMA_PATH = Path(__file__).resolve().parent.parent / "attestor" / "store" / "schema.sql"
+
+
+def _reachable() -> bool:
+    if not HAVE_PSYCOPG2:
+        return False
+    try:
+        c = psycopg2.connect(PG_URL, connect_timeout=2)
+        c.close()
+        return True
+    except Exception:
+        return False
+
+
+pytestmark = pytest.mark.skipif(not _reachable(), reason="local Postgres unreachable")
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Stub LLM (scripted per call, in order)
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class _Choice:
+    def __init__(self, c: str) -> None:
+        self.message = type("M", (), {"content": c})()
+
+
+class _Resp:
+    def __init__(self, c: str) -> None:
+        self.choices = [_Choice(c)]
+
+
+class _Chat:
+    def __init__(self, scripts: List[str]) -> None:
+        self._scripts = list(scripts)
+        self.calls: List[dict] = []
+
+    def create(self, **kw: Any) -> _Resp:
+        self.calls.append(kw)
+        if not self._scripts:
+            return _Resp('{"facts": [], "decisions": []}')
+        return _Resp(self._scripts.pop(0))
+
+
+class ScriptedClient:
+    def __init__(self, scripts: List[str]) -> None:
+        self.chat = type("Chat", (), {"completions": _Chat(scripts)})()
+
+    @property
+    def call_count(self) -> int:
+        return len(self.chat.completions.calls)
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Fixtures
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def admin_conn():
+    c = psycopg2.connect(PG_URL)
+    c.autocommit = True
+    yield c
+    c.close()
+
+
+@pytest.fixture
+def fresh_schema(admin_conn):
+    raw = SCHEMA_PATH.read_text().replace("{embedding_dim}", "16")
+    with admin_conn.cursor() as cur:
+        for tbl in ("memories", "episodes", "sessions", "projects", "users"):
+            cur.execute(f"DROP TABLE IF EXISTS {tbl} CASCADE")
+        cur.execute(raw)
+    yield
+
+
+@pytest.fixture
+def mem_with_episodes(admin_conn, fresh_schema, tmp_path):
+    """SOLO AgentMemory with 3 freshly-ingested episodes pending consolidation."""
+    from attestor.conversation import ConversationTurn
+    from attestor.core import AgentMemory
+
+    mem = AgentMemory(tmp_path, config={
+        "mode": "solo",
+        "backends": ["postgres"],
+        "backend_configs": {"postgres": {
+            "url": "postgresql://localhost:5432",
+            "database": "attestor_v4_test",
+            "auth": {"username": "postgres", "password": "attestor"},
+            "v4": True, "skip_schema_init": True, "embedding_dim": 16,
+        }},
+    })
+
+    # Use a stub for the synchronous extraction so ingest_round doesn't
+    # actually call the LLM during fixture setup.
+    sync_client = ScriptedClient([
+        # Per round: user-extract, agent-extract (resolver short-circuits
+        # because no existing memories yet on round 1, then also for the
+        # rest since synchronous facts are minimal).
+        '{"facts": []}', '{"facts": []}',
+        '{"facts": []}', '{"facts": []}',
+        '{"facts": []}', '{"facts": []}',
+    ])
+    base = datetime.now(timezone.utc)
+    eps = []
+    for i in range(3):
+        u = ConversationTurn(
+            thread_id="t-1", speaker="user", role="user",
+            content=f"user message {i}", ts=base + timedelta(seconds=i * 10),
+        )
+        a = ConversationTurn(
+            thread_id="t-1", speaker="planner", role="assistant",
+            content=f"agent response {i}",
+            ts=base + timedelta(seconds=i * 10 + 1),
+        )
+        r = mem.ingest_round(u, a,
+                             extraction_client=sync_client,
+                             resolver_client=sync_client)
+        eps.append(r.episode)
+    yield mem, eps
+    mem.close()
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Tests
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.live
+def test_run_once_drains_pending_episodes(mem_with_episodes):
+    from attestor.consolidation import SleepTimeConsolidator
+
+    mem, eps = mem_with_episodes
+    # Each episode triggers: user-extract, agent-extract, resolve = 3 calls.
+    # 3 episodes * 3 = up to 9 calls, but resolver short-circuits when
+    # existing=[] (no LLM call). Provide enough scripts.
+    client = ScriptedClient([
+        '{"facts": [{"text": "fact A", "category": "preference", '
+        '"entity": "user", "confidence": 0.9, "source_span": [0, 5]}]}',
+        '{"facts": []}',
+        '{"facts": [{"text": "fact B", "category": "preference", '
+        '"entity": "user", "confidence": 0.9, "source_span": [0, 5]}]}',
+        '{"facts": []}',
+        '{"facts": [{"text": "fact C", "category": "preference", '
+        '"entity": "user", "confidence": 0.9, "source_span": [0, 5]}]}',
+        '{"facts": []}',
+    ])
+
+    cons = SleepTimeConsolidator(
+        mem, model="test-model",
+        extraction_client=client, resolver_client=client,
+    )
+    results = cons.run_once()
+    assert len(results) == 3
+    assert all(r.ok for r in results), [r.error for r in results if not r.ok]
+
+
+@pytest.mark.live
+def test_run_once_marks_done(mem_with_episodes):
+    from attestor.consolidation import (
+        ConsolidationQueue,
+        SleepTimeConsolidator,
+    )
+
+    mem, eps = mem_with_episodes
+    client = ScriptedClient(['{"facts": []}'] * 6)
+    cons = SleepTimeConsolidator(
+        mem, extraction_client=client, resolver_client=client,
+    )
+    cons.run_once()
+    q = ConsolidationQueue(mem._store._conn)
+    s = q.stats()
+    assert s["done"] == 3
+    assert s["pending"] == 0
+    assert s["processing"] == 0
+
+
+@pytest.mark.live
+def test_consolidator_writes_facts_with_consolidation_provenance(mem_with_episodes):
+    from attestor.consolidation import SleepTimeConsolidator
+
+    mem, eps = mem_with_episodes
+    client = ScriptedClient([
+        '{"facts": [{"text": "consolidated fact", "category": "preference", '
+        '"entity": "user", "confidence": 0.9, "source_span": [0, 5]}]}',
+        '{"facts": []}',
+        '{"facts": []}', '{"facts": []}',
+        '{"facts": []}', '{"facts": []}',
+    ])
+    cons = SleepTimeConsolidator(
+        mem, model="test-strong-model",
+        extraction_client=client, resolver_client=client,
+    )
+    results = cons.run_once()
+    written = [
+        mid for r in results for mid in r.written_memory_ids
+    ]
+    assert len(written) >= 1
+    for mid in written:
+        row = mem._store.get(mid)
+        assert row is not None
+        # provenance prefix tags this as a consolidator write
+        assert row.extraction_model.startswith("consolidation:"), (
+            f"expected consolidation provenance, got {row.extraction_model!r}"
+        )
+
+
+@pytest.mark.live
+def test_consolidator_marks_failed_on_extraction_error(mem_with_episodes):
+    """If the extraction client raises, the row is marked failed (not stuck)."""
+    from attestor.consolidation import (
+        ConsolidationQueue,
+        SleepTimeConsolidator,
+    )
+
+    mem, eps = mem_with_episodes
+
+    class ExplodingClient:
+        class _Chat:
+            def create(self, **kw):
+                raise RuntimeError("model down")
+        chat = type("C", (), {"completions": _Chat()})()
+
+    cons = SleepTimeConsolidator(
+        mem, extraction_client=ExplodingClient(),
+        resolver_client=ExplodingClient(),
+    )
+    # The extractor's _call_llm doesn't catch; the exception bubbles up
+    # to _consolidate_one's outer try/except, which marks the row failed
+    # (with the error string). All 3 episodes should land in 'failed'.
+    results = cons.run_once()
+    assert all(not r.ok for r in results)
+    assert all("model down" in (r.error or "") for r in results)
+    q = ConsolidationQueue(mem._store._conn)
+    s = q.stats()
+    assert s["failed"] == 3
+    assert s["done"] == 0
+    assert s["pending"] == 0
+
+
+@pytest.mark.live
+def test_run_once_returns_empty_when_queue_drained(mem_with_episodes):
+    from attestor.consolidation import (
+        ConsolidationQueue,
+        SleepTimeConsolidator,
+    )
+
+    mem, eps = mem_with_episodes
+    client = ScriptedClient(['{"facts": []}'] * 6)
+    cons = SleepTimeConsolidator(
+        mem, extraction_client=client, resolver_client=client,
+    )
+    cons.run_once()
+    # Second pass — nothing left
+    assert cons.run_once() == []

--- a/tests/test_context_pack.py
+++ b/tests/test_context_pack.py
@@ -1,0 +1,123 @@
+"""Phase 6.1 — ContextPack + ContextPackEntry dataclass tests."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from attestor.models import ContextPack, ContextPackEntry
+from attestor.prompts.chain_of_note import DEFAULT_CHAIN_OF_NOTE_PROMPT
+
+
+def _entry(id_: str = "m-1", score: float = 0.9) -> ContextPackEntry:
+    return ContextPackEntry(
+        id=id_, content=f"fact for {id_}", category="preference",
+        entity="user", valid_from="2026-04-01T00:00:00+00:00",
+        valid_until=None, confidence=0.9,
+        source_episode_id="ep-1", score=score,
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Entry
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_entry_to_dict_round_trips() -> None:
+    e = _entry()
+    d = e.to_dict()
+    assert d["id"] == "m-1"
+    assert d["score"] == 0.9
+    assert d["source_episode_id"] == "ep-1"
+
+
+@pytest.mark.unit
+def test_entry_is_frozen() -> None:
+    e = _entry()
+    with pytest.raises(Exception):  # FrozenInstanceError
+        e.score = 0.1  # type: ignore[misc]
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Pack
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_pack_empty_is_legal() -> None:
+    """Abstention case — no relevant memories — must produce a valid pack."""
+    p = ContextPack(
+        query="anything", memories=[], as_of=None, token_count=0,
+        chain_of_note_prompt=DEFAULT_CHAIN_OF_NOTE_PROMPT,
+    )
+    assert p.memory_count == 0
+    rendered = p.render_prompt()
+    assert "[]" in rendered
+    assert "ABSTAIN" in rendered  # the agent still gets the abstain instruction
+
+
+@pytest.mark.unit
+def test_pack_memories_json_is_valid_json() -> None:
+    p = ContextPack(
+        query="prefs", memories=[_entry("m-1"), _entry("m-2")],
+        as_of=None, token_count=42,
+        chain_of_note_prompt=DEFAULT_CHAIN_OF_NOTE_PROMPT,
+    )
+    parsed = json.loads(p.memories_json())
+    assert isinstance(parsed, list)
+    assert len(parsed) == 2
+    assert {m["id"] for m in parsed} == {"m-1", "m-2"}
+
+
+@pytest.mark.unit
+def test_pack_render_prompt_substitutes_memories() -> None:
+    p = ContextPack(
+        query="prefs", memories=[_entry("m-special")],
+        as_of=None, token_count=1,
+        chain_of_note_prompt=DEFAULT_CHAIN_OF_NOTE_PROMPT,
+    )
+    out = p.render_prompt()
+    assert '"id": "m-special"' in out
+    # Placeholder should be gone
+    assert "{memories_json}" not in out
+
+
+@pytest.mark.unit
+def test_pack_to_dict_includes_all_fields() -> None:
+    p = ContextPack(
+        query="q", memories=[_entry()], as_of="2026-04-26T00:00:00+00:00",
+        token_count=10, chain_of_note_prompt=DEFAULT_CHAIN_OF_NOTE_PROMPT,
+    )
+    d = p.to_dict()
+    for key in ("query", "memories", "as_of", "token_count", "chain_of_note_prompt"):
+        assert key in d
+    assert d["as_of"] == "2026-04-26T00:00:00+00:00"
+    assert d["token_count"] == 10
+    assert isinstance(d["memories"], list)
+
+
+@pytest.mark.unit
+def test_pack_memories_preserve_input_order() -> None:
+    """The pack must NOT re-sort — score-descending ordering is the
+    orchestrator's job; the pack is a transport, not a re-ranker."""
+    high = _entry("m-high", score=0.9)
+    low = _entry("m-low", score=0.1)
+    # Caller hands us in low→high order; pack must keep that order.
+    p = ContextPack(
+        query="q", memories=[low, high], as_of=None, token_count=2,
+        chain_of_note_prompt=DEFAULT_CHAIN_OF_NOTE_PROMPT,
+    )
+    parsed = json.loads(p.memories_json())
+    assert [m["id"] for m in parsed] == ["m-low", "m-high"]
+
+
+@pytest.mark.unit
+def test_pack_is_frozen() -> None:
+    p = ContextPack(
+        query="q", memories=[], as_of=None, token_count=0,
+        chain_of_note_prompt="x",
+    )
+    with pytest.raises(Exception):
+        p.query = "modified"  # type: ignore[misc]

--- a/tests/test_recall_as_pack.py
+++ b/tests/test_recall_as_pack.py
@@ -1,0 +1,200 @@
+"""Phase 6.2 — AgentMemory.recall_as_pack end-to-end.
+
+Verifies the public surface returns a ContextPack with citations,
+preserves orchestrator ranking, and threads as_of through correctly.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+try:
+    import psycopg2
+    HAVE_PSYCOPG2 = True
+except ImportError:
+    HAVE_PSYCOPG2 = False
+
+PG_URL = os.environ.get(
+    "PG_TEST_URL",
+    "postgresql://postgres:attestor@localhost:5432/attestor_v4_test",
+)
+SCHEMA_PATH = Path(__file__).resolve().parent.parent / "attestor" / "store" / "schema.sql"
+
+
+def _reachable() -> bool:
+    if not HAVE_PSYCOPG2:
+        return False
+    try:
+        c = psycopg2.connect(PG_URL, connect_timeout=2)
+        c.close()
+        return True
+    except Exception:
+        return False
+
+
+def _ollama_up() -> bool:
+    try:
+        import requests
+        r = requests.get("http://localhost:11434/api/tags", timeout=2)
+        return r.status_code == 200
+    except Exception:
+        return False
+
+
+pytestmark = pytest.mark.skipif(
+    not (_reachable() and _ollama_up()),
+    reason="local Postgres or Ollama unreachable",
+)
+
+
+@pytest.fixture(scope="module")
+def admin_conn():
+    c = psycopg2.connect(PG_URL)
+    c.autocommit = True
+    yield c
+    c.close()
+
+
+@pytest.fixture
+def fresh_schema(admin_conn):
+    raw = SCHEMA_PATH.read_text().replace("{embedding_dim}", "1024")
+    with admin_conn.cursor() as cur:
+        for tbl in ("memories", "episodes", "sessions", "projects", "users"):
+            cur.execute(f"DROP TABLE IF EXISTS {tbl} CASCADE")
+        cur.execute(raw)
+    yield
+
+
+def _build_solo_mem(tmp_path: Path):
+    from attestor.core import AgentMemory
+    return AgentMemory(tmp_path, config={
+        "mode": "solo",
+        "backends": ["postgres"],
+        "backend_configs": {
+            "postgres": {
+                "url": "postgresql://localhost:5432",
+                "database": "attestor_v4_test",
+                "auth": {"username": "postgres", "password": "attestor"},
+                "v4": True, "skip_schema_init": True,
+            }
+        },
+    })
+
+
+@pytest.fixture
+def seeded_mem(admin_conn, fresh_schema, tmp_path):
+    """SOLO mem with a few facts seeded via the public add()."""
+    mem = _build_solo_mem(tmp_path)
+    mem.add(content="user prefers dark mode", category="preference",
+            entity="UI")
+    mem.add(content="user lives in San Francisco", category="location",
+            entity="user")
+    mem.add(content="user enjoys sushi", category="preference",
+            entity="food")
+    yield mem
+    mem.close()
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# recall_as_pack — core surface
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.live
+def test_recall_as_pack_returns_context_pack(seeded_mem):
+    from attestor.models import ContextPack
+    pack = seeded_mem.recall_as_pack("dark mode preference")
+    assert isinstance(pack, ContextPack)
+    assert pack.query == "dark mode preference"
+    assert pack.memory_count >= 1
+
+
+@pytest.mark.live
+def test_recall_as_pack_entries_carry_citation_fields(seeded_mem):
+    pack = seeded_mem.recall_as_pack("dark mode")
+    for e in pack.memories:
+        assert e.id, "memory id must be set for citation"
+        assert e.content
+        assert isinstance(e.confidence, float)
+        # source_episode_id may be None for direct add() rows
+
+
+@pytest.mark.live
+def test_recall_as_pack_includes_default_chain_of_note(seeded_mem):
+    from attestor.prompts.chain_of_note import DEFAULT_CHAIN_OF_NOTE_PROMPT
+    pack = seeded_mem.recall_as_pack("anything")
+    assert pack.chain_of_note_prompt == DEFAULT_CHAIN_OF_NOTE_PROMPT
+    assert "ABSTAIN" in pack.chain_of_note_prompt
+
+
+@pytest.mark.live
+def test_recall_as_pack_render_prompt_inlines_memories(seeded_mem):
+    pack = seeded_mem.recall_as_pack("dark mode")
+    rendered = pack.render_prompt()
+    # Each memory id must appear in the rendered prompt's JSON block
+    for e in pack.memories:
+        assert e.id in rendered
+    assert "{memories_json}" not in rendered
+
+
+@pytest.mark.live
+def test_recall_as_pack_empty_query_still_has_prompt(seeded_mem):
+    """Even when no memories match (abstention case), the prompt is there."""
+    pack = seeded_mem.recall_as_pack("xyzzy_no_such_term_anywhere_in_corpus")
+    assert "ABSTAIN" in pack.chain_of_note_prompt
+
+
+@pytest.mark.live
+def test_recall_as_pack_preserves_ranking(seeded_mem):
+    """Pack memories arrive in the same order the orchestrator returned."""
+    results = seeded_mem.recall("dark mode")
+    real_results = [r for r in results if r.memory.category != "graph_relation"]
+    pack = seeded_mem.recall_as_pack("dark mode")
+    assert [e.id for e in pack.memories] == [r.memory.id for r in real_results]
+
+
+@pytest.mark.live
+def test_recall_as_pack_custom_prompt_override(seeded_mem):
+    custom = "MY CUSTOM PROMPT\n{memories_json}"
+    pack = seeded_mem.recall_as_pack("dark mode", chain_of_note_prompt=custom)
+    assert pack.chain_of_note_prompt == custom
+
+
+@pytest.mark.live
+def test_recall_as_pack_threads_as_of(seeded_mem, admin_conn):
+    """as_of is recorded in the pack metadata."""
+    as_of = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    pack = seeded_mem.recall_as_pack("anything", as_of=as_of)
+    assert pack.as_of == as_of.isoformat()
+
+
+@pytest.mark.live
+def test_recall_as_pack_token_count_is_estimate(seeded_mem):
+    pack = seeded_mem.recall_as_pack("dark mode")
+    expected = sum(len(e.content) for e in pack.memories) // 4
+    assert pack.token_count == expected
+
+
+@pytest.mark.live
+def test_recall_as_pack_to_dict_is_jsonable(seeded_mem):
+    """to_dict must be json.dumps-safe — it's the agent's serialization path."""
+    import json
+    pack = seeded_mem.recall_as_pack("dark mode")
+    serialized = json.dumps(pack.to_dict())
+    assert "ABSTAIN" in serialized
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Backward compat — recall_as_context still returns a string
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.live
+def test_recall_as_context_string_signature_unchanged(seeded_mem):
+    out = seeded_mem.recall_as_context("dark mode")
+    assert isinstance(out, str)

--- a/tests/test_reflection.py
+++ b/tests/test_reflection.py
@@ -1,0 +1,271 @@
+"""Phase 7.3 — REFLECTION_PROMPT + ReflectionEngine.reflect() tests."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, List
+
+import pytest
+
+from attestor.consolidation.reflection import (
+    REFLECTION_PROMPT,
+    ChangedBelief,
+    Contradiction,
+    ReflectionEngine,
+    ReflectionResult,
+    StablePattern,
+    _parse_response,
+)
+from attestor.models import Memory
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Stub LLM
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class _Choice:
+    def __init__(self, c: str) -> None:
+        self.message = type("M", (), {"content": c})()
+
+
+class _Resp:
+    def __init__(self, c: str) -> None:
+        self.choices = [_Choice(c)]
+
+
+class _Chat:
+    def __init__(self, payload: str = "", *, exc: Exception | None = None) -> None:
+        self._p = payload
+        self._exc = exc
+        self.calls: list = []
+
+    def create(self, **kw: Any) -> _Resp:
+        self.calls.append(kw)
+        if self._exc is not None:
+            raise self._exc
+        return _Resp(self._p)
+
+
+class StubClient:
+    def __init__(self, payload: str = "", *, exc: Exception | None = None) -> None:
+        self.chat = type("C", (), {"completions": _Chat(payload, exc=exc)})()
+
+    @property
+    def call_count(self) -> int:
+        return len(self.chat.completions.calls)
+
+    @property
+    def last_prompt(self) -> str:
+        return self.chat.completions.calls[-1]["messages"][0]["content"]
+
+
+def _mem(mid: str, content: str = "fact") -> Memory:
+    return Memory(id=mid, content=content, category="preference",
+                  entity="user", confidence=0.9)
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Prompt content guards
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_prompt_has_four_categories() -> None:
+    for kind in ("STABLE PREFERENCES", "STABLE CONSTRAINTS",
+                 "CHANGED BELIEFS", "CONTRADICTIONS"):
+        assert kind in REFLECTION_PROMPT
+
+
+@pytest.mark.unit
+def test_prompt_forbids_auto_resolve() -> None:
+    """Contradictions must be flagged for human review — load-bearing."""
+    assert "do NOT auto-resolve" in REFLECTION_PROMPT.lower() or \
+        "Do NOT auto-resolve" in REFLECTION_PROMPT
+    assert "HUMAN REVIEW" in REFLECTION_PROMPT
+
+
+@pytest.mark.unit
+def test_prompt_requires_3_evidence() -> None:
+    assert "3+" in REFLECTION_PROMPT or "at least 3" in REFLECTION_PROMPT
+
+
+@pytest.mark.unit
+def test_prompt_format_placeholders() -> None:
+    rendered = REFLECTION_PROMPT.format(user_id="u-1", facts_json="[]")
+    assert "u-1" in rendered
+    assert "{" not in rendered or "{" in REFLECTION_PROMPT  # only schema braces
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# _parse_response — JSON shape → ReflectionResult
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_parse_full_payload() -> None:
+    raw = json.dumps({
+        "stable_preferences": [
+            {"text": "user prefers dark mode",
+             "evidence": ["m1", "m2", "m3"], "confidence": 0.92},
+        ],
+        "stable_constraints": [
+            {"text": "never schedule meetings before 10am",
+             "evidence": ["m4", "m5", "m6"], "confidence": 0.85},
+        ],
+        "changed_beliefs": [
+            {"old": "m7", "new": "m8", "reason": "moved to SF"},
+        ],
+        "contradictions_for_review": [
+            {"facts": ["m9", "m10"], "rationale": "favorite color contradicts"},
+        ],
+    })
+    r = _parse_response(raw)
+    assert len(r.stable_preferences) == 1
+    assert r.stable_preferences[0].evidence == ["m1", "m2", "m3"]
+    assert r.stable_preferences[0].confidence == 0.92
+    assert len(r.stable_constraints) == 1
+    assert len(r.changed_beliefs) == 1
+    assert r.changed_beliefs[0].old == "m7"
+    assert len(r.contradictions_for_review) == 1
+    assert r.contradictions_for_review[0].facts == ["m9", "m10"]
+    assert r.error is None
+
+
+@pytest.mark.unit
+def test_parse_handles_markdown_fence() -> None:
+    raw = "```json\n" + json.dumps({"stable_preferences": []}) + "\n```"
+    r = _parse_response(raw)
+    assert r.stable_preferences == []
+    assert r.error is None
+
+
+@pytest.mark.unit
+def test_parse_bad_json_returns_error() -> None:
+    r = _parse_response("not json")
+    assert r.error == "bad json"
+    assert r.stable_preferences == []
+
+
+@pytest.mark.unit
+def test_parse_drops_pattern_without_text() -> None:
+    raw = json.dumps({
+        "stable_preferences": [
+            {"evidence": ["m1"]},   # no text — drop
+            {"text": "good", "evidence": ["m1"]},
+        ]
+    })
+    r = _parse_response(raw)
+    assert len(r.stable_preferences) == 1
+
+
+@pytest.mark.unit
+def test_parse_drops_pattern_without_evidence_list() -> None:
+    raw = json.dumps({
+        "stable_preferences": [
+            {"text": "x", "evidence": "not a list"},
+            {"text": "y", "evidence": ["m1"]},
+        ]
+    })
+    r = _parse_response(raw)
+    assert len(r.stable_preferences) == 1
+    assert r.stable_preferences[0].text == "y"
+
+
+@pytest.mark.unit
+def test_parse_clamps_confidence() -> None:
+    raw = json.dumps({
+        "stable_preferences": [
+            {"text": "x", "evidence": ["m"], "confidence": 99.0},
+            {"text": "y", "evidence": ["m"], "confidence": -1.0},
+        ]
+    })
+    r = _parse_response(raw)
+    assert r.stable_preferences[0].confidence == 1.0
+    assert r.stable_preferences[1].confidence == 0.0
+
+
+@pytest.mark.unit
+def test_parse_drops_changed_belief_without_old_or_new() -> None:
+    raw = json.dumps({
+        "changed_beliefs": [
+            {"old": "m1"},                # no new
+            {"new": "m2"},                # no old
+            {"old": "m3", "new": "m4", "reason": "ok"},
+        ]
+    })
+    r = _parse_response(raw)
+    assert len(r.changed_beliefs) == 1
+    assert r.changed_beliefs[0].old == "m3"
+
+
+@pytest.mark.unit
+def test_parse_drops_contradiction_with_only_one_fact() -> None:
+    """A 'contradiction' needs at least 2 facts."""
+    raw = json.dumps({
+        "contradictions_for_review": [
+            {"facts": ["m1"], "rationale": "lonely"},
+            {"facts": ["m2", "m3"], "rationale": "real"},
+        ]
+    })
+    r = _parse_response(raw)
+    assert len(r.contradictions_for_review) == 1
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Engine.reflect — end-to-end with stub
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_reflect_empty_facts_returns_empty_result_no_llm() -> None:
+    stub = StubClient(payload='{"stable_preferences": []}')
+    eng = ReflectionEngine(client=stub)
+    r = eng.reflect([])
+    assert r.total_patterns == 0
+    assert stub.call_count == 0
+
+
+@pytest.mark.unit
+def test_reflect_no_client_returns_error() -> None:
+    eng = ReflectionEngine(client=None)
+    r = eng.reflect([_mem("m1")])
+    assert r.error == "no llm client configured"
+
+
+@pytest.mark.unit
+def test_reflect_passes_user_id_and_facts_into_prompt() -> None:
+    stub = StubClient(payload='{"stable_preferences": []}')
+    eng = ReflectionEngine(client=stub)
+    eng.reflect([_mem("mem-x", "user prefers dark mode")], user_id="u-42")
+    assert "u-42" in stub.last_prompt
+    assert "mem-x" in stub.last_prompt
+    assert "user prefers dark mode" in stub.last_prompt
+
+
+@pytest.mark.unit
+def test_reflect_llm_error_returns_error_result() -> None:
+    stub = StubClient(exc=RuntimeError("api down"))
+    eng = ReflectionEngine(client=stub)
+    r = eng.reflect([_mem("m1")])
+    assert r.error is not None
+    assert "api down" in r.error
+
+
+@pytest.mark.unit
+def test_reflect_full_round_trip() -> None:
+    payload = json.dumps({
+        "stable_preferences": [
+            {"text": "user prefers dark mode",
+             "evidence": ["m1", "m2", "m3"], "confidence": 0.9},
+        ],
+        "contradictions_for_review": [
+            {"facts": ["m4", "m5"], "rationale": "favorite color disagrees"},
+        ],
+    })
+    stub = StubClient(payload=payload)
+    eng = ReflectionEngine(client=stub)
+    r = eng.reflect([_mem(f"m{i}") for i in range(5)], user_id="u-1")
+    assert r.total_patterns == 1
+    assert len(r.contradictions_for_review) == 1
+    assert r.error is None

--- a/tests/test_session_promotion.py
+++ b/tests/test_session_promotion.py
@@ -1,0 +1,395 @@
+"""Phase 7.4 — SESSION_PROMOTION + apply tests + end_session enqueue."""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, List
+
+import pytest
+
+try:
+    import psycopg2
+    HAVE_PSYCOPG2 = True
+except ImportError:
+    HAVE_PSYCOPG2 = False
+
+from attestor.consolidation.session_end import (
+    SESSION_PROMOTION_PROMPT,
+    VALID_PROMOTIONS,
+    AppliedPromotion,
+    PromotionDecision,
+    apply_promotions,
+    decide_promotions,
+)
+from attestor.models import Memory
+
+
+PG_URL = os.environ.get(
+    "PG_TEST_URL",
+    "postgresql://postgres:attestor@localhost:5432/attestor_v4_test",
+)
+SCHEMA_PATH = Path(__file__).resolve().parent.parent / "attestor" / "store" / "schema.sql"
+
+
+def _reachable() -> bool:
+    if not HAVE_PSYCOPG2:
+        return False
+    try:
+        c = psycopg2.connect(PG_URL, connect_timeout=2)
+        c.close()
+        return True
+    except Exception:
+        return False
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Stub LLM
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class _Choice:
+    def __init__(self, c: str) -> None:
+        self.message = type("M", (), {"content": c})()
+
+
+class _Resp:
+    def __init__(self, c: str) -> None:
+        self.choices = [_Choice(c)]
+
+
+class _Chat:
+    def __init__(self, payload: str = "", *, exc: Exception | None = None) -> None:
+        self._p = payload
+        self._exc = exc
+        self.calls: list = []
+
+    def create(self, **kw: Any) -> _Resp:
+        self.calls.append(kw)
+        if self._exc is not None:
+            raise self._exc
+        return _Resp(self._p)
+
+
+class StubClient:
+    def __init__(self, payload: str = "", *, exc: Exception | None = None) -> None:
+        self.chat = type("C", (), {"completions": _Chat(payload, exc=exc)})()
+
+
+def _mem(mid: str, content: str = "fact", scope: str = "session") -> Memory:
+    return Memory(id=mid, content=content, category="preference",
+                  entity="user", confidence=0.9, scope=scope)
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Prompt content guards
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_prompt_includes_all_four_operations() -> None:
+    for op in ("KEEP_SESSION", "PROMOTE_PROJECT", "PROMOTE_USER", "DISCARD"):
+        assert op in SESSION_PROMOTION_PROMPT
+
+
+@pytest.mark.unit
+def test_prompt_template_renders() -> None:
+    out = SESSION_PROMOTION_PROMPT.format(
+        memory_count=3, memories_json="[]",
+    )
+    assert "3 items" in out
+    assert "[]" in out
+
+
+@pytest.mark.unit
+def test_valid_operations_set_complete() -> None:
+    assert VALID_PROMOTIONS == {
+        "KEEP_SESSION", "PROMOTE_PROJECT", "PROMOTE_USER", "DISCARD",
+    }
+
+
+@pytest.mark.unit
+def test_decision_rejects_invalid_operation() -> None:
+    with pytest.raises(ValueError, match="operation"):
+        PromotionDecision(memory_id="m", operation="WIDEN", rationale="r")
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# decide_promotions parsing
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_decide_empty_returns_empty() -> None:
+    assert decide_promotions([], client=StubClient(payload="{}")) == []
+
+
+@pytest.mark.unit
+def test_decide_no_client_defaults_keep_session() -> None:
+    out = decide_promotions([_mem("m1")], client=None)
+    assert all(d.operation == "KEEP_SESSION" for d in out)
+
+
+@pytest.mark.unit
+def test_decide_index_aligned_per_id() -> None:
+    payload = json.dumps({
+        "decisions": [
+            {"memory_id": "m1", "operation": "PROMOTE_USER", "rationale": "stable"},
+            {"memory_id": "m2", "operation": "DISCARD", "rationale": "noise"},
+            {"memory_id": "m3", "operation": "KEEP_SESSION", "rationale": "thread-only"},
+        ]
+    })
+    out = decide_promotions(
+        [_mem("m1"), _mem("m2"), _mem("m3")],
+        client=StubClient(payload=payload),
+    )
+    assert [(d.memory_id, d.operation) for d in out] == [
+        ("m1", "PROMOTE_USER"),
+        ("m2", "DISCARD"),
+        ("m3", "KEEP_SESSION"),
+    ]
+
+
+@pytest.mark.unit
+def test_decide_missing_id_defaults_keep() -> None:
+    """LLM omits a decision for one id → that one gets KEEP_SESSION."""
+    payload = json.dumps({
+        "decisions": [
+            {"memory_id": "m1", "operation": "PROMOTE_USER", "rationale": "ok"},
+        ]
+    })
+    out = decide_promotions(
+        [_mem("m1"), _mem("m2")],
+        client=StubClient(payload=payload),
+    )
+    assert out[1].operation == "KEEP_SESSION"
+    assert "default KEEP" in out[1].rationale
+
+
+@pytest.mark.unit
+def test_decide_invalid_operation_defaults_keep() -> None:
+    payload = json.dumps({
+        "decisions": [
+            {"memory_id": "m1", "operation": "MERGE", "rationale": "weird"},
+        ]
+    })
+    out = decide_promotions([_mem("m1")], client=StubClient(payload=payload))
+    assert out[0].operation == "KEEP_SESSION"
+
+
+@pytest.mark.unit
+def test_decide_llm_error_defaults_keep() -> None:
+    out = decide_promotions(
+        [_mem("m1"), _mem("m2")],
+        client=StubClient(exc=RuntimeError("api down")),
+    )
+    assert all(d.operation == "KEEP_SESSION" for d in out)
+
+
+@pytest.mark.unit
+def test_decide_bad_json_defaults_keep() -> None:
+    out = decide_promotions(
+        [_mem("m1")],
+        client=StubClient(payload="not json"),
+    )
+    assert out[0].operation == "KEEP_SESSION"
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# apply_promotions — stub mem
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class _StubStore:
+    def __init__(self) -> None:
+        self.rows: dict = {}
+        self.update_calls = 0
+
+    def get(self, mid):
+        return self.rows.get(mid)
+
+    def update(self, m):
+        self.rows[m.id] = m
+        self.update_calls += 1
+        return m
+
+
+class _StubMem:
+    def __init__(self) -> None:
+        self._store = _StubStore()
+
+
+@pytest.mark.unit
+def test_apply_keep_session_is_noop() -> None:
+    mem = _StubMem()
+    mem._store.rows["m1"] = _mem("m1")
+    out = apply_promotions(
+        [PromotionDecision(memory_id="m1", operation="KEEP_SESSION", rationale="r")],
+        mem=mem,
+    )
+    assert out[0].operation == "KEEP_SESSION"
+    assert mem._store.update_calls == 0
+
+
+@pytest.mark.unit
+def test_apply_promote_project_widens_scope() -> None:
+    mem = _StubMem()
+    mem._store.rows["m1"] = _mem("m1", scope="session")
+    out = apply_promotions(
+        [PromotionDecision(memory_id="m1", operation="PROMOTE_PROJECT", rationale="r")],
+        mem=mem,
+    )
+    assert out[0].new_scope == "project"
+    assert mem._store.rows["m1"].scope == "project"
+
+
+@pytest.mark.unit
+def test_apply_promote_user_widens_to_user() -> None:
+    mem = _StubMem()
+    mem._store.rows["m1"] = _mem("m1", scope="session")
+    apply_promotions(
+        [PromotionDecision(memory_id="m1", operation="PROMOTE_USER", rationale="r")],
+        mem=mem,
+    )
+    assert mem._store.rows["m1"].scope == "user"
+
+
+@pytest.mark.unit
+def test_apply_discard_marks_superseded() -> None:
+    mem = _StubMem()
+    mem._store.rows["m1"] = _mem("m1")
+    out = apply_promotions(
+        [PromotionDecision(memory_id="m1", operation="DISCARD", rationale="noise")],
+        mem=mem,
+    )
+    assert out[0].superseded is True
+    assert mem._store.rows["m1"].status == "superseded"
+    assert mem._store.rows["m1"].valid_until is not None
+
+
+@pytest.mark.unit
+def test_apply_missing_memory_records_error() -> None:
+    mem = _StubMem()
+    out = apply_promotions(
+        [PromotionDecision(memory_id="vanished",
+                           operation="PROMOTE_PROJECT", rationale="r")],
+        mem=mem,
+    )
+    assert out[0].error == "memory vanished"
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# end_session enqueue + AgentMemory.consolidate (live)
+# ──────────────────────────────────────────────────────────────────────────
+
+
+pytestmark_live = pytest.mark.skipif(
+    not _reachable(), reason="local Postgres unreachable",
+)
+
+
+@pytest.fixture(scope="module")
+def admin_conn():
+    if not _reachable():
+        pytest.skip("local Postgres unreachable")
+    c = psycopg2.connect(PG_URL)
+    c.autocommit = True
+    yield c
+    c.close()
+
+
+@pytest.fixture
+def fresh_schema(admin_conn):
+    raw = SCHEMA_PATH.read_text().replace("{embedding_dim}", "16")
+    with admin_conn.cursor() as cur:
+        for tbl in ("memories", "episodes", "sessions", "projects", "users"):
+            cur.execute(f"DROP TABLE IF EXISTS {tbl} CASCADE")
+        cur.execute(raw)
+    yield
+
+
+@pytest.mark.live
+def test_end_session_re_enqueues_done_episodes(admin_conn, fresh_schema):
+    """SessionRepo.end() must move done/failed episodes back to pending."""
+    from attestor.identity.sessions import SessionRepo
+    uid = uuid.uuid4()
+    sid = uuid.uuid4()
+    eid = uuid.uuid4()
+    base = datetime.now(timezone.utc)
+    with admin_conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO users (id, external_id) VALUES (%s, %s)",
+            (str(uid), f"u-end-{uuid.uuid4().hex[:8]}"),
+        )
+        cur.execute(
+            "INSERT INTO sessions (id, user_id) VALUES (%s, %s)",
+            (str(sid), str(uid)),
+        )
+        cur.execute(
+            "INSERT INTO episodes (id, user_id, session_id, thread_id, "
+            "user_turn_text, assistant_turn_text, user_ts, assistant_ts, "
+            "consolidation_state, consolidation_done_at) "
+            "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, 'done', NOW())",
+            (str(eid), str(uid), str(sid), "t", "u", "a", base,
+             base + timedelta(seconds=1)),
+        )
+
+    repo = SessionRepo(admin_conn)
+    sess = repo.end(str(sid))
+    assert sess is not None
+    assert sess.status == "ended"
+
+    with admin_conn.cursor() as cur:
+        cur.execute(
+            "SELECT consolidation_state FROM episodes WHERE id = %s",
+            (str(eid),),
+        )
+        assert cur.fetchone()[0] == "pending"
+
+
+@pytest.mark.live
+def test_agent_memory_consolidate_drains_queue(admin_conn, fresh_schema, tmp_path):
+    """AgentMemory.consolidate(...) is the public one-shot entry point."""
+    from attestor.conversation import ConversationTurn
+    from attestor.core import AgentMemory
+
+    mem = AgentMemory(tmp_path, config={
+        "mode": "solo",
+        "backends": ["postgres"],
+        "backend_configs": {"postgres": {
+            "url": "postgresql://localhost:5432",
+            "database": "attestor_v4_test",
+            "auth": {"username": "postgres", "password": "attestor"},
+            "v4": True, "skip_schema_init": True, "embedding_dim": 16,
+        }},
+    })
+    try:
+        # Stub for ingest path + consolidator
+        class _Chat:
+            def __init__(self, ps): self._ps = list(ps); self.calls = []
+            def create(self, **kw):
+                self.calls.append(kw)
+                if not self._ps:
+                    return _Resp('{"facts": []}')
+                return _Resp(self._ps.pop(0))
+        class _Cli:
+            def __init__(self, ps):
+                self.chat = type("C", (), {"completions": _Chat(ps)})()
+
+        ingest_cli = _Cli(['{"facts": []}'] * 4)
+        u = ConversationTurn(thread_id="t", speaker="user", role="user", content="u1")
+        a = ConversationTurn(thread_id="t", speaker="p", role="assistant", content="a1",
+                             ts=u.ts + timedelta(seconds=1))
+        mem.ingest_round(u, a, extraction_client=ingest_cli, resolver_client=ingest_cli)
+
+        cons_cli = _Cli(['{"facts": []}'] * 4)
+        results = mem.consolidate(
+            limit=10, extraction_client=cons_cli, resolver_client=cons_cli,
+        )
+        assert len(results) == 1
+        assert results[0].ok
+    finally:
+        mem.close()


### PR DESCRIPTION
## Summary

- **Phase 6 — Track D: Chain-of-Note reading.** \`ContextPack\` + \`ContextPackEntry\` dataclasses; \`DEFAULT_CHAIN_OF_NOTE_PROMPT\` with the 5 steps (NOTES / SYNTHESIS / CITE / ABSTAIN / CONFLICT) — the ABSTAIN clause is the AbstentionBench fix that's worth +10 points across LongMemEval. New \`AgentMemory.recall_as_pack()\` returns the structured envelope; legacy \`recall_as_context()\` still returns string.
- **Phase 7 — Track E + tenancy P4: Sleep-time consolidation.** Per-episode queue (\`pending\` → \`processing\` → \`done\`/\`failed\`) with \`FOR UPDATE SKIP LOCKED\` for safe N-worker concurrency + 600s stale-lease reclaim. \`SleepTimeConsolidator\` re-extracts with a stronger model (provenance: \`extraction_model="consolidation:<model>"\`). \`ReflectionEngine\` synthesizes cross-thread patterns; contradictions are \*flagged for human review\*, never auto-resolved. \`SESSION_PROMOTION_PROMPT\` migrates session-scoped memories to \`project\`/\`user\` scope at end of session.

## Test plan

- [x] 676 unit tests pass (was 620 on main); 232 skipped
- [x] 17 ContextPack + Chain-of-Note prompt tests (5 numbered steps + ABSTAIN clause + CITE [mem_42] format guards)
- [x] 11 \`recall_as_pack\` end-to-end tests (citations, ranking preserved, custom prompt override, as_of threading)
- [x] 15 ConsolidationQueue tests (atomic claim, skip-locked, stale-lease reclaim, lifecycle transitions)
- [x] 5 SleepTimeConsolidator tests (drain, mark_done, consolidation provenance, mark_failed on LLM error)
- [x] 17 ReflectionEngine tests (parsing, validation, prompt content guards: do-not-auto-resolve, ≥3 evidence)
- [x] 18 SESSION_PROMOTION tests (4 ops, safe defaults, scope migration, end_session enqueue, AgentMemory.consolidate)
- [ ] 30+ episode reflection success criterion (out of scope — needs corpus + harness)