### PR TITLE
docs: align landing pages + privacy with v4 + dual-LLM smoke quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,45 @@ for r in results:
     print(r.score, r.memory.content)
 ```
 
+### 6. Run a smoke benchmark (optional)
+
+Verify your install end-to-end against a tiny LongMemEval slice. The default
+stack is a **dual-LLM, cross-family** setup that mirrors how we benchmark
+internally — `gpt-5.2` answers, two judges (`gpt-5.2` + `claude-sonnet-4.6`)
+score, and OpenAI's `text-embedding-3-large` (truncated to 1024-D for schema
+compatibility) handles embeddings.
+
+```bash
+export OPENAI_API_KEY=...                              # or OPENROUTER_API_KEY
+.venv/bin/python scripts/lme_smoke_local.py --n 2      # 2-sample oracle smoke
+```
+
+Every model and parameter is overridable via env var **or** CLI flag — pick
+whichever is more ergonomic.
+
+| Env var | CLI flag | Default |
+|---------|----------|---------|
+| `ANSWER_MODEL` | `--answer-model` | `openai/gpt-5.2` |
+| `JUDGE_MODELS` (CSV) | `--judge-model` (repeat) | `openai/gpt-5.2,anthropic/claude-sonnet-4.6` |
+| `DISTILL_MODEL` | `--distill-model` | `openai/gpt-5.2` |
+| `USE_DISTILLATION` (1/0) | `--no-distill` | on |
+| `OPENAI_EMBEDDING_MODEL` | `--embedding-model` | `text-embedding-3-large` |
+| `OPENAI_EMBEDDING_DIMENSIONS` | `--embedding-dim` | `1024` |
+| `PG_URL` | `--pg-url` | `postgresql://postgres:attestor@localhost:5432/attestor_v4_test` |
+| `LME_VARIANT` | `--variant` | `oracle` |
+| `LME_N` | `--n` | `2` |
+| `LME_PARALLEL` | `--parallel` | `2` |
+| `LME_BUDGET` | `--budget` | `4000` |
+
+Quick swap to a cheaper model for tight iteration:
+
+```bash
+ANSWER_MODEL=openai/gpt-4.1-mini .venv/bin/python scripts/lme_smoke_local.py --n 2
+```
+
+The script forces attestor's embedder to OpenAI (`ATTESTOR_DISABLE_LOCAL_EMBED=1`)
+so the smoke is deterministic regardless of whether Ollama is running.
+
 ---
 
 ## Architecture

--- a/docs/attestor.html
+++ b/docs/attestor.html
@@ -722,20 +722,20 @@ section{position:relative;z-index:2}
     <div class="section-head">
       <span class="section-head__kicker">§ 03 — Architecture</span>
       <div>
-        <h2 class="section-head__title">Five retrieval layers. <em style="font-style:italic">Zero inference calls.</em></h2>
-        <p class="section-head__sub">When an agent calls recall, five cooperating layers find, fuse, score, and fit.</p>
+        <h2 class="section-head__title">Semantic-first retrieval. <em style="font-style:italic">Zero inference calls.</em></h2>
+        <p class="section-head__sub">When an agent calls recall, six cooperating steps find, narrow, rank, diversify, decay, and fit.</p>
       </div>
     </div>
 
     <div class="col prose">
       <p>
         When an agent calls <code style="font-family:var(--mono);color:var(--accent);font-size:.9em">recall(query, budget)</code>,
-        five cooperating layers find, fuse, score, and fit the most relevant memories into the requested token ceiling.
+        a six-step semantic-first pipeline finds, narrows, ranks, diversifies, decays, and fits the most relevant memories into the requested token ceiling.
         Ten million memories in the store. Your context window never sees more than the budget. Same query, same ranking, always.
       </p>
     </div>
 
-    <div class="pipeline" aria-label="Five-layer retrieval pipeline diagram">
+    <div class="pipeline" aria-label="Semantic-first retrieval pipeline diagram">
       <svg viewBox="0 0 1080 280" role="img" aria-label="Retrieval pipeline">
         <defs>
           <marker id="arrow" viewBox="0 0 10 10" refX="10" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
@@ -762,56 +762,56 @@ section{position:relative;z-index:2}
         </g>
         <line x1="162" y1="82" x2="208" y2="82" class="flow" marker-end="url(#arrow)"/>
 
-        <!-- Layer 1 -->
+        <!-- Step 1 -->
         <g>
           <rect x="208" y="50" width="152" height="64" class="stage-bg"/>
-          <text x="218" y="46" class="stage-n">01 · Tag Match</text>
-          <text x="218" y="78" class="stage-t">SQLite FTS</text>
-          <text x="218" y="98" class="stage-d">literal + token</text>
+          <text x="218" y="46" class="stage-n">01 · Vector top-K</text>
+          <text x="218" y="78" class="stage-t">pgvector</text>
+          <text x="218" y="98" class="stage-d">cosine · k = 50</text>
         </g>
         <line x1="360" y1="82" x2="388" y2="82" class="flow" marker-end="url(#arrow)"/>
 
-        <!-- Layer 2 -->
+        <!-- Step 2 -->
         <g>
           <rect x="388" y="50" width="152" height="64" class="stage-bg"/>
