### PR TITLE
feat(v4): 4.0.0a4 — introspection-only MCP + Glama Dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Attestor (formerly Memwright) are documented in this file. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.0a4] — 2026-04-27
+
+Introspection-only fallback for the MCP server so external registries (Glama, Smithery) can verify the listing without provisioning Postgres + Neo4j. When `ATTESTOR_MCP_TOLERATE_INIT_FAILURE=1` is set, `attestor mcp` swallows backend connection errors at startup and continues to advertise its 8 tools via `tools/list`. Any `tools/call` against a non-initialized server returns a clear "configure backends to enable execution" error instead of crashing. Production deployments leave the env var unset and behave as before — strict, fail-closed init.
+
+Also adds a top-level `Dockerfile` that builds an introspection-only image (~150 MB, single layer over `python:3.12-slim`) for use as the registry-listing artifact. Real production deployments continue to use `attestor/infra/local/docker-compose.yml` or one of the cloud Terraform stacks under `attestor/infra/{aws_arango,azure,gcp_alloydb}`.
+
 ## [4.0.0a3] — 2026-04-27
 
 Adds the `mcp-name: io.github.bolnet/attestor` marker to the PyPI README so the MCP Registry can validate ownership of the PyPI package and accept the `server.json` publish. No code changes vs `4.0.0a2`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,43 @@
+# Dockerfile — Attestor MCP server (introspection-only profile)
+#
+# Purpose: satisfy the Glama listing check (https://glama.ai/mcp/servers/bolnet/attestor).
+# Glama needs the MCP server to start and respond to introspection (`tools/list`).
+# The full Attestor topology requires Postgres 16 + pgvector and Neo4j 5 + GDS;
+# bundling those into a single container would balloon the image past Glama's
+# build budget. Instead this image runs Attestor in introspection-only mode
+# (ATTESTOR_MCP_TOLERATE_INIT_FAILURE=1) so `tools/list` advertises every
+# tool the real server exposes, and any actual `tools/call` returns a clear
+# "configure backends to enable execution" error.
+#
+# Real production deployment uses attestor/infra/local/docker-compose.yml
+# (Postgres + Neo4j + Attestor) or one of the cloud Terraform stacks under
+# attestor/infra/{aws_arango,azure,gcp_alloydb}.
+
+FROM python:3.12-slim
+
+LABEL org.opencontainers.image.title="Attestor MCP"
+LABEL org.opencontainers.image.description="Audit-grade memory backbone for agent teams. Bi-temporal facts, deterministic retrieval, signed provenance."
+LABEL org.opencontainers.image.source="https://github.com/bolnet/attestor"
+LABEL org.opencontainers.image.url="https://attestor.dev"
+LABEL org.opencontainers.image.licenses="MIT"
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    ATTESTOR_PATH=/data/attestor \
+    ATTESTOR_DISABLE_LOCAL_EMBED=1 \
+    ATTESTOR_MCP_TOLERATE_INIT_FAILURE=1
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libpq5 \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+COPY pyproject.toml README.md ./
+COPY attestor/ attestor/
+RUN pip install --no-cache-dir .
+
+RUN mkdir -p /data/attestor
+
+ENTRYPOINT ["attestor", "mcp"]

