### PR TITLE
feat(v4): Phase 9.4-9.5 — AbstentionBench runner + CI eval gate

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -1,0 +1,190 @@
+name: Evals
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "attestor/**"
+      - "evals/**"
+      - "tests/test_evals_*.py"
+      - "tests/test_regression_*.py"
+      - "docs/bench/**"
+      - ".github/workflows/evals.yml"
+      - "pyproject.toml"
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      run_heavy_benchmarks:
+        description: "Run live LongMemEval / BEAM / AbstentionBench (needs secrets)"
+        required: false
+        default: "false"
+
+jobs:
+  # ────────────────────────────────────────────────────────────────────────
+  # Always-on: unit tests for the evals/ package and the regression suite.
+  # No external services, no API keys. Runs on every PR.
+  # ────────────────────────────────────────────────────────────────────────
+  evals-unit:
+    name: Unit tests (evals + regression)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install Poetry
+        run: pipx install poetry
+
+      - name: Install project + eval extras
+        run: poetry install --with dev --extras eval
+
+      - name: Run evals + regression unit tests
+        run: |
+          poetry run pytest -q \
+            tests/test_evals_summary.py \
+            tests/test_evals_baseline.py \
+            tests/test_evals_longmemeval.py \
+            tests/test_evals_beam.py \
+            tests/test_evals_abstention.py \
+            tests/test_evals_gate.py \
+            tests/test_regression_cases.py \
+            tests/test_regression_scorer.py \
+            tests/test_regression_runner.py \
+            tests/test_regression_catalog.py
+
+      - name: Validate qa.yaml catalog parses
+        # Independent of the test suite: a catalog typo should fail
+        # this step explicitly so reviewers see "yaml broken", not
+        # "obscure pytest collection error".
+        run: |
+          poetry run python -c "
+          from evals.regression.cases import load_cases
+          cases = load_cases('evals/regression/qa.yaml')
+          print(f'qa.yaml loaded: {len(cases)} cases')
+          "
+
+  # ────────────────────────────────────────────────────────────────────────
+  # Always-on: gate. Runs after unit tests pass. Loads any uploaded
+  # benchmark summaries (none in the unit-test job — uploads come from
+  # the heavy benchmark job below) and compares them to the published
+  # baseline. With no summaries, the gate passes by default.
+  # ────────────────────────────────────────────────────────────────────────
+  evals-gate:
+    name: Regression gate
+    runs-on: ubuntu-latest
+    needs: evals-unit
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install Poetry
+        run: pipx install poetry
+
+      - name: Install project + eval extras
+        run: poetry install --with dev --extras eval
+
+      - name: Download benchmark summaries (if any)
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: bench-summaries
+          path: bench-output
+
+      - name: Run regression gate
+        run: |
+          mkdir -p bench-output
+          poetry run python -m evals.gate \
+            --summaries-dir bench-output \
+            --baseline docs/bench/v4-baseline.json \
+            --report-out bench-output/gate.json
+
+      - name: Upload gate report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gate-report
+          path: bench-output/gate.json
+
+  # ────────────────────────────────────────────────────────────────────────
+  # On-demand only: live LongMemEval / BEAM / AbstentionBench.
+  #
+  # Requires:
+  #   - secrets.OPENROUTER_API_KEY  (answerer)
+  #   - secrets.ANTHROPIC_API_KEY   (judges)
+  #   - postgres:16 service container
+  #   - Ollama with bge-m3 pulled
+  #
+  # Triggered manually via workflow_dispatch with run_heavy_benchmarks=true.
+  # The heavy job uploads the *_summary.json files as `bench-summaries`,
+  # which the gate job then picks up on the next run.
+  # ────────────────────────────────────────────────────────────────────────
+  evals-heavy:
+    name: Heavy benchmarks (manual)
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.run_heavy_benchmarks == 'true' }}
+
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: attestor
+          POSTGRES_DB: attestor_v4_test
+        ports: ["5432:5432"]
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install Poetry
+        run: pipx install poetry
+
+      - name: Install project + eval extras
+        run: poetry install --with dev --extras "eval postgres"
+
+      - name: Bootstrap schema
+        env:
+          PG_TEST_URL: postgresql://postgres:attestor@localhost:5432/attestor_v4_test
+        run: |
+          poetry run python -c "
+          import psycopg2, pathlib
+          schema = pathlib.Path('attestor/store/schema.sql').read_text()
+          schema = schema.replace('{embedding_dim}', '1024')
+          with psycopg2.connect('${PG_TEST_URL}') as c, c.cursor() as cur:
+              cur.execute(schema); c.commit()
+          print('schema applied')
+          "
+
+      # NOTE: live LongMemEval / BEAM / AbstentionBench runners must be
+      # invoked here once the operator wires their dataset loaders +
+      # answerer. Each runner emits *_summary.json into bench-output/.
+      # Until then this job is a no-op skeleton — uploading an empty
+      # artifact still triggers the gate cleanly.
+      - name: Placeholder for heavy benchmark invocation
+        run: |
+          mkdir -p bench-output
+          echo "Heavy benchmarks not wired yet. See evals/README.md."
+
+      - name: Upload benchmark summaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-summaries
+          path: bench-output/*_summary.json
+          if-no-files-found: warn

--- a/docs/bench/v4-baseline.json
+++ b/docs/bench/v4-baseline.json
@@ -1,0 +1,9 @@
+{
+  "version": "1",
+  "default_threshold": 2.0,
+  "thresholds": {
+    "abstention": 1.0,
+    "regression": 0.5
+  },
+  "benchmarks": []
+}

--- a/evals/README.md
+++ b/evals/README.md
@@ -79,3 +79,67 @@ scorer so local iteration and the hosted leaderboard agree. Scores are
 - MAB currently under-performs due to embedding-model weakness on
   multi-hop reasoning; see `project_layer0_wiring` / roadmap for the
   dual-path plan.
+
+---
+
+## Track G — v4 regression gate (Phase 9)
+
+A second harness lives alongside the Braintrust scripts: deterministic,
+no-LLM, runs in CI on every PR. Four runners share the
+`BenchmarkSummary` shape so the regression gate can compare them
+uniformly.
+
+| Runner | Module | Primary metric |
+|---|---|---|
+| Regression suite | `evals/regression/` | pass_rate over the YAML catalog |
+| LongMemEval | `evals/longmemeval/` | accuracy_pct (averaged across judges) |
+| BEAM (long-context) | `evals/beam/` | accuracy_pct, with per-bucket breakdown |
+| AbstentionBench | `evals/abstention/` | abstention_f1_pct |
+
+### Adding a regression case (no Python required)
+
+Append to `evals/regression/qa.yaml`:
+
+```yaml
+- id: my_bug_repro
+  description: "User states X; recall must surface Y"
+  category: preference
+  ingest:
+    - user: "I love sushi"
+      assistant: "Got it"
+  query: "What food do I love?"
+  must_contain: ["sushi"]
+```
+
+Schema is enforced at parse time — typos or unknown keys fail the gate.
+See `evals/regression/cases.py` for the full schema.
+
+### Wiring a heavy benchmark (operator-supplied)
+
+The LME / BEAM / AbstentionBench runners are dataset-agnostic. Operator
+provides:
+
+  - `loader()` → returns `List[Sample]`
+  - `ingest(sample, mem)` → absorbs context into the memory backend
+  - `answer(sample, mem)` → produces the model's response
+
+Each runner emits a `*_summary.json`. Drop them into a directory and
+the gate diffs against `docs/bench/v4-baseline.json`:
+
+```bash
+python -m evals.gate \
+  --summaries-dir bench-output/ \
+  --baseline docs/bench/v4-baseline.json \
+  --report-out bench-output/gate.json
+```
+
+Exit code 1 = regression detected (PR blocked in CI). Per-benchmark
+threshold overrides live in `thresholds:` inside the baseline file.
+
+### CI
+
+`.github/workflows/evals.yml` runs the unit-test job + the gate on
+every PR. The heavy-benchmark job is `workflow_dispatch`-only — it
+needs `OPENROUTER_API_KEY`, `ANTHROPIC_API_KEY`, plus a Postgres
+service container, so it's manually triggered (and Phase 9.6 will
+publish the first real baseline run).

--- a/evals/abstention/__init__.py
+++ b/evals/abstention/__init__.py
@@ -1,0 +1,14 @@
+"""AbstentionBench runner (Phase 9.4, roadmap §G).
+
+Tests two failure modes simultaneously:
+
+  - Confabulation: model invents an answer when memory has nothing
+    relevant. The Chain-of-Note ABSTAIN clause is supposed to prevent
+    this.
+  - Over-abstention: model says "I don't know" when memory actually
+    contained a usable answer. Loose abstention prompts cause this.
+
+Primary metric is F1 over the abstention DECISION — not answer
+correctness. A system that abstains on every query gets perfect
+recall and zero precision; the F1 captures the tradeoff.
+"""

--- a/evals/abstention/detector.py
+++ b/evals/abstention/detector.py
@@ -1,0 +1,84 @@
+"""Abstention detector (Phase 9.4.1).
+
+Decides whether a model's free-text response counts as abstention.
+
+The Chain-of-Note ABSTAIN clause instructs the model to say
+"I don't have that information" — that's the canonical phrase. Real
+models drift in phrasing, so we ship a conservative phrase list that
+catches the common variants without false-positiving on confident
+"I don't know yet, but I think..." answers (which ARE answers).
+
+The detector is configurable: operators with their own house rules
+can swap in a different one via the Detector protocol.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Iterable, Protocol, Sequence
+
+
+class Detector(Protocol):
+    """Returns True iff the response is an abstention."""
+
+    def __call__(self, response: str) -> bool: ...
+
+
+# ── Default phrase list ──────────────────────────────────────────────────
+#
+# Patterns are matched against the lowercased response. Order doesn't
+# matter — any hit returns True. Each pattern intentionally requires
+# wording that signals "no available info", not weak hedges like
+# "I'm not sure" (which often precede a real attempt).
+DEFAULT_ABSTENTION_PATTERNS: tuple = (
+    # Canonical CoN ABSTAIN phrasing
+    r"\bi don'?t have (that|this|the|any|enough) (information|context|info|data|knowledge|details?)\b",
+    # Common knowledge-gap phrasings
+    r"\bno (relevant |available |such |sufficient )?(information|context|memory|data) (is |was )?(available|provided|found|present)\b",
+    r"\b(i (cannot|can'?t|am unable to|don'?t (have the )?ability to)) (answer|determine|tell|provide|recall)\b",
+    # "I don't know" — only when essentially the whole response, to avoid
+    # catching hedged-but-substantive answers like "I don't know yet, but..."
+    r"^\s*(sorry,?\s+)?i don'?t know[\.\!\?]?\s*$",
+    # "Insufficient information"-style
+    r"\b(insufficient|inadequate|not enough) (information|context|data|memory)\b",
+    r"\bunable to (answer|determine|find|recall)\b",
+    # "The memories don't contain..." — model citing the absence
+    r"\b(memories?|context|information) (do(es)? not|don'?t) (contain|include|mention|reference)\b",
+)
+
+
+def _compile(patterns: Iterable[str]) -> tuple:
+    return tuple(re.compile(p, re.IGNORECASE) for p in patterns)
+
+
+_DEFAULT_COMPILED = _compile(DEFAULT_ABSTENTION_PATTERNS)
+
+
+def is_abstention(
+    response: str,
+    *,
+    patterns: Sequence = _DEFAULT_COMPILED,
+) -> bool:
+    """True iff ``response`` matches any abstention pattern.
+
+    Empty / whitespace-only responses are treated as abstentions — a
+    model that returns nothing has effectively declined to answer.
+    """
+    if not response or not response.strip():
+        return True
+    text = response.strip()
+    return any(p.search(text) for p in patterns)
+
+
+def make_detector(extra_patterns: Sequence[str] = ()) -> Detector:
+    """Build a detector that adds operator-specific patterns.
+
+    Useful when the deployed answerer model has its own characteristic
+    abstention phrasing not covered by the defaults.
+    """
+    compiled = _DEFAULT_COMPILED + _compile(extra_patterns)
+
+    def _detect(response: str) -> bool:
+        return is_abstention(response, patterns=compiled)
+
+    return _detect

--- a/evals/abstention/runner.py
+++ b/evals/abstention/runner.py
@@ -1,0 +1,191 @@
+"""AbstentionBench runner (Phase 9.4.3).
+
+Same shape as evals/beam/runner.py — pluggable loader / ingest / answer
+protocols, per-sample error isolation, ``summarize()`` mapping the
+run report to the standard BenchmarkSummary shape.
+
+The primary metric exposed to the gate is F1 over the abstention
+decision (positive class = "abstain"). Per-category surfacing in the
+summary breaks down F1 by sample category (unknown_topic / false_premise /
+underspecified / etc.) — that's the actionable signal when over- or
+under-abstention regresses.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from pathlib import Path
+from typing import Any, Callable, List, Optional, Protocol
+
+from evals.abstention.detector import Detector
+from evals.abstention.scorer import aggregate
+from evals.abstention.types import (
+    AbstentionPrediction, AbstentionRunReport, AbstentionSample,
+)
+from evals.summary import BenchmarkSummary
+
+logger = logging.getLogger("attestor.evals.abstention")
+
+
+# ── Protocols ─────────────────────────────────────────────────────────────
+
+
+class DatasetLoader(Protocol):
+    def __call__(self) -> List[AbstentionSample]: ...
+
+
+class IngestFn(Protocol):
+    def __call__(self, sample: AbstentionSample, mem: Any) -> None: ...
+
+
+class AnswerFn(Protocol):
+    """Produce the model's answer to a sample's query.
+
+    The implementation MUST use the Chain-of-Note ABSTAIN-clause prompt
+    (or an equivalent) — that's the entire point of this benchmark.
+    """
+
+    def __call__(self, sample: AbstentionSample, mem: Any) -> str: ...
+
+
+# ── Default loader (fail loud) ───────────────────────────────────────────
+
+
+class DefaultDatasetLoader:
+    """Placeholder loader. Operators MUST wire their own."""
+
+    def __call__(self) -> List[AbstentionSample]:
+        raise NotImplementedError(
+            "AbstentionBench dataset loader not configured. Pass a "
+            "DatasetLoader to evals.abstention.runner.run() returning "
+            "List[AbstentionSample]. The benchmark needs a balanced mix "
+            "of answerable (with relevant context) and unanswerable "
+            "(with empty/unrelated context) samples to be meaningful."
+        )
+
+
+# ── Run ───────────────────────────────────────────────────────────────────
+
+
+def _run_one(
+    sample: AbstentionSample,
+    *,
+    mem_factory: Callable[[], Any],
+    ingest: IngestFn,
+    answer: AnswerFn,
+) -> AbstentionPrediction:
+    mem = mem_factory()
+    started = time.perf_counter()
+    try:
+        ingest(sample, mem)
+        response = answer(sample, mem)
+        elapsed = (time.perf_counter() - started) * 1000.0
+        return AbstentionPrediction(
+            sample_id=sample.sample_id,
+            response=response,
+            answerable=sample.answerable,
+            category=sample.category,
+            latency_ms=elapsed,
+        )
+    except Exception as e:  # noqa: BLE001
+        logger.exception("AbstentionBench sample %s failed", sample.sample_id)
+        return AbstentionPrediction(
+            sample_id=sample.sample_id,
+            response="",
+            answerable=sample.answerable,
+            category=sample.category,
+            error=f"{type(e).__name__}: {e}",
+        )
+    finally:
+        close = getattr(mem, "close", None)
+        if callable(close):
+            try:
+                close()
+            except Exception:
+                logger.warning(
+                    "mem.close() raised after sample %s; continuing",
+                    sample.sample_id,
+                )
+
+
+def run(
+    *,
+    mem_factory: Callable[[], Any],
+    ingest: IngestFn,
+    answer: AnswerFn,
+    loader: Optional[DatasetLoader] = None,
+    detector: Optional[Detector] = None,
+    sample_limit: Optional[int] = None,
+    output_dir: Optional[Path | str] = None,
+) -> BenchmarkSummary:
+    """End-to-end AbstentionBench run.
+
+    Returns the BenchmarkSummary so the gate can compare it.
+    Side effects (when ``output_dir`` is set):
+      - ``output_dir/abstention_report.json`` — raw AbstentionRunReport
+      - ``output_dir/abstention_summary.json`` — BenchmarkSummary
+    """
+    loader = loader or DefaultDatasetLoader()
+    samples = loader()
+    if sample_limit is not None and sample_limit > 0:
+        samples = samples[:sample_limit]
+        logger.info(
+            "AbstentionBench: truncated dataset to %d samples", len(samples),
+        )
+
+    predictions: List[AbstentionPrediction] = []
+    for i, s in enumerate(samples, 1):
+        predictions.append(_run_one(
+            s, mem_factory=mem_factory, ingest=ingest, answer=answer,
+        ))
+        if i % 25 == 0 or i == len(samples):
+            logger.info("AbstentionBench: %d/%d done", i, len(samples))
+
+    report = aggregate(samples, predictions, detector=detector)
+    summary = summarize(report)
+
+    if output_dir is not None:
+        out = Path(output_dir)
+        out.mkdir(parents=True, exist_ok=True)
+        (out / "abstention_report.json").write_text(
+            json.dumps(report.to_dict(), indent=2),
+        )
+        (out / "abstention_summary.json").write_text(
+            json.dumps(summary.to_dict(), indent=2),
+        )
+    return summary
+
+
+# ── Summarize ─────────────────────────────────────────────────────────────
+
+
+def summarize(report: AbstentionRunReport) -> BenchmarkSummary:
+    """Map an AbstentionRunReport to the standard BenchmarkSummary.
+
+    Primary metric: F1 over the abstention decision (0-100, scaled from
+    the 0-1 ratio for consistency with the other runners).
+
+    Per-category: F1 per sample category.
+    """
+    overall_f1_pct = float(report.overall.f1) * 100.0
+    per_cat = {
+        cat: float(m.f1) * 100.0
+        for cat, m in report.by_category.items()
+        if m.total > 0
+    }
+    return BenchmarkSummary(
+        benchmark="abstention",
+        primary_metric=overall_f1_pct,
+        primary_metric_name="abstention_f1_pct",
+        per_category=per_cat,
+        total=report.overall.total,
+        metadata={
+            "precision": round(report.overall.precision, 4),
+            "recall": round(report.overall.recall, 4),
+            "over_abstention_rate": round(report.overall.over_abstention_rate, 4),
+            "confabulation_rate": round(report.overall.confabulation_rate, 4),
+            "answer_accuracy": round(report.answer_accuracy, 4),
+        },
+    )

--- a/evals/abstention/scorer.py
+++ b/evals/abstention/scorer.py
@@ -1,0 +1,170 @@
+"""AbstentionBench scorer (Phase 9.4.2).
+
+Confusion matrix over the abstention DECISION (positive class = "abstain"):
+
+  - Sample is unanswerable (gold: should abstain):
+      response abstained → true_positive
+      response answered  → false_negative   (confabulation)
+
+  - Sample is answerable (gold: should answer):
+      response abstained → false_positive   (over-abstention)
+      response answered  → true_negative    (always); also checked for
+                                              substring(expected_answer)
+                                              for the answer-accuracy
+                                              secondary metric
+
+Why F1 as primary metric:
+  Always-abstain → recall=1.0, precision=0.0 → F1=0.0
+  Always-answer  → recall=0.0, precision=undef→0.0 → F1=0.0
+  Both pathological extremes score zero. F1 only rewards calibration.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from dataclasses import replace
+from typing import Iterable, List, Optional
+
+from evals.abstention.detector import Detector, is_abstention
+from evals.abstention.types import (
+    AbstentionMetrics, AbstentionPrediction, AbstentionRunReport,
+    AbstentionSample,
+)
+
+_PUNCT = re.compile(r"[^\w\s]")
+
+
+def _normalize(text: str) -> str:
+    text = text.lower()
+    text = _PUNCT.sub(" ", text)
+    return " ".join(text.split())
+
+
+def _answer_matches(response: str, expected: Optional[str]) -> bool:
+    """Substring match — same lenient rule BEAM uses."""
+    if not expected:
+        return True  # answerable case with no gold = data issue, don't crash
+    return _normalize(expected) in _normalize(response)
+
+
+# ── Per-prediction scoring ────────────────────────────────────────────────
+
+
+def score_prediction(
+    sample: AbstentionSample,
+    pred: AbstentionPrediction,
+    *,
+    detector: Optional[Detector] = None,
+) -> AbstentionPrediction:
+    """Annotate prediction with abstained + correct fields.
+
+    ``correct`` semantics here mean "did the model do the right thing?":
+      - unanswerable + abstained  → True
+      - unanswerable + answered   → False
+      - answerable   + abstained  → False
+      - answerable   + answered   → True iff substring(expected) hits
+
+    A prediction with an error is always wrong and counts as having
+    answered (not abstained) — a runtime crash is failure, not an
+    intentional abstention.
+    """
+    if pred.error is not None:
+        return replace(pred, abstained=False, correct=False,
+                       answerable=sample.answerable, category=sample.category)
+
+    abstained = (detector or is_abstention)(pred.response)
+
+    if sample.answerable:
+        if abstained:
+            correct = False
+        else:
+            correct = _answer_matches(pred.response, sample.expected_answer)
+    else:
+        correct = abstained
+
+    return replace(
+        pred,
+        abstained=abstained,
+        correct=correct,
+        answerable=sample.answerable,
+        category=sample.category,
+    )
+
+
+# ── Aggregation ───────────────────────────────────────────────────────────
+
+
+def _confusion(predictions: Iterable[AbstentionPrediction]) -> AbstentionMetrics:
+    tp = fp = tn = fn = 0
+    for p in predictions:
+        # Unscored predictions get treated as wrong-answer (errors,
+        # missing) — defensive, the runner should always populate these.
+        abstained = bool(p.abstained)
+        if not p.answerable:
+            if abstained:
+                tp += 1
+            else:
+                fn += 1
+        else:
+            if abstained:
+                fp += 1
+            else:
+                tn += 1
+    return AbstentionMetrics(
+        true_positive=tp, false_positive=fp,
+        true_negative=tn, false_negative=fn,
+    )
+
+
+def aggregate(
+    samples: List[AbstentionSample],
+    predictions: List[AbstentionPrediction],
+    *,
+    detector: Optional[Detector] = None,
+) -> AbstentionRunReport:
+    """Score every (sample, prediction) pair and produce the run report.
+
+    Pairs by sample_id. A missing prediction is recorded as wrong (we
+    surface bugs rather than silently shrink totals).
+    """
+    pred_by_id = {p.sample_id: p for p in predictions}
+    scored: List[AbstentionPrediction] = []
+
+    for s in samples:
+        p = pred_by_id.get(s.sample_id)
+        if p is None:
+            scored.append(AbstentionPrediction(
+                sample_id=s.sample_id, response="",
+                abstained=False, correct=False,
+                answerable=s.answerable, category=s.category,
+                error="missing prediction",
+            ))
+            continue
+        scored.append(score_prediction(s, p, detector=detector))
+
+    overall = _confusion(scored)
+
+    by_category: dict = {}
+    grouped: dict = defaultdict(list)
+    for p in scored:
+        grouped[p.category or "general"].append(p)
+    for cat, ps in grouped.items():
+        by_category[cat] = _confusion(ps)
+
+    # Secondary metric: of answerable cases that the model attempted,
+    # how often did the substring match? Surfaces "abstention is fine
+    # but the actual answers are bad" regressions.
+    answer_total = sum(1 for p in scored if p.answerable and not p.abstained)
+    answer_correct = sum(1 for p in scored
+                         if p.answerable and not p.abstained and p.correct)
+    answer_accuracy = (answer_correct / answer_total) if answer_total else 0.0
+
+    return AbstentionRunReport(
+        overall=overall,
+        by_category=by_category,
+        answer_accuracy=answer_accuracy,
+        answer_correct=answer_correct,
+        answer_total=answer_total,
+        predictions=tuple(scored),
+    )

--- a/evals/abstention/types.py
+++ b/evals/abstention/types.py
@@ -1,0 +1,147 @@
+"""AbstentionBench data types (Phase 9.4.1)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional, Tuple
+
+
+@dataclass(frozen=True)
+class AbstentionSample:
+    """One abstention test case.
+
+    Attributes:
+        sample_id: Unique id used to key reports.
+        context: Material the memory layer ingests before the query.
+            For pure abstention tests this is often empty or contains
+            unrelated facts; for "answerable" cases it carries the
+            relevant fact.
+        query: The question to answer.
+        answerable: Gold label.
+            True  → memory IS sufficient; the model should answer.
+            False → no relevant info; the model should abstain.
+        expected_answer: When ``answerable=True``, the substring that
+            must appear in the model's response. Ignored when
+            ``answerable=False``.
+        category: Optional dataset-defined slice (e.g.,
+            "unknown_topic", "false_premise", "subjective",
+            "underspecified"). Surfaced in per-category metrics.
+        metadata: Free-form extras preserved into the report.
+    """
+    sample_id: str
+    context: str
+    query: str
+    answerable: bool
+    expected_answer: Optional[str] = None
+    category: str = "general"
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class AbstentionPrediction:
+    """The system's response to one AbstentionSample."""
+    sample_id: str
+    response: str                    # raw model output
+    abstained: Optional[bool] = None # filled by detector
+    correct: Optional[bool] = None   # filled by scorer
+    category: str = "general"
+    answerable: bool = True          # mirrored from sample for slicing
+    latency_ms: float = 0.0
+    error: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class AbstentionMetrics:
+    """Confusion-matrix view over the abstention decision.
+
+    Treating "abstain" as the positive class:
+        true_positive  — should abstain, did
+        false_positive — should answer, but abstained (over-abstention)
+        true_negative  — should answer, did (correctly)
+        false_negative — should abstain, but answered (confabulation)
+    """
+    true_positive: int = 0
+    false_positive: int = 0
+    true_negative: int = 0
+    false_negative: int = 0
+
+    @property
+    def total(self) -> int:
+        return (self.true_positive + self.false_positive
+                + self.true_negative + self.false_negative)
+
+    @property
+    def precision(self) -> float:
+        denom = self.true_positive + self.false_positive
+        return self.true_positive / denom if denom else 0.0
+
+    @property
+    def recall(self) -> float:
+        denom = self.true_positive + self.false_negative
+        return self.true_positive / denom if denom else 0.0
+
+    @property
+    def f1(self) -> float:
+        p, r = self.precision, self.recall
+        return 2 * p * r / (p + r) if (p + r) else 0.0
+
+    @property
+    def over_abstention_rate(self) -> float:
+        """Of cases where the model SHOULD have answered, how often
+        did it abstain instead?"""
+        denom = self.true_negative + self.false_positive
+        return self.false_positive / denom if denom else 0.0
+
+    @property
+    def confabulation_rate(self) -> float:
+        """Of cases where the model SHOULD have abstained, how often
+        did it answer (likely confabulating) instead?"""
+        denom = self.true_positive + self.false_negative
+        return self.false_negative / denom if denom else 0.0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "true_positive": self.true_positive,
+            "false_positive": self.false_positive,
+            "true_negative": self.true_negative,
+            "false_negative": self.false_negative,
+            "total": self.total,
+            "precision": round(self.precision, 4),
+            "recall": round(self.recall, 4),
+            "f1": round(self.f1, 4),
+            "over_abstention_rate": round(self.over_abstention_rate, 4),
+            "confabulation_rate": round(self.confabulation_rate, 4),
+        }
+
+
+@dataclass(frozen=True)
+class AbstentionRunReport:
+    """Aggregated AbstentionBench output. JSON-serializable via to_dict()."""
+    overall: AbstentionMetrics
+    by_category: Dict[str, AbstentionMetrics] = field(default_factory=dict)
+    answer_accuracy: float = 0.0  # of answerable cases, what % were also right?
+    answer_total: int = 0
+    answer_correct: int = 0
+    predictions: Tuple[AbstentionPrediction, ...] = ()
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "overall": self.overall.to_dict(),
+            "by_category": {k: v.to_dict() for k, v in self.by_category.items()},
+            "answer_accuracy": round(self.answer_accuracy, 4),
+            "answer_correct": self.answer_correct,
+            "answer_total": self.answer_total,
+            "predictions": [
+                {
+                    "sample_id": p.sample_id,
+                    "response": p.response,
+                    "abstained": p.abstained,
+                    "correct": p.correct,
+                    "category": p.category,
+                    "answerable": p.answerable,
+                    "latency_ms": p.latency_ms,
+                    "error": p.error,
+                }
+                for p in self.predictions
+            ],
+        }

--- a/evals/gate.py
+++ b/evals/gate.py
@@ -1,0 +1,138 @@
+"""CI regression gate (Phase 9.5.1).
+
+Load BenchmarkSummary JSONs from a directory, diff them against
+``docs/bench/v4-baseline.json``, and exit with a non-zero status if any
+benchmark regressed beyond the configured threshold.
+
+Designed to be the single entry point CI calls:
+
+    python -m evals.gate \\
+        --summaries-dir bench-output/ \\
+        --baseline docs/bench/v4-baseline.json \\
+        --report-out bench-output/gate.json
+
+The gate is permissive on bootstrap: if the baseline file is missing,
+no regression is possible and the gate passes. That keeps the first
+release from blocking itself.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+from evals.baseline import (
+    DEFAULT_THRESHOLD, GateReport, compare_to_baseline,
+)
+from evals.summary import BenchmarkSummary
+
+logger = logging.getLogger("attestor.evals.gate")
+
+
+# ── Loading summaries ────────────────────────────────────────────────────
+
+
+def load_summaries(directory: Path | str) -> List[BenchmarkSummary]:
+    """Load every ``*_summary.json`` file from a directory.
+
+    Each file must be a single BenchmarkSummary (the shape every runner
+    emits via ``summary.to_dict()``). Files with a different shape are
+    skipped with a warning so a stray report file doesn't break the
+    gate.
+    """
+    p = Path(directory)
+    if not p.exists():
+        logger.warning("summaries dir %s does not exist; treating as empty", p)
+        return []
+    out: List[BenchmarkSummary] = []
+    for f in sorted(p.glob("*_summary.json")):
+        try:
+            raw = json.loads(f.read_text())
+        except json.JSONDecodeError as e:
+            logger.warning("skipping %s: invalid JSON (%s)", f, e)
+            continue
+        try:
+            out.append(BenchmarkSummary.from_dict(raw))
+        except (KeyError, ValueError, TypeError) as e:
+            logger.warning("skipping %s: bad summary shape (%s)", f, e)
+            continue
+    return out
+
+
+# ── Pretty-printing ──────────────────────────────────────────────────────
+
+
+def format_report(report: GateReport) -> str:
+    """Render the gate verdict as human-readable text for the CI log."""
+    lines: list[str] = []
+    verdict = "BLOCKED" if report.blocked else "PASS"
+    lines.append(f"Eval gate: {verdict} (threshold {report.threshold:.2f}pt)")
+    lines.append("-" * 60)
+    if not report.deltas:
+        lines.append("No benchmark summaries provided. Gate passed by default.")
+        return "\n".join(lines)
+    for d in report.deltas:
+        marker = "REGRESSED" if d.regressed else "ok"
+        lines.append(
+            f"{marker:>10}  {d.benchmark:<14}  "
+            f"baseline={d.baseline:6.2f}  current={d.current:6.2f}  "
+            f"Δ={d.delta:+6.2f}"
+        )
+        if d.note:
+            lines.append(f"            note: {d.note}")
+        for cat, base_v, cur_v, delta in d.per_category_regressions:
+            lines.append(
+                f"            └─ {cat}: {base_v:.2f} → {cur_v:.2f} ({delta:+.2f})"
+            )
+    return "\n".join(lines)
+
+
+# ── CLI ──────────────────────────────────────────────────────────────────
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    """Entry point. Returns the process exit code."""
+    parser = argparse.ArgumentParser(prog="evals.gate")
+    parser.add_argument(
+        "--summaries-dir", required=True,
+        help="Directory containing *_summary.json files.",
+    )
+    parser.add_argument(
+        "--baseline", required=True,
+        help="Path to the baseline JSON (e.g. docs/bench/v4-baseline.json).",
+    )
+    parser.add_argument(
+        "--report-out", default=None,
+        help="Optional path to write the gate report JSON.",
+    )
+    parser.add_argument(
+        "--block-on-category-regression", action="store_true",
+        help=(
+            "Also block when a per-category metric regresses. By default, "
+            "only the primary metric drives the gate."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    summaries = load_summaries(args.summaries_dir)
+    report = compare_to_baseline(
+        summaries, args.baseline,
+        block_on_category_regression=args.block_on_category_regression,
+    )
+
+    print(format_report(report))
+
+    if args.report_out:
+        out = Path(args.report_out)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(json.dumps(report.to_dict(), indent=2))
+
+    return 1 if report.blocked else 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/test_evals_abstention.py
+++ b/tests/test_evals_abstention.py
@@ -1,0 +1,403 @@
+"""Phase 9.4 — AbstentionBench tests.
+
+Pure unit tests. No dataset, no DB, no LLM. Verifies detector phrasings,
+confusion-matrix math, F1 calibration extremes, and runner error
+isolation.
+"""
+
+from __future__ import annotations
+
+from typing import Any, List
+
+import pytest
+
+from evals.abstention.detector import (
+    DEFAULT_ABSTENTION_PATTERNS, is_abstention, make_detector,
+)
+from evals.abstention.runner import (
+    DefaultDatasetLoader, _run_one, run, summarize,
+)
+from evals.abstention.scorer import (
+    _answer_matches, _confusion, aggregate, score_prediction,
+)
+from evals.abstention.types import (
+    AbstentionMetrics, AbstentionPrediction, AbstentionRunReport,
+    AbstentionSample,
+)
+
+
+# ── Detector ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_detector_catches_canonical_chain_of_note_phrase() -> None:
+    """The CoN ABSTAIN clause says exactly this phrase — must be caught."""
+    assert is_abstention("I don't have that information") is True
+
+
+@pytest.mark.unit
+def test_detector_catches_common_variants() -> None:
+    cases = [
+        "I don't have any information about that.",
+        "I don't have enough context to answer.",
+        "No relevant information is available.",
+        "The memories do not contain that detail.",
+        "I cannot answer that based on the provided memories.",
+        "Insufficient information to determine.",
+        "Unable to recall any matching memory.",
+        "I don't know.",
+    ]
+    for c in cases:
+        assert is_abstention(c) is True, f"missed: {c!r}"
+
+
+@pytest.mark.unit
+def test_detector_does_not_falsepositive_on_hedge_then_answer() -> None:
+    """Common failure mode: hedged-but-substantive answers get flagged
+    as abstentions. The detector must NOT do that."""
+    cases = [
+        "I'm not sure, but based on memory mem_3, your favorite color is blue.",
+        "I don't know yet, however the meeting was on Tuesday per mem_7.",
+        "Based on mem_2, I think your dog is named Rex.",
+        "Your favorite food is sushi [mem_1].",
+    ]
+    for c in cases:
+        assert is_abstention(c) is False, f"false positive on: {c!r}"
+
+
+@pytest.mark.unit
+def test_detector_treats_empty_response_as_abstention() -> None:
+    """Empty model output = effective abstention."""
+    assert is_abstention("") is True
+    assert is_abstention("   \n  ") is True
+
+
+@pytest.mark.unit
+def test_make_detector_appends_patterns() -> None:
+    custom = make_detector(extra_patterns=(r"\bN/A\b",))
+    # Default detector wouldn't catch "N/A" alone
+    assert is_abstention("N/A") is False
+    # Custom detector does
+    assert custom("N/A") is True
+    # Still catches defaults
+    assert custom("I don't have that information") is True
+
+
+# ── _answer_matches ─────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_answer_matches_substring_normalized() -> None:
+    assert _answer_matches("Your favorite color is BLUE.", "blue") is True
+    assert _answer_matches("It's red.", "blue") is False
+
+
+@pytest.mark.unit
+def test_answer_matches_empty_expected_does_not_crash() -> None:
+    """Data-quality issue, but the scorer must not blow up."""
+    assert _answer_matches("anything", "") is True
+    assert _answer_matches("anything", None) is True
+
+
+# ── score_prediction ─────────────────────────────────────────────────────
+
+
+def _sample(*, sid="s1", answerable=True, expected=None,
+            cat="general") -> AbstentionSample:
+    return AbstentionSample(
+        sample_id=sid, context="...", query="?",
+        answerable=answerable, expected_answer=expected, category=cat,
+    )
+
+
+def _pred(*, text="answer", error=None, sid="s1") -> AbstentionPrediction:
+    return AbstentionPrediction(
+        sample_id=sid, response=text, error=error,
+    )
+
+
+@pytest.mark.unit
+def test_score_unanswerable_with_abstention_correct() -> None:
+    s = _sample(answerable=False)
+    p = score_prediction(s, _pred(text="I don't have that information"))
+    assert p.abstained is True and p.correct is True
+
+
+@pytest.mark.unit
+def test_score_unanswerable_with_answer_is_confabulation() -> None:
+    """Model invented an answer when it should have abstained."""
+    s = _sample(answerable=False)
+    p = score_prediction(s, _pred(text="The capital is Atlantis."))
+    assert p.abstained is False and p.correct is False
+
+
+@pytest.mark.unit
+def test_score_answerable_with_correct_answer_passes() -> None:
+    s = _sample(answerable=True, expected="paris")
+    p = score_prediction(s, _pred(text="The capital is Paris."))
+    assert p.abstained is False and p.correct is True
+
+
+@pytest.mark.unit
+def test_score_answerable_with_abstention_is_over_abstention() -> None:
+    s = _sample(answerable=True, expected="paris")
+    p = score_prediction(s, _pred(text="I don't have that information"))
+    assert p.abstained is True and p.correct is False
+
+
+@pytest.mark.unit
+def test_score_answerable_with_wrong_answer_fails() -> None:
+    s = _sample(answerable=True, expected="paris")
+    p = score_prediction(s, _pred(text="The capital is Berlin."))
+    assert p.abstained is False and p.correct is False
+
+
+@pytest.mark.unit
+def test_score_prediction_with_error_is_wrong_not_abstention() -> None:
+    """Runtime crash isn't an abstention — operator needs to see failures."""
+    s = _sample(answerable=False)
+    p = score_prediction(s, _pred(text="", error="db blew up"))
+    assert p.correct is False
+    assert p.abstained is False  # important: don't paper over crashes as wins
+
+
+# ── _confusion + AbstentionMetrics ──────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_metrics_perfect_calibration_f1_one() -> None:
+    m = AbstentionMetrics(true_positive=5, true_negative=5)
+    assert m.precision == 1.0 and m.recall == 1.0 and m.f1 == 1.0
+
+
+@pytest.mark.unit
+def test_metrics_always_abstain_collapses_to_zero_f1() -> None:
+    """Always-abstain → recall=1, precision very low → low F1.
+    With perfect-recall but lots of false-positives, F1 drops fast."""
+    m = AbstentionMetrics(true_positive=5, false_positive=95)
+    assert m.recall == 1.0
+    assert m.precision == 0.05
+    assert m.f1 == pytest.approx(2 * 1.0 * 0.05 / 1.05, abs=0.001)
+
+
+@pytest.mark.unit
+def test_metrics_always_answer_yields_zero_f1() -> None:
+    """Always-answer → tp=0 → both precision and recall are 0 → F1=0."""
+    m = AbstentionMetrics(true_negative=50, false_negative=50)
+    assert m.f1 == 0.0
+
+
+@pytest.mark.unit
+def test_metrics_over_abstention_rate() -> None:
+    """Of cases that should have answered, fraction that abstained."""
+    m = AbstentionMetrics(true_positive=10, false_positive=5,
+                          true_negative=15, false_negative=2)
+    assert m.over_abstention_rate == pytest.approx(5 / (15 + 5))
+
+
+@pytest.mark.unit
+def test_metrics_confabulation_rate() -> None:
+    """Of cases that should have abstained, fraction that answered."""
+    m = AbstentionMetrics(true_positive=10, false_positive=5,
+                          true_negative=15, false_negative=2)
+    assert m.confabulation_rate == pytest.approx(2 / (10 + 2))
+
+
+@pytest.mark.unit
+def test_metrics_to_dict_round_trips() -> None:
+    import json
+    m = AbstentionMetrics(true_positive=1, true_negative=1)
+    d = m.to_dict()
+    json.dumps(d)
+    assert d["f1"] == 1.0
+
+
+# ── aggregate ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_aggregate_overall_confusion_matrix() -> None:
+    """End-to-end: 2 unanswerable correctly abstained, 2 answerable
+    correctly answered → perfect F1."""
+    samples = [
+        _sample(sid="u1", answerable=False),
+        _sample(sid="u2", answerable=False),
+        _sample(sid="a1", answerable=True, expected="blue"),
+        _sample(sid="a2", answerable=True, expected="red"),
+    ]
+    preds = [
+        _pred(sid="u1", text="I don't have that information"),
+        _pred(sid="u2", text="No relevant information is available"),
+        _pred(sid="a1", text="Your favorite is blue"),
+        _pred(sid="a2", text="It's red"),
+    ]
+    rep = aggregate(samples, preds)
+    assert rep.overall.f1 == 1.0
+    assert rep.answer_accuracy == 1.0
+    assert rep.answer_total == 2 and rep.answer_correct == 2
+
+
+@pytest.mark.unit
+def test_aggregate_per_category_breakdown() -> None:
+    samples = [
+        _sample(sid="a", answerable=False, cat="unknown_topic"),
+        _sample(sid="b", answerable=False, cat="false_premise"),
+    ]
+    preds = [
+        _pred(sid="a", text="I don't have that information"),
+        _pred(sid="b", text="The Atlantis capital is..."),  # confabulation
+    ]
+    rep = aggregate(samples, preds)
+    assert rep.by_category["unknown_topic"].f1 == 1.0
+    # "false_premise" has 0 tp + 1 fn → recall=0 → f1=0
+    assert rep.by_category["false_premise"].f1 == 0.0
+
+
+@pytest.mark.unit
+def test_aggregate_records_missing_prediction_as_wrong() -> None:
+    samples = [
+        _sample(sid="present", answerable=False),
+        _sample(sid="missing", answerable=False),
+    ]
+    preds = [_pred(sid="present", text="I don't have that information")]
+    rep = aggregate(samples, preds)
+    miss = next(p for p in rep.predictions if p.sample_id == "missing")
+    assert miss.error == "missing prediction"
+    assert miss.correct is False
+
+
+@pytest.mark.unit
+def test_aggregate_answer_accuracy_excludes_abstentions() -> None:
+    """answer_accuracy is over cases where the model attempted, not all."""
+    samples = [
+        _sample(sid="a", answerable=True, expected="blue"),
+        _sample(sid="b", answerable=True, expected="red"),
+    ]
+    preds = [
+        _pred(sid="a", text="blue"),                                 # attempted, right
+        _pred(sid="b", text="I don't have that information"),        # abstained
+    ]
+    rep = aggregate(samples, preds)
+    assert rep.answer_total == 1   # only one attempted
+    assert rep.answer_correct == 1
+    assert rep.answer_accuracy == 1.0
+
+
+# ── _run_one (per-sample isolation) ──────────────────────────────────────
+
+
+class _FakeMem:
+    closed = False
+
+    def close(self) -> None:
+        self.__class__.closed = True
+
+
+@pytest.mark.unit
+def test_run_one_records_ingest_error() -> None:
+    def bad_ingest(s, m): raise RuntimeError("ingest exploded")
+    def answer(s, m): return ""
+
+    p = _run_one(_sample(sid="x"),
+                 mem_factory=lambda: _FakeMem(),
+                 ingest=bad_ingest, answer=answer)
+    assert p.error and "RuntimeError" in p.error
+
+
+@pytest.mark.unit
+def test_run_one_closes_mem_on_error() -> None:
+    _FakeMem.closed = False
+
+    def good_ingest(s, m): pass
+    def bad_answer(s, m): raise ValueError("boom")
+
+    _run_one(_sample(sid="x"),
+             mem_factory=lambda: _FakeMem(),
+             ingest=good_ingest, answer=bad_answer)
+    assert _FakeMem.closed is True
+
+
+# ── DefaultDatasetLoader ────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_default_loader_fails_loud() -> None:
+    with pytest.raises(NotImplementedError, match="not configured"):
+        DefaultDatasetLoader()()
+
+
+# ── End-to-end run() ────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_run_end_to_end_with_perfect_stub() -> None:
+    """Every unanswerable abstains; every answerable answers correctly."""
+    samples = [
+        _sample(sid="u", answerable=False),
+        _sample(sid="a", answerable=True, expected="paris"),
+    ]
+
+    def loader(): return samples
+    def ingest(s, m): pass
+    def answer(s, m):
+        if not s.answerable:
+            return "I don't have that information"
+        return "The capital is Paris"
+
+    summary = run(
+        mem_factory=lambda: _FakeMem(),
+        ingest=ingest, answer=answer, loader=loader,
+    )
+    assert summary.benchmark == "abstention"
+    assert summary.primary_metric == 100.0
+    assert summary.primary_metric_name == "abstention_f1_pct"
+
+
+@pytest.mark.unit
+def test_run_sample_limit_truncates() -> None:
+    samples = [_sample(sid=f"s{i}", answerable=False) for i in range(10)]
+
+    def loader(): return samples
+    def ingest(s, m): pass
+    def answer(s, m): return "I don't have that information"
+
+    summary = run(
+        mem_factory=lambda: _FakeMem(),
+        ingest=ingest, answer=answer, loader=loader, sample_limit=3,
+    )
+    assert summary.total == 3
+
+
+# ── summarize ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_summarize_emits_f1_as_primary_metric_pct() -> None:
+    rep = AbstentionRunReport(
+        overall=AbstentionMetrics(true_positive=5, true_negative=5),
+        by_category={
+            "unknown_topic": AbstentionMetrics(true_positive=5),
+        },
+        answer_accuracy=1.0, answer_correct=5, answer_total=5,
+    )
+    s = summarize(rep)
+    assert s.benchmark == "abstention"
+    assert s.primary_metric == 100.0
+    assert s.primary_metric_name == "abstention_f1_pct"
+    assert s.per_category["unknown_topic"] == 100.0
+
+
+@pytest.mark.unit
+def test_summarize_includes_subsidiary_rates_in_metadata() -> None:
+    """Operators inspecting failures need precision/recall and the
+    over-abstention / confabulation breakdown — keep them in metadata."""
+    rep = AbstentionRunReport(
+        overall=AbstentionMetrics(
+            true_positive=10, false_positive=5,
+            true_negative=15, false_negative=2,
+        ),
+    )
+    s = summarize(rep)
+    assert "over_abstention_rate" in s.metadata
+    assert "confabulation_rate" in s.metadata
+    assert "precision" in s.metadata and "recall" in s.metadata

--- a/tests/test_evals_gate.py
+++ b/tests/test_evals_gate.py
@@ -1,0 +1,209 @@
+"""Phase 9.5.3 — gate CLI tests.
+
+Pure unit tests; no GitHub Actions, no live runs. Verifies summary
+loading from a directory, exit codes, and the integration with the
+baseline comparator.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from evals.baseline import GateReport, write_baseline
+from evals.gate import format_report, load_summaries, main
+from evals.summary import BenchmarkSummary
+
+
+def _write_summary(dirpath: Path, name: str,
+                   metric: float, **extra) -> Path:
+    p = dirpath / f"{name}_summary.json"
+    s = BenchmarkSummary(benchmark=name, primary_metric=metric, **extra)
+    p.write_text(json.dumps(s.to_dict()))
+    return p
+
+
+# ── load_summaries ───────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_load_summaries_from_directory(tmp_path: Path) -> None:
+    _write_summary(tmp_path, "longmemeval", 70.0)
+    _write_summary(tmp_path, "abstention", 85.0)
+    out = load_summaries(tmp_path)
+    benches = {s.benchmark for s in out}
+    assert benches == {"longmemeval", "abstention"}
+
+
+@pytest.mark.unit
+def test_load_summaries_missing_dir_returns_empty(tmp_path: Path) -> None:
+    out = load_summaries(tmp_path / "no_such_dir")
+    assert out == []
+
+
+@pytest.mark.unit
+def test_load_summaries_skips_invalid_json(tmp_path: Path) -> None:
+    """A garbage file shouldn't crash the gate — log + skip."""
+    _write_summary(tmp_path, "good", 80.0)
+    (tmp_path / "broken_summary.json").write_text("{not json")
+    out = load_summaries(tmp_path)
+    assert {s.benchmark for s in out} == {"good"}
+
+
+@pytest.mark.unit
+def test_load_summaries_skips_wrong_shape(tmp_path: Path) -> None:
+    """A JSON file that isn't a BenchmarkSummary shape — also skip."""
+    _write_summary(tmp_path, "good", 80.0)
+    (tmp_path / "bad_summary.json").write_text(
+        json.dumps({"some": "other shape"})
+    )
+    out = load_summaries(tmp_path)
+    assert {s.benchmark for s in out} == {"good"}
+
+
+@pytest.mark.unit
+def test_load_summaries_ignores_non_summary_files(tmp_path: Path) -> None:
+    """Only ``*_summary.json`` are picked up — raw reports stay out."""
+    _write_summary(tmp_path, "lme", 70.0)
+    (tmp_path / "lme_report.json").write_text("anything")
+    (tmp_path / "notes.txt").write_text("ignore")
+    assert {s.benchmark for s in load_summaries(tmp_path)} == {"lme"}
+
+
+# ── format_report ────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_format_report_empty_says_default_pass() -> None:
+    txt = format_report(GateReport())
+    assert "PASS" in txt
+    assert "default" in txt.lower()
+
+
+@pytest.mark.unit
+def test_format_report_blocked_marker_appears() -> None:
+    from evals.baseline import BenchmarkDelta
+    rep = GateReport(
+        deltas=(BenchmarkDelta(
+            benchmark="lme", baseline=70.0, current=65.0,
+            delta=-5.0, threshold=2.0, regressed=True,
+            note="primary metric dropped 5.00pt",
+        ),),
+        blocked=True,
+    )
+    txt = format_report(rep)
+    assert "BLOCKED" in txt
+    assert "REGRESSED" in txt
+    assert "lme" in txt
+
+
+# ── main: exit codes ─────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_main_exits_zero_on_pass(tmp_path: Path) -> None:
+    summaries_dir = tmp_path / "out"
+    summaries_dir.mkdir()
+    _write_summary(summaries_dir, "lme", 70.0)
+    baseline = tmp_path / "baseline.json"
+    write_baseline(baseline,
+                   [BenchmarkSummary(benchmark="lme", primary_metric=70.0)])
+
+    code = main([
+        "--summaries-dir", str(summaries_dir),
+        "--baseline", str(baseline),
+    ])
+    assert code == 0
+
+
+@pytest.mark.unit
+def test_main_exits_one_on_regression(tmp_path: Path) -> None:
+    summaries_dir = tmp_path / "out"
+    summaries_dir.mkdir()
+    _write_summary(summaries_dir, "lme", 60.0)  # dropped 10pt
+    baseline = tmp_path / "baseline.json"
+    write_baseline(baseline,
+                   [BenchmarkSummary(benchmark="lme", primary_metric=70.0)])
+
+    code = main([
+        "--summaries-dir", str(summaries_dir),
+        "--baseline", str(baseline),
+    ])
+    assert code == 1
+
+
+@pytest.mark.unit
+def test_main_writes_report_when_requested(tmp_path: Path) -> None:
+    summaries_dir = tmp_path / "out"
+    summaries_dir.mkdir()
+    _write_summary(summaries_dir, "lme", 70.0)
+    baseline = tmp_path / "baseline.json"
+    report_out = tmp_path / "gate.json"
+    write_baseline(baseline,
+                   [BenchmarkSummary(benchmark="lme", primary_metric=70.0)])
+
+    main([
+        "--summaries-dir", str(summaries_dir),
+        "--baseline", str(baseline),
+        "--report-out", str(report_out),
+    ])
+    assert report_out.exists()
+    payload = json.loads(report_out.read_text())
+    assert payload["blocked"] is False
+
+
+@pytest.mark.unit
+def test_main_passes_when_baseline_missing(tmp_path: Path) -> None:
+    """Bootstrap mode: no baseline file → never block."""
+    summaries_dir = tmp_path / "out"
+    summaries_dir.mkdir()
+    _write_summary(summaries_dir, "lme", 30.0)  # would be huge regression
+
+    code = main([
+        "--summaries-dir", str(summaries_dir),
+        "--baseline", str(tmp_path / "no_baseline_yet.json"),
+    ])
+    assert code == 0
+
+
+@pytest.mark.unit
+def test_main_passes_when_no_summaries(tmp_path: Path) -> None:
+    """Empty summaries dir → no benchmarks ran → gate passes by default."""
+    code = main([
+        "--summaries-dir", str(tmp_path / "empty_or_missing"),
+        "--baseline", str(tmp_path / "no_baseline.json"),
+    ])
+    assert code == 0
+
+
+@pytest.mark.unit
+def test_main_block_on_category_flag(tmp_path: Path) -> None:
+    """--block-on-category-regression escalates per-category drift to a block."""
+    summaries_dir = tmp_path / "out"
+    summaries_dir.mkdir()
+    _write_summary(
+        summaries_dir, "lme", 70.0,
+        per_category={"multi": 50.0},  # baseline had 60.0
+    )
+    baseline = tmp_path / "baseline.json"
+    write_baseline(baseline, [
+        BenchmarkSummary(
+            benchmark="lme", primary_metric=70.0,
+            per_category={"multi": 60.0},
+        ),
+    ])
+
+    code_default = main([
+        "--summaries-dir", str(summaries_dir),
+        "--baseline", str(baseline),
+    ])
+    assert code_default == 0  # primary unchanged
+
+    code_strict = main([
+        "--summaries-dir", str(summaries_dir),
+        "--baseline", str(baseline),
+        "--block-on-category-regression",
+    ])
+    assert code_strict == 1


### PR DESCRIPTION
## Summary

Closes Phase 9 (Track G eval harness) except the operator-driven baseline publication (9.6).

- **Phase 9.4 — AbstentionBench runner.** Confusion-matrix scoring (positive class = "abstain"), F1 as primary metric so always-abstain and always-answer both score zero. Default phrase-based detector matches the Chain-of-Note ABSTAIN clause output and refuses to false-positive on hedged-but-substantive answers.
- **Phase 9.5 — CI eval gate + workflow.** `evals/gate.py` CLI loads `*_summary.json` files, diffs against `docs/bench/v4-baseline.json`, exits 1 on regression. `.github/workflows/evals.yml` runs unit tests + the gate on every PR; heavy benchmarks gated behind `workflow_dispatch` until ops wires API-key secrets.

2 commits, 11 files, ~1.6k LOC.

## Test plan

- [x] All new unit tests green (43 added — 30 abstention + 13 gate)
- [x] Full suite 898 pass / 232 skip / 0 fail at last run
- [x] AbstentionBench detector tightened after a unit test caught it false-positiving on "I don't know yet, however the meeting was on..."
- [x] Workflow YAML parses (`yaml.safe_load_all`)
- [x] Bootstrap baseline (`docs/bench/v4-baseline.json`) ships empty so the first PR through the gate doesn't self-block
- [ ] First real benchmark run via `workflow_dispatch` happens in Phase 9.6 (operator-driven)