-          <text x="398" y="46" class="stage-n">02 · Graph Exp.</text>
-          <text x="398" y="78" class="stage-t">BFS depth 2</text>
-          <text x="398" y="98" class="stage-d">entity walk</text>
+          <text x="398" y="46" class="stage-n">02 · Graph narrow</text>
+          <text x="398" y="78" class="stage-t">Neo4j BFS</text>
+          <text x="398" y="98" class="stage-d">depth ≤ 2 · hop boost</text>
         </g>
         <line x1="540" y1="82" x2="568" y2="82" class="flow" marker-end="url(#arrow)"/>
 
-        <!-- Layer 3 -->
+        <!-- Step 3 -->
         <g>
           <rect x="568" y="50" width="152" height="64" class="stage-bg"/>
-          <text x="578" y="46" class="stage-n">03 · Vector</text>
-          <text x="578" y="78" class="stage-t">Cosine ANN</text>
-          <text x="578" y="98" class="stage-d">384-D dense</text>
+          <text x="578" y="46" class="stage-n">03 · Triples inject</text>
+          <text x="578" y="78" class="stage-t">typed edges</text>
+          <text x="578" y="98" class="stage-d">uses · authored-by</text>
         </g>
         <line x1="720" y1="82" x2="748" y2="82" class="flow" marker-end="url(#arrow)"/>
 
-        <!-- Layer 4 -->
+        <!-- Step 4 -->
         <g>
           <rect x="748" y="50" width="152" height="64" class="stage-bg hl"/>
-          <text x="758" y="46" class="stage-n">04 · RRF + PR</text>
-          <text x="758" y="78" class="stage-t">k = 60</text>
-          <text x="758" y="98" class="stage-d">fusion + pagerank</text>
+          <text x="758" y="46" class="stage-n">04 · MMR diversity</text>
+          <text x="758" y="78" class="stage-t">λ = 0.7</text>
+          <text x="758" y="98" class="stage-d">drop near-dupes</text>
         </g>
         <line x1="900" y1="82" x2="928" y2="82" class="flow" marker-end="url(#arrow)"/>
 
-        <!-- Layer 5 -->
+        <!-- Step 5+6 (combined cell) -->
         <g>
           <rect x="928" y="50" width="132" height="64" class="stage-bg hl"/>
-          <text x="938" y="46" class="stage-n">05 · MMR</text>
-          <text x="938" y="78" class="stage-t">λ = 0.7</text>
-          <text x="938" y="98" class="stage-d">diverse + fit</text>
+          <text x="938" y="46" class="stage-n">05 · Decay + 06 · Fit</text>
+          <text x="938" y="78" class="stage-t">budget pack</text>
+          <text x="938" y="98" class="stage-d">temporal · greedy</text>
         </g>
 
         <!-- Brackets -->
         <path class="bracket" d="M 208 145 Q 208 155 218 155 L 710 155 Q 720 155 720 145"/>
-        <text x="464" y="180" class="btext" text-anchor="middle">· Candidate Retrieval ·</text>
+        <text x="464" y="180" class="btext" text-anchor="middle">· Candidate Generation ·</text>
 
         <path class="bracket" d="M 748 145 Q 748 155 758 155 L 1050 155 Q 1060 155 1060 145"/>
-        <text x="904" y="180" class="btext" text-anchor="middle">· Rank &amp; Fit ·</text>
+        <text x="904" y="180" class="btext" text-anchor="middle">· Rank · Diversify · Fit ·</text>
 
         <!-- Output -->
         <g>
@@ -834,7 +834,7 @@ section{position:relative;z-index:2}
       <div class="storage__cell" role="listitem">
         <div class="storage__k"><span class="idx">Role 01</span> <span>Document</span></div>
         <h4 class="storage__t">Source of truth</h4>
-        <p class="storage__p">Content, tags, entity, category, timestamps, provenance, confidence. SQLite locally, Postgres / Cosmos / DynamoDB / Arango in the cloud.</p>
+        <p class="storage__p">Content, tags, entity, category, timestamps, provenance, confidence. Postgres 16 by default; AlloyDB, Cosmos DB, DynamoDB, or ArangoDB in the cloud.</p>
       </div>
       <div class="storage__cell" role="listitem">
         <div class="storage__k"><span class="idx">Role 02</span> <span>Vector</span></div>
@@ -1053,8 +1053,8 @@ section{position:relative;z-index:2}
       <div class="deploy__cell" role="listitem">
         <svg class="deploy__glyph" viewBox="0 0 32 32" fill="none" stroke="currentColor" stroke-width="1.2"><rect x="3" y="6" width="26" height="17" rx="1"/><path d="M10 27h12M14 23v4M18 23v4"/></svg>
         <h4 class="deploy__t">Laptop</h4>
