### PR TITLE
chore(release): 4.0.0a3 — mcp-name marker for MCP Registry ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to Attestor (formerly Memwright) are documented in this file. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.0a3] — 2026-04-27
+
+Adds the `mcp-name: io.github.bolnet/attestor` marker to the PyPI README so the MCP Registry can validate ownership of the PyPI package and accept the `server.json` publish. No code changes vs `4.0.0a2`.
+
 ## [4.0.0a2] — 2026-04-27
 
 **Hotfix on the same day as 4.0.0a1.** Adds `requests` to required core dependencies so the documented default embedder (local Ollama `bge-m3`) actually works on a fresh `pip install attestor`. In 4.0.0a1, `attestor doctor` raised `RuntimeError: No embedding provider available` even with Ollama running, because `OllamaEmbeddingProvider` lazy-imports `requests` and that wasn't in the wheel's deps. Smoke-verified end-to-end against PyPI: `pip install --pre attestor==4.0.0a2` now succeeds and Ollama probe returns a 1024-D bge-m3 embedding.

--- a/README.md
+++ b/README.md
@@ -569,3 +569,6 @@ It probes Document Store (Postgres), Vector Store (pgvector), Graph Store (Neo4j
 ## License
 
 MIT. See [`LICENSE`](./LICENSE).
+
+<!-- mcp-name: io.github.bolnet/attestor -->
+

--- a/attestor/__init__.py
+++ b/attestor/__init__.py
@@ -23,4 +23,4 @@ __all__ = [
     "User",
     "Visibility",
 ]
-__version__ = "4.0.0a2"
+__version__ = "4.0.0a3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "attestor"
-version = "4.0.0a2"
+version = "4.0.0a3"
 description = "Production-grade memory infrastructure for multi-agent systems. Namespace isolation, RBAC, provenance, ranked retrieval."
 readme = "README.md"
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.bolnet/attestor",
+  "title": "Attestor",
+  "description": "Self-hosted memory for agent teams. Bi-temporal replay, deterministic retrieval, audit log.",
+  "version": "4.0.0a3",
+  "repository": {
+    "url": "https://github.com/bolnet/attestor",
+    "source": "github"
+  },
+  "packages": [
+    {
+      "registryType": "pypi",
+      "identifier": "attestor",
+      "version": "4.0.0a3",
+      "runtimeHint": "python",
+      "transport": {
+        "type": "stdio"
+      },
+      "packageArguments": [
+        {
+          "type": "positional",
+          "value": "mcp",
+          "description": "MCP stdio server subcommand."
+        }
+      ],
+      "environmentVariables": [
+        {
+          "name": "ATTESTOR_PATH",
+          "description": "Directory containing attestor's config.toml. Defaults to ~/.attestor.",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": false
+        },
+        {
+          "name": "ATTESTOR_DISABLE_LOCAL_EMBED",
+          "description": "Set to 1 to skip the local Ollama embedder probe (e.g., on hosts without Ollama). Defaults to unset (Ollama is the default embedder).",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": false
+        },
+        {
+          "name": "OPENAI_API_KEY",
+          "description": "OpenAI API key (used for the OpenAI text-embedding-3-large fallback embedder when Ollama is unavailable).",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": true
+        },
+        {
+          "name": "OPENROUTER_API_KEY",
+          "description": "OpenRouter API key (used for the federated LLM extraction / consolidation paths and for the LongMemEval benchmark runner).",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": true
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adds `mcp-name: io.github.bolnet/attestor` to README so MCP Registry can validate PyPI-package ownership and accept server.json. Also includes the server.json manifest itself. No runtime code changes vs 4.0.0a2.