--- a/README.md
+++ b/README.md
@@ -560,7 +560,7 @@ It probes Document Store (Postgres), Vector Store (pgvector), Graph Store (Neo4j
 
 ## Status & versioning
 
-- **Version:** 4.0.0a3 (alpha) — published to [PyPI](https://pypi.org/project/attestor/) and the [MCP Registry](https://registry.modelcontextprotocol.io/v0/servers?search=attestor) as `io.github.bolnet/attestor`
+- **Version:** 4.0.0a4 (alpha) — published to [PyPI](https://pypi.org/project/attestor/) and the [MCP Registry](https://registry.modelcontextprotocol.io/v0/servers?search=attestor) as `io.github.bolnet/attestor`
 - **v3 → v4:** greenfield rebuild on a v4-native Postgres schema with hard tenant isolation, bi-temporal facts, and a no-LLM retrieval critical path. **There is no automated migration.** v3 was alpha-only with no production users; drop your v3 DB and reinstall.
 - See [`CHANGELOG.md`](./CHANGELOG.md) for the full track-by-track changelog.
 

--- a/attestor/__init__.py
+++ b/attestor/__init__.py
@@ -23,4 +23,4 @@ __all__ = [
     "User",
     "Visibility",
 ]
-__version__ = "4.0.0a3"
+__version__ = "4.0.0a4"

--- a/attestor/cli.py
+++ b/attestor/cli.py
@@ -1131,7 +1131,15 @@ def _cmd_mcp_serve(args):
 
     # Ensure store directory and DB exist
     Path(store_path).mkdir(parents=True, exist_ok=True)
-    AgentMemory(store_path).close()
+    try:
+        AgentMemory(store_path).close()
+    except Exception as init_err:
+        if not os.environ.get("ATTESTOR_MCP_TOLERATE_INIT_FAILURE"):
+            raise
+        print(
+            f"[attestor.mcp] Preflight AgentMemory init failed (tolerated): {init_err}",
+            file=sys.stderr,
+        )
 
     print(f"Starting MCP server for {store_path}...", file=sys.stderr)
     asyncio.run(run_server(store_path))

--- a/attestor/mcp/server.py
+++ b/attestor/mcp/server.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import sys
 from typing import Any
 
@@ -210,7 +211,16 @@ def create_server(memory_path: str):
         )
         sys.exit(1)
 
-    mem = AgentMemory(memory_path)
+    try:
+        mem = AgentMemory(memory_path)
+    except Exception as init_err:
+        if not os.environ.get("ATTESTOR_MCP_TOLERATE_INIT_FAILURE"):
+            raise
+        print(
+            f"[attestor.mcp] AgentMemory init failed (tolerated by ATTESTOR_MCP_TOLERATE_INIT_FAILURE): {init_err}",
+            file=sys.stderr,
+        )
+        mem = None
     server = Server(_brand.PACKAGE_NAME)
 
     # -- Tools --
@@ -374,6 +384,12 @@ def create_server(memory_path: str):
 
     @server.call_tool()
     async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
+        if mem is None:
+            return [TextContent(type="text", text=json.dumps({
+                "error": "Backends are not initialized — Attestor MCP is running in introspection-only mode. "
+                         "Provide working Postgres + Neo4j connections (ATTESTOR_PATH or config.toml) and unset "
+                         "ATTESTOR_MCP_TOLERATE_INIT_FAILURE to enable tool execution.",
+            }))]
         try:
             result = _handle_tool(mem, name, arguments)
             return [TextContent(type="text", text=json.dumps(result, indent=2))]
@@ -381,28 +397,32 @@ def create_server(memory_path: str):
             return [TextContent(type="text", text=json.dumps({"error": str(e)}))]
 
     # -- Resources and Prompts --
+    # When mem is None (introspection-only mode), skip resource/prompt
+    # registration so list_resources / list_prompts return empty rather
+    # than crashing inside handlers that dereference mem.
 
-    handlers = _build_handlers(mem)
+    if mem is not None:
+        handlers = _build_handlers(mem)
 
-    @server.list_resources()
-    async def _list_resources():
-        return await handlers["list_resources"]()
+        @server.list_resources()
+        async def _list_resources():
+            return await handlers["list_resources"]()
 
-    @server.read_resource()
-    async def _read_resource(uri):
-        return await handlers["read_resource"](uri)
+        @server.read_resource()
+        async def _read_resource(uri):
+            return await handlers["read_resource"](uri)
 
-    @server.list_resource_templates()
-    async def _list_resource_templates():
-        return await handlers["list_resource_templates"]()
+        @server.list_resource_templates()
+        async def _list_resource_templates():
+            return await handlers["list_resource_templates"]()
 
-    @server.list_prompts()
-    async def _list_prompts():
-        return await handlers["list_prompts"]()
+        @server.list_prompts()
+        async def _list_prompts():
+            return await handlers["list_prompts"]()
 
-    @server.get_prompt()
-    async def _get_prompt(name, arguments):
-        return await handlers["get_prompt"](name, arguments)
+        @server.get_prompt()
+        async def _get_prompt(name, arguments):
+            return await handlers["get_prompt"](name, arguments)
 
     return server
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "attestor"
-version = "4.0.0a3"
+version = "4.0.0a4"
 description = "Production-grade memory infrastructure for multi-agent systems. Namespace isolation, RBAC, provenance, ranked retrieval."
 readme = "README.md"
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.bolnet/attestor",
   "title": "Attestor",
   "description": "Self-hosted memory for agent teams. Bi-temporal replay, deterministic retrieval, audit log.",
-  "version": "4.0.0a3",
+  "version": "4.0.0a4",
   "repository": {
     "url": "https://github.com/bolnet/attestor",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "attestor",
-      "version": "4.0.0a3",
+      "version": "4.0.0a4",
       "runtimeHint": "python",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Summary
- **Introspection-only fallback**: with \`ATTESTOR_MCP_TOLERATE_INIT_FAILURE=1\`, \`attestor mcp\` swallows backend connection errors at startup, advertises all 8 tools via \`tools/list\`, and returns a clear \"configure backends\" error on \`tools/call\`. Production behavior (env unset) is unchanged.
- **Dockerfile at repo root**: ~150 MB single-layer image over \`python:3.12-slim\` that satisfies Glama's listing check (server starts + responds to introspection). Real production deployments still use \`attestor/infra/local/docker-compose.yml\` or the cloud Terraform stacks.
- **4.0.0a4 version bump** across pyproject.toml, __init__.py, server.json, README, CHANGELOG.

## Why
Glama (the directory that gates punkpeye's awesome-mcp-servers PRs) requires \`docker build\` + \`docker run\` to start the server and respond to MCP introspection. Bundling Postgres+Neo4j into a single Glama-listing image is heavyweight; this introspection-only profile is the right artifact for a registry verification check.

## Test plan
- [x] \`docker build -t attestor-glama-smoke .\` — succeeds in ~10s
- [x] \`docker run --rm -i attestor-glama-smoke < init+tools/list.jsonrpc\` — returns 8 tools (memory_add, memory_get, memory_recall, memory_search, memory_forget, memory_timeline, memory_stats, memory_health)
- [x] tools/call against introspection-only server returns the configure-backends error JSON
- [x] Production behavior preserved (env var unset → fail-closed init as before)