-        <p class="deploy__stack">SQLite · Chroma · NetworkX</p>
-        <p class="deploy__p">Zero config. Embedded. Three storage roles in-process.</p>
+        <p class="deploy__stack">Postgres 16 · pgvector · Neo4j + GDS</p>
+        <p class="deploy__p">Docker Compose. Three storage roles, one command up.</p>
       </div>
       <div class="deploy__cell" role="listitem">
         <svg class="deploy__glyph" viewBox="0 0 32 32" fill="none" stroke="currentColor" stroke-width="1.2"><rect x="3" y="4" width="26" height="6"/><rect x="3" y="13" width="26" height="6"/><rect x="3" y="22" width="26" height="6"/><circle cx="7" cy="7" r="1" fill="currentColor"/><circle cx="7" cy="16" r="1" fill="currentColor"/><circle cx="7" cy="25" r="1" fill="currentColor"/></svg>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1848,36 +1848,39 @@ footer.colophon {
     <div style="margin-top:48px;opacity:1;">
       <h3 style="font-family:var(--ff-display);font-size:28px;letter-spacing:-0.01em;margin:0 0 8px;">Recall flow &mdash; <em>what happens on</em> <code>recall()</code></h3>
       <pre style="background:var(--ink-raise);border:1px solid var(--rule);padding:20px 24px;font-family:var(--ff-mono);font-size:12px;line-height:1.5;overflow-x:auto;color:var(--paper-dim);">
-                   mem.recall(query, budget=2000)
-                                &#9474;
-          &#9484;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9532;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9488;
-          &#9474;                     &#9474;                     &#9474;
-          &#9660;                     &#9660;                     &#9660;
-   &#9484;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9488;     &#9484;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9488;     &#9484;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9488;
-   &#9474; Tag matcher   &#9474;     &#9474; Graph expander&#9474;     &#9474; Vector search &#9474;
-   &#9474;  &#8594; doc store  &#9474;     &#9474;  &#8594; graph store&#9474;     &#9474;  &#8594; vec store  &#9474;
-   &#9474;  FTS, tags,   &#9474;     &#9474;  BFS depth 2  &#9474;     &#9474;  cosine ANN   &#9474;
-   &#9474;  stop-filter  &#9474;     &#9474;  from entities&#9474;     &#9474;  top-K IDs    &#9474;
-   &#9492;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9516;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9496;     &#9492;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9516;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9496;     &#9492;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9516;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9496;
-           &#9474;                     &#9474;                     &#9474;
-           &#9492;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9532;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9496;
-                                 &#9660;
-                     Candidate memory IDs (~100s)
-                                 &#9474;
-                                 &#9660;
-                    Hydrate IDs &#8592; document store
-                                 &#9474;
-                                 &#9660;
-              Fusion + Rank  (RRF k=60 &#183; PageRank &#183; confidence decay)
-                                 &#9474;
-                                 &#9660;
-              Diversity + Fit  (MMR &#955;=0.7 &#183; greedy token-budget pack)
-                                 &#9474;
-                                 &#9660;
-                   Ranked memories &#8804; budget tokens
+                  mem.recall(query, budget=2000)
+                               &#9474;
+                               &#9660;
+            &#9484;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9488;
+            &#9474; 01  Vector top-K   &#8594; vec store &#9474;
+            &#9474;     pgvector &#183; cosine &#183; k=50    &#9474;
+            &#9492;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9516;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9496;
+                               &#9660;
+            &#9484;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9488;
+            &#9474; 02  Graph narrow   &#8594; graph     &#9474;
+            &#9474;     Neo4j BFS depth &#8804; 2          &#9474;
+            &#9474;     hop-affinity boost / penalty &#9474;
+            &#9492;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9516;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9496;
+                               &#9660;
+            &#9484;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9488;
+            &#9474; 03  Triples inject               &#9474;
+            &#9474;     uses &#183; authored-by &#183; supersedes &#9474;
+            &#9474;     synthetic-memory facts       &#9474;
+            &#9492;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9516;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9496;
+                               &#9660;
+            &#9484;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9488;
+            &#9474; 04  MMR diversity &#955; = 0.7        &#9474;
+            &#9474; 05  Decay + temporal boost        &#9474;
+            &#9474; 06  Greedy token pack &#8804; budget    &#9474;
+            &#9492;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9516;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9496;
+                               &#9660;
+                  List[RetrievalResult] &#8804; budget
                           (zero LLM calls)
+
+   Optional BM25 / FTS lane &#8594; fused with the vector lane via RRF k=60
+   when the document store has the content_tsv tsvector column populated.
 </pre>
-      <p class="caption" style="font-size:13px;color:var(--muted);font-style:italic;">Only memory IDs travel between layers until the hydrate step. A store with ten million rows still returns a tight result set inside the caller&rsquo;s token ceiling.</p>
+      <p class="caption" style="font-size:13px;color:var(--muted);font-style:italic;">Each step takes the previous step&rsquo;s candidate set as input. Only memory IDs travel until the final budget-fit step hydrates the keepers from the document store. A store with ten million rows still returns a tight result set inside the caller&rsquo;s token ceiling.</p>
     </div>
 
     <!-- Three pillars — Isolation, Temporal, Provenance -->
@@ -2120,6 +2123,7 @@ footer.colophon {
         <button class="tab-btn active" onclick="switchTab(event, 'tab-python')"><span class="tab-num">01</span>Python API</button>
         <button class="tab-btn" onclick="switchTab(event, 'tab-rest')"><span class="tab-num">02</span>REST API</button>
         <button class="tab-btn" onclick="switchTab(event, 'tab-mcp')"><span class="tab-num">03</span>MCP</button>
+        <button class="tab-btn" onclick="switchTab(event, 'tab-smoke')"><span class="tab-num">04</span>Smoke benchmark</button>
       </div>
 
       <div id="tab-python" class="tab-panel active">
@@ -2177,6 +2181,31 @@ results = executor.<span class="fn">recall</span>(<span class="string">"order se
 <span class="comment">#   memory_add        memory_recall     memory_search</span>
 <span class="comment">#   memory_get        memory_forget     memory_timeline</span>
 <span class="comment">#   memory_stats      memory_health</span></div>
+      </div>
+
+      <div id="tab-smoke" class="tab-panel">
+        <div class="code-block" data-lang="Bash &middot; Dual-LLM smoke benchmark"><button class="code-copy-btn" onclick="copyCodeBlock(this)">Copy</button><span class="comment"># Run a tiny LongMemEval smoke against your local install.</span>
+<span class="comment"># Defaults: dual-LLM cross-family judging + OpenAI embeddings.</span>
+<span class="cmd">$ export OPENAI_API_KEY=...</span>
+<span class="cmd">$ .venv/bin/python scripts/lme_smoke_local.py --n 2</span>
+
+<span class="comment"># Default stack (override any of these via env or CLI flag):</span>
+<span class="comment">#   answerer  : openai/gpt-5.2</span>
+<span class="comment">#   judges    : openai/gpt-5.2 + anthropic/claude-sonnet-4.6  (dual)</span>
+<span class="comment">#   distiller : openai/gpt-5.2  (Mem0-style fact extraction on)</span>
+<span class="comment">#   embedder  : text-embedding-3-large @ 1024-D (schema-compat)</span>
+
+<span class="comment"># Swap any slot in one line — env var or CLI flag, your call:</span>
+<span class="cmd">$ ANSWER_MODEL=openai/gpt-4.1-mini python scripts/lme_smoke_local.py --n 2</span>
+<span class="cmd">$ python scripts/lme_smoke_local.py --judge-model openai/gpt-5.2 \</span>
+<span class="cmd">                                   --judge-model anthropic/claude-haiku-4.5</span>
+
+<span class="comment"># Everything else is also configurable:</span>
+<span class="comment">#   --embedding-model / --embedding-dim   pin embedder + dim</span>
+<span class="comment">#   --variant {oracle,s,m}  --n N         dataset slice + size</span>
+<span class="comment">#   --parallel K  --budget T              concurrency + token budget</span>
+<span class="comment">#   --no-distill                          turn off Mem0-style distillation</span>
+<span class="comment">#   --pg-url postgres://&hellip;                target a different Postgres</span></div>
       </div>
     </div>
   </div>

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -11,45 +11,46 @@
     <div class="container">
       <a href="./" style="color: var(--text-secondary); text-decoration: none; font-size: 0.9rem;">&larr; Back to Attestor</a>
       <h1 style="font-size: 2rem; margin-top: 24px;">Privacy Policy</h1>
-      <p class="tagline">Last updated: March 16, 2026</p>
+      <p class="tagline">Last updated: April 27, 2026</p>
     </div>
   </section>
 
   <section class="problem" style="padding: 40px 0;">
     <div class="container">
       <h2>Summary</h2>
-      <p class="problem-text">Attestor stores all data locally on your machine. No data is collected, transmitted, or shared with anyone.</p>
+      <p class="problem-text">Attestor stores all data in infrastructure you control &mdash; either entirely on-device or in a database you administer. Nothing leaves your network unless you explicitly opt into a cloud provider for embeddings or LLM-based extraction.</p>
 
       <h2>Data Storage</h2>
-      <p class="problem-text">All memories, entity graphs, and vector embeddings are stored in local files on your device:</p>
+      <p class="problem-text">Memories, entity graphs, and vector embeddings live in the storage backends you configure. The default topology is fully self-hosted:</p>
       <ul style="color: var(--text-secondary); margin-bottom: 2rem; padding-left: 1.5rem; line-height: 2;">
-        <li><strong>SQLite database</strong> — <code>memory.db</code> in your store directory</li>
-        <li><strong>ChromaDB vectors</strong> — <code>chroma/</code> directory in your store</li>
-        <li><strong>NetworkX graph</strong> — <code>graph.json</code> in your store</li>
-        <li><strong>Configuration</strong> — <code>config.json</code> in your store</li>
+        <li><strong>Document &amp; vector store</strong> &mdash; PostgreSQL 16 with the <code>pgvector</code> extension (source of truth for content, tags, entity, provenance, confidence, and dense embeddings)</li>
+        <li><strong>Graph store</strong> &mdash; Neo4j 5 with the GDS plugin (entity nodes plus typed edges such as <code>uses</code>, <code>authored-by</code>, <code>supersedes</code>)</li>
+        <li><strong>Configuration</strong> &mdash; <code>~/.attestor.toml</code> on your machine</li>
+        <li><strong>Local Docker option</strong> &mdash; <code>attestor setup local</code> generates a Docker Compose file that brings both services up on your laptop</li>
       </ul>
+      <p class="problem-text">Postgres and Neo4j can also be swapped for any of the supported alternatives (AlloyDB, ArangoDB, AWS DynamoDB + OpenSearch + Neptune, Azure Cosmos DB, GCP AlloyDB) &mdash; the storage role still runs in your cloud account, never ours.</p>
 
       <h2>No Data Collection</h2>
       <p class="problem-text">Attestor does not:</p>
       <ul style="color: var(--text-secondary); margin-bottom: 2rem; padding-left: 1.5rem; line-height: 2;">
-        <li>Send any data to external servers</li>
+        <li>Send any data to attestor-operated servers (we don&rsquo;t run any)</li>
         <li>Collect usage analytics or telemetry</li>
         <li>Require account registration</li>
         <li>Phone home or check licenses</li>
-        <li>Access any network resources</li>
+        <li>Access any network resources you didn&rsquo;t configure</li>
       </ul>
 
       <h2>Embeddings</h2>
-      <p class="problem-text">Vector embeddings are computed locally using sentence-transformers (all-MiniLM-L6-v2). The model runs on your machine. No text is sent to any API for embedding computation.</p>
+      <p class="problem-text">By default Attestor computes embeddings using local Ollama (<code>bge-m3</code>, 1024-D) on <code>http://localhost:11434</code> &mdash; nothing leaves the machine. If a cloud embedding provider is configured (OpenAI <code>text-embedding-3-large</code>, AWS Bedrock, Azure OpenAI, or Vertex AI), text is sent to that provider under your account&rsquo;s privacy terms. Provider selection is fully under your control via the <code>ATTESTOR_EMBEDDING_PROVIDER</code> environment variable.</p>
 
       <h2>Claude Code Integration</h2>
-      <p class="problem-text">When used as a Claude Code plugin or MCP server, Attestor runs locally alongside Claude Code. Memory data flows between Attestor and Claude Code on your machine via the Model Context Protocol (stdio). No memory data is sent to Anthropic's servers — only your conversation with Claude is sent, which may include recalled memories that Claude Code injects into the conversation context.</p>
+      <p class="problem-text">When used as a Claude Code plugin or MCP server, Attestor runs locally alongside Claude Code. Memory data flows between Attestor and Claude Code on your machine via the Model Context Protocol (stdio). No memory data is sent to Anthropic&rsquo;s servers &mdash; only your conversation with Claude is sent, which may include recalled memories that Claude Code injects into the conversation context.</p>
 
       <h2>Third-Party Services</h2>
-      <p class="problem-text">Attestor has zero external dependencies by default. Optional features (LLM-based extraction) require an API key you provide and control.</p>
+      <p class="problem-text">Attestor has no built-in third-party telemetry or analytics. Optional features that <em>do</em> reach the network &mdash; cloud embedding providers, LLM-based extraction (OpenRouter / OpenAI / Anthropic), or the LongMemEval benchmark runners &mdash; are off by default and require an API key you provide and control. The default Postgres + Neo4j topology requires no third-party service.</p>
 
       <h2>Open Source</h2>
-      <p class="problem-text">Attestor is open source under the Apache 2.0 license. You can audit the complete source code at <a href="https://github.com/bolnet/attestor" style="color: var(--orange-light);">github.com/bolnet/attestor</a>.</p>
+      <p class="problem-text">Attestor is open source under the MIT license. You can audit the complete source code at <a href="https://github.com/bolnet/attestor" style="color: var(--orange-light);">github.com/bolnet/attestor</a>.</p>
 
       <h2>Contact</h2>
       <p class="problem-text">For privacy questions, open an issue at <a href="https://github.com/bolnet/attestor/issues" style="color: var(--orange-light);">github.com/bolnet/attestor/issues</a>.</p>
@@ -63,7 +64,7 @@
         <a href="https://pypi.org/project/attestor/">PyPI</a>
         <a href="./">Home</a>
       </div>
-      <p class="footer-license">Apache 2.0 License</p>
+      <p class="footer-license">MIT License</p>
     </div>
   </footer>
 </body>

--- a/scripts/lme_smoke_local.py
+++ b/scripts/lme_smoke_local.py
@@ -1,19 +1,45 @@
-"""Local LongMemEval smoke — Ollama only, no cloud APIs.
+"""Local LongMemEval smoke — minimal, fully configurable, dual-LLM.
 
-Tiny driver:
-  - Loads the LME 'oracle' variant (small + fast — 12 samples, ~1k tokens each).
-  - Runs N samples (default 2) through ingest → answer → dual judge.
-  - Answerer + judges = local Ollama via OpenAI-compatible API.
-  - Embedder = local Ollama bge-m3 (auto-detected by attestor).
-  - Postgres = attestor_v4_test on localhost.
+Default stack (override via env vars or CLI flags below):
+  - Embedder: OpenAI ``text-embedding-3-large`` (truncated to 1024-D)
+  - Answer:   ``openai/gpt-5.2``
+  - Judges:   ``openai/gpt-5.2`` + ``anthropic/claude-sonnet-4.6``  (dual)
+  - Distill:  ``openai/gpt-5.2``  (Mem0-style fact extraction enabled)
+
+Why this stack:
+  - Dual-LLM cross-family judging (one OpenAI, one Anthropic) avoids
+    same-family collusion bias on the score.
+  - text-embedding-3-large @ 1024 dims keeps schema-compat with the
+    existing v4 attestor schema (``embedding_dim=1024``) — no migration.
+  - All four model slots are env-configurable so swapping in cheaper /
+    faster models for iteration is one-line.
+
+Configuration (every default is overridable):
+
+  Env vars                          CLI flag                 Default
+  -------------------------------- ------------------------ -------------------
+  ANSWER_MODEL                      --answer-model            openai/gpt-5.2
+  JUDGE_MODELS  (CSV)               --judge-model (repeat)    openai/gpt-5.2,anthropic/claude-sonnet-4.6
+  DISTILL_MODEL                     --distill-model           openai/gpt-5.2
+  USE_DISTILLATION  (1/0)           --no-distill              1 (on)
+  OPENAI_EMBEDDING_MODEL            --embedding-model         text-embedding-3-large
+  OPENAI_EMBEDDING_DIMENSIONS       --embedding-dim           1024
+  PG_URL                            --pg-url                  postgresql://postgres:attestor@localhost:5432/attestor_v4_test
+  LME_VARIANT                       --variant                 oracle
+  LME_N                             --n                       2
+  LME_PARALLEL                      --parallel                2
+  LME_BUDGET                        --budget                  4000
+
+Required:
+  OPENAI_API_KEY      — used for both the LLM calls and embeddings
+                        (set OPENROUTER_API_KEY instead if you prefer
+                        the OpenRouter routing layer).
 
 Usage (from repo root):
-    .venv/bin/python scripts/lme_smoke_local.py --n 2
+    OPENAI_API_KEY=... .venv/bin/python scripts/lme_smoke_local.py --n 2
 
-Prereqs:
-  - Ollama running with bge-m3 + qwen2.5:14b-instruct + mistral-small:24b pulled.
-  - Postgres at localhost:5432, db `attestor_v4_test`, user/pass postgres/attestor.
-  - Schema applied with embedding_dim=1024 (this script reapplies it on each run).
+Quick iteration with a cheaper model:
+    ANSWER_MODEL=openai/gpt-4.1-mini .venv/bin/python scripts/lme_smoke_local.py --n 2
 """
 
 from __future__ import annotations
@@ -27,50 +53,130 @@ import sys
 import tempfile
 from pathlib import Path
 
-# Force line-buffered stdout/stderr so progress shows in real time even
-# when piped (`... | tee`, `... | tail -f`, CI capture). Equivalent to
-# `python -u` but doesn't require remembering the flag.
+# Force line-buffered stdout/stderr for live progress in pipes / tee / CI.
 try:
     sys.stdout.reconfigure(line_buffering=True)
     sys.stderr.reconfigure(line_buffering=True)
-except AttributeError:  # pragma: no cover — pre-3.7 fallback path
+except AttributeError:  # pragma: no cover — pre-3.7 fallback
     pass
 
-# Make `attestor` importable when invoked as `python scripts/...`
 ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(ROOT))
 
-# Force local Ollama BEFORE importing attestor.longmemeval — _get_client
-# reads LME_LLM_BASE_URL at call time, but setting early is safest.
-os.environ.setdefault("LME_LLM_BASE_URL", "http://localhost:11434/v1")
-
 SCHEMA_PATH = ROOT / "attestor" / "store" / "schema.sql"
 
-PG_URL = "postgresql://postgres:attestor@localhost:5432/attestor_v4_test"
-ANSWER_MODEL = os.environ.get("ANSWER_MODEL", "qwen2.5:14b-instruct")
-JUDGE_MODELS = os.environ.get(
-    "JUDGE_MODELS", "qwen2.5:14b-instruct,mistral-small:24b",
-).split(",")
-EMBEDDING_DIM = 1024  # bge-m3
+
+# ─── Defaults (every one is overridable) ───
+DEFAULTS = {
+    "answer_model":    "openai/gpt-5.2",
+    "judge_models":    "openai/gpt-5.2,anthropic/claude-sonnet-4.6",
+    "distill_model":   "openai/gpt-5.2",
+    "use_distill":     True,
+    "embedding_model": "text-embedding-3-large",
+    "embedding_dim":   1024,
+    "pg_url":          "postgresql://postgres:attestor@localhost:5432/attestor_v4_test",
+    "variant":         "oracle",
+    "n":               2,
+    "parallel":        2,
+    "budget":          4000,
+}
 
 
-def _apply_fresh_schema() -> None:
+def _env_or(name: str, default):
+    """Read env var; coerce to the type of the default (bool / int / str)."""
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    if isinstance(default, bool):
+        return raw.strip().lower() in ("1", "true", "yes", "y", "on")
+    if isinstance(default, int):
+        return int(raw)
+    return raw
+
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(prog="lme_smoke_local",
+                                description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--answer-model",
+                   default=_env_or("ANSWER_MODEL", DEFAULTS["answer_model"]))
+    p.add_argument("--judge-model", action="append", default=None,
+                   help="Repeat for multiple judges. If omitted, uses JUDGE_MODELS env (CSV) or the default pair.")
+    p.add_argument("--distill-model",
+                   default=_env_or("DISTILL_MODEL", DEFAULTS["distill_model"]))
+    p.add_argument("--no-distill", action="store_true",
+                   help="Disable distillation (default is on)")
+    p.add_argument("--embedding-model",
+                   default=_env_or("OPENAI_EMBEDDING_MODEL", DEFAULTS["embedding_model"]))
+    p.add_argument("--embedding-dim", type=int,
+                   default=_env_or("OPENAI_EMBEDDING_DIMENSIONS", DEFAULTS["embedding_dim"]))
+    p.add_argument("--pg-url",
+                   default=_env_or("PG_URL", DEFAULTS["pg_url"]))
+    p.add_argument("--variant",
+                   default=_env_or("LME_VARIANT", DEFAULTS["variant"]),
+                   help="LME variant (oracle|s|m); oracle is smallest / fastest")
+    p.add_argument("--n", type=int,
+                   default=_env_or("LME_N", DEFAULTS["n"]))
+    p.add_argument("--parallel", type=int,
+                   default=_env_or("LME_PARALLEL", DEFAULTS["parallel"]))
+    p.add_argument("--budget", type=int,
+                   default=_env_or("LME_BUDGET", DEFAULTS["budget"]))
+    p.add_argument("--skip-schema", action="store_true",
+                   help="Skip schema reapply (faster repeat runs)")
+    p.add_argument("--verbose", action="store_true")
+    args = p.parse_args()
+
+    # Resolve judge models with the documented precedence:
+    # CLI flag (repeated) > JUDGE_MODELS env (CSV) > default pair.
+    if args.judge_model:
+        judges = args.judge_model
+    else:
+        raw = os.environ.get("JUDGE_MODELS", DEFAULTS["judge_models"])
+        judges = [j.strip() for j in raw.split(",") if j.strip()]
+    args.judge_models = judges
+
+    args.use_distillation = not args.no_distill and _env_or(
+        "USE_DISTILLATION", DEFAULTS["use_distill"]
+    )
+
+    return args
+
+
+# ─── Setup helpers ───
+
+def _force_openai_embedder(model: str, dim: int) -> None:
+    """Push attestor's embedding probe to OpenAI text-embedding-3-large.
+
+    attestor/store/embeddings.py probes Ollama first by default; we
+    disable that and pin model + dimensions so the smoke is deterministic
+    regardless of what's running on localhost:11434.
+    """
+    os.environ["ATTESTOR_DISABLE_LOCAL_EMBED"] = "1"
+    os.environ["OPENAI_EMBEDDING_MODEL"] = model
+    os.environ["OPENAI_EMBEDDING_DIMENSIONS"] = str(dim)
+
+
+def _apply_fresh_schema(pg_url: str, embedding_dim: int) -> None:
     """Drop + recreate v4 tables so each smoke starts clean."""
     import psycopg2
 
-    raw = SCHEMA_PATH.read_text().replace("{embedding_dim}", str(EMBEDDING_DIM))
-    with psycopg2.connect(PG_URL) as c, c.cursor() as cur:
+    raw = SCHEMA_PATH.read_text().replace("{embedding_dim}", str(embedding_dim))
+    with psycopg2.connect(pg_url) as c, c.cursor() as cur:
         for tbl in ("deletion_audit", "user_quotas", "memories", "episodes",
                     "sessions", "projects", "users"):
             cur.execute(f"DROP TABLE IF EXISTS {tbl} CASCADE")
         cur.execute(raw)
         c.commit()
-    print(f"[smoke] schema applied (embedding_dim={EMBEDDING_DIM})")
+    print(f"[smoke] schema applied (embedding_dim={embedding_dim})")
 
 
-def _mem_factory():
+def _mem_factory(pg_url: str):
     """Return a zero-arg callable producing fresh AgentMemory instances."""
     from attestor.core import AgentMemory
+    from urllib.parse import urlparse
+
+    parsed = urlparse(pg_url)
+    db = (parsed.path or "/").lstrip("/") or "attestor_v4_test"
 
     def _make():
         # Each sample gets its own SOLO user via tempdir path (LME's
@@ -80,9 +186,12 @@ def _mem_factory():
             "mode": "solo",
             "backends": ["postgres"],
             "backend_configs": {"postgres": {
-                "url": "postgresql://localhost:5432",
-                "database": "attestor_v4_test",
-                "auth": {"username": "postgres", "password": "attestor"},
+                "url": f"{parsed.scheme}://{parsed.hostname}:{parsed.port or 5432}",
+                "database": db,
+                "auth": {
+                    "username": parsed.username or "postgres",
+                    "password": parsed.password or "attestor",
+                },
                 "v4": True,
                 "skip_schema_init": True,
             }},
@@ -91,28 +200,42 @@ def _mem_factory():
     return _make
 
 
-async def _run(n: int, variant: str, verbose: bool) -> None:
-    from attestor.longmemeval import (
-        load_or_download, run_async,
-    )
+# ─── Main run ───
 
-    print(f"[smoke] loading LME variant={variant!r}…")
-    samples = load_or_download(variant=variant)
-    print(f"[smoke] dataset has {len(samples)} samples; running first {n}")
+async def _run(args: argparse.Namespace) -> None:
+    from attestor.longmemeval import load_or_download, run_async
 
-    samples = samples[:n]
-    print(f"[smoke] answerer={ANSWER_MODEL!r} judges={JUDGE_MODELS!r}")
-    print(f"[smoke] LME_LLM_BASE_URL={os.environ['LME_LLM_BASE_URL']!r}")
+    if not (os.environ.get("OPENAI_API_KEY") or os.environ.get("OPENROUTER_API_KEY")):
+        sys.stderr.write(
+            "[smoke] error: neither OPENAI_API_KEY nor OPENROUTER_API_KEY is set.\n"
+            "        Both LLM calls and the OpenAI embedder need one of these.\n"
+        )
+        raise SystemExit(2)
+
+    print(f"[smoke] loading LME variant={args.variant!r}…")
+    samples = load_or_download(variant=args.variant)
+    print(f"[smoke] dataset has {len(samples)} samples; running first {args.n}")
+
+    print(f"[smoke] embedder  = {args.embedding_model!r} @ {args.embedding_dim}-D")
+    print(f"[smoke] answerer  = {args.answer_model!r}")
+    print(f"[smoke] judges    = {args.judge_models!r}  (dual-LLM)")
+    if args.use_distillation:
+        print(f"[smoke] distiller = {args.distill_model!r}  (distillation ON)")
+    else:
+        print("[smoke] distiller = (distillation OFF)")
+    print(f"[smoke] budget    = {args.budget} tokens · parallel = {args.parallel}")
 
     report = await run_async(
-        samples,
-        mem_factory=_mem_factory(),
-        answer_model=ANSWER_MODEL,
-        judge_models=JUDGE_MODELS,
-        api_key=None,           # _get_client picks up the local placeholder
-        budget=2000,
-        parallel=1,             # one at a time — local hardware
-        verbose=verbose,
+        samples[: args.n],
+        mem_factory=_mem_factory(args.pg_url),
+        answer_model=args.answer_model,
+        judge_models=args.judge_models,
+        distill_model=args.distill_model,
+        use_distillation=args.use_distillation,
+        api_key=None,  # _get_client reads OPENAI_API_KEY / OPENROUTER_API_KEY
+        budget=args.budget,
+        parallel=args.parallel,
+        verbose=args.verbose,
     )
 
     print()
@@ -123,25 +246,19 @@ async def _run(n: int, variant: str, verbose: bool) -> None:
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(prog="lme_smoke_local")
-    parser.add_argument("--n", type=int, default=2,
-                        help="Number of samples (default 2)")
-    parser.add_argument("--variant", default="oracle",
-                        help="LME variant (oracle|s|m); oracle is smallest")
-    parser.add_argument("--verbose", action="store_true")
-    parser.add_argument("--skip-schema", action="store_true",
-                        help="Skip schema reapply (faster repeat runs)")
-    args = parser.parse_args()
+    args = _parse_args()
 
     logging.basicConfig(
         level=logging.INFO if args.verbose else logging.WARNING,
         format="%(asctime)s %(levelname)s %(name)s: %(message)s",
     )
 
-    if not args.skip_schema:
-        _apply_fresh_schema()
+    _force_openai_embedder(args.embedding_model, args.embedding_dim)
 
-    asyncio.run(_run(args.n, args.variant, args.verbose))
+    if not args.skip_schema:
+        _apply_fresh_schema(args.pg_url, args.embedding_dim)
+
+    asyncio.run(_run(args))
     return 0
 
 


### PR DESCRIPTION
## Summary

Follow-up to #57. Closes the remaining v3 → v4 doc drift on the marketing surface and ships a configurable dual-LLM smoke driver matching the canonical benchmark stack.

- **`scripts/lme_smoke_local.py`** — full rewrite. Defaults: `openai/gpt-5.2` answerer + dual judges (`openai/gpt-5.2` + `anthropic/claude-sonnet-4.6`) + `openai/gpt-5.2` distiller; OpenAI `text-embedding-3-large` at 1024-D for embeddings. Every slot overridable via env var **or** CLI flag (`ANSWER_MODEL` / `--answer-model`, `JUDGE_MODELS` / `--judge-model`, `DISTILL_MODEL`, `--no-distill`, `OPENAI_EMBEDDING_MODEL`, `--embedding-dim`, `PG_URL`, `LME_VARIANT`, `--n`, `--parallel`, `--budget`). The previous Ollama-only variant was misleading — "local" now means the same stack we benchmark against, not the same machine.
- **`README.md`** — new `6. Run a smoke benchmark` section under Quick Start with the full env / CLI override matrix and a one-line "swap to cheaper model" example.
- **`docs/index.html`** — new `04 · Smoke benchmark` tab in the Quickstart section; recall-flow ASCII redrawn from the v3 3-way parallel (Tag · Graph · Vector → fusion) to the v4 sequential 6-step semantic-first flow.
- **`docs/attestor.html`** — "Five retrieval layers" → "Semantic-first retrieval"; embedded pipeline SVG redrawn for 6 steps; Document role description corrected (Postgres 16 default; AlloyDB / Cosmos / DynamoDB / ArangoDB alternatives); Laptop deploy cell `SQLite · Chroma · NetworkX` → `Postgres 16 · pgvector · Neo4j + GDS`.
- **`docs/privacy.html`** — storage section rewritten (Postgres + pgvector + Neo4j default, Docker Compose path, cloud alternatives); embedder section updated (local Ollama `bge-m3` default; cloud providers opt-in via `ATTESTOR_EMBEDDING_PROVIDER`); license corrected from Apache 2.0 → MIT (matches LICENSE file); date bumped to 2026-04-27.

After this PR, every marketing surface (`docs/index.html`, `docs/attestor.html`, `docs/privacy.html`, all 6 SVGs from #57) describes the v4 architecture with zero references to the old SQLite + ChromaDB + NetworkX + 5-layer-cascade story.

## Test plan
- [x] `python scripts/lme_smoke_local.py --help` renders the full override matrix
- [x] Resolved defaults verified: answerer `openai/gpt-5.2`; judges `[openai/gpt-5.2, anthropic/claude-sonnet-4.6]`; embedder `text-embedding-3-large @ 1024-D`
- [x] AST-parses cleanly; missing `OPENAI_API_KEY` raises a clear actionable error
- [x] `docs/index.html` Quickstart section: clicking the new "04 · Smoke benchmark" tab in a browser shows the run command + dual-LLM defaults block + override examples
- [x] Recall-flow ASCII renders sequentially with the 6 steps in the right order
- [x] Final stale-term sweep across `*.html` + `*.svg`: 0 hits for `5-layer`, `Five layer`, `SQLite`, `ChromaDB`, `sentence-transformers`, `Apache 2.0`
- [ ] CI: smoke script not invoked in CI (no API keys); no orchestrator changes — backward compatible

🤖 Generated with [Claude Code](https://claude.com/claude-code)