### PR TITLE
docs(landing): interactive recall pipeline + multi-LLM cooperation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,28 +2,49 @@
 
 **The memory layer for agent teams.** Self-hosted, deterministic retrieval, zero LLM in the critical path.
 
+[![PyPI](https://img.shields.io/pypi/v/attestor?label=PyPI&color=C15F3C&labelColor=1A1614)](https://pypi.org/project/attestor/)
+[![PyPI Downloads](https://img.shields.io/pypi/dm/attestor?label=installs%2Fmo&color=C15F3C&labelColor=1A1614)](https://pypi.org/project/attestor/)
+[![GitHub Stars](https://img.shields.io/github/stars/bolnet/attestor?style=flat&label=stars&color=C15F3C&labelColor=1A1614)](https://github.com/bolnet/attestor/stargazers)
+[![Build](https://github.com/bolnet/attestor/actions/workflows/workflow.yml/badge.svg)](https://github.com/bolnet/attestor/actions/workflows/workflow.yml)
+[![Evals](https://github.com/bolnet/attestor/actions/workflows/evals.yml/badge.svg)](https://github.com/bolnet/attestor/actions/workflows/evals.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-1A1614.svg?labelColor=C15F3C)](LICENSE)
+
 ```
-pip install attestor          # Python library + CLI + REST API + MCP server
+pip install attestor
 ```
 
-- **PyPI:** `attestor`
-- **Import:** `attestor`
-- **Status:** v4.0.0 alpha (greenfield; no v3 migration path)
-- **License:** see `LICENSE`
+| | |
+|---|---|
+| **Version** | `4.0.0a1` (alpha; greenfield rebuild — no v3 migration path) |
+| **PyPI** | `attestor` |
+| **Import** | `attestor` |
+| **Live site** | <https://attestor.dev/> |
+| **Repo** | <https://github.com/bolnet/attestor> |
+| **License** | MIT |
 
 ---
 
 ## What it is
 
-Attestor is a memory store for multi-agent systems where the same memories are persisted across **three storage roles** — document, vector, and graph — and read back through a **deterministic 6-step retrieval pipeline** that never calls an LLM on the hot path.
+Attestor is a memory store for agent teams that need a **shared, tenant-isolated memory** with **bi-temporal replay**, **deterministic retrieval**, and an **auditable supersession chain**. It runs as a Python library, a Starlette REST service, or an MCP server — same API in all three.
 
-It is designed for:
+It is built around three claims, each grounded in code:
 
-- agent teams that need a shared, tenant-isolated memory store with RBAC and audit trails
-- products that must answer *"what did we know on 2026-03-01?"* (bi-temporal replay)
-- environments where latency, cost, and reproducibility matter more than peak relevance
+1. **Bi-temporal — replay any past state.** Every memory has both event time (`valid_from` / `valid_until`) and transaction time (`t_created` / `t_expired`). Nothing is deleted; everything is queryable forever (`attestor/temporal/manager.py:43-73`, `core.py:888-890`).
+2. **Semantic-first retrieval, no LLM in the hot path.** A six-step deterministic pipeline. Same query → same ranking. Unit-testable (`attestor/retrieval/orchestrator.py:1-14`).
+3. **Conversation ingest with auditable conflict resolution.** Two-pass speaker-locked extraction, then a four-decision (`ADD / UPDATE / INVALIDATE / NOOP`) resolver per fact. Every supersession carries an `evidence_episode_id` (`attestor/extraction/conflict_resolver.py:98`).
 
-It is **not** a general vector database, a RAG framework, or an LLM agent runtime. It plugs into your agent stack as a backend.
+### Designed for
+
+- Multi-agent products where many LLMs write to the same memory store
+- Regulated chat systems that need point-in-time reconstruction (compliance, audit, FOIA-style queries)
+- Self-hosted deployments — your VPC, your Postgres, your Neo4j
+
+### *Not* designed for
+
+- A general-purpose vector database
+- A RAG framework with built-in chunking, reranking, and orchestration
+- An LLM agent runtime — Attestor is the memory backend; the agent loop is yours
 
 ---
 
@@ -32,40 +53,40 @@ It is **not** a general vector database, a RAG framework, or an LLM agent runtim
 ### 1. Install
 
 ```bash
-pip install attestor
-# or
-pipx install attestor
+pip install attestor                 # or: pipx install attestor
 ```
 
-### 2. Bring up a local Postgres + Neo4j
+### 2. Bring up local Postgres + Neo4j
 
 ```bash
-attestor setup local      # writes docker-compose.yml under attestor/infra/local
+attestor setup local                                       # writes attestor/infra/local/docker-compose.yml
 docker compose -f attestor/infra/local/docker-compose.yml up -d
 ```
 
-Postgres ships with `pgvector`. Neo4j ships with GDS for PageRank / BFS / Leiden.
+Postgres 16 ships with `pgvector` (document + vector roles). Neo4j 5 ships with GDS (graph role: PageRank, BFS, Leiden).
 
 ### 3. Pull the default embedder
 
 ```bash
-ollama pull bge-m3        # 1024-D, 8K context, local default
+ollama pull bge-m3                   # 1024-D, 8K context, local-first default
 ```
 
-### 4. Verify everything is wired up
+The provider chain in `attestor/store/embeddings.py` checks `http://localhost:11434` first; cloud providers are fallbacks. Override via `ATTESTOR_EMBEDDING_PROVIDER` / `ATTESTOR_EMBEDDING_MODEL`.
+
+### 4. Verify (mandatory)
 
 ```bash
 attestor doctor
 ```
 
-You should see green for **Document Store (Postgres)**, **Vector Store (pgvector)**, **Graph Store (Neo4j)**, and **Retrieval Pipeline**.
+You should see green for **Document Store**, **Vector Store**, **Graph Store**, and **Retrieval Pipeline**. If the graph store is offline, recall continues against the surviving roles — degradation is explicit and tiered (`core.py:99-115`).
 
 ### 5. Use it
 
 ```python
 from attestor import AgentMemory, AgentContext, AgentRole
 
-mem = AgentMemory()  # picks up env / ~/.attestor.toml automatically
+mem = AgentMemory()                  # picks up env / ~/.attestor.toml automatically
 
 ctx = AgentContext(
     agent_id="researcher-1",
@@ -85,93 +106,33 @@ for r in results:
     print(r.score, r.memory.content)
 ```
 
+> **SOLO mode (zero-config).** In v4, `AgentMemory().add('foo')` auto-provisions a singleton `local` user, an Inbox project (`metadata.is_inbox=true`), and a daily session — so the snippet above works on a fresh database without configuring identity (`core.py:179-209`). For multi-tenant production use, pass an explicit `AgentContext` with a real `namespace`.
+
 ### 6. Run a smoke benchmark (optional)
 
-Verify your install end-to-end against a tiny LongMemEval slice. The default
-stack is a **dual-LLM, cross-family** setup that mirrors how we benchmark
-internally — `gpt-5.2` answers, two judges (`gpt-5.2` + `claude-sonnet-4.6`)
-score, and OpenAI's `text-embedding-3-large` (truncated to 1024-D for schema
-compatibility) handles embeddings.
+Verify your install end-to-end against a tiny LongMemEval slice. Defaults match the canonical benchmark stack: `openai/gpt-5.2` answerer, dual judges (`openai/gpt-5.2` + `anthropic/claude-sonnet-4.6`), `openai/gpt-5.2` distiller, OpenAI `text-embedding-3-large` truncated to 1024-D.
 
 ```bash
-export OPENAI_API_KEY=...                              # or OPENROUTER_API_KEY
-.venv/bin/python scripts/lme_smoke_local.py --n 2      # 2-sample oracle smoke
+export OPENAI_API_KEY=...
+.venv/bin/python scripts/lme_smoke_local.py --n 2
 ```
 
-Every model and parameter is overridable via env var **or** CLI flag — pick
-whichever is more ergonomic.
-
-| Env var | CLI flag | Default |
-|---------|----------|---------|
-| `ANSWER_MODEL` | `--answer-model` | `openai/gpt-5.2` |
-| `JUDGE_MODELS` (CSV) | `--judge-model` (repeat) | `openai/gpt-5.2,anthropic/claude-sonnet-4.6` |
-| `DISTILL_MODEL` | `--distill-model` | `openai/gpt-5.2` |
-| `USE_DISTILLATION` (1/0) | `--no-distill` | on |
-| `OPENAI_EMBEDDING_MODEL` | `--embedding-model` | `text-embedding-3-large` |
-| `OPENAI_EMBEDDING_DIMENSIONS` | `--embedding-dim` | `1024` |
-| `PG_URL` | `--pg-url` | `postgresql://postgres:attestor@localhost:5432/attestor_v4_test` |
-| `LME_VARIANT` | `--variant` | `oracle` |
-| `LME_N` | `--n` | `2` |
-| `LME_PARALLEL` | `--parallel` | `2` |
-| `LME_BUDGET` | `--budget` | `4000` |
-
-Quick swap to a cheaper model for tight iteration:
-
-```bash
-ANSWER_MODEL=openai/gpt-4.1-mini .venv/bin/python scripts/lme_smoke_local.py --n 2
-```
-
-The script forces attestor's embedder to OpenAI (`ATTESTOR_DISABLE_LOCAL_EMBED=1`)
-so the smoke is deterministic regardless of whether Ollama is running.
+Every model and parameter is overridable via env var or CLI flag. See `--help` for the full table.
 
 ---
 
 ## Architecture
 
-### Three storage roles
+### Bi-temporal — replay any past state
 
-Every memory is persisted across the required backends in your topology:
+Every memory carries two time axes:
 
-| Role | Purpose | Default | Alternatives |
-|------|---------|---------|--------------|
-| **Document** | Source of truth (content, tags, entity, ts, provenance, confidence) | Postgres | AlloyDB, ArangoDB, DynamoDB, Cosmos DB |
-| **Vector** | Dense embedding per memory | Postgres + pgvector | AlloyDB ScaNN, ArangoDB, OpenSearch Serverless, Cosmos DiskANN |
-| **Graph** | Entity nodes + typed edges (`uses`, `authored-by`, `supersedes`) | Neo4j (GDS) | AGE on AlloyDB, ArangoDB, Neptune, NetworkX (Azure) |
+| Axis | Columns | Meaning |
+|------|---------|---------|
+| **Event time** | `valid_from`, `valid_until` | When the fact is true *in the world* |
+| **Transaction time** | `t_created`, `t_expired` | When the row landed *in the store* |
 
-Postgres is always the source of truth. Neo4j (or whichever graph store you pick) is **derived state, rebuildable from Postgres**. If the vector or graph store goes down, the document path keeps serving — degradation is explicit and tiered.
-
-### Retrieval — semantic-first, no LLM in the loop
-
-The orchestrator (`attestor/retrieval/orchestrator.py`) runs the same 6 steps for every query:
-
-1. **Vector semantic search** — top-K = 50 nearest by cosine
-2. **Graph narrow** — soft boost by hop-distance (BFS depth ≤ 2) from each candidate's entity to the question entities
-3. **Triples injection** — typed-edge facts injected as synthetic memories so the consumer can reason over relations, not just text
-4. **MMR rerank** — λ = 0.7 diversity vs. relevance trade-off
-5. **Confidence decay + temporal boost** — recency / decay applied per memory
-6. **Budget fit** — greedy pack into the agent's token budget
-
-Optional **BM25 / FTS lane** (`bm25_lane=...` on the orchestrator) runs a `tsvector` keyword search in parallel and **fuses with the vector lane via Reciprocal Rank Fusion (RRF, k = 60)**. Useful for acronyms, IDs, and rare proper nouns where embeddings under-recall. Gracefully no-ops on backends that don't have the `content_tsv` column.
-
-Every call writes a JSONL trace to `logs/attestor_trace.jsonl` (disable with `ATTESTOR_TRACE=0`).
-
-### Multi-agent primitives
-
-- **Six RBAC roles** (`AgentRole` enum): `ORCHESTRATOR`, `PLANNER`, `EXECUTOR`, `RESEARCHER`, `REVIEWER`, `MONITOR`
-- **Namespace isolation** via Postgres Row-Level Security on every tenant table (`tenant_isolation_*` policies on the `attestor.current_user_id` session var)
-- **Provenance** on every memory (who wrote it, which session, which episode)
-- **Per-agent write quotas and token budgets**
-- **Recall cache** per `AgentContext` session — repeated queries are deduplicated transparently
-- **`AgentContext.scratchpad: Dict[str, Any]`** — typed lane for planner → executor handoffs without rounding through the store
-
-### Bi-temporal — nothing is deleted
-
-Every memory has two time axes:
-
-- **Event time** — `valid_from` / `valid_until` (when the fact is true in the world)
-- **Transaction time** — `t_created` / `t_expired` (when the row landed in the store)
-
-Plus a `superseded_by` chain. Old facts are never deleted — they remain queryable forever.
+Plus a `superseded_by` chain. Old facts are never deleted — they remain queryable forever (`attestor/temporal/manager.py:30-66`).
 
 ```python
 # What did we believe on March 1?
@@ -181,17 +142,155 @@ mem.recall(query="who runs engineering?", as_of="2026-03-01T00:00:00Z", context=
 mem.recall(query="alice", time_window=("2026-02-01", "2026-04-01"), context=ctx)
 ```
 
-**Auto-supersession on write.** `add()` runs `TemporalManager.check_contradictions()` against the new memory before insert; any active row with the same `(entity, category, namespace)` and different content is automatically marked superseded by the new id (`status="superseded"`, `valid_until=now`, `superseded_by=<new_id>`). Detection is rule-based string-equality today — soft / similarity-based contradiction is on the roadmap.
+`as_of` and `time_window` propagate end-to-end through the orchestrator and document store. Auto-supersession on write is wired into `core.py:add()` (`core.py:762, 784-785`): on every `add`, the temporal manager finds active rows with the same `(entity, category, namespace)` and different content, marks them `superseded`, sets `valid_until=now`, and links `superseded_by=<new_id>`. Detection is rule-based string equality today.
+
+### Tenant isolation — Postgres Row-Level Security
+
+Every tenant table (`users`, `projects`, `sessions`, `episodes`, `memories`, `user_quotas`, `deletion_audit`) carries a `tenant_isolation_*` policy keyed off the `attestor.current_user_id` session variable. An empty / unset value fails closed — no rows visible (`attestor/store/schema.sql:311-327`).
+
+> **Honest disclosure.** Enforcement lives in **Postgres**, not Python. The `AgentRole` enum in `attestor/context.py:49-56` is metadata that flows onto memories for provenance; it does *not* gate operations in Python. RLS is what actually controls access. This is correct architecture for a memory backend, but worth knowing if you read the Python alone.
+
+### The retrieval pipeline — semantic-first, six steps
+
+`attestor/retrieval/orchestrator.py` runs the same six steps for every query:
+
+1. **Vector top-K** — pgvector cosine, k=50
+2. **Graph narrow** — Neo4j BFS depth ≤ 2 from each candidate's entity to the question entities; affinity bonus per hop (0-hop=+0.30, 1-hop=+0.20, 2-hop=+0.10; unreachable=−0.05). Discrete, not "soft".
+3. **Triples inject** — typed-edge facts (`uses`, `authored-by`, `supersedes`) injected as synthetic memories
+4. **MMR rerank** — λ=0.7
+5. **Confidence decay + temporal boost** — recency lifts; stale, low-confidence rows fall
+6. **Budget fit** — greedy monotonic-by-score pack into the caller's token budget
+
+Every call writes a JSONL trace to `logs/attestor_trace.jsonl` (disable via `ATTESTOR_TRACE=0`).
+
+### Three storage roles
+
+| Role | Purpose | Default | Alternatives |
+|------|---------|---------|--------------|
+| **Document** | Source of truth (content, tags, entity, ts, provenance, confidence) | Postgres 16 | AlloyDB, ArangoDB, DynamoDB, Cosmos DB |
+| **Vector** | Dense embedding per memory | pgvector | AlloyDB ScaNN, ArangoDB, OpenSearch Serverless, Cosmos DiskANN |
+| **Graph** | Entity nodes + typed edges | Neo4j 5 + GDS | Apache AGE on AlloyDB, ArangoDB, Neptune, NetworkX (Azure) |
+
+Postgres is the source of truth. Neo4j is **derived state, rebuildable from Postgres**. If the vector or graph store goes down, the document path keeps serving — degradation is explicit and tiered.
+
+### Optional BM25 / FTS lane
+
+A trigger-maintained `content_tsv` tsvector + GIN index lifts queries that embeddings under-recall (acronyms, IDs, rare proper nouns). Enabled when v4 schema is detected; fuses with the vector lane via Reciprocal Rank Fusion (RRF, k=60). Graceful no-op on backends without the column (`core.py:122-130`).
+
+---
+
+## Conversation ingest
+
+The heavyweight write path that turns conversation turns into auditable memories. `core.py:ingest_round(turn)` orchestrates four passes:
+
+```
+turn  →  extract_user_facts(user_turn)        ┐
+        extract_agent_facts(assistant_turn)   ┘  → resolve_conflicts → apply
+```
+
+### Two-pass speaker-locked extraction
+
+`attestor/extraction/round_extractor.py:216, 258` — separate prompts for user vs assistant turns. The user-turn extractor only emits facts attributable to the user; the assistant-turn extractor only emits facts the assistant introduced. Stops cross-attribution. The "+53.6 over Mem0" delta in our LongMemEval scores comes from this split.
+
+### Four-decision conflict resolver
+
+`attestor/extraction/conflict_resolver.py:40, 98` — for each newly-extracted fact, an LLM call against existing similar memories returns one of:
+
+| Decision | Effect |
+|----------|--------|
+| `ADD` | New info, no existing match — write fresh memory |
+| `UPDATE` | Same entity + predicate, refined value — keep existing id |
+| `INVALIDATE` | Old memory contradicted — mark superseded (timeline replays) |
+| `NOOP` | Already represented — skip |
+
+Each `Decision` carries `evidence_episode_id`. Every supersession is auditable. Failsafe: parse failure on a single fact yields `ADD`-by-default — better a duplicate-ish row than a silent drop.
+
+> **Two write paths, two contracts.** `mem.add(...)` runs the lightweight rule-based supersession (§Bi-temporal). `mem.ingest_round(turn)` runs the full four-decision pipeline. Pick `ingest_round` for conversational data; pick `add` for structured writes where you've already done the conflict reasoning.
+
+### Sleep-time consolidation
+
+`mem.consolidate()` (`core.py:526`) re-extracts and synthesizes facts from recent episodes with a stronger model. Currently a Python-API-only call — no CLI command. Schedule it from your application (cron, systemd timer, ECS scheduled task) when you want fresher facts than the streaming extractor produces.
+
+### Reflection engine
+
+`attestor/consolidation/reflection.py` runs periodic synthesis across N episodes for one user. Outputs:
+
+- `stable_preferences` — patterns appearing in 3+ episodes
+- `stable_constraints` — rules the user repeatedly invokes
+- `changed_beliefs` — preferences that shifted (old → new, with explicit invalidate)
+- `contradictions_for_review` — flagged for **HUMAN REVIEW**, *not* auto-resolved
+
+The "do not auto-resolve" stance is the load-bearing piece for regulated chat systems. The prompt is explicit (`reflection.py:35-66`): *"Do NOT auto-resolve contradictions. Flag them for human review."*
 
 ### Chain-of-Note reading
 
 ```python
 pack = mem.recall_as_pack(query="who runs engineering?", context=ctx)
-# pack.memories: list of {id, content, validity_window, confidence, source_episode_id}
-# pack.prompt: default Chain-of-Note prompt (NOTES → SYNTHESIS → CITE → ABSTAIN → CONFLICT)
+# pack.memories : list of {id, content, validity_window, confidence, source_episode_id}
+# pack.prompt   : default Chain-of-Note prompt with NOTES → SYNTHESIS → CITE → ABSTAIN → CONFLICT structure
 ```
 
-The default prompt has explicit ABSTAIN and CONFLICT clauses — every frontier model defaults to confabulation otherwise.
+The default prompt has explicit `ABSTAIN` and `CONFLICT` clauses — every frontier model defaults to confabulation otherwise.
+
+---
+
+## Multi-agent primitives
+
+### Six roles
+
+`AgentRole`: `ORCHESTRATOR`, `PLANNER`, `EXECUTOR`, `RESEARCHER`, `REVIEWER`, `MONITOR` (`attestor/context.py:49-56`). The role flows onto every memory's metadata for provenance. Access enforcement happens at the Postgres RLS layer (see §Tenant isolation).
+
+### AgentContext — handoff, scratchpad, trail
+
+```python
+orchestrator = AgentContext.from_env(agent_id="orchestrator", namespace="project:acme")
+planner      = orchestrator.as_agent("planner",  role=AgentRole.PLANNER)
+executor     = planner.as_agent("executor",      role=AgentRole.EXECUTOR)
+
+# Each child carries parent_agent_id + accumulating agent_trail.
+# All three share the same scratchpad: Dict[str, Any] for typed handoff data.
+```
+
+`as_agent()` creates a child context with `parent_agent_id`, full `agent_trail`, and a shared `scratchpad`. The trail accumulates — useful for proving "this answer came from agent X who got it from agent Y."
+
+### Per-agent token budgets
+
+`AgentContext.token_budget` (default 20 000) is enforced — `recall()` packs results greedily until the budget is exhausted (`scorer.py:fit_to_budget`). `token_budget_used` accumulates across calls in a session.
+
+### Optional write quotas
+
+`mem.set_quota(user_id, daily_writes=...)` → enforced on `add` against the v4 `user_quotas` table (`core.py:592-621`). Optional; unset means unlimited.
+
+---
+
+## Security & Compliance
+
+### Row-Level Security
+
+Cross-link to §Tenant isolation. RLS policies are the access-control surface; the Python layer trusts them. Set `attestor.current_user_id` per connection.
+
+### Provenance on every memory
+
+Every memory carries `agent_id`, `session_id`, `source_episode_id`. The supersession chain (`superseded_by`) is preserved forever. Conversation episodes are stored verbatim, separate from the memories extracted from them — meaning you can always reconstruct *which conversation turn produced which fact*.
+
+### Deletion audit log
+
+Hard deletes (e.g., GDPR purges) write a row to `deletion_audit` before the cascade — what was deleted, when, why, by whom. This is the carve-out for the otherwise-immutable schema.
+
+### GDPR — export and purge
+
+```python
+mem.export_user(external_id="user-42")     # full data export (memories + episodes + sessions + projects)
+mem.purge_user(external_id="user-42",      # cascading hard delete with audit trail
+               reason="GDPR right-to-erasure request 2026-04-27")
+mem.deletion_audit_log(limit=100)          # forensic readback
+```
+
+`core.py:557-590`. v4 only. Returns / writes everything Subject Access requires for Art. 15 / Art. 17.
+
+### Optional: Ed25519 provenance signing
+
+Enable via config (`signing.enabled = true`). On every `add`, attestor signs the canonical payload `id || agent_id || t_created || content_hash` with an Ed25519 key. `mem.verify_memory(memory_id)` returns `bool` (`core.py:623-640`). Optional, off by default — turn on for adversarial-write contexts where you need cryptographic non-repudiation.
 
 ---
 
@@ -201,12 +300,12 @@ Same API across all three. Only configuration changes.
 
 | Mode | Shape | When to use |
 |------|-------|-------------|
-| **A — Embedded library** | `AgentMemory(config)` in-process, talks directly to Postgres + Neo4j | Single-process agents, scripts, notebooks |
-| **B — Sidecar** | `attestor api` on `localhost:8080`, language-agnostic HTTP client shares the same Postgres + Neo4j | Polyglot agents on one box (Python + TS + Go) |
+| **A — Embedded library** | `AgentMemory(config)` in-process; talks directly to Postgres + Neo4j | Single-process agents, scripts, notebooks |
+| **B — Sidecar** | `attestor api` on `localhost:8080`; language-agnostic HTTP client shares the same Postgres + Neo4j | Polyglot agents on one box (Python + TS + Go) |
 | **C — Shared service** | One Attestor service in front of an agent mesh (App Runner / Cloud Run / Container Apps) backed by managed Postgres + Neo4j | Production multi-agent platforms |
 
 ```bash
-attestor api    --port 8080         # Mode B / C — Starlette ASGI REST API
+attestor api    --port 8080         # Mode B / C — Starlette ASGI REST
 attestor serve  --transport stdio   # MCP stdio server
 attestor mcp    --transport http    # MCP HTTP server
 ```
@@ -218,7 +317,7 @@ attestor mcp    --transport http    # MCP HTTP server
 | Backend | Document | Vector | Graph | Status |
 |---------|:--------:|:------:|:-----:|--------|
 | **Postgres + Neo4j** *(default)* | ✓ | pgvector | Neo4j + GDS | Production-ready |
-| **ArangoDB** | ✓ | ✓ | ✓ | Production-ready (single backend covers all 3 roles) |
+| **ArangoDB** | ✓ | ✓ | ✓ | Production-ready (one engine, all 3 roles) |
 | **AWS** | DynamoDB | OpenSearch Serverless | Neptune | Backend code + Terraform shipped |
 | **Azure** | Cosmos DB | Cosmos DiskANN | NetworkX (in-process) | Backend code shipped, Terraform forthcoming |
 | **GCP** | AlloyDB | AlloyDB ScaNN | AGE on AlloyDB | Backend code shipped, Terraform forthcoming |
@@ -236,16 +335,17 @@ Reference Terraform lives under `attestor/infra/`.
 
 ## Embeddings
 
-Provider auto-detect (`attestor/store/embeddings.py`), in this order:
+Provider auto-detect (`attestor/store/embeddings.py:get_embedding_provider`), in this order:
 
 1. **Local Ollama `bge-m3`** — 1024-D, 8K context — used when `http://localhost:11434` is reachable
 2. **Cloud-native** — Bedrock Titan / Vertex / Azure OpenAI when their SDK + creds are present
-3. **OpenAI `text-embedding-3-large`** (3072-D) — when `OPENAI_API_KEY` is set
+3. **OpenAI `text-embedding-3-large`** (3072-D native; pin `OPENAI_EMBEDDING_DIMENSIONS=1024` for schema compat)
 4. **OpenRouter** — for federated runs
 
-Local models are the default. Cloud APIs are fallbacks. Override via env:
+Local-first by design. Override:
 
 ```bash
+export ATTESTOR_DISABLE_LOCAL_EMBED=1            # skip the Ollama probe entirely
 export ATTESTOR_EMBEDDING_PROVIDER=openai
 export ATTESTOR_EMBEDDING_MODEL=text-embedding-3-large
 ```
@@ -254,35 +354,32 @@ export ATTESTOR_EMBEDDING_MODEL=text-embedding-3-large
 
 ## CLI
 
-`attestor --help` lists all commands. The most useful ones:
+`attestor --help` lists everything. The most useful commands:
 
 | Command | Purpose |
 |---------|---------|
 | `attestor init` | Create a starter config |
-| `attestor setup local` | Generate local Docker Compose for Postgres + Neo4j |
+| `attestor setup local` | Generate Docker Compose for Postgres + Neo4j |
 | `attestor doctor` | Health-check every store + the retrieval pipeline |
-| `attestor add` | Add a memory |
-| `attestor recall` | Recall relevant memories |
-| `attestor search` | Search with filters (entity / category / namespace / time window) |
-| `attestor list` | List memories |
-| `attestor timeline` | Show entity timeline |
+| `attestor add` / `recall` / `search` / `list` | CRUD-ish memory ops |
+| `attestor timeline` | Entity timeline (uses bi-temporal manager) |
 | `attestor stats` | Store statistics |
-| `attestor export` / `import` | JSON export and import |
+| `attestor export` / `import` | JSON dump / restore |
 | `attestor compact` | Remove archived memories |
-| `attestor update` / `forget` | Mutate a memory's content / archive it |
-| `attestor inspect` | Inspect the raw database |
+| `attestor update` / `forget` | Mutate / archive a memory |
+| `attestor inspect` | Inspect raw database state |
 | `attestor api` | Start the Starlette REST API |
 | `attestor serve` | Start MCP server (stdio) |
 | `attestor mcp` | Start MCP server (HTTP) |
-| `attestor ui` | Browser UI for the store |
-| `attestor hook {session-start,post-tool-use,stop}` | Run a Claude Code lifecycle hook |
-| `attestor locomo` / `attestor mab` / `attestor lme` | Built-in benchmark runners (LoCoMo, MultiAgentBench, LongMemEval) |
+| `attestor ui` | Read-only browser UI for the store |
+| `attestor hook {session-start, post-tool-use, stop}` | Run a Claude Code lifecycle hook |
+| `attestor lme` / `locomo` / `mab` | Built-in benchmark runners (see §Evaluation) |
 
 ---
 
 ## MCP server
 
-`attestor serve` exposes an MCP server with these tools:
+`attestor serve` exposes an MCP server with eight tools:
 
 | Tool | Purpose |
 |------|---------|
@@ -319,7 +416,7 @@ Single instruction users can give Claude Code:
 install attestor
 ```
 
-(Or run `/install-attestor`.) The installer (`commands/install-attestor.md`) interviews you on:
+(Or run `/install-attestor`.) The installer interviews you on:
 
 1. **Scope** — global (`~/.claude/.mcp.json`) vs project (`.mcp.json`)
 2. **Postgres connection** — local Docker, Neon, RDS, etc.
@@ -333,54 +430,89 @@ Then it installs `attestor` via pipx, writes the MCP config, optionally writes `
 
 ---
 
+## Evaluation
+
+> **Boundary statement.** The dual-LLM judge stack is a **benchmarking** mechanism, *not* the runtime contract. Recall in production is single-pipeline and deterministic. Multiple judges score answers in evaluation only — never in user-facing reads.
+
+| Runner | Source | Measures |
+|--------|--------|----------|
+| `attestor lme` | LongMemEval (Google's long-memory benchmark) | answer accuracy under long history, distillation, dual-judge cross-family |
+| `attestor locomo` | LoCoMo | conversational long-memory consistency |
+| `attestor mab` | MultiAgentBench | multi-agent coordination |
+| AbstentionBench (CI gate) | internal | when *not* to answer — known unknowns |
+| `scripts/lme_smoke_local.py` | dual-LLM smoke | quick install verification (see Quick Start §6) |
+
+The smoke driver mirrors the canonical published-benchmark stack exactly. See `--help` for the full env-var / CLI-flag override matrix.
+
+---
+
 ## Project layout
 
 ```
 attestor/
-  core.py                -- AgentMemory (main public API)
-  client.py              -- MemoryClient (HTTP drop-in for remote Attestor)
-  context.py             -- AgentContext (identity, role, namespace, budget, scratchpad)
-  models.py              -- Memory, RetrievalResult, ContextPack
-  cli.py                 -- attestor CLI entry point
-  api.py                 -- Starlette ASGI REST API
-  longmemeval.py         -- LongMemEval benchmark runner
+  core.py                  -- AgentMemory (main public API)
+  client.py                -- MemoryClient (HTTP drop-in for remote Attestor)
+  context.py               -- AgentContext, AgentRole, Visibility
+  models.py                -- Memory, RetrievalResult, ContextPack
+  cli.py                   -- attestor CLI entry point
+  api.py                   -- Starlette ASGI REST API
+  longmemeval.py           -- LongMemEval benchmark runner (dual-judge)
+  locomo.py                -- LoCoMo runner
+  doctor_v4.py             -- v4 schema + invariant validator
+  init_wizard.py           -- interactive install flow
   store/
-    base.py              -- DocumentStore / VectorStore / GraphStore protocols
-    registry.py          -- Backend selection
-    connection.py        -- Config layering / env resolution
-    embeddings.py        -- Provider auto-detect (Ollama / OpenAI / Bedrock / Vertex / Azure)
-    postgres_backend.py  -- pgvector (document + vector roles)
-    neo4j_backend.py     -- Neo4j + GDS (graph role)
-    arango_backend.py    -- All 3 roles in one
-    aws_backend.py       -- DynamoDB + OpenSearch Serverless + Neptune
-    azure_backend.py     -- Cosmos DB DiskANN + NetworkX
-    gcp_backend.py       -- AlloyDB pgvector + AGE + ScaNN
-    schema.sql           -- v4 Postgres schema (RLS, bi-temporal columns)
+    base.py                -- DocumentStore / VectorStore / GraphStore protocols
+    registry.py            -- backend selection
+    connection.py          -- config layering / env resolution
+    embeddings.py          -- provider auto-detect (Ollama / OpenAI / Bedrock / Vertex / Azure)
+    postgres_backend.py    -- pgvector (document + vector roles)
+    neo4j_backend.py       -- Neo4j + GDS (graph role)
+    arango_backend.py      -- all 3 roles in one
+    aws_backend.py         -- DynamoDB + OpenSearch Serverless + Neptune
+    azure_backend.py       -- Cosmos DB DiskANN + NetworkX
+    gcp_backend.py         -- AlloyDB pgvector + AGE + ScaNN
+    schema.sql             -- v4 Postgres schema (RLS, bi-temporal columns, content_tsv)
+  conversation/
+    ingest.py              -- ingest_round() pipeline
+  extraction/
+    round_extractor.py     -- 2-pass speaker-locked extraction
+    conflict_resolver.py   -- 4-decision contract (ADD/UPDATE/INVALIDATE/NOOP)
+    rule_based.py          -- deterministic fact extraction (no LLM)
+    prompts.py             -- shared prompt templates
+  consolidation/
+    consolidator.py        -- sleep-time re-extraction
+    reflection.py          -- cross-thread synthesis (stable patterns + flagged contradictions)
   graph/
-    extractor.py         -- Deterministic entity / relation extraction
+    extractor.py           -- entity / relation extraction
   retrieval/
-    orchestrator.py      -- 6-step semantic-first pipeline
+    orchestrator.py        -- 6-step semantic-first pipeline
     tag_matcher.py
-    scorer.py            -- MMR, confidence decay, entity boost, fit
-    trace.py             -- JSONL trace writer
+    scorer.py              -- MMR, confidence decay, entity boost, fit-to-budget
+    trace.py               -- JSONL trace writer
   temporal/
-    manager.py           -- Timelines, supersession, contradiction detection, as_of replay
-  extraction/             -- Rule-based + optional LLM memory extraction
+    manager.py             -- timelines, supersession, contradiction detection, as_of replay
+  identity/
+    signing.py             -- Ed25519 provenance signing (optional)
+    defaults.py            -- SOLO mode auto-provisioning
   mcp/
-    server.py            -- MCP server (tools, resources, prompts)
+    server.py              -- MCP server (tools, resources, prompts)
   hooks/
     session_start.py
     post_tool_use.py
     stop.py
+  ui/
+    app.py                 -- Starlette read-only viewer
+    static/, templates/    -- Evidence Board UI
   utils/
     config.py, tokens.py
   infra/
-    local/                -- Docker Compose (Postgres + Neo4j)
-    aws_arango/           -- Reference Terraform
-tests/                    -- Unit tests; live cloud tests env-gated
-evals/                    -- LongMemEval / LoCoMo / MultiAgentBench harnesses
-docs/                     -- Architecture notes, ADRs
-commands/                 -- /install-attestor, etc.
+    local/                 -- Docker Compose (Postgres + Neo4j)
+    aws_arango/            -- Reference Terraform
+tests/                     -- Unit tests; live cloud tests env-gated
+evals/                     -- LongMemEval / LoCoMo / MultiAgentBench / AbstentionBench harnesses
+docs/                      -- Architecture notes, ADRs
+commands/                  -- /install-attestor, etc.
+scripts/                   -- lme_smoke_local.py, etc.
 ```
 
 ---
@@ -393,17 +525,14 @@ poetry run pytest tests/ -q                          # unit tests, no external s
 ATTESTOR_LIVE_PG=1 poetry run pytest tests/live -q   # live integration (env-gated)
 ```
 
-Style:
+Style: `black` formatting, `isort` imports, `ruff` lint, `mypy` types. PEP 8, type-annotated signatures, dataclasses for DTOs. Many small files (200–400 lines typical, 800 max).
 
-- `black` for formatting, `isort` for imports, `ruff` for lint, `mypy` for types
-- PEP 8, type-annotated signatures, dataclasses for DTOs
-- Many small files (200–400 lines typical, 800 max)
-
-Conventions worth knowing before you contribute:
+Conventions worth knowing:
 
 - Postgres is the source of truth. Neo4j is derived; rebuild it from Postgres if it drifts.
 - Non-fatal errors in vector / graph paths are caught and logged. The document path never silently breaks.
 - Configuration layering: env vars → `~/.attestor.toml` → in-code overrides.
+- Two write paths: `add()` for structured (lightweight rule-based supersession), `ingest_round()` for conversational (full 2-pass + 4-decision contract).
 
 ---
 
@@ -431,12 +560,12 @@ It probes Document Store (Postgres), Vector Store (pgvector), Graph Store (Neo4j
 
 ## Status & versioning
 
-- **Version:** 4.0.0 (alpha)
-- **v3 → v4:** greenfield rebuild. v3 was alpha-only with no production users; **there is no automated migration**. Drop your v3 DB and reinstall.
+- **Version:** 4.0.0a1 (alpha)
+- **v3 → v4:** greenfield rebuild on a v4-native Postgres schema with hard tenant isolation, bi-temporal facts, and a no-LLM retrieval critical path. **There is no automated migration.** v3 was alpha-only with no production users; drop your v3 DB and reinstall.
 - See [`CHANGELOG.md`](./CHANGELOG.md) for the full track-by-track changelog.
 
 ---
 
 ## License
 
-See [`LICENSE`](./LICENSE).
+MIT. See [`LICENSE`](./LICENSE).

--- a/docs/index.html
+++ b/docs/index.html
@@ -1735,10 +1735,638 @@ footer.colophon {
       <p class="standfirst">When an agent calls <code style="font-family:var(--ff-mono);font-size:15px;color:var(--accent);background:var(--ink-raise);padding:2px 8px;border:1px solid var(--rule);">recall(query, budget)</code>, six cooperating steps find, narrow, rank, diversify, decay, and fit the most relevant memories into the requested token ceiling. Ten million memories in the store. Your context window never sees more than the budget. And because there&rsquo;s no LLM in the path, the same query always returns the same ranking. You can unit&#8209;test it.</p>
     </div>
 
-    <figure class="reveal" style="margin:28px auto 8px;max-width:1040px;background:#f4efe3;border:1px solid var(--rule-strong);border-radius:6px;padding:20px;">
-      <img src="pipeline.svg" alt="Semantic-first retrieval pipeline — vector top-K, graph narrow, triples inject, MMR diversity, decay, budget fit" style="display:block;width:100%;height:auto;">
-      <figcaption style="font-family:var(--ff-mono);font-size:11px;text-transform:uppercase;letter-spacing:0.16em;color:#3a3530;text-align:center;margin-top:12px;">Fig. 3 &mdash; Same pipeline. Ten memories or ten million. The budget holds.</figcaption>
+    <!-- ── Interactive recall pipeline (live trace) ────────────────── -->
+    <style>
+      .recall-stage {
+        margin: 32px auto 8px;
+        max-width: 1080px;
+        background: var(--ink);
+        border: 1px solid var(--rule-strong);
+        padding: 22px 24px 18px;
+        font-family: var(--ff-mono);
+        position: relative;
+      }
+      .recall-stage::before {
+        content: "";
+        position: absolute;
+        top: 7px; left: 7px; right: 7px; bottom: 7px;
+        border: 1px solid var(--rule);
+        pointer-events: none;
+      }
+      .recall-stage__head {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        font-size: 10px;
+        letter-spacing: 0.22em;
+        text-transform: uppercase;
+        color: var(--paper-dim);
+        padding-bottom: 12px;
+        border-bottom: 1px dashed var(--rule);
+      }
+      .recall-stage__label { color: var(--accent); }
+      .recall-stage__status { display: inline-flex; align-items: center; gap: 8px; }
+      .recall-stage__status-dot {
+        width: 7px; height: 7px;
+        border-radius: 50%;
+        background: var(--paper-dim);
+      }
+      .recall-stage[data-state="playing"] .recall-stage__status-dot {
+        background: var(--accent);
+        animation: rs-pulse 1.2s ease-in-out infinite;
+        box-shadow: 0 0 6px var(--accent);
+      }
+      @keyframes rs-pulse {
+        0%, 100% { opacity: 1; }
+        50% { opacity: 0.35; }
+      }
+      .recall-stage__query {
+        font-family: var(--ff-mono);
+        font-size: 14px;
+        color: var(--paper);
+        padding: 18px 0 22px;
+        border-bottom: 1px dashed var(--rule);
+        white-space: nowrap;
+        overflow: hidden;
+      }
+      .recall-stage__prompt { color: var(--paper-dim); }
+      .recall-stage__query-text { color: var(--accent); }
+      .recall-stage__cursor {
+        display: inline-block;
+        width: 8px; height: 14px;
+        background: var(--accent);
+        margin-left: 1px;
+        vertical-align: -2px;
+        animation: rs-blink 1s steps(1) infinite;
+      }
+      @keyframes rs-blink {
+        0%, 50% { opacity: 1; }
+        51%, 100% { opacity: 0; }
+      }
+      .recall-stage__grid {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 10px;
+        padding: 22px 0;
+      }
+      .recall-stage__cell {
+        position: relative;
+        border: 1px solid var(--rule);
+        background: transparent;
+        padding: 14px 16px 50px;
+        min-height: 150px;
+        transition: border-color 0.4s, background 0.4s;
+      }
+      .recall-stage__cell[data-active="true"] {
+        border-color: var(--accent);
+        background: var(--ink-raise);
+      }
+      .recall-stage__cell[data-passed="true"] {
+        border-color: rgba(193, 95, 60, 0.35);
+      }
+      .recall-stage__cell-num {
+        position: absolute;
+        top: 8px; right: 14px;
+        font-family: var(--ff-display);
+        font-size: 30px;
+        font-weight: 300;
+        color: var(--accent);
+        font-style: italic;
+        line-height: 1;
+        opacity: 0.65;
+      }
+      .recall-stage__cell[data-active="true"] .recall-stage__cell-num,
+      .recall-stage__cell[data-passed="true"] .recall-stage__cell-num { opacity: 1; }
+      .recall-stage__cell-tag {
+        display: block;
+        font-size: 9px;
+        letter-spacing: 0.22em;
+        text-transform: uppercase;
+        color: var(--paper-dim);
+        margin-bottom: 4px;
+      }
+      .recall-stage__cell-name {
+        display: block;
+        font-family: var(--ff-display);
+        font-size: 18px;
+        font-weight: 500;
+        color: var(--paper);
+        margin-bottom: 4px;
+        font-style: italic;
+      }
+      .recall-stage__cell-engine {
+        display: block;
+        font-size: 11px;
+        color: var(--paper-dim);
+        margin-bottom: 14px;
+      }
+      .recall-stage__tiles {
+        display: grid;
+        grid-template-columns: repeat(10, 1fr);
+        gap: 2px;
+        height: 28px;
+        margin-bottom: 8px;
+      }
+      .recall-stage__tiles > i {
+        display: block;
+        background: rgba(245, 241, 232, 0.06);
+        border-radius: 1px;
+        transition: background 0.25s, transform 0.35s, opacity 0.25s;
+      }
+      .recall-stage__tiles > i[data-state="kept"] { background: var(--paper-dim); }
+      .recall-stage__tiles > i[data-state="boosted"] {
+        background: var(--accent);
+        transform: scale(1.6);
+        box-shadow: 0 0 4px var(--accent);
+      }
+      .recall-stage__tiles > i[data-state="triple"] {
+        background: var(--accent-warm, #d6a574);
+        transform: rotate(45deg) scale(1.1);
+      }
+      .recall-stage__tiles > i[data-state="rejected"] {
+        background: rgba(245, 241, 232, 0.04);
+        opacity: 0.5;
+      }
+      .recall-stage__cell-count {
+        position: absolute;
+        bottom: 12px; right: 16px;
+        font-family: var(--ff-mono);
+        font-size: 22px;
+        color: var(--paper);
+        font-variant-numeric: tabular-nums;
+        letter-spacing: -0.02em;
+      }
+      .recall-stage__cell-count-label {
+        position: absolute;
+        bottom: 38px; right: 16px;
+        font-size: 9px;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        color: var(--paper-dim);
+      }
+      .recall-stage__result {
+        background: var(--ink-raise);
+        border: 1px solid var(--rule);
+        padding: 16px 20px;
+        min-height: 64px;
+        font-size: 12px;
+        color: var(--paper-dim);
+        margin: 8px 0 14px;
+        font-family: var(--ff-mono);
+        line-height: 1.85;
+      }
+      .recall-stage__result-line {
+        display: grid;
+        grid-template-columns: auto 1fr auto;
+        gap: 14px;
+        opacity: 0;
+        transform: translateY(4px);
+        transition: opacity 0.4s, transform 0.4s;
+        align-items: baseline;
+      }
+      .recall-stage__result-line[data-visible="true"] {
+        opacity: 1;
+        transform: translateY(0);
+      }
+      .recall-stage__result-score { color: var(--accent); font-variant-numeric: tabular-nums; }
+      .recall-stage__result-text { color: var(--paper); }
+      .recall-stage__result-meta { color: var(--rule-strong); font-size: 10px; letter-spacing: 0.06em; }
+      .recall-stage__result-empty {
+        color: var(--paper-dim);
+        font-style: italic;
+        font-size: 13px;
+      }
+      .recall-stage__proof {
+        font-size: 10px;
+        letter-spacing: 0.22em;
+        text-transform: uppercase;
+        text-align: center;
+        color: var(--paper-dim);
+        padding: 14px 0;
+        border-top: 1px dashed var(--rule);
+        border-bottom: 1px dashed var(--rule);
+      }
+      .recall-stage__proof-em { color: var(--accent); }
+      .recall-stage__sep { margin: 0 12px; color: var(--rule-strong); }
+      .recall-stage__controls {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding-top: 14px;
+        flex-wrap: wrap;
+      }
+      .recall-stage__btn {
+        background: transparent;
+        border: 1px solid var(--rule);
+        color: var(--paper-dim);
+        padding: 6px 12px;
+        font-family: var(--ff-mono);
+        font-size: 10px;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        cursor: pointer;
+        transition: border-color 0.2s, color 0.2s;
+      }
+      .recall-stage__btn:hover { color: var(--accent); border-color: var(--accent); }
+      .recall-stage__btn--active { color: var(--accent); border-color: var(--accent); }
+      .recall-stage__btn--small { padding: 5px 8px; font-size: 9px; letter-spacing: 0.12em; }
+      .recall-stage__scrub-wrap { display: flex; align-items: center; gap: 8px; flex: 1; min-width: 220px; }
+      .recall-stage__scrub {
+        flex: 1;
+        height: 2px;
+        background: var(--rule);
+        outline: none;
+        cursor: pointer;
+        -webkit-appearance: none;
+        appearance: none;
+      }
+      .recall-stage__scrub::-webkit-slider-thumb {
+        -webkit-appearance: none;
+        appearance: none;
+        width: 12px; height: 12px;
+        background: var(--accent);
+        border-radius: 50%;
+        cursor: pointer;
+      }
+      .recall-stage__scrub::-moz-range-thumb {
+        width: 12px; height: 12px;
+        background: var(--accent);
+        border: none;
+        border-radius: 50%;
+        cursor: pointer;
+      }
+      .recall-stage__time {
+        font-size: 10px;
+        color: var(--paper-dim);
+        font-variant-numeric: tabular-nums;
+        letter-spacing: 0.12em;
+        min-width: 78px;
+        text-align: right;
+      }
+      .recall-stage__artifacts {
+        font-size: 9px;
+        color: var(--paper-dim);
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        text-align: center;
+        padding-top: 14px;
+        margin-top: 6px;
+      }
+      .recall-stage__art-link { color: var(--paper-dim); text-decoration: none; }
+      .recall-stage__art-link:hover { color: var(--accent); }
+      .recall-stage__art-link--soon { opacity: 0.55; cursor: not-allowed; }
+      @media (max-width: 760px) {
+        .recall-stage__grid { grid-template-columns: 1fr; }
+        .recall-stage__query { white-space: normal; }
+      }
+    </style>
+
+    <figure class="recall-stage reveal" data-state="idle">
+      <div class="recall-stage__head">
+        <span class="recall-stage__label">&sect; Live trace &middot; Recall pipeline</span>
+        <span class="recall-stage__status">
+          <span class="recall-stage__status-dot"></span>
+          <span data-status-text>Idle &middot; auto-plays on scroll</span>
+        </span>
+      </div>
+
+      <div class="recall-stage__query">
+        <span class="recall-stage__prompt">$ mem.recall(</span><span class="recall-stage__query-text" data-query></span><span class="recall-stage__cursor"></span><span class="recall-stage__prompt">, budget=2000)</span>
+      </div>
+
+      <div class="recall-stage__grid">
+        <div class="recall-stage__cell" data-cell="1">
+          <span class="recall-stage__cell-num">01</span>
+          <span class="recall-stage__cell-tag">Stage 01</span>
+          <span class="recall-stage__cell-name">Vector Top-K</span>
+          <span class="recall-stage__cell-engine">pgvector &middot; cosine &middot; k=50</span>
+          <div class="recall-stage__tiles" data-tiles></div>
+          <span class="recall-stage__cell-count-label">candidates</span>
+          <span class="recall-stage__cell-count" data-count>—</span>
+        </div>
+        <div class="recall-stage__cell" data-cell="2">
+          <span class="recall-stage__cell-num">02</span>
+          <span class="recall-stage__cell-tag">Stage 02</span>
+          <span class="recall-stage__cell-name">Graph Narrow</span>
+          <span class="recall-stage__cell-engine">Neo4j BFS &middot; depth &le; 2</span>
+          <div class="recall-stage__tiles" data-tiles></div>
+          <span class="recall-stage__cell-count-label">kept</span>
+          <span class="recall-stage__cell-count" data-count>—</span>
+        </div>
+        <div class="recall-stage__cell" data-cell="3">
+          <span class="recall-stage__cell-num">03</span>
+          <span class="recall-stage__cell-tag">Stage 03</span>
+          <span class="recall-stage__cell-name">Triples Inject</span>
+          <span class="recall-stage__cell-engine">typed edges &middot; uses &middot; auth-by</span>
+          <div class="recall-stage__tiles" data-tiles></div>
+          <span class="recall-stage__cell-count-label">+triples</span>
+          <span class="recall-stage__cell-count" data-count>—</span>
+        </div>
+        <div class="recall-stage__cell" data-cell="4">
+          <span class="recall-stage__cell-num">04</span>
+          <span class="recall-stage__cell-tag">Stage 04</span>
+          <span class="recall-stage__cell-name">MMR Diversity</span>
+          <span class="recall-stage__cell-engine">&lambda; = 0.7 &middot; drop near-dups</span>
+          <div class="recall-stage__tiles" data-tiles></div>
+          <span class="recall-stage__cell-count-label">distinct</span>
+          <span class="recall-stage__cell-count" data-count>—</span>
+        </div>
+        <div class="recall-stage__cell" data-cell="5">
+          <span class="recall-stage__cell-num">05</span>
+          <span class="recall-stage__cell-tag">Stage 05</span>
+          <span class="recall-stage__cell-name">Decay + Boost</span>
+          <span class="recall-stage__cell-engine">recency &middot; confidence</span>
+          <div class="recall-stage__tiles" data-tiles></div>
+          <span class="recall-stage__cell-count-label">re-ranked</span>
+          <span class="recall-stage__cell-count" data-count>—</span>
+        </div>
+        <div class="recall-stage__cell" data-cell="6">
+          <span class="recall-stage__cell-num">06</span>
+          <span class="recall-stage__cell-tag">Stage 06</span>
+          <span class="recall-stage__cell-name">Budget Fit</span>
+          <span class="recall-stage__cell-engine">greedy pack &middot; &le; 2000 tok</span>
+          <div class="recall-stage__tiles" data-tiles></div>
+          <span class="recall-stage__cell-count-label">packed</span>
+          <span class="recall-stage__cell-count" data-count>—</span>
+        </div>
+      </div>
+
+      <div class="recall-stage__result" data-result>
+        <div class="recall-stage__result-empty">Result frame &mdash; ranked memories will land here when the pipeline completes.</div>
+      </div>
+
+      <div class="recall-stage__proof">
+        <span class="recall-stage__proof-em">0 LLM calls</span>
+        <span class="recall-stage__sep">&middot;</span>
+        <span>6 deterministic steps</span>
+        <span class="recall-stage__sep">&middot;</span>
+        <span>same query &rarr; <span class="recall-stage__proof-em">same ranking</span></span>
+      </div>
+
+      <div class="recall-stage__controls">
+        <button class="recall-stage__btn" data-action="toggle">&#9654; Play</button>
+        <button class="recall-stage__btn" data-action="replay">&#8634; Replay</button>
+        <div class="recall-stage__scrub-wrap">
+          <input type="range" min="0" max="14000" value="0" step="50" data-scrub class="recall-stage__scrub" aria-label="Scrub timeline">
+          <span class="recall-stage__time" data-time>00.0 / 14.0</span>
+        </div>
+        <button class="recall-stage__btn recall-stage__btn--small" data-speed="0.5">0.5&times;</button>
+        <button class="recall-stage__btn recall-stage__btn--small recall-stage__btn--active" data-speed="1">1&times;</button>
+        <button class="recall-stage__btn recall-stage__btn--small" data-speed="2">2&times;</button>
+      </div>
+
+      <div class="recall-stage__artifacts">
+        <a href="pipeline.svg" download class="recall-stage__art-link">&darr; Static pipeline (SVG)</a>
+        <span class="recall-stage__sep">&middot;</span>
+        <a href="#" class="recall-stage__art-link recall-stage__art-link--soon" onclick="event.preventDefault();" title="Render with Remotion — coming soon">&darr; Render as MP4 <span style="opacity:.55">(soon)</span></a>
+      </div>
     </figure>
+
+    <script>
+    (function () {
+      const root = document.querySelector('.recall-stage');
+      if (!root) return;
+
+      const STATE = {
+        duration: 14000,
+        speed: 1.0,
+        playing: false,
+        t: 0,
+        autoplayed: false,
+        lastTick: 0,
+      };
+
+      const PHASES = [
+        { name: 'query',  from: 0,     to: 1800 },
+        { name: 'stage1', from: 1800,  to: 3500 },
+        { name: 'stage2', from: 3500,  to: 5400 },
+        { name: 'stage3', from: 5400,  to: 7200 },
+        { name: 'stage4', from: 7200,  to: 9000 },
+        { name: 'stage5', from: 9000,  to: 10700 },
+        { name: 'stage6', from: 10700, to: 12500 },
+        { name: 'result', from: 12500, to: 14000 },
+      ];
+
+      const COUNTS = {
+        1: { entry: 0,  peak: 50, exit: 50 },
+        2: { entry: 50, peak: 50, exit: 38 },
+        3: { entry: 38, peak: 42, exit: 42 },
+        4: { entry: 42, peak: 42, exit: 24 },
+        5: { entry: 24, peak: 24, exit: 24 },
+        6: { entry: 24, peak: 24, exit: 8  },
+      };
+
+      const QUERY_FULL = '"who runs engineering at acme?"';
+
+      const RESULT_LINES = [
+        { score: 0.94, text: 'Alice promoted to VP Engineering',  meta: 'valid_from 2026-03-15' },
+        { score: 0.91, text: 'Engineering org reports to Alice',  meta: '[authored-by]' },
+        { score: 0.88, text: 'Alice was engineering manager',     meta: 'superseded 2026-03-15' },
+        { score: 0.82, text: 'Acme org chart Q1 2026',            meta: 'episode #4421' },
+        { score: 0.79, text: 'Alice hired at Acme',               meta: 'valid_from 2024-01-08' },
+        { score: 0.71, text: 'Acme leadership announce',          meta: 'agent: researcher-1' },
+        { score: 0.65, text: 'Engineering headcount: 142',        meta: 'q1-snapshot' },
+        { score: 0.58, text: 'Alice background: ex-Stripe',       meta: '[authored-by]' },
+      ];
+
+      // Pre-build tiles (50 per cell)
+      const cells = Array.from(root.querySelectorAll('[data-cell]'));
+      cells.forEach((cell) => {
+        const tiles = cell.querySelector('[data-tiles]');
+        tiles.innerHTML = '';
+        for (let i = 0; i < 50; i++) tiles.appendChild(document.createElement('i'));
+      });
+
+      // Pre-build result list
+      const resultNode = root.querySelector('[data-result]');
+      function renderResultLines(visibleCount) {
+        if (visibleCount <= 0) {
+          resultNode.innerHTML = '<div class="recall-stage__result-empty">Result frame &mdash; ranked memories will land here when the pipeline completes.</div>';
+          return;
+        }
+        resultNode.innerHTML = RESULT_LINES.map((line, i) => `
+          <div class="recall-stage__result-line" data-line="${i}" data-visible="${i < visibleCount ? 'true' : 'false'}">
+            <span class="recall-stage__result-score">${line.score.toFixed(2)}</span>
+            <span class="recall-stage__result-text">${line.text}</span>
+            <span class="recall-stage__result-meta">— ${line.meta}</span>
+          </div>
+        `).join('');
+      }
+
+      const queryNode  = root.querySelector('[data-query]');
+      const statusNode = root.querySelector('[data-status-text]');
+      const scrubNode  = root.querySelector('[data-scrub]');
+      const timeNode   = root.querySelector('[data-time]');
+      const playBtn    = root.querySelector('[data-action="toggle"]');
+
+      function statusFor(name) {
+        return ({
+          query:  'Embed query &middot; pgvector probe',
+          stage1: 'Stage 01 &middot; Vector top-K (cosine)',
+          stage2: 'Stage 02 &middot; Graph narrow (BFS &le; 2)',
+          stage3: 'Stage 03 &middot; Inject typed-edge triples',
+          stage4: 'Stage 04 &middot; MMR diversity rerank',
+          stage5: 'Stage 05 &middot; Decay + temporal boost',
+          stage6: 'Stage 06 &middot; Greedy budget pack',
+          result: 'Hydrate from doc store &middot; trace written',
+        })[name] || 'Idle';
+      }
+
+      function ease(p) { return p < 0.5 ? 2*p*p : 1 - Math.pow(-2*p+2, 2)/2; }
+
+      function render(t) {
+        const phase = PHASES.find(p => t >= p.from && t < p.to) || PHASES[PHASES.length - 1];
+        const phaseProgress = Math.min(1, Math.max(0, (t - phase.from) / (phase.to - phase.from)));
+        const phaseIdx = PHASES.indexOf(phase);
+
+        // Query typing
+        const qp = Math.min(1, t / 1800);
+        queryNode.textContent = QUERY_FULL.substring(0, Math.floor(QUERY_FULL.length * qp));
+
+        // Cells
+        cells.forEach((cell, idx) => {
+          const stageNum = idx + 1;
+          const expectedPhaseIdx = stageNum; // stage1 is idx 1
+          const isActive = phaseIdx === expectedPhaseIdx;
+          const hasPassed = phaseIdx > expectedPhaseIdx;
+          cell.setAttribute('data-active', isActive ? 'true' : 'false');
+          cell.setAttribute('data-passed', hasPassed ? 'true' : 'false');
+
+          const cfg = COUNTS[stageNum];
+          const tiles = cell.querySelectorAll('[data-tiles] > i');
+          const countNode = cell.querySelector('[data-count]');
+
+          let visible;
+          if (!isActive && !hasPassed) {
+            visible = -1;
+          } else if (isActive) {
+            const e = ease(phaseProgress);
+            if (phaseProgress < 0.5) {
+              visible = Math.round(cfg.entry + (cfg.peak - cfg.entry) * (e * 2));
+            } else {
+              visible = Math.round(cfg.peak + (cfg.exit - cfg.peak) * ((e - 0.5) * 2));
+            }
+          } else {
+            visible = cfg.exit;
+          }
+
+          countNode.textContent = visible < 0 ? '—' : visible;
+
+          tiles.forEach((tile, i) => {
+            if (visible < 0) {
+              tile.removeAttribute('data-state');
+              return;
+            }
+            if (i < visible) {
+              if (stageNum === 2 && i < 8) tile.setAttribute('data-state', 'boosted');
+              else if (stageNum === 3 && i >= 38) tile.setAttribute('data-state', 'triple');
+              else if (stageNum === 5 && (i % 4 === 0)) tile.setAttribute('data-state', 'boosted');
+              else tile.setAttribute('data-state', 'kept');
+            } else {
+              tile.setAttribute('data-state', 'rejected');
+            }
+          });
+        });
+
+        // Result frame
+        if (phase.name === 'result') {
+          const visCount = Math.ceil(RESULT_LINES.length * Math.min(1, phaseProgress * 1.2));
+          renderResultLines(visCount);
+        } else if (phaseIdx >= PHASES.findIndex(p => p.name === 'result')) {
+          renderResultLines(RESULT_LINES.length);
+        } else if (phase.name === 'stage6' && phaseProgress > 0.7) {
+          renderResultLines(Math.ceil(2 * (phaseProgress - 0.7) / 0.3));
+        } else {
+          renderResultLines(0);
+        }
+
+        // Scrub + time
+        if (!STATE._scrubbing) scrubNode.value = String(Math.round(t));
+        const sec = (t / 1000).toFixed(1);
+        timeNode.textContent = `${sec.padStart(4, '0')} / 14.0`;
+
+        // Status
+        if (STATE.playing) {
+          statusNode.innerHTML = statusFor(phase.name);
+        } else if (t === 0) {
+          statusNode.innerHTML = 'Idle &middot; auto-plays on scroll';
+        } else if (t >= STATE.duration - 1) {
+          statusNode.innerHTML = 'Done &middot; <span style="color:var(--accent)">0 LLM calls</span> &middot; replay anytime';
+        } else {
+          statusNode.innerHTML = 'Paused';
+        }
+
+        // Play button label
+        playBtn.innerHTML = STATE.playing ? '&#10074;&#10074; Pause' : '&#9654; Play';
+      }
+
+      function tick(now) {
+        if (!STATE.playing) return;
+        const dt = (now - STATE.lastTick) * STATE.speed;
+        STATE.lastTick = now;
+        STATE.t = Math.min(STATE.duration, STATE.t + dt);
+        render(STATE.t);
+        if (STATE.t >= STATE.duration) {
+          STATE.playing = false;
+          root.setAttribute('data-state', 'idle');
+          render(STATE.t);
+          return;
+        }
+        requestAnimationFrame(tick);
+      }
+      function play() {
+        if (STATE.t >= STATE.duration - 1) STATE.t = 0;
+        STATE.playing = true;
+        STATE.lastTick = performance.now();
+        root.setAttribute('data-state', 'playing');
+        requestAnimationFrame(tick);
+        render(STATE.t);
+      }
+      function pause() {
+        STATE.playing = false;
+        root.setAttribute('data-state', 'idle');
+        render(STATE.t);
+      }
+      function replay() { STATE.t = 0; play(); }
+      function setSpeed(s) {
+        STATE.speed = s;
+        root.querySelectorAll('[data-speed]').forEach(b => b.classList.remove('recall-stage__btn--active'));
+        const btn = root.querySelector(`[data-speed="${s}"]`);
+        if (btn) btn.classList.add('recall-stage__btn--active');
+      }
+
+      // Wire controls
+      playBtn.addEventListener('click', () => STATE.playing ? pause() : play());
+      root.querySelector('[data-action="replay"]').addEventListener('click', replay);
+      root.querySelectorAll('[data-speed]').forEach(b => {
+        b.addEventListener('click', () => setSpeed(parseFloat(b.dataset.speed)));
+      });
+      scrubNode.addEventListener('input', (e) => {
+        STATE._scrubbing = true;
+        if (STATE.playing) pause();
+        STATE.t = parseInt(e.target.value, 10);
+        render(STATE.t);
+      });
+      scrubNode.addEventListener('change', () => { STATE._scrubbing = false; });
+
+      // Auto-play on scroll into view (once)
+      const obs = new IntersectionObserver((entries) => {
+        entries.forEach(e => {
+          if (e.isIntersecting && !STATE.autoplayed) {
+            STATE.autoplayed = true;
+            STATE.t = 0;
+            play();
+          }
+        });
+      }, { threshold: 0.4 });
+      obs.observe(root);
+
+      // Initial paint
+      render(0);
+    })();
+    </script>
+
+    <p style="font-family:var(--ff-mono);font-size:11px;text-transform:uppercase;letter-spacing:0.16em;color:var(--paper-dim);text-align:center;margin:8px 0 28px;">Fig. 3 &mdash; Live trace. Same pipeline. Ten memories or ten million. Replay it; it ranks the same.</p>
 
     <div class="pipeline reveal">
       <div class="pipeline-step">
@@ -1941,6 +2569,114 @@ footer.colophon {
         </div>
       </div>
     </div>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════════════════════════
+     § 03.5 · MULTI-LLM COOPERATION
+     ═══════════════════════════════════════════════════ -->
+<section id="cooperation" style="border-top:1px solid var(--rule);">
+  <div class="container">
+    <div class="section-filing reveal">
+      <span class="section-num">&sect; 03.5</span>
+      <span class="section-name">&mdash; Multi-LLM cooperation</span>
+      <span>Many models &middot; one auditable memory</span>
+    </div>
+
+    <div class="reveal">
+      <h2 class="section-head">Many LLMs, one memory. <em>Conflicts resolved on contract,</em> not vibes.</h2>
+      <p class="standfirst">Real agent teams have a planner, an executor, and a reviewer &mdash; often on different model families. They write to the same memory store. Without a contract for how those writes interact, you get duplicate facts, lost edits, and silent overwrites. Attestor ships five mechanisms that turn multi-LLM writes into an auditable transaction log.</p>
+    </div>
+
+    <!-- Five mechanisms grid -->
+    <div style="display:grid;grid-template-columns:repeat(2,1fr);gap:18px;margin-top:32px;">
+
+      <!-- 01 — Write-time supersession -->
+      <div class="reveal" style="padding:26px 28px;border:1px solid var(--rule-strong);background:var(--ink-raise);border-left:3px solid var(--accent);">
+        <div style="font-family:var(--ff-mono);font-size:10px;letter-spacing:0.22em;color:var(--accent);">MECHANISM &middot; 01</div>
+        <h4 style="font-family:var(--ff-display);font-size:24px;font-weight:600;margin:8px 0 12px;">Write-time supersession</h4>
+        <p style="font-size:14.5px;line-height:1.65;color:var(--paper-dim);margin:0 0 14px;">Deterministic. Zero LLM in the loop. On every <code style="font-family:var(--ff-mono);font-size:12px;color:var(--accent);">add()</code>, attestor checks for active rows with the same <code>(entity, category, namespace)</code> and different content. Each match is auto-marked <code>superseded</code> with <code>valid_until=now</code> and <code>superseded_by=&lt;new_id&gt;</code>.</p>
+        <div style="font-family:var(--ff-mono);font-size:12px;color:var(--paper);background:var(--ink);border:1px solid var(--rule);padding:14px;line-height:1.7;">
+<span style="color:var(--muted);"># add()</span><br>
+<span style="color:var(--muted);">  &darr;</span><br>
+<span style="color:var(--accent-warm);">  check_contradictions(memory)</span><br>
+<span style="color:var(--muted);">  &darr;</span><br>
+<span style="color:var(--accent-warm);">  store.insert(memory)</span><br>
+<span style="color:var(--muted);">  &darr;</span><br>
+<span style="color:var(--accent);">  for old in contradictions: supersede(old, memory.id)</span>
+        </div>
+        <p style="font-size:12.5px;color:var(--muted);font-style:italic;margin:12px 0 0;">Old facts are <strong>never deleted</strong>. <code style="font-family:var(--ff-mono);font-size:11px;">recall(as_of=&hellip;)</code> still returns them.</p>
+      </div>
+
+      <!-- 02 — Ingest-time 4-decision contract -->
+      <div class="reveal" style="padding:26px 28px;border:1px solid var(--rule-strong);background:var(--ink-raise);border-left:3px solid var(--accent);">
+        <div style="font-family:var(--ff-mono);font-size:10px;letter-spacing:0.22em;color:var(--accent);">MECHANISM &middot; 02</div>
+        <h4 style="font-family:var(--ff-display);font-size:24px;font-weight:600;margin:8px 0 12px;">Four-decision conflict resolver</h4>
+        <p style="font-size:14.5px;line-height:1.65;color:var(--paper-dim);margin:0 0 14px;">For conversation ingest, every newly extracted fact gets one of four decisions from the LLM. Each carries an <code style="font-family:var(--ff-mono);font-size:12px;color:var(--accent);">evidence_episode_id</code> &mdash; every supersession is auditable.</p>
+        <div style="display:grid;grid-template-columns:auto 1fr;gap:6px 16px;font-family:var(--ff-mono);font-size:12px;line-height:1.6;">
+          <code style="color:var(--accent);">ADD</code>          <span style="color:var(--paper-dim);">no existing match &mdash; write fresh</span>
+          <code style="color:var(--accent);">UPDATE</code>       <span style="color:var(--paper-dim);">refined value, keep id</span>
+          <code style="color:var(--accent);">INVALIDATE</code>   <span style="color:var(--paper-dim);">old contradicted &mdash; mark superseded</span>
+          <code style="color:var(--accent);">NOOP</code>         <span style="color:var(--paper-dim);">already represented &mdash; skip</span>
+        </div>
+        <p style="font-size:12.5px;color:var(--muted);font-style:italic;margin:14px 0 0;">Failsafe: any LLM/parse failure falls back to <code style="font-family:var(--ff-mono);font-size:11px;color:var(--accent);">ADD</code>-by-default. Better a duplicate-ish row than a silent drop.</p>
+      </div>
+
+      <!-- 03 — Speaker-locked extraction -->
+      <div class="reveal" style="padding:26px 28px;border:1px solid var(--rule-strong);background:var(--ink-raise);">
+        <div style="font-family:var(--ff-mono);font-size:10px;letter-spacing:0.22em;color:var(--accent);">MECHANISM &middot; 03</div>
+        <h4 style="font-family:var(--ff-display);font-size:24px;font-weight:600;margin:8px 0 12px;">Speaker-locked extraction</h4>
+        <p style="font-size:14.5px;line-height:1.65;color:var(--paper-dim);margin:0 0 14px;">Two passes per round, with separate prompts. User-turn extractor only emits facts attributable to the user; assistant-turn extractor only emits facts the assistant introduced. Stops cross-attribution &mdash; the &ldquo;Mem0 +53.6&rdquo; fix in our LongMemEval scores.</p>
+        <div style="font-family:var(--ff-mono);font-size:12px;color:var(--paper);background:var(--ink);border:1px solid var(--rule);padding:14px;line-height:1.7;">
+<span style="color:var(--muted);">user turn &rarr;</span> <span class="kw" style="color:var(--accent-warm);">extract_user_facts(turn)</span><br>
+<span style="color:var(--muted);">                     &darr; speaker = "user"</span><br>
+<br>
+<span style="color:var(--muted);">assistant turn &rarr;</span> <span class="kw" style="color:var(--accent-warm);">extract_agent_facts(turn)</span><br>
+<span style="color:var(--muted);">                          &darr; speaker = "&lt;agent_id&gt;"</span>
+        </div>
+      </div>
+
+      <!-- 04 — Sleep-time reflection -->
+      <div class="reveal" style="padding:26px 28px;border:1px solid var(--rule-strong);background:var(--ink-raise);">
+        <div style="font-family:var(--ff-mono);font-size:10px;letter-spacing:0.22em;color:var(--accent);">MECHANISM &middot; 04</div>
+        <h4 style="font-family:var(--ff-display);font-size:24px;font-weight:600;margin:8px 0 12px;">Sleep-time reflection</h4>
+        <p style="font-size:14.5px;line-height:1.65;color:var(--paper-dim);margin:0 0 14px;">Periodic synthesis across a user&rsquo;s recent facts. One LLM call distills many episodes into structured outputs:</p>
+        <ul style="font-family:var(--ff-mono);font-size:12px;color:var(--paper-dim);line-height:1.85;margin:0 0 12px;padding-left:20px;">
+          <li><code style="color:var(--accent);">stable_preferences</code> &mdash; patterns appearing in 3+ episodes</li>
+          <li><code style="color:var(--accent);">stable_constraints</code> &mdash; rules the user repeatedly invokes</li>
+          <li><code style="color:var(--accent);">changed_beliefs</code> &mdash; preferences shifted (old &rarr; new)</li>
+          <li><code style="color:var(--accent);">contradictions_for_review</code> &mdash; flagged, <strong>not auto-resolved</strong></li>
+        </ul>
+        <p style="font-size:12.5px;color:var(--muted);font-style:italic;margin:0;">Hard contradictions in regulated chat systems must be a human decision &mdash; the prompt is explicit: <em>do NOT auto-resolve</em>.</p>
+      </div>
+
+      <!-- 05 — Dual-judge anti-collusion -->
+      <div class="reveal" style="padding:26px 28px;border:1px solid var(--rule-strong);background:var(--ink-raise);grid-column:1 / span 2;border-left:3px solid var(--accent);">
+        <div style="font-family:var(--ff-mono);font-size:10px;letter-spacing:0.22em;color:var(--accent);">MECHANISM &middot; 05</div>
+        <h4 style="font-family:var(--ff-display);font-size:24px;font-weight:600;margin:8px 0 12px;">Dual-judge benchmarking &mdash; anti-collusion by construction</h4>
+        <p style="font-size:14.5px;line-height:1.65;color:var(--paper-dim);margin:0 0 14px;">Every LongMemEval answer is scored by <strong>two independent judges from different model families</strong> &mdash; the second judge anchors out answerer-judge collusion. Same model judging its own answer rewards itself; cross-family judging surfaces real disagreement.</p>
+        <div style="display:grid;grid-template-columns:1fr auto 1fr;gap:18px;align-items:center;">
+          <div style="font-family:var(--ff-mono);font-size:13px;background:var(--ink);border:1px solid var(--rule-strong);padding:14px;text-align:center;">
+            <div style="color:var(--muted);font-size:11px;letter-spacing:0.18em;">JUDGE 01</div>
+            <div style="color:var(--accent);margin-top:6px;">openai/gpt-5.2</div>
+          </div>
+          <div style="font-family:var(--ff-mono);font-size:11px;color:var(--muted);text-align:center;letter-spacing:0.16em;">vs cross<br>family</div>
+          <div style="font-family:var(--ff-mono);font-size:13px;background:var(--ink);border:1px solid var(--rule-strong);padding:14px;text-align:center;">
+            <div style="color:var(--muted);font-size:11px;letter-spacing:0.18em;">JUDGE 02</div>
+            <div style="color:var(--accent);margin-top:6px;">anthropic/claude-sonnet-4.6</div>
+          </div>
+        </div>
+        <p style="font-size:12.5px;color:var(--muted);font-style:italic;margin:14px 0 0;">The <code style="font-family:var(--ff-mono);font-size:11px;color:var(--accent);">scripts/lme_smoke_local.py</code> driver runs this exact dual-judge stack against your install. See the Quickstart &raquo; <em>Smoke benchmark</em> tab.</p>
+      </div>
+
+    </div>
+
+    <!-- Provenance closing line -->
+    <div class="reveal" style="margin-top:36px;padding:22px 26px;border:1px dashed var(--rule-strong);background:var(--ink-raise);">
+      <div style="font-family:var(--ff-mono);font-size:10px;letter-spacing:0.22em;color:var(--accent);margin-bottom:8px;">PROVENANCE INVARIANT</div>
+      <p style="font-size:14.5px;line-height:1.65;color:var(--paper);margin:0;">Every memory carries <code style="font-family:var(--ff-mono);font-size:12px;color:var(--accent);">agent_id</code>, <code style="font-family:var(--ff-mono);font-size:12px;color:var(--accent);">session_id</code>, and <code style="font-family:var(--ff-mono);font-size:12px;color:var(--accent);">source_episode_id</code>. Every <code style="font-family:var(--ff-mono);font-size:12px;color:var(--accent);">supersede</code> writes the prior id into <code style="font-family:var(--ff-mono);font-size:12px;color:var(--accent);">superseded_by</code>. Cryptographic signing is opt-in (Phase 8.1). The result: any disputed answer can be traced back to <em>which agent wrote which fact, when, and what it superseded</em>.</p>
+    </div>
+
   </div>
 </section>
 


### PR DESCRIPTION
## Summary

Two big additions to the marketing landing (`docs/index.html`) aimed at the dual audience the live site at https://attestor.dev/ serves: developers evaluating the project and senior VCs / hiring execs assessing for invest-or-hire.

### § 03 — Live retrieval pipeline (replaces static SVG)

Self-contained interactive scene. Auto-plays on scroll, ~14 seconds, walks a real query through all six deterministic steps (Vector Top-K → Graph Narrow → Triples Inject → MMR Diversity → Decay+Boost → Budget Fit). Each stage lights up when active, tweens its candidate count (50 → 38 → 42 → 24 → 24 → 8), and renders a 50-tile mini-grid where tiles take state (kept / boosted / triple / rejected). Final result frame shows eight ranked memories with provenance metadata; proof line confirms "0 LLM calls · 6 deterministic steps · same query → same ranking".

Controls: Play/Pause, Replay, scrub bar, 0.5× / 1× / 2× speed. Pure CSS + vanilla JS, no library. Investor affordances: static-SVG download + "Render as MP4 (soon)" placeholder for the upcoming Remotion render.

### § 03.5 — Multi-LLM cooperation grid (new section)

2-column grid covering the five mechanisms that turn multi-LLM writes into an auditable transaction log:

- **01** Write-time supersession (deterministic, no LLM)
- **02** Four-decision conflict resolver (`ADD / UPDATE / INVALIDATE / NOOP`) with `evidence_episode_id` audit trail
- **03** Speaker-locked extraction (the "+53.6 over Mem0" fix)
- **04** Sleep-time reflection — *contradictions flagged for HUMAN REVIEW, not auto-resolved* (regulated-systems posture, prompt is explicit)
- **05** Dual-judge benchmarking — cross-family judges (`openai/gpt-5.2` + `anthropic/claude-sonnet-4.6`) anchor out answerer-judge collusion

Closes with a Provenance Invariant callout naming the `agent_id` / `session_id` / `source_episode_id` fields and the `superseded_by` chain.

## Why
The capability audit (PR #58 follow-up) found these features are real and production-ready in code but completely invisible on the marketing surface — particularly the four-decision contract and the human-review posture on contradictions. That gap closes here.

## Test plan
- [x] Loads at http://127.0.0.1:9999/index.html with 0 console errors
- [x] Auto-plays once on scroll-into-view, then stops (does not loop)
- [x] Stage activation tested at t=4500ms (Stage 02 active, count tweens correctly)
- [x] Stage 04 active at t=8200ms (count tweening 38 → 24)
- [x] Final frame at t=14000ms shows result frame with 8 lines + proof line
- [x] Replay button resets to t=0 and auto-plays
- [x] Scrubber pauses + jumps to arbitrary time correctly
- [x] Speed buttons (0.5×/1×/2×) toggle active state
- [x] Responsive: grid collapses to single column under 760px
- [ ] CI: no test changes; pure docs-html addition

🤖 Generated with [Claude Code](https://claude.com/claude-code)