### PR TITLE
v4 doc/UI alignment + local Ollama support for LongMemEval

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,16 @@ logs/*.jsonl
 logs/*.log
 logs/*.pid
 
+# Auto-generated benchmark / classifier / LME run outputs (and their hashes).
+# These are too large and too noisy to track. Curated *_fails.json and
+# *_delta.json files are exempt below.
+logs/bench_*.json
+logs/classifier_*.json
+logs/lme_*.json
+logs/lme_*.json.sha256
+!logs/*_fails.json
+!logs/*_delta.json
+
 # Local tooling caches
 .DS_Store
 .claude/

--- a/README.md
+++ b/README.md
@@ -1,1378 +1,403 @@
-<!-- ══════════════════════════════════════════════════════════════
-     MASTHEAD
-     ══════════════════════════════════════════════════════════════ -->
+# Attestor
 
-<p align="center"><sub>&sect; 00 &middot; MASTHEAD &middot; FILED UNDER INFRASTRUCTURE &middot; BY SURENDRA SINGH &middot; &mdash; FOR PUBLICATION &mdash;</sub></p>
+**The memory layer for agent teams.** Self-hosted, deterministic retrieval, zero LLM in the critical path.
 
-<p align="center"><sub><b>ATTESTOR</b> &mdash; A MEMORY JOURNAL FOR AGENTIC SYSTEMS &middot; VOL. 02 &middot; REV. 0.1 &middot; EST. 2026 &middot; NEW YORK &middot; MIT</sub></p>
+```
+pip install attestor          # Python library + CLI + REST API + MCP server
+```
 
-<p align="center">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bolnet/attestor/main/docs/logo.svg">
-    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bolnet/attestor/main/docs/logo-dark.svg">
-    <img alt="Attestor" src="https://raw.githubusercontent.com/bolnet/attestor/main/docs/logo.svg" width="400">
-  </picture>
-</p>
-
-<h3 align="center"><em>The memory layer for agent teams.</em></h3>
-
-<p align="center"><sub>Self&#8209;hosted &middot; Deterministic retrieval &middot; No LLM in the critical path</sub></p>
-
-<p align="center">
-  <a href="https://pypi.org/project/attestor/"><img src="https://img.shields.io/pypi/v/attestor?color=C15F3C&style=flat-square" alt="PyPI"></a>
-  <a href="https://pypi.org/project/attestor/"><img src="https://img.shields.io/pypi/dm/attestor?style=flat-square&color=C15F3C" alt="PyPI downloads"></a>
-  <a href="https://github.com/bolnet/attestor/stargazers"><img src="https://img.shields.io/github/stars/bolnet/attestor?style=flat-square&color=C15F3C" alt="GitHub stars"></a>
-  <a href="https://pypi.org/project/attestor/"><img src="https://img.shields.io/pypi/pyversions/attestor?style=flat-square" alt="Python"></a>
-  <a href="https://github.com/bolnet/attestor/blob/main/LICENSE"><img src="https://img.shields.io/github/license/bolnet/attestor?style=flat-square" alt="License"></a>
-  <a href="https://registry.modelcontextprotocol.io/servers/io.github.bolnet/attestor"><img src="https://img.shields.io/badge/MCP-Registry-C15F3C?style=flat-square" alt="MCP Registry"></a>
-</p>
-
-<p align="center"><sub><a href="#problem">Problem &darr;</a> &middot; <a href="#multi-agent">Multi&#8209;Agent &darr;</a> &middot; <a href="#pipeline">Pipeline &darr;</a> &middot; <a href="#deploy">Deploy &darr;</a> &middot; <a href="#principles">Principles &darr;</a> &middot; <a href="#reference">Reference &darr;</a></sub></p>
+- **PyPI:** `attestor`
+- **Import:** `attestor`
+- **Status:** v4.0.0 alpha (greenfield; no v3 migration path)
+- **License:** see `LICENSE`
 
 ---
 
-<p align="center">
-  <img src="docs/constellation.svg" alt="Six stars out of eight hundred light up — Attestor recalls exactly what this moment needs" width="100%">
-</p>
+## What it is
 
-<p align="center"><sub><b><i>Attestor doesn&rsquo;t search. It remembers.</i></b></sub></p>
+Attestor is a memory store for multi-agent systems where the same memories are persisted across **three storage roles** — document, vector, and graph — and read back through a **deterministic 6-step retrieval pipeline** that never calls an LLM on the hot path.
 
----
+It is designed for:
 
-### The problem
+- agent teams that need a shared, tenant-isolated memory store with RBAC and audit trails
+- products that must answer *"what did we know on 2026-03-01?"* (bi-temporal replay)
+- environments where latency, cost, and reproducibility matter more than peak relevance
 
-**Agent prototypes don&rsquo;t survive production. Memory is why.** Single agents rediscover the same facts every run. Multi&#8209;agent pipelines are worse &mdash; the planner&rsquo;s decisions never reach the executor, the researcher&rsquo;s findings never reach the reviewer. Teams paper over it by stuffing giant prompts between agents, burning tokens on stale context. That&rsquo;s a workaround, not an architecture.
-
-### The solution &mdash; at a glance
-
-<p align="center">
-  <img src="docs/timeline.svg" alt="Write · Write · Write · Write ... Read — memories accumulate across sessions, load_context primes the next task" width="100%">
-</p>
-
-<sub><b>Memory accumulates. Load primes.</b> &nbsp;Four writes across Mon&ndash;Thu land as persisted memories. Friday morning a fresh Portfolio Planner wakes up to a new task, calls <code>mem.load_context()</code>, and Attestor ranks + dedupes + budget&#8209;fits all four back into the context window. The agent resumes with full continuity &mdash; earnings signal, risk cap, prior stance, compliance precedent &mdash; <b>not RAG over documents, but the agents&rsquo; own history replayed into a fresh context</b>. Zero LLM calls in the critical path.</sub>
+It is **not** a general vector database, a RAG framework, or an LLM agent runtime. It plugs into your agent stack as a backend.
 
 ---
 
-<p align="center">
-  <b>Production&#8209;grade memory infrastructure for multi&#8209;agent systems.</b><br>
-  <sub>The memory tier your agents need when they leave your laptop and start running in production.</sub>
-</p>
+## Quick start
 
-<p align="center"><sub>Namespace isolation &middot; RBAC &middot; Provenance tracking &middot; Temporal correctness &middot; Ranked retrieval &middot; Token budgets &mdash; built for orchestrator&#8209;worker and planner&#8209;executor pipelines. Python library, REST API, or containerized service. No SaaS middleman, no per&#8209;seat fees, no vendor lock&#8209;in.</sub></p>
+### 1. Install
+
+```bash
+pip install attestor
+# or
+pipx install attestor
+```
+
+### 2. Bring up a local Postgres + Neo4j
+
+```bash
+attestor setup local      # writes docker-compose.yml under attestor/infra/local
+docker compose -f attestor/infra/local/docker-compose.yml up -d
+```
+
+Postgres ships with `pgvector`. Neo4j ships with GDS for PageRank / BFS / Leiden.
+
+### 3. Pull the default embedder
+
+```bash
+ollama pull bge-m3        # 1024-D, 8K context, local default
+```
+
+### 4. Verify everything is wired up
+
+```bash
+attestor doctor
+```
+
+You should see green for **Document Store (Postgres)**, **Vector Store (pgvector)**, **Graph Store (Neo4j)**, and **Retrieval Pipeline**.
+
+### 5. Use it
 
 ```python
-from attestor import AgentMemory
+from attestor import AgentMemory, AgentContext, AgentRole
 
-mem = AgentMemory("./store")
-mem.add("Order service uses event sourcing", entity="order-service", tags=["arch"])
-mem.recall("how is the order service structured?", budget=2000)
+mem = AgentMemory()  # picks up env / ~/.attestor.toml automatically
+
+ctx = AgentContext(
+    agent_id="researcher-1",
+    role=AgentRole.RESEARCHER,
+    namespace="acme-prod",
+)
+
+mem.add(
+    content="Alice is the engineering manager",
+    entity="alice",
+    category="role",
+    context=ctx,
+)
+
+results = mem.recall(query="who runs engineering?", context=ctx)
+for r in results:
+    print(r.score, r.memory.content)
 ```
-
-```bash
-poetry add attestor
-```
-
-<p align="center"><sub>MIT &middot; Python 3.10&ndash;3.14 &middot; Production deploy in one command</sub></p>
-
-<table align="center">
-<tr><th colspan="2" align="center">&sect; Spec Sheet</th></tr>
-<tr><td>Storage Roles</td><td><b>Doc &middot; Vector &middot; Graph</b></td></tr>
-<tr><td>Interfaces</td><td><b>Python &middot; REST &middot; MCP</b></td></tr>
-<tr><td>Retrieval Layers</td><td><b>5</b> &mdash; tag &middot; graph BFS &middot; vector &middot; RRF fusion &middot; MMR + budget pack</td></tr>
-<tr><td>Tenancy</td><td><b>Postgres Row&#8209;Level Security</b> &mdash; hard isolation per <code>users</code> row, even on app&#8209;level bugs</td></tr>
-<tr><td>Temporal</td><td><b>Bi&#8209;temporal</b> &mdash; <code>valid_from</code>/<code>valid_until</code> + <code>t_created</code>/<code>t_expired</code>; <code>recall(as_of=...)</code> replays the past</td></tr>
-<tr><td>Reading</td><td><b>Chain&#8209;of&#8209;Note</b> &mdash; structured ContextPack with NOTES &rarr; SYNTHESIS &rarr; CITE &rarr; <b>ABSTAIN</b> &rarr; CONFLICT</td></tr>
-<tr><td>Provenance</td><td><b>Ed25519</b> signatures over canonical payload; <code>verify_memory()</code> detects raw&#8209;DB tampering</td></tr>
-<tr><td>Compliance</td><td><b>GDPR delete + export</b>, RLS&#8209;EXEMPT <code>deletion_audit</code> outlives the user</td></tr>
-<tr><td>Quality gate</td><td><b>4&#8209;benchmark CI</b> &mdash; LongMemEval &middot; BEAM &middot; AbstentionBench &middot; deterministic regression suite</td></tr>
-<tr><td>RBAC Roles</td><td><b>6</b></td></tr>
-<tr><td>Cloud Targets</td><td><b>Amazon Web Services &middot; Microsoft Azure &middot; Google Cloud Platform</b></td></tr>
-<tr><td>License</td><td><b>MIT</b></td></tr>
-</table>
-
-<sub><b>4.0 highlights:</b> v4 is a greenfield rebuild &mdash; bi&#8209;temporal facts with as&#8209;of replay, hard tenant isolation via Postgres RLS, the Chain&#8209;of&#8209;Note ABSTAIN clause, Ed25519 provenance signing, GDPR delete/export with an RLS&#8209;exempt audit trail, JWT auth for HOSTED mode, and a regression gate that runs four benchmarks on every PR. See <a href="./CHANGELOG.md">CHANGELOG.md</a> for the full list.</sub>
-
----
-
-<a id="problem"></a>
-
-## &sect; 01 &mdash; The Problem
-
-<sub><b>Why agent prototypes don't survive production</b></sub>
-
-Agent prototypes don't survive production. Memory is usually why.
-
-Single agents rediscover the same facts every run. Multi&#8209;agent pipelines are worse &mdash; the planner's decisions never reach the executor, the researcher's findings never reach the reviewer. Teams end up stuffing giant prompts between agents to paper over the gap. That's not an architecture &mdash; that's a workaround.
-
-<sub><i>What we hear from teams building agent pipelines:</i></sub>
-
-> *We had a planner, a coder, a reviewer, a deployer &mdash; four agents in a pipeline. None of them knew what the others learned. We were passing giant prompts between them and burning tokens on stale information.*
-
-<table>
-<tr><th>Without Attestor</th><th>With Attestor</th></tr>
-<tr><td>01 &mdash; Each agent starts blind &mdash; no knowledge of what others learned</td><td>01 &mdash; Shared memory &mdash; planner writes, coder reads, reviewer sees both</td></tr>
-<tr><td>02 &mdash; Giant prompts passed between agents burn context tokens</td><td>02 &mdash; Token&#8209;budget recall &mdash; each agent pulls only what fits</td></tr>
-<tr><td>03 &mdash; No access control &mdash; any agent can overwrite any state</td><td>03 &mdash; Six RBAC roles, namespace isolation, write quotas per agent</td></tr>
-<tr><td>04 &mdash; Contradicting facts from different agents go undetected</td><td>04 &mdash; Contradictions auto&#8209;resolved &mdash; newer facts supersede older ones</td></tr>
-<tr><td>05 &mdash; Session ends, everything learned is gone forever</td><td>05 &mdash; Persistent across sessions, pipelines, and agent restarts</td></tr>
-</table>
-
-More agents, more sessions, more memories &mdash; retrieval gets better while context cost stays flat.
-
----
-
-<a id="multi-agent"></a>
-
-## &sect; 02 &mdash; Multi-Agent Systems
-
-<sub><b>Orchestrator &middot; Planner &middot; Executor &middot; Reviewer</b></sub>
-
-Not a chatbot plugin. Infrastructure for agent teams.
-
-Every recall and write is scoped to an `AgentContext` &mdash; a lightweight dataclass carrying identity, role, namespace, parent trail, token budget, write quota, and visibility. Contexts are immutable; spawning a sub&#8209;agent returns a new context with inherited provenance.
-
-| # | Primitive | What it does |
-|---|---|---|
-| 01 | **Namespace isolation** | Every agent, project, or tenant gets its own namespace. Planner writes, coder reads, reviewer sees both. Isolated by default, shared when you configure it. |
-| 02 | **Six RBAC roles** | Orchestrator, Planner, Executor, Researcher, Reviewer, Monitor. Read&#8209;only observers to full admins. |
-| 03 | **Provenance tracking** | Know which agent wrote which memory, when, and under which parent session. The reviewer can trace a decision back to the planner three sessions ago. |
-| 04 | **Cross&#8209;agent contradiction resolution** | Agent A learns *"user works at Google."* Agent B learns *"user works at Meta."* Attestor auto&#8209;supersedes. Full history preserved. Zero inference calls in the critical path. |
-| 05 | **Token budgets per agent** | `recall(query, budget=2000)` &mdash; a summarizer uses 500 tokens; a deep reasoner uses 5,000. Each agent receives exactly what fits in its context window. |
-| 06 | **Write quotas &amp; review flags** | Rate&#8209;limit writes per namespace, flag writes for human review, add compliance tags for audit. |
-
----
-
-<a id="pipeline"></a>
-
-## &sect; 03 &mdash; The Retrieval Pipeline
-
-<sub><b>Five layers &middot; zero inference calls</b></sub>
-
-Five layers. No LLM. Everything deterministic.
-
-When an agent calls `recall(query, budget)`, five cooperating layers find, fuse, score, and fit the most relevant memories into the requested token ceiling. The store can hold ten million memories; the context window never sees more than the budget.
-
-| # | Layer | Backend | Mechanism |
-|---|---|---|---|
-| 01 | **Tag Match** | Postgres | Tag index, FTS / trigram, exact + partial hits |
-| 02 | **Graph Expansion** | Neo4j (GDS) | Multi&#8209;hop BFS (depth 2) |
-| 03 | **Vector Search** | pgvector | Cosine similarity (HNSW) |
-| 04 | **Fusion + Rank** | In&#8209;process | RRF (k=60) + PageRank + confidence decay |
-| 05 | **Diversity + Fit** | In&#8209;process | MMR (&lambda;=0.7) + greedy token&#8209;budget pack |
-
-### Storage roles
-
-<p align="center"><img src="docs/storage-roles.svg" alt="Storage roles — document store, vector store, graph store" width="100%"></p>
-
-Every memory is persisted across **three complementary stores**. Every supported backend combination is just a different technology choice for one or more of these roles.
-
-| Role | What it stores | Why it exists |
-|---|---|---|
-| **Document store** | The source of truth &mdash; content, tags, entity, category, timestamps, provenance, confidence | Where `add()` commits; where `recall()` hydrates final memory text |
-| **Vector store** | Dense embedding per memory, keyed by memory ID | Finds memories by *meaning* when no tag or word overlaps the query |
-| **Graph store** | Entity nodes + typed edges (`uses`, `authored-by`, `supersedes`) | Connects memories indirectly &mdash; query &ldquo;Python&rdquo; can surface &ldquo;Django&rdquo; via the graph |
-
-### Ingestion flow &mdash; what happens on `add()`
-
-<sub>Example framing &mdash; a <b>market intelligence system</b> feeding a financial advisor pipeline. Every signal the desk cares about lands here.</sub>
-
-```mermaid
-flowchart TB
-    N1["<b>News wires</b><br/>Reuters &bull; Bloomberg<br/><i>breaking headlines</i>"]
-    N2["<b>Market data</b><br/>ticks &bull; OHLC<br/><i>prices &bull; volumes</i>"]
-    N3["<b>Earnings reports</b><br/>10-K &bull; 10-Q &bull; 8-K<br/><i>guidance &bull; surprises</i>"]
-    N4["<b>Leadership changes</b><br/>CEO &bull; CFO &bull; Board<br/><i>appointments &bull; exits</i>"]
-    N5["<b>Geopolitical events</b><br/>tariffs &bull; sanctions<br/><i>policy &bull; conflict</i>"]
-
-    subgraph SOURCES ["&sect; MARKET INTELLIGENCE SOURCES"]
-        direction LR
-        N1 ~~~ N2 ~~~ N3 ~~~ N4 ~~~ N5
-    end
-
-    SOURCES ==>|"<b>mem.add(content, tags, entity, provenance, ts)</b>"| API{{"<b>INGEST API</b>"}}
-
-    D1["<b>Document store</b><br/>insert row<br/>content &bull; tags &bull; entity<br/>ts &bull; source &bull; confidence"]
-    D2["<b>Vector store</b><br/>embed text<br/>&rarr; 384-d vector<br/>keyed by memory ID"]
-    D3["<b>Graph store</b><br/>extract entities + edges<br/>issuer &bull; sector &bull; person<br/>country &bull; event"]
-
-    subgraph WRITE ["&sect; PARALLEL WRITES &mdash; one logical transaction"]
-        direction LR
-        D1 ~~~ D2 ~~~ D3
-    end
-
-    API --> D1
-    API --> D2
-    API --> D3
-
-    CD["<b>Contradiction check</b><br/>per entity &bull; per field<br/>e.g. JPM CFO is X vs new JPM CFO is Y"]
-
-    D1 ==> CD
-    D2 ==> CD
-    D3 ==> CD
-
-    CD ==>|newer fact wins| SUP["<b>Supersede older fact</b><br/>keep in timeline for audit"]
-    SUP ==> DONE["<b>Committed &bull; recallable</b>"]
-
-    style SOURCES fill:#F5F1E8,stroke:#1A1614,stroke-width:2px,color:#1A1614
-    style WRITE   fill:#FBF8F1,stroke:#1A1614,stroke-width:2px,color:#1A1614
-    style API     fill:#1A1614,stroke:#C15F3C,stroke-width:2px,color:#F5F1E8
-    style CD      fill:#F5F1E8,stroke:#C15F3C,stroke-width:3px,color:#1A1614
-    style SUP     fill:#FBF8F1,stroke:#C15F3C,stroke-width:2px,color:#1A1614
-    style DONE    fill:#1A1614,stroke:#C15F3C,stroke-width:2px,color:#F5F1E8
-    style N1      fill:#FBF8F1,stroke:#1A1614,color:#1A1614
-    style N2      fill:#FBF8F1,stroke:#1A1614,color:#1A1614
-    style N3      fill:#FBF8F1,stroke:#1A1614,color:#1A1614
-    style N4      fill:#FBF8F1,stroke:#1A1614,color:#1A1614
-    style N5      fill:#FBF8F1,stroke:#1A1614,color:#1A1614
-    style D1      fill:#FBF8F1,stroke:#1A1614,color:#1A1614
-    style D2      fill:#FBF8F1,stroke:#1A1614,color:#1A1614
-    style D3      fill:#FBF8F1,stroke:#1A1614,color:#1A1614
-```
-
-<sub>The three writes commit as one logical transaction. On SQL backends it&rsquo;s a real DB transaction; on distributed backends it&rsquo;s sequenced with best-effort rollback. Contradictions don&rsquo;t overwrite &mdash; older facts are <b>superseded</b> and retained in the timeline so auditors can reconstruct what the desk knew, and when.</sub>
-
----
-
-### Ingestion flow &mdash; variant B &bull; agent-to-agent conversation capture
-
-<sub>A <b>different kind of ingestion</b>: the memories are not external feeds &mdash; they are <b>the agents&rsquo; own conversation</b> as they debate a trade proposal. Every turn is captured with speaker, timestamp, entity, and a decision marker.</sub>
-
-```mermaid
-flowchart TB
-    T1["<b>Portfolio Planner</b><br/><i>&ldquo;Proposing to add 2% JPM<br/>ahead of Q3 print&rdquo;</i>"]
-    T2["<b>Market Researcher</b><br/><i>&ldquo;Consensus EPS is +4% QoQ,<br/>whisper number suggests beat&rdquo;</i>"]
-    T3["<b>Risk Analyst</b><br/><i>&ldquo;Tariff headline risk this week<br/>&mdash; raise stop to 8%&rdquo;</i>"]
-    T4["<b>Compliance Reviewer</b><br/><i>&ldquo;Ok with position limit.<br/>Logging rationale.&rdquo;</i>"]
-    DEC["<b>Decision reached</b><br/>buy 2% JPM &bull; stop 8% &bull; pre-earnings"]
-
-    subgraph CONV ["&sect; AGENT-TO-AGENT CONVERSATION &mdash; trade proposal thread"]
-        direction LR
-        T1 --> T2
-        T2 --> T3
-        T3 --> T4
-        T4 --> DEC
-    end
-
-    CAP["<b>Turn-level capture</b><br/>speaker &bull; utterance &bull; ts<br/>entity: JPM &bull; topic: position sizing<br/>kind: <i>conversation</i>"]
-
-    CONV ==>|auto-capture hook<br/>every turn| CAP
-    CAP ==>|"<b>mem.add(content, speaker, thread_id, kind=&quot;chat&quot;)</b>"| API{{"<b>INGEST API</b>"}}
-
-    DOC[("<b>Document store</b><br/>turn rows, thread_id,<br/>speaker, ts, decision flag")]
-    VEC[("<b>Vector store</b><br/>embedding per turn")]
-    GR[("<b>Graph store</b><br/>edges: agent &rarr; entity<br/>agent &rarr; decision")]
-
-    API --> DOC
-    API --> VEC
-    API --> GR
-
-    DONE["<b>Thread memorialised</b><br/>replayable &bull; attributable &bull; auditable"]
-    DOC ==> DONE
-    VEC ==> DONE
-    GR ==> DONE
-
-    style CONV fill:#F5F1E8,stroke:#1A1614,stroke-width:2px,color:#1A1614
-    style CAP  fill:#F5F1E8,stroke:#C15F3C,stroke-width:3px,color:#1A1614
-    style API  fill:#1A1614,stroke:#C15F3C,stroke-width:2px,color:#F5F1E8
-    style DONE fill:#1A1614,stroke:#C15F3C,stroke-width:2px,color:#F5F1E8
-    style T1   fill:#FBF8F1,stroke:#1A1614,color:#1A1614
-    style T2   fill:#FBF8F1,stroke:#1A1614,color:#1A1614
-    style T3   fill:#FBF8F1,stroke:#1A1614,color:#1A1614
-    style T4   fill:#FBF8F1,stroke:#1A1614,color:#1A1614
-    style DEC  fill:#FBF8F1,stroke:#C15F3C,stroke-width:2px,color:#1A1614
-    style DOC  fill:#FBF8F1,stroke:#1A1614,color:#1A1614
-    style VEC  fill:#FBF8F1,stroke:#1A1614,color:#1A1614
-    style GR   fill:#FBF8F1,stroke:#1A1614,color:#1A1614
-```
-
-<sub>Different from feed ingestion: the <b>source is the agents themselves</b>, not the outside world. Every turn is attributed to a speaker, tied to a thread, and flagged if it contained a decision. Nothing is paraphrased &mdash; the verbatim utterance is preserved so the reasoning can be reconstructed under audit.</sub>
-
-### Recall flow &mdash; what happens on `recall()`
-
-<sub>Same market intelligence system &mdash; now the <b>Portfolio Planner</b> asks a real question ahead of the morning call.</sub>
-
-```mermaid
-flowchart TB
-    U["<b>Financial Advisor</b><br/>typing into chat UI<br/>ahead of the 8am call"]
-    BUBBLE["<b>Chat message</b><br/><i>What do we know about JPM&rsquo;s CFO transition<br/>and the fallout for US regional banks?</i>"]
-
-    subgraph CHAT ["&sect; ADVISOR CHAT INTERFACE &mdash; human in the loop"]
-        direction LR
-        U ==> BUBBLE
-    end
-
-    CHAT ==>|routed to| AGENT(["<b>Portfolio Planner agent</b><br/>decomposes intent &bull; issues recall"])
-
-    Q1["<i>JPM CFO transition</i>"]
-    Q2["<i>Semiconductor supply-chain<br/>risk after latest tariff move</i>"]
-    Q3["<i>Earnings surprises in<br/>US regional banks, last 90 days</i>"]
-
-    subgraph QUERIES ["&sect; DECOMPOSED RECALL QUERIES &mdash; what the agent actually asks attestor"]
-        direction LR
-        Q1 ~~~ Q2 ~~~ Q3
-    end
-
-    AGENT ==> QUERIES
-    QUERIES ==>|"<b>mem.recall(query, budget=2000)</b>"| API{{"<b>RECALL API</b>"}}
-
-    L1["<b>01 &bull; Tag Match</b><br/>&rarr; document store<br/>FTS on JPM, CFO,<br/>tariff, earnings"]
-    L2["<b>02 &bull; Graph Expansion</b><br/>&rarr; graph store<br/>BFS: JPM &rarr; CFO<br/>&rarr; Jeremy Barnum"]
-    L3["<b>03 &bull; Vector Search</b><br/>&rarr; vector store<br/>cosine on query<br/>top-K nearest embeddings"]
-
-    subgraph SOURCES ["&sect; STAGE A &mdash; parallel sources &bull; fan-out across 3 indexes"]
-        direction LR
-        L1 ~~~ L2 ~~~ L3
-    end
-
-    API --> L1
-    API --> L2
-    API --> L3
-
-    IDS[("Candidate memory IDs<br/>~100s &bull; deduped")]
-
-    L1 --> IDS
-    L2 --> IDS
-    L3 --> IDS
-
-    L4["<b>04 &bull; Fusion &amp; Rank</b><br/>RRF k=60 &bull; PageRank boost on central entities<br/>&bull; confidence decay on stale prints"]
-    L5["<b>05 &bull; Diversity &amp; Fit</b><br/>MMR &lambda;=0.7 &mdash; drop near-duplicate news wires<br/>&bull; greedy pack under 2,000 tokens"]
-    OUT["<b>Portfolio Planner context</b>"]
-    REPLY["<b>Chat reply to advisor</b><br/>sourced &bull; dated &bull; auditable"]
-
-    IDS ==>|hydrate from doc store| L4
-    L4 ==> L5
-    L5 ==>|ranked memories &le; budget<br/>zero LLM calls in the path| OUT
-    OUT ==>|grounded answer streamed to chat| REPLY
-
-    style CHAT    fill:#F5F1E8,stroke:#1A1614,stroke-width:2px,color:#1A1614
-    style U       fill:#FBF8F1,stroke:#1A1614,color:#1A1614
-    style BUBBLE  fill:#FBF8F1,stroke:#C15F3C,stroke-width:2px,color:#1A1614
-    style AGENT   fill:#1A1614,stroke:#C15F3C,stroke-width:2px,color:#F5F1E8
-    style REPLY   fill:#FBF8F1,stroke:#C15F3C,stroke-width:2px,color:#1A1614
-    style QUERIES fill:#F5F1E8,stroke:#1A1614,stroke-width:2px,color:#1A1614
-    style SOURCES fill:#FBF8F1,stroke:#C15F3C,stroke-width:2px,color:#1A1614
-    style API     fill:#1A1614,stroke:#C15F3C,stroke-width:2px,color:#F5F1E8
-    style L1      fill:#FBF8F1,stroke:#C15F3C,color:#1A1614
-    style L2      fill:#FBF8F1,stroke:#C15F3C,color:#1A1614
-    style L3      fill:#FBF8F1,stroke:#C15F3C,color:#1A1614
-    style IDS     fill:#F5F1E8,stroke:#1A1614,color:#1A1614
-    style L4      fill:#F5F1E8,stroke:#C15F3C,stroke-width:3px,color:#1A1614
-    style L5      fill:#F5F1E8,stroke:#C15F3C,stroke-width:3px,color:#1A1614
-    style OUT     fill:#1A1614,stroke:#C15F3C,stroke-width:2px,color:#F5F1E8
-    style Q1      fill:#FBF8F1,stroke:#1A1614,color:#1A1614
-    style Q2      fill:#FBF8F1,stroke:#1A1614,color:#1A1614
-    style Q3      fill:#FBF8F1,stroke:#1A1614,color:#1A1614
-```
-
-<sub>Only memory IDs travel between layers until the hydrate step. A store with ten million market-intel rows still returns a tight result set inside the caller&rsquo;s token ceiling. Graph expansion is the step that lets <i>&ldquo;tariff&rdquo;</i> surface memories about <i>&ldquo;TSMC&rdquo;</i> and <i>&ldquo;Nvidia&rdquo;</i> without either word appearing in the query.</sub>
-
----
-
-### Recall flow &mdash; variant B &bull; agent context recall
-
-<sub>A <b>different kind of recall</b>: no human in the loop. An agent resuming a task &mdash; or handing off to a peer &mdash; pulls back <b>its own prior working context</b>: earlier decisions, peer rationale, what was true at the last checkpoint.</sub>
-
-```mermaid
-flowchart TB
-    RESUME["<b>Risk Analyst</b> resuming mid-task<br/>or <b>Compliance Reviewer</b> taking handoff<br/><i>no user prompt &mdash; agent self-initiated</i>"]
-
-    INTENT["<b>Context intent</b><br/>&ldquo;what did the desk already decide<br/>about JPM this week, and why?&rdquo;"]
-
-    RESUME ==> INTENT
-    INTENT ==>|"<b>mem.recall_context(thread_id, entity=&quot;JPM&quot;, since=7d)</b>"| API{{"<b>CONTEXT RECALL API</b>"}}
-
-    F1["<b>Thread filter</b><br/>same thread_id<br/>or same namespace"]
-    F2["<b>Entity filter</b><br/>entity = JPM<br/>and related via graph"]
-    F3["<b>Temporal filter</b><br/>within last 7d<br/>supersedes resolved"]
-    F4["<b>Speaker filter</b><br/>peer agents in role<br/>RBAC-visible only"]
-
-    subgraph FILTERS ["&sect; CONTEXT FILTERS &mdash; tighter than open-query recall"]
-        direction LR
-        F1 ~~~ F2 ~~~ F3 ~~~ F4
-    end
-
-    API --> FILTERS
-
-    TURNS["<b>Prior conversation turns</b><br/>Planner proposal &bull; Researcher consensus<br/>Analyst stop raise &bull; Compliance sign-off"]
-    DECS["<b>Prior decisions</b><br/>buy 2% JPM &bull; stop 8%<br/>decided 3 days ago"]
-    DELTA["<b>What changed since</b><br/>new tariff headline today<br/>stop needs re-evaluation"]
-
-    FILTERS ==> TURNS
-    FILTERS ==> DECS
-    FILTERS ==> DELTA
-
-    PACK["<b>Context pack</b><br/>chronologically ordered<br/>&bull; speaker-attributed<br/>&bull; fit to agent token budget"]
-
-    TURNS ==> PACK
-    DECS ==> PACK
-    DELTA ==> PACK
-
-    PACK ==>|loaded into agent<br/>working memory| RESUMED["<b>Agent resumes task</b><br/>with full prior context<br/>&bull; no re-asking peers<br/>&bull; no lost decisions"]
-
-    style RESUME   fill:#F5F1E8,stroke:#1A1614,stroke-width:2px,color:#1A1614
-    style INTENT   fill:#FBF8F1,stroke:#C15F3C,stroke-width:2px,color:#1A1614
-    style API      fill:#1A1614,stroke:#C15F3C,stroke-width:2px,color:#F5F1E8
-    style FILTERS  fill:#FBF8F1,stroke:#C15F3C,stroke-width:2px,color:#1A1614
-    style F1       fill:#FBF8F1,stroke:#1A1614,color:#1A1614
-    style F2       fill:#FBF8F1,stroke:#1A1614,color:#1A1614
-    style F3       fill:#FBF8F1,stroke:#1A1614,color:#1A1614
-    style F4       fill:#FBF8F1,stroke:#1A1614,color:#1A1614
-    style TURNS    fill:#F5F1E8,stroke:#1A1614,color:#1A1614
-    style DECS     fill:#F5F1E8,stroke:#C15F3C,stroke-width:2px,color:#1A1614
-    style DELTA    fill:#F5F1E8,stroke:#C15F3C,stroke-width:2px,color:#1A1614
-    style PACK     fill:#F5F1E8,stroke:#C15F3C,stroke-width:3px,color:#1A1614
-    style RESUMED  fill:#1A1614,stroke:#C15F3C,stroke-width:2px,color:#F5F1E8
-```
-
-<sub>Differs from open-query recall in three ways: <b>(1)</b> the caller is an <b>agent</b>, not a human &mdash; triggered by resume / handoff, not by a chat message; <b>(2)</b> the filters are <b>tighter</b> &mdash; thread, namespace, RBAC, time window &mdash; not just semantic similarity; <b>(3)</b> the output preserves <b>chronology and attribution</b> rather than ranking purely by relevance. This is how a long-running pipeline stays coherent across restarts, handoffs, and multi-day workflows.</sub>
-
----
-
-### Isolation &mdash; namespace &amp; RBAC boundary
-
-<sub>Multi-tenant by construction. Every memory lives inside a <b>namespace</b>; every agent is bound to one of six <b>roles</b> (<code>ORCHESTRATOR</code>, <code>PLANNER</code>, <code>EXECUTOR</code>, <code>RESEARCHER</code>, <code>REVIEWER</code>, <code>MONITOR</code>); every call is authorised before it touches storage.</sub>
-
-```mermaid
-flowchart TB
-    CALLER["<b>Incoming call</b><br/>agent identity &bull; API key / JWT<br/>claims: namespace, role, thread"]
-
-    AUTH["<b>AuthZ gate</b><br/>verify signature &bull; resolve role<br/>&bull; check write quota per agent"]
-
-    CALLER ==> AUTH
-
-    R1["<b>ORCHESTRATOR</b><br/>spawns sub-agents<br/>full read/write"]
-    R2["<b>PLANNER</b><br/>decomposes tasks<br/>writes plans + decisions"]
-    R3["<b>EXECUTOR</b><br/>runs the work<br/>add + recall own thread"]
-    R4["<b>RESEARCHER</b><br/>gathers facts<br/>often read-only"]
-    R5["<b>REVIEWER</b><br/>audits decisions<br/>read + flag-for-review"]
-    R6["<b>MONITOR</b><br/>observability only<br/>read + timeline"]
-
-    subgraph ROLES ["&sect; RBAC ROLES &mdash; 6 built-in, customisable"]
-        direction LR
-        R1 ~~~ R2 ~~~ R3 ~~~ R4 ~~~ R5 ~~~ R6
-    end
-
-    AUTH ==> ROLES
-
-    NS1["<b>namespace: fund-alpha</b><br/>portfolio planner threads<br/>risk analyst threads"]
-    NS2["<b>namespace: fund-beta</b><br/>separate data plane<br/>no cross-read"]
-    NS3["<b>namespace: research</b><br/>shared feed ingest<br/>read-only for funds"]
-
-    subgraph TENANTS ["&sect; NAMESPACE BOUNDARIES &mdash; hard isolation"]
-        direction LR
-        NS1 ~~~ NS2 ~~~ NS3
-    end
-
-    ROLES ==>|"filtered by namespace + role"| TENANTS
-
-    STORE[("<b>Doc &bull; Vector &bull; Graph</b><br/>row-level tenant column<br/>filtered on every query")]
-
-    TENANTS ==> STORE
-
-    style CALLER  fill:#F5F1E8,stroke:#1A1614,stroke-width:2px,color:#1A1614
-    style AUTH    fill:#1A1614,stroke:#C15F3C,stroke-width:2px,color:#F5F1E8
-    style ROLES   fill:#FBF8F1,stroke:#C15F3C,stroke-width:2px,color:#1A1614
-    style TENANTS fill:#F5F1E8,stroke:#C15F3C,stroke-width:2px,color:#1A1614
-    style STORE   fill:#FBF8F1,stroke:#1A1614,stroke-width:2px,color:#1A1614
-    style R1      fill:#FBF8F1,stroke:#1A1614,color:#1A1614
-    style R2      fill:#FBF8F1,stroke:#1A1614,color:#1A1614
-    style R3      fill:#FBF8F1,stroke:#1A1614,color:#1A1614
-    style R4      fill:#FBF8F1,stroke:#1A1614,color:#1A1614
-    style R5      fill:#FBF8F1,stroke:#1A1614,color:#1A1614
-    style R6      fill:#FBF8F1,stroke:#1A1614,color:#1A1614
-    style NS1     fill:#FBF8F1,stroke:#C15F3C,color:#1A1614
-    style NS2     fill:#FBF8F1,stroke:#C15F3C,color:#1A1614
-    style NS3     fill:#FBF8F1,stroke:#C15F3C,color:#1A1614
-```
-
-<sub>Namespaces are enforced at the row level (tenant column on every row, filtered on every query), not just in application code. Cross-namespace reads require an <code>ORCHESTRATOR</code> or <code>REVIEWER</code> context. Every write records the agent&rsquo;s trail (parent chain, session id, namespace) as provenance metadata so feed ingests cannot impersonate a peer.</sub>
-
----
-
-### Temporal &mdash; timeline &amp; supersession
-
-<sub>Attestor doesn&rsquo;t overwrite &mdash; it <b>supersedes</b>. Every fact has a validity window, and the timeline is replayable to any point in the past. Auditors can answer not just <i>&ldquo;what does the desk know?&rdquo;</i> but <i>&ldquo;what did the desk know on 2026-04-10 at 08:00?&rdquo;</i></sub>
-
-```mermaid
-flowchart LR
-    F1["<b>fact v1</b><br/><i>JPM CFO is Jeremy Barnum</i><br/>valid_from: 2022-05<br/>valid_to: <b>&infin;</b><br/>confidence: 0.95"]
-    F2["<b>fact v2</b><br/><i>JPM CFO is Jane Doe</i><br/>valid_from: 2026-04-11<br/>valid_to: <b>&infin;</b><br/>confidence: 0.98<br/>supersedes: v1"]
-    F3["<b>fact v3</b><br/><i>JPM CFO appointment delayed</i><br/>valid_from: 2026-04-12<br/>valid_to: <b>&infin;</b><br/>confidence: 0.90<br/>supersedes: v2"]
-
-    subgraph TL ["&sect; TIMELINE &mdash; same entity, multiple states, none deleted"]
-        direction LR
-        F1 ==>|"new fact ingested<br/>contradiction detected"| F2
-        F2 ==>|"corrected headline<br/>contradiction detected"| F3
-    end
-
-    Q1["<b>recall today</b><br/><i>who is JPM CFO?</i>"]
-    Q2["<b>recall as-of 2026-04-11</b><br/><i>who was JPM CFO yesterday?</i>"]
-    Q3["<b>auditor replay</b><br/><i>show full timeline</i>"]
-
-    Q1 -->|"valid_to = &infin;<br/>latest confident fact"| A1["<b>v3 only</b><br/>&ldquo;appointment delayed&rdquo;"]
-    Q2 -->|"filter: valid_at 2026-04-11"| A2["<b>v2 only</b><br/>&ldquo;Jane Doe&rdquo;"]
-    Q3 -->|"no filter<br/>full chain"| A3["<b>v1 &rarr; v2 &rarr; v3</b><br/>with supersession edges"]
-
-    TL ==> Q1
-    TL ==> Q2
-    TL ==> Q3
-
-    style TL fill:#F5F1E8,stroke:#C15F3C,stroke-width:2px,color:#1A1614
-    style F1 fill:#FBF8F1,stroke:#6B5F4F,color:#1A1614
-    style F2 fill:#FBF8F1,stroke:#C15F3C,stroke-width:2px,color:#1A1614
-    style F3 fill:#FBF8F1,stroke:#C15F3C,stroke-width:3px,color:#1A1614
-    style Q1 fill:#1A1614,stroke:#C15F3C,color:#F5F1E8
-    style Q2 fill:#1A1614,stroke:#C15F3C,color:#F5F1E8
-    style Q3 fill:#1A1614,stroke:#C15F3C,color:#F5F1E8
-    style A1 fill:#FBF8F1,stroke:#1A1614,color:#1A1614
-    style A2 fill:#FBF8F1,stroke:#1A1614,color:#1A1614
-    style A3 fill:#FBF8F1,stroke:#1A1614,color:#1A1614
-```
-
-<sub>Supersession is a <b>graph edge</b>, not a delete. The document store keeps every version; the graph store links <code>v1 &mdash;supersedes&rarr; v2</code>. Recall defaults to &ldquo;latest confident fact,&rdquo; but any call can pass <code>as_of</code> to replay the past, which is how regulatory audit and post-mortem reconstruction both work on the same primitive.</sub>
-
----
-
-### Provenance &mdash; source-to-citation chain
-
-<sub>Every sentence the agent writes back to the advisor is <b>traceable to its source</b>. Not a paraphrase of a paraphrase &mdash; a cryptographic chain from raw feed ingest to grounded answer.</sub>
-
-```mermaid
-flowchart LR
-    RAW["<b>Raw signal</b><br/><i>Reuters wire, 08:14 UTC</i><br/>&ldquo;JPM names Jane Doe CFO&rdquo;<br/>sha256: a1b2c3&hellip;"]
-
-    ING["<b>Ingest</b><br/>parse &bull; entity extract<br/>attach provenance envelope<br/>source_id &bull; source_ts &bull; hash"]
-
-    MEM["<b>Memory row</b><br/>id: mem_42<br/>content, entity=JPM<br/>provenance: {source_id, hash,<br/>ingest_ts, confidence: 0.98}"]
-
-    RECALL["<b>Retrieval</b><br/>5-layer pipeline<br/>returns mem_42 among others"]
-
-    ANS["<b>Agent answer</b><br/><i>&ldquo;Jane Doe was named CFO on<br/>2026-04-11 [source: Reuters]&rdquo;</i><br/>citations: [mem_42]"]
-
-    AUDIT["<b>Auditor click-through</b><br/>mem_42 &rarr; raw Reuters wire<br/>with timestamp + hash check"]
-
-    RAW ==> ING
-    ING ==> MEM
-    MEM ==> RECALL
-    RECALL ==> ANS
-    ANS -.->|citation link<br/>resolves to| AUDIT
-    AUDIT -.->|verifies hash<br/>against raw signal| RAW
-
-    style RAW    fill:#F5F1E8,stroke:#1A1614,stroke-width:2px,color:#1A1614
-    style ING    fill:#FBF8F1,stroke:#C15F3C,color:#1A1614
-    style MEM    fill:#FBF8F1,stroke:#C15F3C,stroke-width:2px,color:#1A1614
-    style RECALL fill:#FBF8F1,stroke:#C15F3C,color:#1A1614
-    style ANS    fill:#1A1614,stroke:#C15F3C,stroke-width:2px,color:#F5F1E8
-    style AUDIT  fill:#F5F1E8,stroke:#C15F3C,stroke-width:3px,color:#1A1614
-```
-
-<sub>The citation in the agent&rsquo;s reply is not a string the LLM chose to emit &mdash; it&rsquo;s the <code>memory_id</code> carried through the retrieval pipeline. An auditor clicks the citation and lands on the raw wire with timestamp and content hash. If the upstream signal was tampered with, the hash check fails. This is what distinguishes <i>grounded</i> from <i>plausible</i>.</sub>
-
----
-
-<a id="deploy"></a>
-
-## &sect; 04 &mdash; Deployment Matrix
-
-<sub><b>Your cloud &middot; your infrastructure &middot; Terraform templates included</b></sub>
-
-Same API. Every backend. Your infrastructure, not theirs.
-
-Attestor ships as a Python library, a REST API, or a containerized service. Reference Terraform templates for Amazon Web Services (ECS Fargate + ArangoDB), Microsoft Azure (Container Apps + Cosmos DB), and Google Cloud Platform (Cloud Run + AlloyDB) live under `attestor/infra/`. Clone, set your own variables, `terraform apply` in your account &mdash; no SaaS middleman, no per-seat fees, no vendor lock-in.
-
-```bash
-$ pip install attestor
-$ attestor api --host 0.0.0.0 --port 8080
-```
-
-<sub>Starlette ASGI on <code>http://localhost:8080</code>. Backed by Postgres (pgvector) + Neo4j (GDS) &mdash; run them locally via the included Docker Compose stack, or point at managed Postgres and Neo4j AuraDB. Every agent in your stack talks to the same URL &mdash; they share memory instantly. Self&#8209;hosted, in your infrastructure, behind your firewall.</sub>
-
-| # | Target | Notes |
-|---|---|---|
-| 01 | **AWS** &mdash; ECS Fargate + ArangoDB | ECS task with ArangoDB sidecar behind an ALB. Terraform template included &mdash; clone, adapt, `terraform apply` in your account. |
-| 02 | **Azure** &mdash; Container Apps | Cosmos DB DiskANN for doc + vector; NetworkX for graph. Terraform template included. |
-| 03 | **Google Cloud Platform** &mdash; Cloud Run + AlloyDB | AlloyDB (PostgreSQL + ScaNN + pgvector + AGE) behind Cloud Run. Terraform template included. |
-| 04 | **PostgreSQL** backend | pgvector + Apache AGE. Neon serverless or any Postgres 16. Doc &middot; Vector &middot; Graph |
-| 05 | **ArangoDB** backend | Multi&#8209;model: graph + document + vector in one engine. Oasis or self&#8209;hosted. |
-| 06 | **Local / On&#8209;Prem** | Self&#8209;hosted Postgres + Neo4j via the included Docker Compose stack. Air&#8209;gapped deployments, no egress to third parties. |
-
-### Same container, pluggable stores
-
-<p align="center">
-  <img src="docs/deployment-matrix.svg" alt="Deployment matrix — one Attestor container, six targets, three storage roles swap per target" width="100%">
-</p>
-
-<sub><i>Every deployment is the same Python library wrapped in the same Starlette ASGI container. <code>DocumentStore</code>, <code>VectorStore</code>, and <code>GraphStore</code> are three interfaces; each column above is one implementation of each. Same API, same retrieval behavior, your infrastructure.</i></sub>
-
-### Runtime topology &mdash; three integration modes
-
-<sub>The same Attestor engine runs in three shapes &mdash; same storage, same retrieval, different coupling. Pick by latency budget and blast radius.</sub>
-
-```mermaid
-flowchart TB
-    subgraph M1 ["&sect; MODE A &mdash; EMBEDDED LIBRARY &bull; lowest latency"]
-        direction LR
-        AG1["<b>Agent process</b><br/>Python &bull; import attestor"]
-        MW1["<b>Attestor in-proc</b><br/>AgentMemory('./store')"]
-        ST1[("<b>Local stores</b><br/>Postgres (pgvector) · Neo4j (GDS)<br/>via Docker Compose")]
-        AG1 ==> MW1 ==> ST1
-    end
-
-    subgraph M2 ["&sect; MODE B &mdash; SIDECAR CONTAINER &bull; process isolation"]
-        direction LR
-        AG2["<b>Agent container</b><br/>any language<br/>HTTP client"]
-        MW2["<b>Attestor sidecar</b><br/>attestor api<br/>on localhost:8080"]
-        ST2[("<b>Shared volume</b><br/>or managed backends")]
-        AG2 ==>|"HTTP / MCP<br/>same pod"| MW2 ==> ST2
-    end
-
-    subgraph M3 ["&sect; MODE C &mdash; SHARED SERVICE &bull; multi-agent mesh"]
-        direction LR
-        AF1["<b>Agent A</b>"]
-        AF2["<b>Agent B</b>"]
-        AF3["<b>Agent C</b>"]
-        MW3["<b>Attestor service</b><br/>App Runner · Cloud Run<br/>· Container Apps"]
-        ST3[("<b>Managed backends</b><br/>Postgres · ArangoDB · Cosmos")]
-        AF1 ==> MW3
-        AF2 ==> MW3
-        AF3 ==> MW3
-        MW3 ==> ST3
-    end
-
-    style M1 fill:#F5F1E8,stroke:#1A1614,stroke-width:2px,color:#1A1614
-    style M2 fill:#F5F1E8,stroke:#C15F3C,stroke-width:2px,color:#1A1614
-    style M3 fill:#F5F1E8,stroke:#C15F3C,stroke-width:3px,color:#1A1614
-    style AG1 fill:#FBF8F1,stroke:#1A1614,color:#1A1614
-    style MW1 fill:#FBF8F1,stroke:#C15F3C,stroke-width:2px,color:#1A1614
-    style ST1 fill:#FBF8F1,stroke:#1A1614,color:#1A1614
-    style AG2 fill:#FBF8F1,stroke:#1A1614,color:#1A1614
-    style MW2 fill:#FBF8F1,stroke:#C15F3C,stroke-width:2px,color:#1A1614
-    style ST2 fill:#FBF8F1,stroke:#1A1614,color:#1A1614
-    style AF1 fill:#FBF8F1,stroke:#1A1614,color:#1A1614
-    style AF2 fill:#FBF8F1,stroke:#1A1614,color:#1A1614
-    style AF3 fill:#FBF8F1,stroke:#1A1614,color:#1A1614
-    style MW3 fill:#1A1614,stroke:#C15F3C,stroke-width:2px,color:#F5F1E8
-    style ST3 fill:#FBF8F1,stroke:#1A1614,color:#1A1614
-```
-
-<sub><b>Mode A</b> is sub-millisecond for a single agent prototyping on a laptop. <b>Mode B</b> adds language independence &mdash; a Go or Rust agent can call the sidecar over HTTP without Python in its image. <b>Mode C</b> is the production shape: one Attestor service in front of a multi-agent mesh, with managed storage behind. Code path is identical across all three &mdash; only configuration changes.</sub>
-
-### Promotion path
-
-<p align="center">
-  <img src="docs/promotion-path.svg" alt="Promotion path — laptop to dev VM to managed cloud, same API throughout" width="100%">
-</p>
-
-<sub><i>Prototype on a laptop. Promote to Docker Compose on a VM without rewriting a single line. Promote to managed container runtime by swapping the storage URLs. The code never learns which backend it&rsquo;s talking to.</i></sub>
-
----
-
-<a id="principles"></a>
-
-## &sect; 05 &mdash; Principles
-
-<sub><b>What we won't compromise on</b></sub>
-
-| # | Principle | What it means |
-|---|---|---|
-| 01 | **Self&#8209;hosted by default** | Your data stays in your infrastructure. No SaaS middleman, no per&#8209;seat fees, no lock&#8209;in. Run on a laptop, a VM, or any cloud. |
-| 02 | **Deterministic retrieval** | Tag match, graph traversal, vector search, RRF fusion, MMR diversity &mdash; all deterministic. No LLM judges. No hidden inference calls in the critical path. |
-| 03 | **One API, every backend** | Same `mem.recall()` call whether the store is a local Postgres + Neo4j pair or ArangoDB behind a Cloud Run service. Swap backends without rewriting agents. |
-| 04 | **Agent teams are first&#8209;class** | Namespaces, roles, quotas, and provenance are not bolt&#8209;ons. The primitives were designed for orchestrator&ndash;worker pipelines from day one. |
-| 05 | **Boring where it counts** | Postgres, pgvector, Neo4j, GDS. Proven, debuggable, no magic. Terraform templates, not a hosted console. |
-
----
-
-<p align="center"><b>Install <code>attestor</code> and point your agents at one URL. They share memory instantly.</b></p>
-
-<p align="center"><sub><a href="#reference">&darr; Reference documentation follows</a></sub></p>
-
----
-
-<a id="reference"></a>
-
-# Reference
-
-<sub><i>Everything below is the technical manual. If you are evaluating, the pitch ended at &sect; 05.</i></sub>
-
-## Table of Contents
-
-- [Quick Start](#quick-start)
-- [Architecture](#architecture)
-- [How It Works](#how-it-works)
-- [Python API](#python-api)
-- [REST API](#rest-api)
-- [MCP Integration](#mcp-integration)
-- [Cloud Backends](#cloud-backends)
-- [Cloud Deployment](#cloud-deployment)
-- [Embedding Providers](#embedding-providers)
-- [CLI Reference](#cli-reference)
-- [Configuration](#configuration)
-- [Testing](#testing)
-- [Compatibility](#compatibility)
-- [Uninstall](#uninstall)
-
----
-
-## Quick Start
-
-Attestor needs a Postgres (pgvector) + Neo4j (GDS) pair. Bring both up locally with the bundled Docker Compose stack:
-
-```bash
-cd attestor/infra/local
-cp .env.example .env      # set OPENAI_API_KEY
-docker compose up -d postgres neo4j
-```
-
-Install and point Attestor at the stack:
-
-```bash
-poetry add attestor
-export POSTGRES_URL="postgresql://postgres:attestor@localhost:5432/attestor"
-export NEO4J_URI="bolt://localhost:7687"
-export NEO4J_USERNAME="neo4j"
-export NEO4J_PASSWORD="attestor"
-```
-
-```python
-from attestor import AgentMemory
-
-mem = AgentMemory()       # reads env / config.toml
-mem.add("Architecture decision: event sourcing for order service",
-        category="technical", entity="order-service", tags=["arch", "decision"])
-results = mem.recall("how is the order service structured?", budget=2000)
-```
-
-For REST API self-host, MCP integration, and cloud deploy — see [REST API](#rest-api), [MCP Integration](#mcp-integration), [Cloud Deployment](#cloud-deployment). `attestor doctor` verifies all components (Postgres document + pgvector, Neo4j graph, retrieval pipeline).
 
 ---
 
 ## Architecture
 
-<p align="center">
-  <img src="docs/architecture.svg" alt="Attestor Architecture" width="100%">
-</p>
+### Three storage roles
 
-The diagram above shows how a call to `AgentMemory.recall()` flows: the top-level API in `core.py` fans out across the three storage roles (document, vector, graph), the retrieval orchestrator fuses and ranks their results, and the scorer packs them into the caller&rsquo;s token budget. The tree below enumerates every module referenced in the diagram.
-
-### Component Overview
-
-```
-attestor/
-├── core.py                    # AgentMemory — public API surface (add / recall / search / timeline / health)
-├── models.py                  # Memory + RetrievalResult dataclasses
-├── context.py                 # AgentContext — multi-agent provenance, RBAC, token budgets
-├── client.py                  # MemoryClient — drop-in HTTP client that mirrors AgentMemory
-├── cli.py                     # CLI entry point (22 subcommands — add, recall, doctor, api, mcp, hook, ...)
-├── api.py                     # Starlette ASGI REST API (8 routes)
-├── locomo.py                  # LOCOMO benchmark runner (evaluation, not runtime)
-├── mab.py                     # MAB benchmark runner (evaluation, not runtime)
-├── store/
-│   ├── base.py                # Abstract interfaces: DocumentStore, VectorStore, GraphStore
-│   ├── registry.py            # Backend factory + selection by config
-│   ├── connection.py          # Shared connection helpers
-│   ├── embeddings.py          # Provider auto-detect (OpenAI / Bedrock / Vertex AI / Azure OpenAI / local opt-in)
-│   ├── postgres_backend.py    # PostgreSQL + pgvector (document + vector roles)
-│   ├── neo4j_backend.py       # Neo4j + GDS (graph role, PageRank / BFS / Leiden)
-│   ├── schema.sql             # Postgres schema definition
-│   ├── arango_backend.py      # ArangoDB (native doc + vector + graph) — opt-in backend
-│   ├── aws_backend.py         # Amazon Web Services (DynamoDB + OpenSearch Serverless + Neptune)
-│   ├── azure_backend.py       # Microsoft Azure (Cosmos DB DiskANN + NetworkX in-process for graph)
-│   └── gcp_backend.py         # Google Cloud Platform AlloyDB (PostgreSQL + ScaNN + Vertex AI embeddings)
-├── graph/
-│   └── extractor.py           # Entity/relation extraction (4-output GraphRAG)
-├── retrieval/
-│   ├── orchestrator.py        # 5-layer cascade with RRF fusion
-│   ├── tag_matcher.py         # Stop-word filtered tag extraction
-│   └── scorer.py              # Temporal + entity + PageRank boosts, confidence decay
-├── temporal/
-│   └── manager.py             # Contradiction detection + supersession
-├── extraction/
-│   ├── extractor.py           # Memory extraction orchestrator
-│   ├── rule_based.py          # Deterministic rule-based extractor
-│   └── llm_extractor.py       # Optional LLM-backed extractor
-├── mcp/
-│   └── server.py              # MCP server (8 tools, 2 resources, 2 prompts)
-├── hooks/
-│   ├── session_start.py       # Context injection at session start
-│   ├── post_tool_use.py       # Auto-capture from Write/Edit/Bash
-│   └── stop.py                # Session summary generation
-├── utils/
-│   ├── config.py              # MemoryConfig dataclass + load/save
-│   └── tokens.py              # Token-budget helpers
-└── infra/                     # Reference Terraform templates (you supply state + credentials)
-    └── aws_arango/            # VPC + ECS Fargate + ArangoDB CE sidecar + ALB (validated end-to-end)
-```
-
-`core.py` is the only module intended as a public API — every other path is internal and may change between releases. Agents running in-process import `AgentMemory`; agents talking to a remote Attestor service import `MemoryClient` from `client.py` (same method surface, HTTP transport).
-
-### Three Storage Roles
-
-Every backend implements one or more of these roles:
+Every memory is persisted across the required backends in your topology:
 
 | Role | Purpose | Default | Alternatives |
 |------|---------|---------|--------------|
-| **Document** | Core storage, CRUD, filtering | Postgres | AlloyDB, ArangoDB, DynamoDB, Cosmos DB |
-| **Vector** | Semantic similarity search | Postgres (pgvector, HNSW) | ScaNN (AlloyDB), ArangoDB, OpenSearch Serverless, Cosmos DiskANN |
-| **Graph** | Entity relationships, multi-hop BFS, PageRank / Leiden | Neo4j (GDS) | Apache AGE (AlloyDB), ArangoDB, Neptune, NetworkX-in-process (Azure) |
+| **Document** | Source of truth (content, tags, entity, ts, provenance, confidence) | Postgres | AlloyDB, ArangoDB, DynamoDB, Cosmos DB |
+| **Vector** | Dense embedding per memory | Postgres + pgvector | AlloyDB ScaNN, ArangoDB, OpenSearch Serverless, Cosmos DiskANN |
+| **Graph** | Entity nodes + typed edges (`uses`, `authored-by`, `supersedes`) | Neo4j (GDS) | AGE on AlloyDB, ArangoDB, Neptune, NetworkX (Azure) |
 
-Backends fill one or more roles; the default topology is `postgres` (doc + vector) + `neo4j` (graph), with alternatives selectable via `config.toml`. Degradation is explicit and tiered: if the vector store is unreachable, retrieval falls back to tag + graph layers; if the graph store is unreachable, retrieval falls back to tag + vector; the document store is the only hard dependency. Non-fatal errors in vector or graph operations are caught and logged — the document path never breaks.
+Postgres is always the source of truth. Neo4j (or whichever graph store you pick) is **derived state, rebuildable from Postgres**. If the vector or graph store goes down, the document path keeps serving — degradation is explicit and tiered.
 
----
+### Retrieval — semantic-first, no LLM in the loop
 
-## How It Works
+The orchestrator (`attestor/retrieval/orchestrator.py`) runs the same 6 steps for every query:
 
-### Memory is infrastructure, not a prompt attachment
+1. **Vector semantic search** — top-K = 50 nearest by cosine
+2. **Graph narrow** — soft boost by hop-distance (BFS depth ≤ 2) from each candidate's entity to the question entities
+3. **Triples injection** — typed-edge facts injected as synthetic memories so the consumer can reason over relations, not just text
+4. **MMR rerank** — λ = 0.7 diversity vs. relevance trade-off
+5. **Confidence decay + temporal boost** — recency / decay applied per memory
+6. **Budget fit** — greedy pack into the agent's token budget
 
-Attestor runs as a separate tier — a library, a container, or a cloud service — that agents query on demand. Stored memories never enter the context window until an agent explicitly calls `recall()` with a token budget. Retrieval cost stays constant as the store grows from 100 to 5,000,000 memories; only the ranking candidate pool expands.
+Optional **BM25 / FTS lane** (`bm25_lane=...` on the orchestrator) runs a `tsvector` keyword search in parallel and **fuses with the vector lane via Reciprocal Rank Fusion (RRF, k = 60)**. Useful for acronyms, IDs, and rare proper nouns where embeddings under-recall. Gracefully no-ops on backends that don't have the `content_tsv` column.
 
-### Token cost is bounded by budget, not store size
+Every call writes a JSONL trace to `logs/attestor_trace.jsonl` (disable with `ATTESTOR_TRACE=0`).
 
-```
-Naive context-injection approach:
-  Month 1:   2K tokens loaded every message
-  Month 6:  15K tokens loaded every message  ← context crowded
+### Multi-agent primitives
 
-Attestor:
-  Month 1:   ≤2K tokens returned per recall  (ranked from 100 memories)
-  Month 6:   ≤2K tokens returned per recall  (ranked from 5,000 memories)
-                                             ← bounded cost, deeper recall
-```
+- **Six RBAC roles** (`AgentRole` enum): `ORCHESTRATOR`, `PLANNER`, `EXECUTOR`, `RESEARCHER`, `REVIEWER`, `MONITOR`
+- **Namespace isolation** via Postgres Row-Level Security on every tenant table (`tenant_isolation_*` policies on the `attestor.current_user_id` session var)
+- **Provenance** on every memory (who wrote it, which session, which episode)
+- **Per-agent write quotas and token budgets**
+- **Recall cache** per `AgentContext` session — repeated queries are deduplicated transparently
+- **`AgentContext.scratchpad: Dict[str, Any]`** — typed lane for planner → executor handoffs without rounding through the store
 
-### How a recall works
+### Bi-temporal — nothing is deleted
 
-When an agent calls `memory_recall("deployment setup", budget=2000)`:
+Every memory has two time axes:
 
-```
-Store: 5,000 memories
+- **Event time** — `valid_from` / `valid_until` (when the fact is true in the world)
+- **Transaction time** — `t_created` / `t_expired` (when the row landed in the store)
 
-  Tag search finds:     15 memories tagged "deployment"
-  Graph search finds:    8 memories linked to "AWS", "Docker" entities
-  Vector search finds:  20 semantically similar memories
-
-  After dedup + RRF fusion:  30 unique candidates, scored and ranked
-
-  Budget fitting (2,000 tokens):
-    Memory A (score 0.95):  500 tokens → in   (total: 500)
-    Memory B (score 0.90):  600 tokens → in   (total: 1,100)
-    Memory C (score 0.88):  400 tokens → in   (total: 1,500)
-    Memory D (score 0.85):  300 tokens → in   (total: 1,800)
-    Memory E (score 0.80):  400 tokens → SKIP (exceeds 2,000)
-
-  Result: 4 memories, 1,800 tokens. 4,996 memories never entered context.
-```
-
----
-
-## MCP Integration
-
-Attestor ships an MCP server so any MCP-compatible client (Claude Code, Cursor, Windsurf, custom agents) can store and retrieve memories. Start it with `attestor mcp`.
-
-| Tool | Purpose | Key Parameters |
-|------|---------|----------------|
-| `memory_add` | Store a fact | `content`, `tags[]`, `category`, `entity`, `namespace`, `event_date`, `confidence` |
-| `memory_recall` | Smart multi-layer retrieval | `query`, `budget` (default: 2000), `namespace` |
-| `memory_search` | Filter with date ranges | `query`, `category`, `entity`, `namespace`, `status`, `after`, `before`, `limit` |
-| `memory_get` | Fetch by ID | `memory_id` |
-| `memory_forget` | Archive (soft delete) | `memory_id` |
-| `memory_timeline` | Chronological entity history | `entity`, `namespace` |
-| `memory_stats` | Store size, counts | — |
-| `memory_health` | Health check (call first!) | — |
-
-### Categories
-
-`core_belief` · `preference` · `career` · `project` · `technical` · `personal` · `location` · `relationship` · `event` · `session` · `general`
-
-### MCP Resources
-
-- **`attestor://entity/{name}`** — Entity details + related entities from graph
-- **`attestor://memory/{id}`** — Full memory object
-
-### MCP Prompts
-
-- **`recall`** — Search memories for relevant context
-- **`timeline`** — Chronological history of an entity
-
----
-
-## Retrieval Pipeline
-
-The retrieval system uses a 5-layer cascade with multi-signal fusion:
-
-```
-Query: "deployment setup"
-  │
-  ├─ Layer 0: Graph Expansion
-  │  Extract entities from query → BFS traversal (depth=2)
-  │  "deployment" → finds "AWS", "Docker", "Terraform" connections
-  │
-  ├─ Layer 1: Tag Match (Postgres FTS / trigram)
-  │  extract_tags(query) → tag_search() → score 1.0
-  │
-  ├─ Layer 2: Entity-Field Search
-  │  Memories about graph-connected entities → score 0.5
-  │
-  ├─ Layer 3: Vector Search (pgvector HNSW)
-  │  Semantic similarity → score = 1 - cosine_distance
-  │
-  ├─ Layer 4: Graph Relation Triples
-  │  Inject relationship context → score 0.6
-  │
-  ▼ FUSION
-  ├─ Reciprocal Rank Fusion (RRF, k=60)
-  │  score = Σ 1/(k + rank_in_source)
-  │  OR Graph Blend: 0.7 * norm_vector + 0.3 * norm_pagerank
-  │
-  ▼ SCORING
-  ├─ Temporal Boost: +0.2 * max(0, 1 - age_days/90)
-  ├─ Entity Boost:   +0.30 exact match, +0.15 substring
-  ├─ PageRank Boost:  +0.3 * entity_pagerank_score
-  │
-  ▼ DIVERSITY
-  ├─ MMR Rerank: λ*relevance - (1-λ)*max_jaccard_similarity (λ=0.7)
-  │
-  ▼ CONFIDENCE
-  ├─ Time Decay:    -0.001 per hour since last access
-  ├─ Access Boost:  +0.03 per access_count
-  ├─ Clamp:         [0.1, 1.0]
-  │
-  ▼ BUDGET
-  └─ Greedy selection by score until token budget filled
-```
-
-Querying "Python" also finds memories about "FastAPI" if they're connected in the entity graph. Multi-hop reasoning through relationship traversal.
-
----
-
-## Python API
-
-### Basic Usage
+Plus a `superseded_by` chain. Old facts are never deleted — they remain queryable forever.
 
 ```python
-from attestor import AgentMemory
+# What did we believe on March 1?
+mem.recall(query="who runs engineering?", as_of="2026-03-01T00:00:00Z", context=ctx)
 
-mem = AgentMemory("./my-agent")  # auto-provisions all backends
-
-# Store
-mem.add("User prefers Python over Java",
-        tags=["preference", "coding"],
-        category="preference",
-        entity="Python")
-
-# Recall with token budget
-results = mem.recall("what language?", budget=2000)
-
-# Formatted context for prompt injection
-context = mem.recall_as_context("user background", budget=4000)
-
-# Search with filters
-memories = mem.search(category="project", entity="Python", limit=10)
-
-# Timeline
-history = mem.timeline("Python")
-
-# Contradiction handling — automatic
-mem.add("User works at Google", tags=["career"], category="career", entity="Google")
-mem.add("User works at Meta", tags=["career"], category="career", entity="Meta")
-# ^ Google memory auto-superseded
-
-# Namespace isolation
-mem.add("Team standup at 9am", namespace="team:alpha")
-results = mem.recall("standup time", namespace="team:alpha")
-
-# Maintenance
-mem.forget(memory_id)             # Archive
-mem.forget_before("2025-01-01")   # Archive old memories
-mem.compact()                     # Permanently delete archived
-mem.export_json("backup.json")    # Export
-mem.import_json("backup.json")    # Import (dedup by content hash)
-
-# Health & stats
-mem.health()  # → {sqlite: ok, chroma: ok, networkx: ok, retrieval: ok}
-mem.stats()   # → {total: 500, active: 480, ...}
-
-# Context manager
-with AgentMemory("./store") as mem:
-    mem.add("auto-closed on exit")
+# Show me everything we knew about Alice between Feb and Apr
+mem.recall(query="alice", time_window=("2026-02-01", "2026-04-01"), context=ctx)
 ```
 
-### Memory Object
+**Auto-supersession on write.** `add()` runs `TemporalManager.check_contradictions()` against the new memory before insert; any active row with the same `(entity, category, namespace)` and different content is automatically marked superseded by the new id (`status="superseded"`, `valid_until=now`, `superseded_by=<new_id>`). Detection is rule-based string-equality today — soft / similarity-based contradiction is on the roadmap.
+
+### Chain-of-Note reading
 
 ```python
-@dataclass
-class Memory:
-    id: str                    # UUID
-    content: str               # The actual fact/observation
-    tags: List[str]            # Searchable tags
-    category: str              # Classification (preference, career, project, ...)
-    entity: str                # Primary entity (company, tool, person)
-    namespace: str             # Isolation key (default: "default")
-    created_at: str            # ISO timestamp
-    event_date: str            # When the fact occurred
-    valid_from: str            # Temporal validity start
-    valid_until: str           # Set when superseded
-    superseded_by: str         # ID of replacement memory
-    confidence: float          # 0.0-1.0
-    status: str                # active | superseded | archived
-    access_count: int          # Times recalled
-    last_accessed: str         # Last recall timestamp
-    content_hash: str          # SHA-256 for dedup
-    metadata: Dict[str, Any]   # Arbitrary JSON
+pack = mem.recall_as_pack(query="who runs engineering?", context=ctx)
+# pack.memories: list of {id, content, validity_window, confidence, source_episode_id}
+# pack.prompt: default Chain-of-Note prompt (NOTES → SYNTHESIS → CITE → ABSTAIN → CONFLICT)
+```
+
+The default prompt has explicit ABSTAIN and CONFLICT clauses — every frontier model defaults to confabulation otherwise.
+
+---
+
+## Runtime topologies
+
+Same API across all three. Only configuration changes.
+
+| Mode | Shape | When to use |
+|------|-------|-------------|
+| **A — Embedded library** | `AgentMemory(config)` in-process, talks directly to Postgres + Neo4j | Single-process agents, scripts, notebooks |
+| **B — Sidecar** | `attestor api` on `localhost:8080`, language-agnostic HTTP client shares the same Postgres + Neo4j | Polyglot agents on one box (Python + TS + Go) |
+| **C — Shared service** | One Attestor service in front of an agent mesh (App Runner / Cloud Run / Container Apps) backed by managed Postgres + Neo4j | Production multi-agent platforms |
+
+```bash
+attestor api    --port 8080         # Mode B / C — Starlette ASGI REST API
+attestor serve  --transport stdio   # MCP stdio server
+attestor mcp    --transport http    # MCP HTTP server
 ```
 
 ---
 
-## Multi-Agent Systems
+## Backends
 
-Attestor is built for production multi-agent pipelines — orchestrator-worker, planner-executor, researcher-reviewer, and hierarchical swarms. Every recall and write is scoped to an `AgentContext` that carries identity, role, namespace, parent trail, token budget, write quota, and visibility policy. Contexts are immutable; spawning a sub-agent returns a new context with inherited provenance.
+| Backend | Document | Vector | Graph | Status |
+|---------|:--------:|:------:|:-----:|--------|
+| **Postgres + Neo4j** *(default)* | ✓ | pgvector | Neo4j + GDS | Production-ready |
+| **ArangoDB** | ✓ | ✓ | ✓ | Production-ready (single backend covers all 3 roles) |
+| **AWS** | DynamoDB | OpenSearch Serverless | Neptune | Backend code + Terraform shipped |
+| **Azure** | Cosmos DB | Cosmos DiskANN | NetworkX (in-process) | Backend code shipped, Terraform forthcoming |
+| **GCP** | AlloyDB | AlloyDB ScaNN | AGE on AlloyDB | Backend code shipped, Terraform forthcoming |
+
+Override the default via config:
+
+```toml
+# ~/.attestor.toml
+backend = "postgres+neo4j"   # or "arangodb" | "aws" | "azure" | "gcp"
+```
+
+Reference Terraform lives under `attestor/infra/`.
+
+---
+
+## Embeddings
+
+Provider auto-detect (`attestor/store/embeddings.py`), in this order:
+
+1. **Local Ollama `bge-m3`** — 1024-D, 8K context — used when `http://localhost:11434` is reachable
+2. **Cloud-native** — Bedrock Titan / Vertex / Azure OpenAI when their SDK + creds are present
+3. **OpenAI `text-embedding-3-large`** (3072-D) — when `OPENAI_API_KEY` is set
+4. **OpenRouter** — for federated runs
+
+Local models are the default. Cloud APIs are fallbacks. Override via env:
+
+```bash
+export ATTESTOR_EMBEDDING_PROVIDER=openai
+export ATTESTOR_EMBEDDING_MODEL=text-embedding-3-large
+```
+
+---
+
+## CLI
+
+`attestor --help` lists all commands. The most useful ones:
+
+| Command | Purpose |
+|---------|---------|
+| `attestor init` | Create a starter config |
+| `attestor setup local` | Generate local Docker Compose for Postgres + Neo4j |
+| `attestor doctor` | Health-check every store + the retrieval pipeline |
+| `attestor add` | Add a memory |
+| `attestor recall` | Recall relevant memories |
+| `attestor search` | Search with filters (entity / category / namespace / time window) |
+| `attestor list` | List memories |
+| `attestor timeline` | Show entity timeline |
+| `attestor stats` | Store statistics |
+| `attestor export` / `import` | JSON export and import |
+| `attestor compact` | Remove archived memories |
+| `attestor update` / `forget` | Mutate a memory's content / archive it |
+| `attestor inspect` | Inspect the raw database |
+| `attestor api` | Start the Starlette REST API |
+| `attestor serve` | Start MCP server (stdio) |
+| `attestor mcp` | Start MCP server (HTTP) |
+| `attestor ui` | Browser UI for the store |
+| `attestor hook {session-start,post-tool-use,stop}` | Run a Claude Code lifecycle hook |
+| `attestor locomo` / `attestor mab` / `attestor lme` | Built-in benchmark runners (LoCoMo, MultiAgentBench, LongMemEval) |
+
+---
+
+## MCP server
+
+`attestor serve` exposes an MCP server with these tools:
+
+| Tool | Purpose |
+|------|---------|
+| `memory_add` | Write a memory with provenance |
+| `memory_get` | Fetch one memory by id |
+| `memory_recall` | Run the full retrieval pipeline |
+| `memory_search` | Filtered list (entity / category / time / namespace) |
+| `memory_forget` | Archive a memory by id |
+| `memory_timeline` | Chronology for an entity |
+| `memory_stats` | Store statistics |
+| `memory_health` | Per-role health snapshot — call this first when integrating |
+
+Plus MCP **resources** (memory listings) and **prompts** (canned recall prompts for IDE assistants).
+
+---
+
+## Hooks (Claude Code)
+
+Three lifecycle hooks ship in `attestor/hooks/`:
+
+- **`session_start`** — injects relevant memories into the session context based on cwd / repo
+- **`post_tool_use`** — auto-captures useful artifacts from `Write` / `Edit` / `Bash`
+- **`stop`** — writes a session summary on exit
+
+Wire them up via the installer (next section) or by hand in `~/.claude/settings.json`.
+
+---
+
+## Install for Claude Code
+
+Single instruction users can give Claude Code:
+
+```
+install attestor
+```
+
+(Or run `/install-attestor`.) The installer (`commands/install-attestor.md`) interviews you on:
+
+1. **Scope** — global (`~/.claude/.mcp.json`) vs project (`.mcp.json`)
+2. **Postgres connection** — local Docker, Neon, RDS, etc.
+3. **Neo4j connection** — local Docker, AuraDB, etc.
+4. **Backend override** — default `postgres+neo4j`, or `arangodb` / `aws` / `azure` / `gcp`
+5. **Embedding provider** — local Ollama (default), OpenAI, or cloud-native
+6. **Hooks** — whether to wire `session-start` / `post-tool-use` / `stop`
+7. **Namespace + default token budget**
+
+Then it installs `attestor` via pipx, writes the MCP config, optionally writes `settings.json` hooks, and runs `attestor doctor` to verify.
+
+---
+
+## Project layout
+
+```
+attestor/
+  core.py                -- AgentMemory (main public API)
+  client.py              -- MemoryClient (HTTP drop-in for remote Attestor)
+  context.py             -- AgentContext (identity, role, namespace, budget, scratchpad)
+  models.py              -- Memory, RetrievalResult, ContextPack
+  cli.py                 -- attestor CLI entry point
+  api.py                 -- Starlette ASGI REST API
+  longmemeval.py         -- LongMemEval benchmark runner
+  store/
+    base.py              -- DocumentStore / VectorStore / GraphStore protocols
+    registry.py          -- Backend selection
+    connection.py        -- Config layering / env resolution
+    embeddings.py        -- Provider auto-detect (Ollama / OpenAI / Bedrock / Vertex / Azure)
+    postgres_backend.py  -- pgvector (document + vector roles)
+    neo4j_backend.py     -- Neo4j + GDS (graph role)
+    arango_backend.py    -- All 3 roles in one
+    aws_backend.py       -- DynamoDB + OpenSearch Serverless + Neptune
+    azure_backend.py     -- Cosmos DB DiskANN + NetworkX
+    gcp_backend.py       -- AlloyDB pgvector + AGE + ScaNN
+    schema.sql           -- v4 Postgres schema (RLS, bi-temporal columns)
+  graph/
+    extractor.py         -- Deterministic entity / relation extraction
+  retrieval/
+    orchestrator.py      -- 6-step semantic-first pipeline
+    tag_matcher.py
+    scorer.py            -- MMR, confidence decay, entity boost, fit
+    trace.py             -- JSONL trace writer
+  temporal/
+    manager.py           -- Timelines, supersession, contradiction detection, as_of replay
+  extraction/             -- Rule-based + optional LLM memory extraction
+  mcp/
+    server.py            -- MCP server (tools, resources, prompts)
+  hooks/
+    session_start.py
+    post_tool_use.py
+    stop.py
+  utils/
+    config.py, tokens.py
+  infra/
+    local/                -- Docker Compose (Postgres + Neo4j)
+    aws_arango/           -- Reference Terraform
+tests/                    -- Unit tests; live cloud tests env-gated
+evals/                    -- LongMemEval / LoCoMo / MultiAgentBench harnesses
+docs/                     -- Architecture notes, ADRs
+commands/                 -- /install-attestor, etc.
+```
+
+---
+
+## Development
+
+```bash
+poetry install
+poetry run pytest tests/ -q                          # unit tests, no external services needed
+ATTESTOR_LIVE_PG=1 poetry run pytest tests/live -q   # live integration (env-gated)
+```
+
+Style:
+
+- `black` for formatting, `isort` for imports, `ruff` for lint, `mypy` for types
+- PEP 8, type-annotated signatures, dataclasses for DTOs
+- Many small files (200–400 lines typical, 800 max)
+
+Conventions worth knowing before you contribute:
+
+- Postgres is the source of truth. Neo4j is derived; rebuild it from Postgres if it drifts.
+- Non-fatal errors in vector / graph paths are caught and logged. The document path never silently breaks.
+- Configuration layering: env vars → `~/.attestor.toml` → in-code overrides.
+
+---
+
+## Health check
+
+Always call this first when integrating:
+
+```bash
+attestor doctor                  # CLI
+```
 
 ```python
-from attestor.context import AgentContext, AgentRole, Visibility
-
-# Create a root context
-ctx = AgentContext.from_env(
-    agent_id="orchestrator",
-    namespace="project:acme",
-    role=AgentRole.ORCHESTRATOR,
-    token_budget=20000,
-)
-
-# Spawn child contexts for sub-agents (immutable — returns new instance)
-planner = ctx.as_agent("planner", role=AgentRole.PLANNER, token_budget=5000)
-researcher = ctx.as_agent("researcher", role=AgentRole.RESEARCHER, read_only=True)
-
-# Provenance tracking — metadata auto-enriched
-planner.add_memory("Architecture decision: use event sourcing",
-                   category="technical", visibility=Visibility.TEAM)
-# metadata includes: _agent_id, _session_id, _namespace, _visibility, _role
-
-# Recall is scoped to namespace + cached within session
-results = researcher.recall("architecture decisions")
-
-# Token budget tracked
-print(researcher.token_budget - researcher.token_budget_used)
-
-# Governance
-researcher.flag_for_review("Need human approval for deployment plan")
-researcher.add_compliance_tag("SOC2")
-
-# Session introspection
-summary = ctx.session_summary()
-# → {agent_trail, memories_written, memories_recalled, token_usage, review_flags}
+mem = AgentMemory()
+print(mem.health())              # Python API
 ```
 
-### AgentContext Features
+```jsonc
+// MCP
+{ "tool": "memory_health" }
+```
 
-| Feature | Description |
-|---------|-------------|
-| **Namespace isolation** | Each agent/project gets isolated memory partition |
-| **RBAC roles** | ORCHESTRATOR, PLANNER, EXECUTOR, RESEARCHER, REVIEWER, MONITOR |
-| **Read-only mode** | Agents can recall but not write |
-| **Write quotas** | `max_writes_per_agent` (default: 100) |
-| **Token budgets** | Per-agent budget tracking |
-| **Recall cache** | Dedup redundant queries within a session |
-| **Scratchpad** | Inter-agent data passing |
-| **Provenance** | Agent trail, parent tracking, visibility levels |
-| **Compliance** | Review flags, compliance tags for audit |
-| **Distributed mode** | Set `memory_url` to use HTTP client instead of local |
+It probes Document Store (Postgres), Vector Store (pgvector), Graph Store (Neo4j), and the retrieval pipeline. If any role is degraded, `recall()` continues against the surviving roles and the response includes the degradation in its trace.
 
 ---
 
-## Cloud Backends
-
-Each cloud backend fills all three roles (document, vector, graph) in a single service:
-
-### PostgreSQL (Neon, Cloud SQL, self-hosted)
-
-Uses pgvector for vectors, Apache AGE for graph. AGE is optional — without it, graph gracefully degrades.
-
-```python
-mem = AgentMemory("./store", config={
-    "backends": ["postgres"],
-    "postgres": {"url": "postgresql://user:pass@host:5432/attestor"}
-})
-```
-
-### ArangoDB (ArangoGraph Cloud, Docker)
-
-Native document, vector, and graph support in one database.
-
-```python
-mem = AgentMemory("./store", config={
-    "backends": ["arangodb"],
-    "arangodb": {"url": "https://instance.arangodb.cloud:8529", "database": "attestor"}
-})
-```
-
-### Azure (Cosmos DB)
-
-Cosmos DB with DiskANN vector indexing. Graph via NetworkX persisted to Cosmos containers.
-
-```python
-mem = AgentMemory("./store", config={
-    "backends": ["azure"],
-    "azure": {"cosmos_endpoint": "https://account.documents.azure.com:443/"}
-})
-```
-
-### Google Cloud Platform (AlloyDB)
-
-Extends PostgreSQL backend with AlloyDB Connector (IAM auth) and Vertex AI embeddings (768D).
-
-```python
-mem = AgentMemory("./store", config={
-    "backends": ["gcp"],
-    "gcp": {"project_id": "my-project", "cluster": "attestor", "instance": "primary"}
-})
-```
-
-### Installing cloud extras
-
-```bash
-poetry add "attestor[postgres]"    # PostgreSQL
-poetry add "attestor[arangodb]"    # ArangoDB
-poetry add "attestor[aws]"         # AWS (DynamoDB + OpenSearch + Neptune)
-poetry add "attestor[azure]"       # Azure Cosmos DB
-poetry add "attestor[gcp]"         # Google Cloud Platform AlloyDB + Vertex AI
-poetry add "attestor[docker]"      # opt-in local Docker auto-start for ArangoDB when backend.docker = true and mode = "local"
-poetry add "attestor[all]"         # Everything
-```
-
-- `pipx install "attestor[docker]"` &mdash; opt-in local Docker auto-start for ArangoDB when `backend.docker = true` and `mode = "local"`.
-
----
-
-## Cloud Deployment
-
-The `attestor/infra/` directory ships **reference Terraform templates** &mdash; not push-button deploy scripts. Clone the template that matches your target cloud, set your own variables, supply your own credentials, and `terraform apply` from your own workstation. We have validated each template end-to-end; you keep ownership of state, secrets, and account.
-
-```bash
-cd attestor/infra/aws_arango
-cp variables.tf my.tfvars            # edit: arango_password, region, project_name
-terraform init
-terraform apply -var-file=my.tfvars
-# tear down
-terraform destroy -var-file=my.tfvars
-```
-
-**Prerequisites**: Docker (to build the image), Terraform &ge; 1.5, the relevant cloud CLI (`aws`/`gcloud`/`az`) authenticated to **your** account.
-
-| Cloud | Reference template | What it provisions | Status |
-|-------|--------------------|--------------------|--------|
-| Amazon Web Services | `attestor/infra/aws_arango/` | VPC + ECR + ECS Fargate task (attestor + ArangoDB CE sidecar) + ALB | Validated end-to-end |
-| Microsoft Azure | Container Apps + Cosmos DB | Backend code ships in `store/azure_backend.py`; Terraform template forthcoming | Backend ready, template pending |
-| Google Cloud Platform | Cloud Run + AlloyDB | Backend code ships in `store/gcp_backend.py`; Terraform template forthcoming | Backend ready, template pending |
-
-> Today only the AWS template is shipped. Azure and Google Cloud Platform users can run the backend directly against their existing managed services (Cosmos DB / AlloyDB) while the deploy templates are being finalised.
-
-> Sensitive variables (passwords, API keys, account IDs) are declared `sensitive = true` in the templates and read from your `.tfvars` &mdash; **never commit `.tfvars` or `*.tfstate*`**; both are already in `.gitignore`.
-
-### REST API Endpoints
-
-All deployments expose the same Starlette ASGI API:
-
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| `GET` | `/health` | Component health check |
-| `GET` | `/stats` | Store statistics |
-| `POST` | `/add` | Add a memory |
-| `POST` | `/recall` | Smart retrieval with budget |
-| `POST` | `/search` | Filtered search |
-| `POST` | `/timeline` | Entity chronological history |
-| `POST` | `/forget` | Archive a memory |
-| `GET` | `/memory/{id}` | Get memory by ID |
-
-Response envelope: `{"ok": true, "data": {...}}` or `{"ok": false, "error": "message"}`
-
----
-
-## Embedding Providers
-
-Attestor auto-detects the best available embedding provider:
-
-| Priority | Provider | Model | Dimensions | Trigger |
-|----------|----------|-------|------------|---------|
-| 1 | Cloud-native | Bedrock Titan / Azure OpenAI / Vertex AI | 768-1536 | Cloud backend configured |
-| 2 | OpenAI / OpenRouter | text-embedding-3-small | 1536 | `OPENAI_API_KEY` or `OPENROUTER_API_KEY` set |
-| 3 | Local (opt-in) | all-MiniLM-L6-v2 | 384 | Install `attestor[local-embeddings]`; no API key needed |
-
-The local provider is opt-in — install the `local-embeddings` extra to pull `sentence-transformers` (~90MB on first use). All providers implement the same interface — switching is transparent.
-
----
-
-## CLI Reference
-
-### MCP Server
-
-```bash
-attestor mcp                          # Start MCP server (uses ~/.attestor)
-attestor mcp --path /custom/path      # Custom store location
-```
-
-### Memory Operations
-
-```bash
-attestor add ./store "User prefers Python" --tags "pref,coding" --category preference
-attestor recall ./store "what language?" --budget 4000
-attestor search ./store --category project --entity Python --limit 20
-attestor list ./store --status active --category technical
-attestor timeline ./store --entity Python
-attestor get ./store <memory-id>
-attestor forget ./store <memory-id>
-```
-
-### Maintenance
-
-```bash
-attestor doctor                        # Health check (Postgres, pgvector, Neo4j, Retrieval)
-attestor stats ./store                 # Memory counts, DB size, breakdowns
-attestor export ./store -o backup.json
-attestor import ./store backup.json
-attestor compact ./store               # Permanently delete archived memories
-attestor inspect ./store               # Raw DB inspection
-```
-
-### Lifecycle Hooks
-
-```bash
-attestor hook session-start           # Inject context at agent session start
-attestor hook post-tool-use           # Auto-capture tool observations
-attestor hook stop                    # Generate session summary on exit
-```
-
-Hooks integrate with any harness that supports session lifecycle callbacks.
-
----
-
-## Configuration
-
-### Store location
-
-Default: `~/.attestor/` holds only local configuration. Storage lives in Postgres + Neo4j.
-
-```
-~/.attestor/
-└── config.toml     # Retrieval tuning + backend connection info
-```
-
-Storage state:
-
-- **Postgres** (documents + pgvector embeddings) — managed via your Postgres instance / Docker volume
-- **Neo4j** (graph nodes + edges) — managed via your Neo4j instance / Docker volume
-
-### config.json
-
-All fields optional. Defaults apply if the file doesn't exist:
-
-```json
-{
-  "default_token_budget": 2000,
-  "min_results": 3,
-  "backends": ["postgres", "neo4j"],
-  "enable_mmr": true,
-  "mmr_lambda": 0.7,
-  "fusion_mode": "rrf",
-  "confidence_gate": 0.0,
-  "confidence_decay_rate": 0.001,
-  "confidence_boost_rate": 0.03
-}
-```
-
-| Parameter | Default | Description |
-|-----------|---------|-------------|
-| `default_token_budget` | 2000 | Max tokens returned per recall |
-| `min_results` | 3 | Minimum results to return |
-| `enable_mmr` | true | Maximal Marginal Relevance diversity reranking |
-| `mmr_lambda` | 0.7 | Relevance vs diversity balance (0=diverse, 1=relevant) |
-| `fusion_mode` | "rrf" | "rrf" (parameter-free) or "graph_blend" (weighted) |
-| `confidence_decay_rate` | 0.001 | Score penalty per hour since last access |
-| `confidence_boost_rate` | 0.03 | Score boost per access count |
-| `confidence_gate` | 0.0 | Minimum confidence threshold to include in results |
-
-### Environment Variables
-
-| Variable | Purpose |
-|----------|---------|
-| `ATTESTOR_PATH` | Default store path |
-| `ATTESTOR_URL` | Remote API URL (distributed mode) |
-| `ATTESTOR_NAMESPACE` | Default namespace |
-| `ATTESTOR_TOKEN_BUDGET` | Default token budget |
-| `ATTESTOR_SESSION_ID` | Session ID for provenance tracking |
-
----
-
-## Testing
-
-### Running Tests
-
-```bash
-# All unit tests — Postgres + Neo4j integration layers are env-gated
-poetry run pytest tests/ -v
-
-# With coverage
-poetry run pytest tests/ -v --cov=attestor --cov-report=term-missing
-
-# Live integration tests (need credentials)
-NEON_DATABASE_URL='postgresql://...' poetry run pytest tests/test_postgres_live.py -v
-AZURE_COSMOS_ENDPOINT='https://...' poetry run pytest tests/test_azure_live.py -v
-```
-
-### Test Coverage
-
-- **607 unit tests** covering all backends, retrieval, config, embeddings, and CLI
-- **14 live integration tests** per cloud backend (Neon, Azure, ArangoDB)
-- **Mock tests** for every cloud backend — no cloud account needed
-- Unit tests run without external services; integration tests are env-gated on live Postgres / Neo4j / cloud backends
-
----
-
-## Compatibility
-
-### MCP Clients
-
-| Client | Config File |
-|--------|-------------|
-| Any MCP client | Standard MCP stdio transport |
-| Claude Code | `.mcp.json` (project) or `~/.claude/.mcp.json` (global) |
-| Cursor | `.cursor/mcp.json` |
-| Windsurf | MCP config in settings |
-
-Same `attestor mcp` command for every client.
-
-### Python
-
-- Python 3.10, 3.11, 3.12, 3.13, 3.14
-
----
-
-## Uninstall
-
-### 1. Remove MCP server config (if used)
-
-Delete the `memory` entry from your MCP client's config file.
-
-### 2. Uninstall the package
-
-```bash
-poetry remove attestor
-```
-
-### 3. Delete stored memories (optional)
-
-```bash
-# Export first if you want a backup
-attestor export ~/.attestor -o attestor-backup.json
-
-# Then delete
-rm -rf ~/.attestor
-```
+## Status & versioning
+
+- **Version:** 4.0.0 (alpha)
+- **v3 → v4:** greenfield rebuild. v3 was alpha-only with no production users; **there is no automated migration**. Drop your v3 DB and reinstall.
+- See [`CHANGELOG.md`](./CHANGELOG.md) for the full track-by-track changelog.
 
 ---
 
 ## License
 
-MIT
-
----
-
-<sub>mcp-name: io.github.bolnet/attestor</sub>
+See [`LICENSE`](./LICENSE).

--- a/attestor/longmemeval.py
+++ b/attestor/longmemeval.py
@@ -1091,7 +1091,14 @@ JUDGE_PROMPT = (
 
 
 def _get_client(api_key: Optional[str] = None) -> Any:
-    """Instantiate an OpenAI client pointed at OpenRouter for benchmark runs."""
+    """Instantiate an OpenAI-compatible client.
+
+    Default target is OpenRouter. Override with ``LME_LLM_BASE_URL`` to
+    point at any OpenAI-compatible endpoint — most importantly local
+    Ollama at ``http://localhost:11434/v1`` for offline / no-key runs.
+    When the base URL points at localhost, ``OPENROUTER_API_KEY`` is
+    optional (Ollama accepts any non-empty key).
+    """
     try:
         from openai import OpenAI
     except ImportError as e:  # pragma: no cover — import-time error path
@@ -1100,12 +1107,21 @@ def _get_client(api_key: Optional[str] = None) -> Any:
             "`poetry add --group dev openai`."
         ) from e
 
+    base_url = os.environ.get("LME_LLM_BASE_URL", OPENROUTER_BASE_URL)
+    is_local = "localhost" in base_url or "127.0.0.1" in base_url
+
     key = api_key or os.environ.get("OPENROUTER_API_KEY")
     if not key:
-        raise RuntimeError(
-            "OPENROUTER_API_KEY not set — required for LongMemEval answer/judge."
-        )
-    return OpenAI(base_url=OPENROUTER_BASE_URL, api_key=key)
+        if is_local:
+            key = "ollama"  # placeholder; Ollama ignores the key
+        else:
+            raise RuntimeError(
+                "OPENROUTER_API_KEY not set — required for LongMemEval "
+                "answer/judge against a remote endpoint. Set "
+                "LME_LLM_BASE_URL=http://localhost:11434/v1 to run "
+                "against local Ollama instead."
+            )
+    return OpenAI(base_url=base_url, api_key=key)
 
 
 def _chat(client: Any, model: str, prompt: str, *, max_tokens: int = 300) -> str:

--- a/attestor/retrieval/orchestrator.py
+++ b/attestor/retrieval/orchestrator.py
@@ -403,13 +403,17 @@ class RetrievalOrchestrator:
         t = time.monotonic()
         vector_hits_raw: List[Dict] = []
         candidates: List[Dict] = []
+        vector_error: Optional[str] = None
         if self.vector_store:
             try:
                 vector_hits_raw = self.vector_store.search(
                     query, limit=VECTOR_TOP_K, namespace=namespace
                 )
-            except Exception:
+            except Exception as e:
                 vector_hits_raw = []
+                vector_error = f"{type(e).__name__}: {e}"
+        else:
+            vector_error = "no vector_store configured"
         for vr in vector_hits_raw:
             mid = vr["memory_id"]
             memory = self.store.get(mid)
@@ -422,7 +426,7 @@ class RetrievalOrchestrator:
                 "memory": memory, "distance": distance,
                 "vector_sim": max(0.0, 1.0 - distance),
             })
-        layers.append({
+        vector_layer: Dict = {
             "name": "Vector Top-K",
             "description": f"Top {VECTOR_TOP_K} by cosine similarity",
             "count": len(candidates),
@@ -439,7 +443,10 @@ class RetrievalOrchestrator:
                 }
                 for c in candidates
             ],
-        })
+        }
+        if vector_error:
+            vector_layer["error"] = vector_error
+        layers.append(vector_layer)
 
         # Graph narrow
         t = time.monotonic()
@@ -523,6 +530,14 @@ class RetrievalOrchestrator:
             ],
         })
 
+        warnings: List[str] = []
+        if vector_error:
+            warnings.append(
+                "Vector lane failed — query did not produce an embedding. "
+                "Likely the embedder (Ollama / OpenAI) is unreachable. "
+                f"Underlying error: {vector_error}"
+            )
+
         return {
             "query": query,
             "namespace": namespace,
@@ -530,6 +545,7 @@ class RetrievalOrchestrator:
             "total_latency_ms": round((time.monotonic() - t_total) * 1000, 2),
             "layers": layers,
             "final_count": len(final),
+            "warnings": warnings,
             "config": {
                 "pipeline": "semantic_first",
                 "vector_top_k": VECTOR_TOP_K,

--- a/attestor/ui/static/app.css
+++ b/attestor/ui/static/app.css
@@ -6,14 +6,9 @@
 
 @import url("https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght,SOFT,WONK@9..144,300..900,0..100,0..1&family=Instrument+Sans:ital,wght@0,400..700;1,400..700&display=swap");
 
-/* Departure Mono — hosted on GitHub by designer Helena Zhang, free for any use */
-@font-face {
-  font-family: "Departure Mono";
-  src: url("https://cdn.jsdelivr.net/gh/helenabyte/departure-mono@v1.422/fonts/webfonts/DepartureMono-Regular.woff2") format("woff2");
-  font-weight: 400;
-  font-style: normal;
-  font-display: swap;
-}
+/* Mono stack falls back through IBM Plex Mono → ui-monospace → Menlo. */
+/* Departure Mono was previously loaded from a CDN URL that 404'd; */
+/* dropped to avoid console errors. Re-add via self-host when desired. */
 
 :root {
   /* ink & paper */
@@ -978,6 +973,23 @@ select.field {
   font-size: 20px;
   color: var(--ghost);
   font-variation-settings: "opsz" 144, "SOFT" 100;
+}
+
+.recall-warnings {
+  margin: 16px 0 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.recall-warning {
+  font-family: var(--f-mono);
+  font-size: 12px;
+  letter-spacing: 0.04em;
+  color: var(--rust, #c04a2a);
+  background: rgba(192, 74, 42, 0.08);
+  border-left: 3px solid var(--rust, #c04a2a);
+  padding: 10px 14px;
+  line-height: 1.5;
 }
 
 .recall-header {

--- a/attestor/ui/static/recall.js
+++ b/attestor/ui/static/recall.js
@@ -1,5 +1,5 @@
 // Attestor — Recall Pipeline Replay
-// Renders the 5-layer retrieval cascade step by step.
+// Renders the semantic-first retrieval pipeline step by step.
 
 (function () {
   "use strict";
@@ -124,6 +124,14 @@
         </div>
       </div>
     `;
+
+    if (Array.isArray(data.warnings) && data.warnings.length > 0) {
+      html += `<div class="recall-warnings">`;
+      data.warnings.forEach((w) => {
+        html += `<div class="recall-warning">⚠ ${esc(w)}</div>`;
+      });
+      html += `</div>`;
+    }
 
     html += renderPipelineDiagram(data);
 

--- a/attestor/ui/templates/base.html
+++ b/attestor/ui/templates/base.html
@@ -4,7 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{% block title %}Attestor — Forensic Archive{% endblock %}</title>
-  <link rel="stylesheet" href="/ui/static/app.css?v=2">
+  <link rel="icon" type="image/svg+xml" href="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><rect width='16' height='16' rx='3' fill='%230A0C10'/><text x='8' y='12' font-family='Georgia,serif' font-size='12' font-weight='700' fill='%23E9DDC0' text-anchor='middle'>m</text></svg>">
+  <link rel="stylesheet" href="/ui/static/app.css?v=3">
   <script src="https://unpkg.com/htmx.org@2.0.4" defer></script>
 </head>
 <body>
@@ -41,7 +42,7 @@
 
   <footer class="ticker">
     <div class="ticker__pulse" data-secs="0">Live · read-only</div>
-    <div class="ticker__mid">ATTESTOR v2 · DETERMINISTIC RETRIEVAL · NO LLM IN CRITICAL PATH</div>
+    <div class="ticker__mid">ATTESTOR v4 · DETERMINISTIC RETRIEVAL · NO LLM IN CRITICAL PATH</div>
     <div>{{ stats.total_memories or 0 }} · ON DISK</div>
   </footer>
 

--- a/attestor/ui/templates/memories/recall.html
+++ b/attestor/ui/templates/memories/recall.html
@@ -5,7 +5,7 @@
 <section class="page-head">
   <h1 class="page-head__title">Recall<br><em>Pipeline.</em></h1>
   <div class="page-head__meta">
-    <div>5-layer cascade</div>
+    <div>semantic-first pipeline</div>
     <div>deterministic · no LLM</div>
     <div>replay · debug</div>
   </div>
@@ -43,7 +43,7 @@
   </aside>
 
   <section class="recall-area" id="recall-area">
-    <div class="recall-empty">Enter a query and execute to replay the 5-layer retrieval cascade.</div>
+    <div class="recall-empty">Enter a query and execute to replay the semantic-first retrieval pipeline.</div>
   </section>
 
   <section class="budget-explore-area" id="budget-explore-area"></section>

--- a/docs/architecture.svg
+++ b/docs/architecture.svg
@@ -82,12 +82,12 @@
     <text class="cream" x="24" y="200" font-size="13">Provenance &#183; Token budgets</text>
     <text class="cream" x="24" y="220" font-size="13">Write quotas &#183; Review flags</text>
 
-    <text class="accent sans" x="24" y="256" font-size="11">RETRIEVAL &#183; 5-LAYER CASCADE</text>
-    <text class="cream" x="24" y="280" font-size="13">01 &#183; Tag match</text>
-    <text class="cream" x="24" y="298" font-size="13">02 &#183; Graph expansion (BFS)</text>
-    <text class="cream" x="24" y="316" font-size="13">03 &#183; Vector search</text>
-    <text class="cream" x="24" y="334" font-size="13">04 &#183; RRF fusion + PageRank</text>
-    <text class="cream" x="24" y="352" font-size="13">05 &#183; MMR diversity + budget fit</text>
+    <text class="accent sans" x="24" y="256" font-size="11">RETRIEVAL &#183; SEMANTIC-FIRST PIPELINE</text>
+    <text class="cream" x="24" y="280" font-size="13">01 &#183; Vector top-K (pgvector)</text>
+    <text class="cream" x="24" y="298" font-size="13">02 &#183; Graph narrow (Neo4j BFS &#8804; 2)</text>
+    <text class="cream" x="24" y="316" font-size="13">03 &#183; Triples + temporal boost</text>
+    <text class="cream" x="24" y="334" font-size="13">04 &#183; MMR diversity (&#955;=0.7)</text>
+    <text class="cream" x="24" y="352" font-size="13">05 &#183; Decay + budget fit</text>
 
     <text class="cream sans" x="356" y="374" font-size="10" text-anchor="end" opacity="0.7">ZERO LLM IN THE RETRIEVAL PATH</text>
   </g>
@@ -108,20 +108,20 @@
     <rect class="card" x="0" y="20"  width="360" height="110" rx="2"/>
     <text class="accent sans" x="20" y="46" font-size="11">01 &#183; DOCUMENT</text>
     <text class="ink" x="20" y="74" font-size="18" font-weight="700">Source of truth</text>
-    <text class="muted" x="20" y="96"  font-size="11">SQLite &#183; PostgreSQL &#183; AlloyDB &#183; ArangoDB</text>
+    <text class="muted" x="20" y="96"  font-size="11">PostgreSQL &#183; AlloyDB &#183; ArangoDB</text>
     <text class="muted" x="20" y="114" font-size="11">DynamoDB &#183; Cosmos DB</text>
 
     <rect class="card" x="0" y="150" width="360" height="110" rx="2"/>
     <text class="accent sans" x="20" y="176" font-size="11">02 &#183; VECTOR</text>
     <text class="ink" x="20" y="204" font-size="18" font-weight="700">Semantic search</text>
-    <text class="muted" x="20" y="226" font-size="11">ChromaDB &#183; pgvector &#183; ScaNN &#183; ArangoDB</text>
+    <text class="muted" x="20" y="226" font-size="11">pgvector &#183; AlloyDB ScaNN &#183; ArangoDB</text>
     <text class="muted" x="20" y="244" font-size="11">OpenSearch Serverless &#183; Cosmos DiskANN</text>
 
     <rect class="card" x="0" y="280" width="360" height="110" rx="2"/>
     <text class="accent sans" x="20" y="306" font-size="11">03 &#183; GRAPH</text>
     <text class="ink" x="20" y="334" font-size="18" font-weight="700">Entities &amp; multi-hop</text>
-    <text class="muted" x="20" y="356" font-size="11">NetworkX &#183; Apache AGE &#183; ArangoDB</text>
-    <text class="muted" x="20" y="374" font-size="11">Neptune &#183; NetworkX-on-Cosmos</text>
+    <text class="muted" x="20" y="356" font-size="11">Neo4j + GDS &#183; Apache AGE &#183; ArangoDB</text>
+    <text class="muted" x="20" y="374" font-size="11">Neptune &#183; NetworkX (Azure)</text>
   </g>
 
   <line class="hair" x1="40" y1="510" x2="1360" y2="510"/>

--- a/docs/deployment-matrix.svg
+++ b/docs/deployment-matrix.svg
@@ -30,7 +30,7 @@
   <g transform="translate(40,108)">
     <rect class="same" width="1520" height="60" rx="2"/>
     <text fill="#F5F1E8" x="24" y="26" font-size="11" class="sans" font-weight="700">&#167; ATTESTOR ENGINE</text>
-    <text fill="#F5F1E8" x="24" y="48" font-size="14" class="mono">mem.add()  &#183;  mem.recall()  &#183;  mem.load_context()  &#183;  mem.timeline()  &#183;  RBAC  &#183;  namespaces  &#183;  5-layer retrieval  &#183;  temporal model</text>
+    <text fill="#F5F1E8" x="24" y="48" font-size="14" class="mono">mem.add()  &#183;  mem.recall()  &#183;  mem.recall_as_pack()  &#183;  mem.timeline()  &#183;  RBAC  &#183;  namespaces  &#183;  semantic-first pipeline  &#183;  bi-temporal model</text>
     <text class="accent sans" fill="#C15F3C" x="1496" y="36" font-size="11" text-anchor="end" font-weight="700">SAME PYTHON LIB &#183; SAME STARLETTE ASGI CONTAINER</text>
   </g>
 
@@ -49,20 +49,20 @@
     <rect class="paper" width="236" height="340" rx="2"/>
     <text class="accent sans" x="18" y="28" font-size="11" font-weight="700">01 &#183; LOCAL</text>
     <text class="ink" x="18" y="56" font-size="18" font-weight="700">Laptop</text>
-    <text class="muted" x="18" y="76" font-size="11" font-style="italic">air-gapped &#183; zero config</text>
+    <text class="muted" x="18" y="76" font-size="11" font-style="italic">docker compose &#183; offline</text>
     <line class="hair" x1="18" y1="92" x2="218" y2="92"/>
     <text class="muted sans" x="18" y="114" font-size="9">DOC</text>
-    <text class="ink mono" x="18" y="132" font-size="12">SQLite</text>
+    <text class="ink mono" x="18" y="132" font-size="12">Postgres 16</text>
     <line class="hair" x1="18" y1="148" x2="218" y2="148"/>
     <text class="muted sans" x="18" y="170" font-size="9">VECTOR</text>
-    <text class="ink mono" x="18" y="188" font-size="12">ChromaDB</text>
+    <text class="ink mono" x="18" y="188" font-size="12">pgvector</text>
     <line class="hair" x1="18" y1="204" x2="218" y2="204"/>
     <text class="muted sans" x="18" y="226" font-size="9">GRAPH</text>
-    <text class="ink mono" x="18" y="244" font-size="12">NetworkX</text>
+    <text class="ink mono" x="18" y="244" font-size="12">Neo4j + GDS</text>
     <line class="hair" x1="18" y1="268" x2="218" y2="268"/>
     <text class="muted sans" x="18" y="290" font-size="9">RUNTIME</text>
-    <text class="ink" x="18" y="308" font-size="11">in-process library</text>
-    <text class="muted" x="18" y="324" font-size="10" font-style="italic">~/.attestor</text>
+    <text class="ink" x="18" y="308" font-size="11">attestor api / library</text>
+    <text class="muted" x="18" y="324" font-size="10" font-style="italic">infra/local/docker-compose</text>
   </g>
 
   <!-- COL 2: Self-host -->

--- a/docs/index.html
+++ b/docs/index.html
@@ -1530,9 +1530,9 @@ footer.colophon {
       <span><b>ACCESS</b>RBAC</span>
       <span><b>TRACE</b>PROVENANCE</span>
       <span><b>CONTEXT</b>TOKEN BUDGETS</span>
-      <span><b>RETRIEVAL LAYERS</b>5</span>
+      <span><b>PIPELINE</b>SEMANTIC-FIRST</span>
       <span><b>PYTHON</b>3.10 &mdash; 3.14</span>
-      <span><b>STACK</b>SQLite &middot; ChromaDB &middot; NetworkX</span>
+      <span><b>STACK</b>Postgres &middot; pgvector &middot; Neo4j</span>
       <span><b>CLOUD</b>PostgreSQL &middot; ArangoDB &middot; Cosmos &middot; AlloyDB</span>
       <span><b>DEPLOY</b>AWS &middot; Azure &middot; GCP</span>
       <span><b>RETRIEVAL</b>RRF &middot; PageRank &middot; MMR</span>
@@ -1542,9 +1542,9 @@ footer.colophon {
       <span><b>ACCESS</b>RBAC</span>
       <span><b>TRACE</b>PROVENANCE</span>
       <span><b>CONTEXT</b>TOKEN BUDGETS</span>
-      <span><b>RETRIEVAL LAYERS</b>5</span>
+      <span><b>PIPELINE</b>SEMANTIC-FIRST</span>
       <span><b>PYTHON</b>3.10 &mdash; 3.14</span>
-      <span><b>STACK</b>SQLite &middot; ChromaDB &middot; NetworkX</span>
+      <span><b>STACK</b>Postgres &middot; pgvector &middot; Neo4j</span>
       <span><b>CLOUD</b>PostgreSQL &middot; ArangoDB &middot; Cosmos &middot; AlloyDB</span>
       <span><b>DEPLOY</b>AWS &middot; Azure &middot; GCP</span>
       <span><b>RETRIEVAL</b>RRF &middot; PageRank &middot; MMR</span>
@@ -1727,16 +1727,16 @@ footer.colophon {
     <div class="section-filing reveal">
       <span class="section-num">&sect; 03</span>
       <span class="section-name">&mdash; The Retrieval Pipeline</span>
-      <span>Five layers &middot; zero inference calls</span>
+      <span>Semantic-first &middot; zero inference calls</span>
     </div>
 
     <div class="reveal">
-      <h2 class="section-head">Five layers. <em>No LLM.</em> Fully deterministic.</h2>
-      <p class="standfirst">When an agent calls <code style="font-family:var(--ff-mono);font-size:15px;color:var(--accent);background:var(--ink-raise);padding:2px 8px;border:1px solid var(--rule);">recall(query, budget)</code>, five cooperating layers find, fuse, score, and fit the most relevant memories into the requested token ceiling. Ten million memories in the store. Your context window never sees more than the budget. And because there&rsquo;s no LLM in the path, the same query always returns the same ranking. You can unit&#8209;test it.</p>
+      <h2 class="section-head">Semantic-first. <em>No LLM.</em> Fully deterministic.</h2>
+      <p class="standfirst">When an agent calls <code style="font-family:var(--ff-mono);font-size:15px;color:var(--accent);background:var(--ink-raise);padding:2px 8px;border:1px solid var(--rule);">recall(query, budget)</code>, six cooperating steps find, narrow, rank, diversify, decay, and fit the most relevant memories into the requested token ceiling. Ten million memories in the store. Your context window never sees more than the budget. And because there&rsquo;s no LLM in the path, the same query always returns the same ranking. You can unit&#8209;test it.</p>
     </div>
 
     <figure class="reveal" style="margin:28px auto 8px;max-width:1040px;background:#f4efe3;border:1px solid var(--rule-strong);border-radius:6px;padding:20px;">
-      <img src="pipeline.svg" alt="Five-layer retrieval pipeline — tag match, graph expansion, vector search, fusion, diversity+fit" style="display:block;width:100%;height:auto;">
+      <img src="pipeline.svg" alt="Semantic-first retrieval pipeline — vector top-K, graph narrow, triples inject, MMR diversity, decay, budget fit" style="display:block;width:100%;height:auto;">
       <figcaption style="font-family:var(--ff-mono);font-size:11px;text-transform:uppercase;letter-spacing:0.16em;color:#3a3530;text-align:center;margin-top:12px;">Fig. 3 &mdash; Same pipeline. Ten memories or ten million. The budget holds.</figcaption>
     </figure>
 
@@ -1744,42 +1744,50 @@ footer.colophon {
       <div class="pipeline-step">
         <div class="step-index">01</div>
         <div class="step-body">
-          <h3>Tag Match</h3>
-          <p>Stop-word filtered tag extraction against SQLite's tag index. Exact and partial hits. Fast. Deterministic.</p>
+          <h3>Vector Top-K</h3>
+          <p>Embed the query (local Ollama bge-m3 by default; cloud providers as fallback) and fetch the 50 nearest memories from pgvector by cosine similarity.</p>
         </div>
-        <div class="step-engine"><b>SQLite</b>Tag index &middot; FTS</div>
+        <div class="step-engine"><b>pgvector</b>k=50 &middot; cosine</div>
       </div>
       <div class="pipeline-step">
         <div class="step-index">02</div>
         <div class="step-body">
-          <h3>Graph Expansion</h3>
-          <p>Multi-hop BFS on the entity graph. Query "Python" discovers "FastAPI," "Django," and "pip" through relationship edges.</p>
+          <h3>Graph Narrow</h3>
+          <p>BFS depth&nbsp;&le;&nbsp;2 on the entity graph from each candidate's entity to the question entities. Boosts hits by hop distance; penalises unreachable.</p>
         </div>
-        <div class="step-engine"><b>NetworkX / AGE</b>BFS &middot; depth 2</div>
+        <div class="step-engine"><b>Neo4j + GDS</b>BFS &middot; depth &le; 2</div>
       </div>
       <div class="pipeline-step">
         <div class="step-index">03</div>
         <div class="step-body">
-          <h3>Vector Search</h3>
-          <p>Semantic similarity for everything tag and graph miss. Cloud-native embeddings when available; local sentence-transformers otherwise.</p>
+          <h3>Triples Inject</h3>
+          <p>Inject typed-edge triples (<code>uses</code>, <code>authored-by</code>, <code>supersedes</code>) as synthetic memories so consumers reason over relations, not just text.</p>
         </div>
-        <div class="step-engine"><b>ChromaDB / pgvector</b>Cosine similarity</div>
+        <div class="step-engine"><b>Graph store</b>typed edges</div>
       </div>
       <div class="pipeline-step">
         <div class="step-index">04</div>
         <div class="step-body">
-          <h3>RRF Fusion + PageRank</h3>
-          <p>Reciprocal Rank Fusion blends results from every layer; PageRank boosts memories about well-connected entities; confidence decay favors recent writes.</p>
+          <h3>MMR Diversity</h3>
+          <p>Maximal Marginal Relevance rerank with &lambda;=0.7 trades relevance against diversity, eliminating near-duplicate candidates while preserving topical coverage.</p>
         </div>
-        <div class="step-engine"><b>Fusion</b>RRF &middot; k=60</div>
+        <div class="step-engine"><b>MMR</b>&lambda; = 0.7</div>
       </div>
       <div class="pipeline-step">
         <div class="step-index">05</div>
         <div class="step-body">
-          <h3>MMR Diversity + Budget Fit</h3>
-          <p>Maximal Marginal Relevance eliminates near-duplicates. Greedy selection packs the top-scoring memories into the caller's token budget. The rest never enter context.</p>
+          <h3>Decay + Boost</h3>
+          <p>Confidence decay penalises stale, low-confidence rows; temporal boost lifts recent writes. Optional BM25/FTS lane fuses with vector via RRF (k=60).</p>
         </div>
-        <div class="step-engine"><b>MMR</b>&lambda; = 0.7</div>
+        <div class="step-engine"><b>Fusion</b>RRF &middot; k=60</div>
+      </div>
+      <div class="pipeline-step">
+        <div class="step-index">06</div>
+        <div class="step-body">
+          <h3>Budget Fit</h3>
+          <p>Greedy monotonic-by-score selection packs the surviving memories into the caller's token budget. The rest never enter context.</p>
+        </div>
+        <div class="step-engine"><b>Greedy</b>token pack</div>
       </div>
     </div>
 
@@ -1922,7 +1930,7 @@ footer.colophon {
 <span style="color:var(--muted);">memory row</span><br>
 &nbsp;&nbsp;<span style="color:var(--accent-warm);">id &middot; content &middot; provenance</span><br>
 <span style="color:var(--accent);">&darr;</span><br>
-<span style="color:var(--muted);">5-layer recall</span><br>
+<span style="color:var(--muted);">semantic-first recall</span><br>
 <span style="color:var(--accent);">&darr;</span><br>
 <b style="color:var(--accent);">agent answer [mem_42]</b>
           </div>
@@ -1954,7 +1962,7 @@ footer.colophon {
       <h3 style="font-family:var(--ff-display);font-size:28px;font-weight:500;margin:0 0 14px;color:var(--paper);">Self-host locally in <em>one command</em>.</h3>
       <pre style="background:var(--ink);color:var(--paper);font-family:var(--ff-mono);font-size:14px;padding:18px 22px;border:1px solid var(--rule-strong);border-radius:4px;overflow-x:auto;margin:0 0 14px;"><span style="color:var(--accent);">$</span> pip install attestor
 <span style="color:var(--accent);">$</span> attestor api --host 0.0.0.0 --port 8080</pre>
-      <p style="margin:0;color:var(--paper-dim);font-size:15px;line-height:1.7;">Starlette ASGI on <code style="font-family:var(--ff-mono);font-size:13px;background:var(--ink);color:var(--paper);padding:2px 6px;border:1px solid var(--rule-strong);border-radius:3px;">http://localhost:8080</code>. SQLite + ChromaDB + NetworkX provision automatically under <code style="font-family:var(--ff-mono);font-size:13px;background:var(--ink);color:var(--paper);padding:2px 6px;border:1px solid var(--rule-strong);border-radius:3px;">~/.attestor</code>. Point every agent in your stack at the same URL &mdash; they share memory instantly. No Docker. No API keys. Air-gap it behind your firewall and walk away.</p>
+      <p style="margin:0;color:var(--paper-dim);font-size:15px;line-height:1.7;">Starlette ASGI on <code style="font-family:var(--ff-mono);font-size:13px;background:var(--ink);color:var(--paper);padding:2px 6px;border:1px solid var(--rule-strong);border-radius:3px;">http://localhost:8080</code>. Run <code style="font-family:var(--ff-mono);font-size:13px;background:var(--ink);color:var(--paper);padding:2px 6px;border:1px solid var(--rule-strong);border-radius:3px;">attestor setup local</code> to bring up Postgres&nbsp;16 + Neo4j (with GDS) via the bundled Docker Compose. Point every agent in your stack at the same URL &mdash; they share memory instantly. No SaaS. No API keys. Air-gap it behind your firewall and walk away.</p>
     </div>
 
     <div class="matrix reveal">
@@ -1991,7 +1999,7 @@ footer.colophon {
       <div class="matrix-cell">
         <span class="matrix-tag">Backend &middot; 06</span>
         <h3>Local / On-Prem</h3>
-        <p>SQLite + ChromaDB + NetworkX. Air-gapped deployments. Full data sovereignty.</p>
+        <p>Postgres + pgvector + Neo4j via Docker Compose. Air-gapped deployments. Full data sovereignty.</p>
         <div class="matrix-spec">No network egress</div>
       </div>
     </div>
@@ -2008,7 +2016,7 @@ footer.colophon {
         <div style="padding:16px;border:1px solid var(--rule-strong);background:var(--ink-raise);">
           <div style="font-family:var(--ff-mono);font-size:10px;letter-spacing:0.2em;color:var(--accent);">LANE &#183; 01</div>
           <div style="font-family:var(--ff-display);font-size:18px;font-weight:700;margin:6px 0 10px;">Laptop</div>
-          <div style="color:var(--muted);line-height:1.6;"><code>pip install</code><br><b>Doc:</b> SQLite<br><b>Vec:</b> ChromaDB<br><b>Graph:</b> NetworkX</div>
+          <div style="color:var(--muted);line-height:1.6;"><code>attestor setup local</code><br><b>Doc:</b> Postgres 16<br><b>Vec:</b> pgvector<br><b>Graph:</b> Neo4j + GDS</div>
         </div>
         <div style="padding:16px;border:1px solid var(--rule-strong);background:var(--ink-raise);">
           <div style="font-family:var(--ff-mono);font-size:10px;letter-spacing:0.2em;color:var(--accent);">LANE &#183; 02</div>

--- a/docs/pipeline.svg
+++ b/docs/pipeline.svg
@@ -1,7 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1400 820" font-family="Georgia, 'Times New Roman', serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1400 880" font-family="Georgia, 'Times New Roman', serif">
   <defs>
     <marker id="arr" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="9" markerHeight="9" orient="auto-start-reverse">
       <path d="M0,0 L10,5 L0,10 z" fill="#1A1614"/>
+    </marker>
+    <marker id="arr-accent" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="9" markerHeight="9" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#C15F3C"/>
     </marker>
     <style>
       .bg { fill: #F5F1E8; }
@@ -12,6 +15,7 @@
       .rule { stroke: #1A1614; stroke-width: 0.75; }
       .hair { stroke: #C9C0B0; stroke-width: 0.75; }
       .flow { stroke: #1A1614; stroke-width: 1.25; fill: none; }
+      .flow-accent { stroke: #C15F3C; stroke-width: 1.25; stroke-dasharray: 4 3; fill: none; }
       .mono { font-family: 'Menlo', 'Consolas', 'Courier New', monospace; }
       .sans { font-family: 'Helvetica Neue', 'Arial', sans-serif; letter-spacing: 0.12em; }
       .sect { font-size: 11px; letter-spacing: 0.2em; }
@@ -23,101 +27,118 @@
   </defs>
 
   <!-- Paper -->
-  <rect class="bg" width="1400" height="820"/>
+  <rect class="bg" width="1400" height="880"/>
 
-  <!-- Masthead rules -->
+  <!-- Masthead -->
   <line class="rule" x1="40" y1="44" x2="1360" y2="44"/>
   <line class="hair" x1="40" y1="50" x2="1360" y2="50"/>
-  <text class="ink sans sect" x="40" y="36">&#167; HIGH-LEVEL ARCHITECTURE &#183; RETRIEVAL PIPELINE &#183; FIVE LAYERS &#183; ZERO INFERENCE CALLS</text>
+  <text class="ink sans sect" x="40" y="36">&#167; HIGH-LEVEL ARCHITECTURE &#183; RETRIEVAL PIPELINE &#183; SEMANTIC-FIRST &#183; ZERO INFERENCE CALLS</text>
   <text class="muted sans sect" x="1360" y="36" text-anchor="end">FIG. 03 &#183; ATTESTOR</text>
 
   <!-- Input -->
-  <text class="muted sans tag" x="700" y="86" text-anchor="middle">AGENT CALL</text>
-  <text class="ink mono" x="700" y="116" text-anchor="middle" font-size="18">mem.recall(query, budget=2000)</text>
-  <line class="flow" x1="700" y1="132" x2="700" y2="160"/>
+  <text class="muted sans tag" x="700" y="84" text-anchor="middle">AGENT CALL</text>
+  <text class="ink mono" x="700" y="114" text-anchor="middle" font-size="18">mem.recall(query, budget=2000)</text>
+  <line class="flow" x1="700" y1="128" x2="700" y2="160" marker-end="url(#arr)"/>
 
-  <!-- Fan-out to three parallel source layers -->
-  <path class="flow" d="M 700,160 L 260,190" fill="none"/>
-  <path class="flow" d="M 700,160 L 700,190"/>
-  <path class="flow" d="M 700,160 L 1140,190"/>
-
-  <!-- Stage label: PARALLEL SOURCES -->
-  <text class="muted sans stage" x="40" y="186">STAGE A &#183; PARALLEL SOURCES</text>
+  <!-- Stage A label -->
+  <text class="muted sans stage" x="40" y="186">STAGE A &#183; CANDIDATE GENERATION</text>
   <line class="hair" x1="40" y1="192" x2="1360" y2="192"/>
 
-  <!-- Card 01 — Tag Match -->
+  <!-- Card 01 — Vector Top-K -->
   <g transform="translate(80,210)">
     <rect class="card" width="360" height="200" rx="2"/>
     <text class="accent" x="20" y="80" font-size="64" font-family="Georgia, serif">01</text>
     <line class="hair" x1="20" y1="96" x2="340" y2="96"/>
-    <text class="muted sans tag" x="20" y="116">LAYER &#183; TAG MATCH</text>
-    <text class="ink title" x="20" y="144">Tag Match</text>
-    <text class="muted mono" x="20" y="164" font-size="11">SQLite &#183; FTS</text>
-    <text class="ink body" x="20" y="188">Stop-word filtered tags against the</text>
+    <text class="muted sans tag" x="20" y="116">STEP &#183; VECTOR TOP-K</text>
+    <text class="ink title" x="20" y="144">Vector search</text>
+    <text class="muted mono" x="20" y="164" font-size="11">pgvector &#183; cosine &#183; k=50</text>
+    <text class="ink body" x="20" y="186">Embed query, fetch the 50 nearest</text>
   </g>
-  <text class="ink body" x="100" y="422">SQLite tag index. Exact + partial hits.</text>
+  <text class="ink body" x="100" y="430">memories. Local Ollama bge-m3 by default.</text>
 
-  <!-- Card 02 — Graph Expansion -->
+  <!-- Card 02 — Graph Narrow -->
   <g transform="translate(520,210)">
     <rect class="card" width="360" height="200" rx="2"/>
     <text class="accent" x="20" y="80" font-size="64" font-family="Georgia, serif">02</text>
     <line class="hair" x1="20" y1="96" x2="340" y2="96"/>
-    <text class="muted sans tag" x="20" y="116">LAYER &#183; GRAPH EXPANSION</text>
-    <text class="ink title" x="20" y="144">Graph Expansion</text>
-    <text class="muted mono" x="20" y="164" font-size="11">NetworkX &#183; Apache AGE</text>
-    <text class="ink body" x="20" y="188">Multi-hop BFS on the entity graph.</text>
+    <text class="muted sans tag" x="20" y="116">STEP &#183; GRAPH NARROW</text>
+    <text class="ink title" x="20" y="144">Graph affinity</text>
+    <text class="muted mono" x="20" y="164" font-size="11">Neo4j + GDS &#183; BFS depth &#8804; 2</text>
+    <text class="ink body" x="20" y="186">Boost candidates whose entity is near</text>
   </g>
-  <text class="ink body" x="540" y="422">&#8220;Python&#8221; discovers &#8220;FastAPI,&#8221; &#8220;Django.&#8221;</text>
+  <text class="ink body" x="540" y="430">the question entities by hop distance.</text>
 
-  <!-- Card 03 — Vector Search -->
+  <!-- Card 03 — Triples Inject -->
   <g transform="translate(960,210)">
     <rect class="card" width="360" height="200" rx="2"/>
     <text class="accent" x="20" y="80" font-size="64" font-family="Georgia, serif">03</text>
     <line class="hair" x1="20" y1="96" x2="340" y2="96"/>
-    <text class="muted sans tag" x="20" y="116">LAYER &#183; VECTOR SEARCH</text>
-    <text class="ink title" x="20" y="144">Vector Search</text>
-    <text class="muted mono" x="20" y="164" font-size="11">ChromaDB &#183; pgvector</text>
-    <text class="ink body" x="20" y="188">Semantic similarity &#8212; everything tag</text>
+    <text class="muted sans tag" x="20" y="116">STEP &#183; TRIPLES INJECT</text>
+    <text class="ink title" x="20" y="144">Typed-edge facts</text>
+    <text class="muted mono" x="20" y="164" font-size="11">uses &#183; authored-by &#183; supersedes</text>
+    <text class="ink body" x="20" y="186">Inject relation triples as synthetic</text>
   </g>
-  <text class="ink body" x="980" y="422">and graph miss. Cosine similarity.</text>
+  <text class="ink body" x="980" y="430">memories so reasoners see the graph.</text>
 
-  <!-- Fan-in to fusion -->
-  <path class="flow" d="M 260,440 L 700,480"/>
-  <path class="flow" d="M 700,440 L 700,480"/>
-  <path class="flow" d="M 1140,440 L 700,480" marker-end="url(#arr)"/>
+  <!-- Optional BM25 lane note -->
+  <line class="flow-accent" x1="260" y1="448" x2="260" y2="478"/>
+  <text class="accent sans tag" x="280" y="468">OPTIONAL BM25 / FTS LANE &#8594; FUSED VIA RRF k=60</text>
 
-  <!-- Stage label: FUSE & RANK -->
-  <text class="muted sans stage" x="40" y="506">STAGE B &#183; FUSE &#183; RANK &#183; DIVERSIFY &#183; FIT</text>
-  <line class="hair" x1="40" y1="512" x2="1360" y2="512"/>
+  <!-- Sequence flow within Stage A -->
+  <line class="flow" x1="440" y1="310" x2="520" y2="310" marker-end="url(#arr)"/>
+  <line class="flow" x1="880" y1="310" x2="960" y2="310" marker-end="url(#arr)"/>
 
-  <!-- Card 04 — Fusion + Rank -->
-  <g transform="translate(260,530)">
-    <rect class="card" width="880" height="110" rx="2"/>
-    <text class="accent" x="30" y="78" font-size="56" font-family="Georgia, serif">04</text>
-    <line class="hair" x1="130" y1="30" x2="130" y2="90"/>
-    <text class="muted sans tag" x="150" y="40">LAYER &#183; FUSION + RANK</text>
-    <text class="ink title" x="150" y="68">Fusion &amp; Ranking</text>
-    <text class="muted mono" x="150" y="88" font-size="11">In-process &#183; RRF k=60 &#183; PageRank &#183; Confidence decay</text>
-    <line class="hair" x1="560" y1="30" x2="560" y2="90"/>
-    <text class="ink body" x="580" y="58">Reciprocal Rank Fusion blends all three layers.</text>
-    <text class="ink body" x="580" y="78">PageRank boosts central entities; recency decays old writes.</text>
+  <!-- Bridge to Stage B -->
+  <line class="flow" x1="700" y1="468" x2="700" y2="510" marker-end="url(#arr)"/>
+
+  <!-- Stage B label -->
+  <text class="muted sans stage" x="40" y="536">STAGE B &#183; RANK &#183; DIVERSIFY &#183; FIT</text>
+  <line class="hair" x1="40" y1="542" x2="1360" y2="542"/>
+
+  <!-- Card 04 — MMR Diversity -->
+  <g transform="translate(80,560)">
+    <rect class="card" width="360" height="200" rx="2"/>
+    <text class="accent" x="20" y="80" font-size="64" font-family="Georgia, serif">04</text>
+    <line class="hair" x1="20" y1="96" x2="340" y2="96"/>
+    <text class="muted sans tag" x="20" y="116">STEP &#183; MMR DIVERSITY</text>
+    <text class="ink title" x="20" y="144">Diversity rerank</text>
+    <text class="muted mono" x="20" y="164" font-size="11">Maximal Marginal Relevance &#183; &#955;=0.7</text>
+    <text class="ink body" x="20" y="186">Eliminate near-duplicate candidates</text>
   </g>
+  <text class="ink body" x="100" y="780">while preserving topical coverage.</text>
 
-  <line class="flow" x1="700" y1="640" x2="700" y2="680" marker-end="url(#arr)"/>
-
-  <!-- Card 05 — Diversity + Fit -->
-  <g transform="translate(260,680)">
-    <rect class="card" width="880" height="110" rx="2"/>
-    <text class="accent" x="30" y="78" font-size="56" font-family="Georgia, serif">05</text>
-    <line class="hair" x1="130" y1="30" x2="130" y2="90"/>
-    <text class="muted sans tag" x="150" y="40">LAYER &#183; DIVERSITY + FIT</text>
-    <text class="ink title" x="150" y="68">Diversity &amp; Budget Fit</text>
-    <text class="muted mono" x="150" y="88" font-size="11">In-process &#183; MMR &#955;=0.7 &#183; Greedy token pack</text>
-    <line class="hair" x1="560" y1="30" x2="560" y2="90"/>
-    <text class="ink body" x="580" y="58">Maximal Marginal Relevance eliminates near-duplicates.</text>
-    <text class="ink body" x="580" y="78">Greedy selection packs results into the caller&#8217;s token budget.</text>
+  <!-- Card 05 — Decay + Boost -->
+  <g transform="translate(520,560)">
+    <rect class="card" width="360" height="200" rx="2"/>
+    <text class="accent" x="20" y="80" font-size="64" font-family="Georgia, serif">05</text>
+    <line class="hair" x1="20" y1="96" x2="340" y2="96"/>
+    <text class="muted sans tag" x="20" y="116">STEP &#183; DECAY + BOOST</text>
+    <text class="ink title" x="20" y="144">Confidence + temporal</text>
+    <text class="muted mono" x="20" y="164" font-size="11">recency boost &#183; confidence decay</text>
+    <text class="ink body" x="20" y="186">Recent and high-confidence memories</text>
   </g>
+  <text class="ink body" x="540" y="780">rise; stale, low-confidence ones fall.</text>
+
+  <!-- Card 06 — Budget Fit -->
+  <g transform="translate(960,560)">
+    <rect class="card" width="360" height="200" rx="2"/>
+    <text class="accent" x="20" y="80" font-size="64" font-family="Georgia, serif">06</text>
+    <line class="hair" x1="20" y1="96" x2="340" y2="96"/>
+    <text class="muted sans tag" x="20" y="116">STEP &#183; BUDGET FIT</text>
+    <text class="ink title" x="20" y="144">Greedy token pack</text>
+    <text class="muted mono" x="20" y="164" font-size="11">monotonic by score &#183; budget=2000</text>
+    <text class="ink body" x="20" y="186">Pack the top-scoring memories until</text>
+  </g>
+  <text class="ink body" x="980" y="780">the caller&#8217;s token budget is filled.</text>
+
+  <!-- Sequence flow within Stage B -->
+  <line class="flow" x1="440" y1="660" x2="520" y2="660" marker-end="url(#arr)"/>
+  <line class="flow" x1="880" y1="660" x2="960" y2="660" marker-end="url(#arr)"/>
+
+  <!-- Output -->
+  <line class="flow" x1="700" y1="800" x2="700" y2="836" marker-end="url(#arr)"/>
+  <text class="ink mono" x="700" y="858" text-anchor="middle" font-size="14">List[RetrievalResult] &#8804; budget</text>
 
   <!-- Bottom rule -->
-  <line class="rule" x1="40" y1="810" x2="1360" y2="810"/>
+  <line class="rule" x1="40" y1="870" x2="1360" y2="870"/>
 </svg>

--- a/docs/promotion-path.svg
+++ b/docs/promotion-path.svg
@@ -55,7 +55,7 @@
     <text class="ink mono" x="20" y="84" font-size="12">pip install attestor</text>
     <text class="ink mono" x="20" y="102" font-size="12">attestor api</text>
     <line class="hair" x1="20" y1="112" x2="300" y2="112"/>
-    <text class="muted" x="20" y="124" font-size="10">SQLite &#183; ChromaDB &#183; NetworkX</text>
+    <text class="muted" x="20" y="124" font-size="10">Postgres 16 &#183; pgvector &#183; Neo4j (Docker)</text>
   </g>
 
   <!-- STATION 2: DEV VM -->

--- a/docs/storage-roles.svg
+++ b/docs/storage-roles.svg
@@ -46,7 +46,7 @@
     <line class="hair" x1="24" y1="328" x2="396" y2="328"/>
     <text class="muted sans" x="24" y="318" font-size="10"></text>
   </g>
-  <text class="muted sans" x="64" y="450" font-size="10">FILLED BY &#183; SQLITE &#183; POSTGRES 16 &#183; COSMOS DB &#183; ARANGODB</text>
+  <text class="muted sans" x="64" y="450" font-size="10">FILLED BY &#183; POSTGRES 16 &#183; ALLOYDB &#183; ARANGODB &#183; DYNAMODB &#183; COSMOS DB</text>
 
   <!-- Card 2 — Vector store -->
   <g transform="translate(490,90)">
@@ -73,7 +73,7 @@
     <text class="ink" x="24" y="314" font-size="13">or word overlaps the query.</text>
     <line class="hair" x1="24" y1="328" x2="396" y2="328"/>
   </g>
-  <text class="muted sans" x="514" y="450" font-size="10">FILLED BY &#183; CHROMADB &#183; PGVECTOR &#183; COSMOS DISKANN &#183; ARANGODB</text>
+  <text class="muted sans" x="514" y="450" font-size="10">FILLED BY &#183; PGVECTOR &#183; ALLOYDB SCANN &#183; ARANGODB &#183; OPENSEARCH &#183; COSMOS DISKANN</text>
 
   <!-- Card 3 — Graph store -->
   <g transform="translate(940,90)">
@@ -100,5 +100,5 @@
     <text class="ink" x="24" y="314" font-size="13">via the graph, not the text.</text>
     <line class="hair" x1="24" y1="328" x2="396" y2="328"/>
   </g>
-  <text class="muted sans" x="964" y="450" font-size="10">FILLED BY &#183; NETWORKX &#183; APACHE AGE &#183; ARANGODB &#183; COSMOS GRAPH</text>
+  <text class="muted sans" x="964" y="450" font-size="10">FILLED BY &#183; NEO4J + GDS &#183; APACHE AGE &#183; ARANGODB &#183; NEPTUNE &#183; NETWORKX</text>
 </svg>

--- a/docs/timeline.svg
+++ b/docs/timeline.svg
@@ -85,7 +85,7 @@
 
   <!-- Recall label -->
   <text class="accent sans" x="700" y="108" font-size="11" text-anchor="middle" font-weight="700">&#8592; LOAD_CONTEXT RANKS, DEDUPES, BUDGET-FITS ALL FOUR PRIOR MEMORIES</text>
-  <text class="muted sans" x="700" y="124" font-size="10" text-anchor="middle">5-LAYER PIPELINE &#183; ZERO LLM CALLS &#183; DETERMINISTIC</text>
+  <text class="muted sans" x="700" y="124" font-size="10" text-anchor="middle">SEMANTIC-FIRST PIPELINE &#183; ZERO LLM CALLS &#183; DETERMINISTIC</text>
 
   <!-- Outcome box at right -->
   <g transform="translate(40,430)">

--- a/logs/phase2_temporal_fails.json
+++ b/logs/phase2_temporal_fails.json
@@ -1,0 +1,56 @@
+[
+  {
+    "sample_id": "conv-26",
+    "question": "When did Melanie go camping in July?",
+    "expected": "two weekends before 17 July 2023",
+    "previous_output": "July 15, 2023",
+    "previous_score": 0,
+    "category": "multi_hop",
+    "judge_reasoning": "Two weekends before July 17, 2023 would be around July 1-2, not July 15, so the predicted date is incorrect."
+  },
+  {
+    "sample_id": "conv-26",
+    "question": "When did Caroline go to a pride parade during the summer?",
+    "expected": "The week before 3 July 2023",
+    "previous_output": "August 11, 2023",
+    "previous_score": 0,
+    "category": "multi_hop",
+    "judge_reasoning": "The predicted date (August 11, 2023) contradicts the reference date (week before July 3, 2023)."
+  },
+  {
+    "sample_id": "conv-26",
+    "question": "When did Melanie go to the pottery workshop?",
+    "expected": "The Friday before 15 July 2023",
+    "previous_output": "July 7, 2023",
+    "previous_score": 0,
+    "category": "multi_hop",
+    "judge_reasoning": "July 7, 2023 does not match the Friday before July 15, 2023 (which is July 14)."
+  },
+  {
+    "sample_id": "conv-26",
+    "question": "When did Caroline go to the adoption meeting?",
+    "expected": "The friday before 15 July 2023",
+    "previous_output": "July 7, 2023",
+    "previous_score": 0,
+    "category": "multi_hop",
+    "judge_reasoning": "The predicted date July 7 does not match the Friday before July 15, 2023, which would be July 14."
+  },
+  {
+    "sample_id": "conv-26",
+    "question": "When did Melanie run a charity race?",
+    "expected": "The sunday before 25 May 2023",
+    "previous_output": "May 20, 2023",
+    "previous_score": 0,
+    "category": "multi_hop",
+    "judge_reasoning": "The Sunday before May 25, 2023 was May 21, but the prediction says May 20, which is incorrect."
+  },
+  {
+    "sample_id": "conv-41",
+    "question": "When did John have his first firefighter call-out?",
+    "expected": "The sunday before 3` July 2023",
+    "previous_output": "July 30, 2023",
+    "previous_score": 0,
+    "category": "multi_hop",
+    "judge_reasoning": "The predicted date July 30, 2023 does not match the reference of the Sunday before July 3, 2023 (which would be July 2, 2023)."
+  }
+]

--- a/scripts/lme_smoke_local.py
+++ b/scripts/lme_smoke_local.py
@@ -1,0 +1,149 @@
+"""Local LongMemEval smoke — Ollama only, no cloud APIs.
+
+Tiny driver:
+  - Loads the LME 'oracle' variant (small + fast — 12 samples, ~1k tokens each).
+  - Runs N samples (default 2) through ingest → answer → dual judge.
+  - Answerer + judges = local Ollama via OpenAI-compatible API.
+  - Embedder = local Ollama bge-m3 (auto-detected by attestor).
+  - Postgres = attestor_v4_test on localhost.
+
+Usage (from repo root):
+    .venv/bin/python scripts/lme_smoke_local.py --n 2
+
+Prereqs:
+  - Ollama running with bge-m3 + qwen2.5:14b-instruct + mistral-small:24b pulled.
+  - Postgres at localhost:5432, db `attestor_v4_test`, user/pass postgres/attestor.
+  - Schema applied with embedding_dim=1024 (this script reapplies it on each run).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+# Force line-buffered stdout/stderr so progress shows in real time even
+# when piped (`... | tee`, `... | tail -f`, CI capture). Equivalent to
+# `python -u` but doesn't require remembering the flag.
+try:
+    sys.stdout.reconfigure(line_buffering=True)
+    sys.stderr.reconfigure(line_buffering=True)
+except AttributeError:  # pragma: no cover — pre-3.7 fallback path
+    pass
+
+# Make `attestor` importable when invoked as `python scripts/...`
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+# Force local Ollama BEFORE importing attestor.longmemeval — _get_client
+# reads LME_LLM_BASE_URL at call time, but setting early is safest.
+os.environ.setdefault("LME_LLM_BASE_URL", "http://localhost:11434/v1")
+
+SCHEMA_PATH = ROOT / "attestor" / "store" / "schema.sql"
+
+PG_URL = "postgresql://postgres:attestor@localhost:5432/attestor_v4_test"
+ANSWER_MODEL = os.environ.get("ANSWER_MODEL", "qwen2.5:14b-instruct")
+JUDGE_MODELS = os.environ.get(
+    "JUDGE_MODELS", "qwen2.5:14b-instruct,mistral-small:24b",
+).split(",")
+EMBEDDING_DIM = 1024  # bge-m3
+
+
+def _apply_fresh_schema() -> None:
+    """Drop + recreate v4 tables so each smoke starts clean."""
+    import psycopg2
+
+    raw = SCHEMA_PATH.read_text().replace("{embedding_dim}", str(EMBEDDING_DIM))
+    with psycopg2.connect(PG_URL) as c, c.cursor() as cur:
+        for tbl in ("deletion_audit", "user_quotas", "memories", "episodes",
+                    "sessions", "projects", "users"):
+            cur.execute(f"DROP TABLE IF EXISTS {tbl} CASCADE")
+        cur.execute(raw)
+        c.commit()
+    print(f"[smoke] schema applied (embedding_dim={EMBEDDING_DIM})")
+
+
+def _mem_factory():
+    """Return a zero-arg callable producing fresh AgentMemory instances."""
+    from attestor.core import AgentMemory
+
+    def _make():
+        # Each sample gets its own SOLO user via tempdir path (LME's
+        # per-sample isolation guarantee).
+        path = tempfile.mkdtemp(prefix="lme_smoke_")
+        return AgentMemory(path, config={
+            "mode": "solo",
+            "backends": ["postgres"],
+            "backend_configs": {"postgres": {
+                "url": "postgresql://localhost:5432",
+                "database": "attestor_v4_test",
+                "auth": {"username": "postgres", "password": "attestor"},
+                "v4": True,
+                "skip_schema_init": True,
+            }},
+        })
+
+    return _make
+
+
+async def _run(n: int, variant: str, verbose: bool) -> None:
+    from attestor.longmemeval import (
+        load_or_download, run_async,
+    )
+
+    print(f"[smoke] loading LME variant={variant!r}…")
+    samples = load_or_download(variant=variant)
+    print(f"[smoke] dataset has {len(samples)} samples; running first {n}")
+
+    samples = samples[:n]
+    print(f"[smoke] answerer={ANSWER_MODEL!r} judges={JUDGE_MODELS!r}")
+    print(f"[smoke] LME_LLM_BASE_URL={os.environ['LME_LLM_BASE_URL']!r}")
+
+    report = await run_async(
+        samples,
+        mem_factory=_mem_factory(),
+        answer_model=ANSWER_MODEL,
+        judge_models=JUDGE_MODELS,
+        api_key=None,           # _get_client picks up the local placeholder
+        budget=2000,
+        parallel=1,             # one at a time — local hardware
+        verbose=verbose,
+    )
+
+    print()
+    print("=" * 60)
+    print(f"[smoke] DONE — {report.total} samples")
+    print(f"[smoke] by_judge: {json.dumps(report.by_judge, indent=2)}")
+    print(f"[smoke] by_category: {json.dumps(report.by_category, indent=2)}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(prog="lme_smoke_local")
+    parser.add_argument("--n", type=int, default=2,
+                        help="Number of samples (default 2)")
+    parser.add_argument("--variant", default="oracle",
+                        help="LME variant (oracle|s|m); oracle is smallest")
+    parser.add_argument("--verbose", action="store_true")
+    parser.add_argument("--skip-schema", action="store_true",
+                        help="Skip schema reapply (faster repeat runs)")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO if args.verbose else logging.WARNING,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    if not args.skip_schema:
+        _apply_fresh_schema()
+
+    asyncio.run(_run(args.n, args.variant, args.verbose))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- **README rewritten** to match actual v4 code: semantic-first 6-step retrieval (Vector Top-K → Graph Narrow → Triples Inject → MMR → Decay → Budget Fit), local Ollama bge-m3 as the default embedder, Postgres + Neo4j stack, full CLI + MCP tool list. Down from 1380 lines to 385, no aspirational claims.
- **UI polish** — footer `v2 → v4`; recall page `5-layer cascade → semantic-first pipeline`; broken Departure Mono CDN font removed (falls back to IBM Plex Mono); inline favicon kills the `/favicon.ico` 404; recall trace now surfaces vector-lane errors as `warnings[]` so the UI can show an "embedder unreachable" banner.
- **LongMemEval local-Ollama path** — runner accepts `LME_LLM_BASE_URL` to point at any OpenAI-compatible endpoint; `scripts/lme_smoke_local.py` drives a 2-sample oracle smoke against Ollama + local Postgres in one command (matches the project preference for local-first models).
- **Marketing site** (`docs/index.html` + 6 SVGs) brought to v4: `pipeline.svg` fully redrawn as the 6-step semantic-first pipeline; `architecture.svg`, `storage-roles.svg`, `deployment-matrix.svg`, `promotion-path.svg`, `timeline.svg` all corrected (SQLite/ChromaDB/NetworkX → Postgres + pgvector + Neo4j).
- **`.gitignore`** — auto-generated bench/classifier/lme run outputs ignored; curated `*_fails.json` / `*_delta.json` kept tracked.

## Test plan
- [x] `attestor ui` boots; all 8 nav tabs render (Memories, Graph, Recall, Timeline, Agents, Health, Config, Ops); 0 console errors after fixes
- [x] Recall page executes a query end-to-end against the local pgvector store and renders the 3-layer trace with per-step latency
- [x] Health page correctly reports tiered degradation when Neo4j is offline (PG OK, Vector OK, Graph ERROR, Pipeline OK 2/3)
- [x] `docs/index.html` renders the new 6-step pipeline figure + cards in a browser; ticker + lane cards show v4 stack labels
- [x] `python -m attestor.longmemeval` honours `LME_LLM_BASE_URL=http://localhost:11434/v1` (Ollama placeholder key)
- [ ] CI: unit tests still pass against the orchestrator changes (vector-error surfacing is additive — backward compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)