### PR TITLE
Make configs/attestor.yaml the actual runtime SoT

### DIFF
--- a/attestor/api.py
+++ b/attestor/api.py
@@ -19,16 +19,15 @@ _mem = None
 
 
 def _build_config() -> Optional[Dict[str, Any]]:
-    """Build backend config from env. Returns None for embedded default.
+    """Build backend config. Returns None when no backend can be resolved.
 
-    Layer 0 stack (preferred): POSTGRES_URL + NEO4J_URI together → Postgres
-    (doc + vector via pgvector) plus Neo4j (graph + GDS).
-
-    Resolution order:
-        1. POSTGRES_URL [+ optional NEO4J_URI]  -> Postgres (+ Neo4j) stack
-        2. NEO4J_URI alone                      -> graph-only (rare; for tests)
-        3. ARANGO_URL                           -> single-engine ArangoDB
-        4. None                                 -> error; Attestor requires a configured backend
+    Resolution order (top wins):
+        1. Explicit env vars: POSTGRES_URL [+ NEO4J_URI] / NEO4J_URI alone /
+           ARANGO_URL — preserved for cloud deploys that bind secrets via env.
+        2. ``configs/attestor.yaml`` via ``attestor.config.get_stack()`` —
+           when no env vars are set we honor the YAML SoT. Pass
+           ATTESTOR_CONFIG=/path/to/yaml to override the default file.
+        3. None — caller bubbles a clear error.
     """
     postgres_url = os.environ.get("POSTGRES_URL")
     neo4j_uri = os.environ.get("NEO4J_URI")
@@ -82,7 +81,16 @@ def _build_config() -> Optional[Dict[str, Any]]:
                 },
             },
         }
-    return None
+
+    # No env override — defer to the YAML SoT.
+    try:
+        from attestor.config import build_backend_config, get_stack
+        return build_backend_config(get_stack())
+    except SystemExit:
+        # YAML missing required env (e.g. NEO4J_PASSWORD) — return None so
+        # the api surfaces a clear "configure backends" error rather than
+        # the loader's exit message.
+        return None
 
 
 def _get_mem():

--- a/attestor/cli.py
+++ b/attestor/cli.py
@@ -229,16 +229,16 @@ def main(argv=None):
     )
     p_locomo.add_argument("--data", default=None, help="Path to locomo10.json (downloads if not provided)")
     p_locomo.add_argument(
-        "--judge-model", default="openai/gpt-4.1-mini",
-        help="LLM for judging answers",
+        "--judge-model", default=None,
+        help="LLM for judging answers (default: stack.models.judge from configs/attestor.yaml)",
     )
     p_locomo.add_argument(
-        "--answer-model", default="openai/gpt-4.1-mini",
-        help="LLM for answer synthesis",
+        "--answer-model", default=None,
+        help="LLM for answer synthesis (default: stack.models.answerer from configs/attestor.yaml)",
     )
     p_locomo.add_argument(
-        "--extraction-model", default="openai/gpt-4.1-mini",
-        help="LLM for fact extraction",
+        "--extraction-model", default=None,
+        help="LLM for fact extraction (default: stack.models.extraction from configs/attestor.yaml)",
     )
     p_locomo.add_argument("--use-extraction", action="store_true", help="Extract facts with LLM")
     p_locomo.add_argument("--resolve-pronouns", action="store_true", default=True, help="Resolve pronouns/time refs (default: on)")
@@ -261,8 +261,8 @@ def main(argv=None):
         help="Category codes: AR, CR, TTL, LRU (default: AR CR)",
     )
     p_mab.add_argument(
-        "--answer-model", default="openai/gpt-4.1-mini",
-        help="LLM for answer synthesis (OpenRouter model ID)",
+        "--answer-model", default=None,
+        help="LLM for answer synthesis (default: stack.models.benchmark_default from configs/attestor.yaml)",
     )
     p_mab.add_argument("--max-examples", type=int, default=None, help="Max examples per category")
     p_mab.add_argument("--skip-examples", type=int, default=0, help="Skip first N examples per category")
@@ -293,12 +293,13 @@ def main(argv=None):
         help="HuggingFace dataset variant when auto-downloading (default: s)",
     )
     p_lme.add_argument(
-        "--answer-model", default="openai/gpt-4.1-mini",
-        help="LLM for answer synthesis",
+        "--answer-model", default=None,
+        help="LLM for answer synthesis (default: stack.models.answerer from configs/attestor.yaml)",
     )
     p_lme.add_argument(
         "--judge-model", action="append", default=None,
-        help="LLM for judging answers. Pass multiple times for dual-judge scoring.",
+        help="LLM for judging answers (default: [stack.models.judge, stack.models.verifier]). "
+             "Pass multiple times for dual-judge scoring.",
     )
     p_lme.add_argument(
         "--use-extraction", action="store_true",
@@ -310,8 +311,8 @@ def main(argv=None):
              "into 0..N third-person facts with absolute dates before embed/graph.",
     )
     p_lme.add_argument(
-        "--distill-model", default="openai/gpt-5.1",
-        help="OpenRouter model id for the distiller (default: openai/gpt-5.1).",
+        "--distill-model", default=None,
+        help="LLM for the per-turn distiller (default: stack.models.distill from configs/attestor.yaml)",
     )
     p_lme.add_argument("--max-samples", type=int, default=None, help="Cap on samples")
     p_lme.add_argument(
@@ -909,16 +910,22 @@ def _cmd_locomo(args):
         _load_env_file(args.env_file)
     api_key = os.environ.get("OPENROUTER_API_KEY")
 
+    from attestor.config import get_stack
     from attestor.locomo import run_locomo, print_locomo
+
+    stack = get_stack()
+    judge_model = args.judge_model or stack.models.judge
+    answer_model = args.answer_model or stack.models.answerer
+    extraction_model = args.extraction_model or stack.models.extraction
 
     print("Running LOCOMO benchmark...")
     print("(Long Conversation Memory -- industry-standard benchmark)\n")
 
     results = run_locomo(
         data_path=args.data,
-        judge_model=args.judge_model,
-        answer_model=args.answer_model,
-        extraction_model=args.extraction_model,
+        judge_model=judge_model,
+        answer_model=answer_model,
+        extraction_model=extraction_model,
         use_extraction=args.use_extraction,
         resolve_pronouns=args.resolve_pronouns,
         max_conversations=args.max_conversations,
@@ -1014,9 +1021,15 @@ def _cmd_longmemeval(args):
         samples = samples[: args.max_samples]
         print(f"capped to {len(samples)} samples")
 
+    from attestor.config import get_stack
     from attestor.longmemeval import DEFAULT_JUDGES  # local import to avoid cycle
 
-    judge_models = args.judge_model or list(DEFAULT_JUDGES)
+    stack = get_stack()
+    # Judge panel: CLI flag > YAML (judge + verifier) > legacy DEFAULT_JUDGES
+    judge_models = args.judge_model or [stack.models.judge, stack.models.verifier]
+    answer_model = args.answer_model or stack.models.answerer
+    distill_model = args.distill_model or stack.models.distill
+    verify_model = args.verify_model or stack.models.verifier
 
     from attestor._paths import resolve_store_path
     import threading
@@ -1038,24 +1051,24 @@ def _cmd_longmemeval(args):
             return AgentMemory(store_path, config=backend_config)
 
     print(
-        f"Running LongMemEval: answer={args.answer_model} "
+        f"Running LongMemEval: answer={answer_model} "
         f"judges={judge_models} samples={len(samples)} budget={args.budget} "
         f"parallel={args.parallel}"
     )
     report = run(
         samples,
         mem_factory=mem_factory,
-        answer_model=args.answer_model,
+        answer_model=answer_model,
         judge_models=judge_models,
         api_key=api_key,
         budget=args.budget,
         use_extraction=args.use_extraction,
         use_distillation=args.use_distillation,
-        distill_model=args.distill_model,
+        distill_model=distill_model,
         max_facts=args.max_facts,
         parallel=args.parallel,
         verify=args.verify,
-        verify_model=args.verify_model,
+        verify_model=verify_model,
         verbose=args.verbose,
         output_path=args.output,
         dataset_path=dataset_path,

--- a/attestor/config.py
+++ b/attestor/config.py
@@ -1,0 +1,462 @@
+"""Single source of truth for Attestor configuration.
+
+Every model name, DB URL, embedder choice, retrieval budget, registry
+address and per-cloud deploy plan in this codebase comes from one
+file: ``configs/attestor.yaml``. This module is the loader.
+
+Public surface
+--------------
+
+    get_stack(*, strict=False) -> StackConfig
+        Lazy-loads, parses, and caches the YAML. Subsequent calls
+        return the same object. Pass ``strict=True`` to fail loudly
+        when required env refs are missing (the loader otherwise
+        substitutes safe placeholders so tests/CI work without a
+        full secrets set).
+
+    set_stack(stack)
+        Replace the cached stack. For tests + benchmark harnesses that
+        want to swap configs at runtime.
+
+    reset_stack()
+        Drop the cache so the next ``get_stack()`` re-reads the YAML.
+
+    StackConfig (frozen dataclass)
+        Resolved values. See class for fields.
+
+Resolution order (highest to lowest priority):
+
+    1. Explicit CLI flag passed by the user
+    2. Explicit env var (e.g. POSTGRES_URL, VOYAGE_API_KEY, ANSWER_MODEL)
+    3. ``configs/attestor.yaml`` value
+    4. Hardcoded fallback (only when YAML is absent AND env unset)
+
+Env override:
+    ATTESTOR_CONFIG=/path/to/different.yaml
+        Use a non-default config file. Useful for one-off A/B runs.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_CONFIG = REPO_ROOT / "configs" / "attestor.yaml"
+
+
+# ─── Hardcoded fallbacks (USED ONLY when YAML is missing) ──────────────
+#
+# These are the canonical defaults captured at the time the YAML was
+# written. They exist so tests / CI can run in a stripped checkout
+# without `configs/attestor.yaml`. Production deployments must have
+# the YAML; the runtime emits a warning when these fallbacks fire.
+
+_FALLBACK_POSTGRES_URL = "postgresql://postgres:attestor@localhost:5432/attestor_v4_test"
+_FALLBACK_NEO4J_URL = "bolt://localhost:7687"
+_FALLBACK_NEO4J_DB = "neo4j"
+_FALLBACK_NEO4J_USER = "neo4j"
+_FALLBACK_EMBEDDER_PROVIDER = "voyage"
+_FALLBACK_EMBEDDER_MODEL = "voyage-4"
+_FALLBACK_EMBEDDER_DIM = 1024
+_FALLBACK_ANSWERER = "openai/gpt-4.1"
+_FALLBACK_JUDGE = "openai/gpt-4.1"
+_FALLBACK_EXTRACTION = "openai/gpt-4.1-mini"
+_FALLBACK_DISTILL = "openai/gpt-4.1-mini"
+_FALLBACK_VERIFIER = "anthropic/claude-sonnet-4-6"
+_FALLBACK_PLANNER = "anthropic/claude-opus-4.7"
+_FALLBACK_BENCHMARK = "openai/gpt-4.1-mini"
+_FALLBACK_BUDGET = 4000
+_FALLBACK_PARALLEL = 2
+
+
+# ─── Dataclasses ──────────────────────────────────────────────────────
+
+@dataclass(frozen=True)
+class PostgresCfg:
+    url: str
+    v4: bool
+    skip_schema_init: bool
+
+
+@dataclass(frozen=True)
+class Neo4jCfg:
+    url: str
+    username: str
+    password: str
+    database: str
+
+
+@dataclass(frozen=True)
+class EmbedderCfg:
+    provider: str
+    model: str
+    dimensions: int
+
+
+@dataclass(frozen=True)
+class ModelsCfg:
+    """Per-role model assignment.
+
+    All seven roles are required. Roles map to actual call sites:
+
+      answerer    — final answer synthesis from retrieved context
+                    (attestor.locomo.answer_question, longmemeval.run_async)
+      judge       — single-judge correctness verdict on benchmark answers
+                    (locomo.judge_answer, longmemeval.judge_*)
+      extraction  — fact extraction during ingest
+                    (extraction.llm_extractor, extraction.round_extractor)
+      distill     — Mem0-style distillation during ingest
+                    (longmemeval.run_async distill_model)
+      verifier    — second-pass cross-check after judge
+                    (mab.run_*, longmemeval verifier role)
+      planner     — query rewriting / multi-step planning
+                    (retrieval.planner)
+      benchmark_default — generic fallback for ad-hoc bench commands
+                          where no specific role applies
+    """
+    answerer: str
+    judge: str
+    extraction: str
+    distill: str
+    verifier: str
+    planner: str
+    benchmark_default: str
+
+
+@dataclass(frozen=True)
+class ImageCfg:
+    ref: str
+    api_ref_template: str
+    registries: Dict[str, str] = field(default_factory=dict)
+
+    def native_ref(self, key: str, *, version: Optional[str] = None) -> str:
+        if key not in self.registries:
+            raise KeyError(f"unknown registry key {key!r}")
+        base = self.registries[key]
+        tag = f"api-{version}" if version else "latest"
+        return f"{base}:{tag}"
+
+
+@dataclass(frozen=True)
+class StackConfig:
+    postgres: PostgresCfg
+    neo4j: Neo4jCfg
+    embedder: EmbedderCfg
+    models: ModelsCfg
+    image: ImageCfg
+    budget: int
+    parallel: int
+    clouds: Dict[str, Dict[str, Any]]
+
+
+# ─── YAML helpers ─────────────────────────────────────────────────────
+
+def _resolve_env_password(node: Any, *, strict: bool) -> str:
+    """Resolve a password from ``password`` (literal) or ``password_env``."""
+    if isinstance(node, dict):
+        if node.get("password"):
+            return str(node["password"])
+        env_name = node.get("password_env")
+        if env_name:
+            value = os.environ.get(env_name)
+            if value:
+                return value
+            if strict:
+                raise SystemExit(
+                    f"[attestor.config] required env {env_name!r} not set"
+                )
+            return ""  # placeholder for non-strict (tests / CI without secrets)
+    if strict:
+        raise SystemExit(
+            f"[attestor.config] could not resolve password from {node!r}"
+        )
+    return ""
+
+
+def _build_fallback_stack() -> StackConfig:
+    """Hardcoded stack used when ``configs/attestor.yaml`` is absent."""
+    return StackConfig(
+        postgres=PostgresCfg(
+            url=os.environ.get("POSTGRES_URL", _FALLBACK_POSTGRES_URL),
+            v4=True,
+            skip_schema_init=True,
+        ),
+        neo4j=Neo4jCfg(
+            url=os.environ.get("NEO4J_URI", _FALLBACK_NEO4J_URL),
+            username=os.environ.get("NEO4J_USERNAME", _FALLBACK_NEO4J_USER),
+            password=os.environ.get("NEO4J_PASSWORD", ""),
+            database=os.environ.get("NEO4J_DATABASE", _FALLBACK_NEO4J_DB),
+        ),
+        embedder=EmbedderCfg(
+            provider=_FALLBACK_EMBEDDER_PROVIDER,
+            model=_FALLBACK_EMBEDDER_MODEL,
+            dimensions=_FALLBACK_EMBEDDER_DIM,
+        ),
+        models=ModelsCfg(
+            answerer=_FALLBACK_ANSWERER,
+            judge=_FALLBACK_JUDGE,
+            extraction=_FALLBACK_EXTRACTION,
+            distill=_FALLBACK_DISTILL,
+            verifier=_FALLBACK_VERIFIER,
+            planner=_FALLBACK_PLANNER,
+            benchmark_default=_FALLBACK_BENCHMARK,
+        ),
+        image=ImageCfg(ref="", api_ref_template="", registries={}),
+        budget=_FALLBACK_BUDGET,
+        parallel=_FALLBACK_PARALLEL,
+        clouds={},
+    )
+
+
+def _parse_yaml(cfg_path: Path, *, strict: bool) -> StackConfig:
+    raw = yaml.safe_load(cfg_path.read_text())
+    stack_blk = raw.get("stack") or {}
+    image_blk = raw.get("image") or {}
+    clouds_blk = raw.get("clouds") or {}
+
+    pg = stack_blk.get("postgres") or {}
+    neo = stack_blk.get("neo4j") or {}
+    emb = stack_blk.get("embedder") or {}
+    models = stack_blk.get("models") or {}
+
+    return StackConfig(
+        postgres=PostgresCfg(
+            url=pg.get("url", _FALLBACK_POSTGRES_URL),
+            v4=bool(pg.get("v4", True)),
+            skip_schema_init=bool(pg.get("skip_schema_init", True)),
+        ),
+        neo4j=Neo4jCfg(
+            url=neo.get("url", _FALLBACK_NEO4J_URL),
+            username=(neo.get("auth") or {}).get("username", _FALLBACK_NEO4J_USER),
+            password=_resolve_env_password(neo.get("auth") or {}, strict=strict),
+            database=neo.get("database", _FALLBACK_NEO4J_DB),
+        ),
+        embedder=EmbedderCfg(
+            provider=emb.get("provider", _FALLBACK_EMBEDDER_PROVIDER),
+            model=emb.get("model", _FALLBACK_EMBEDDER_MODEL),
+            dimensions=int(emb.get("dimensions", _FALLBACK_EMBEDDER_DIM)),
+        ),
+        models=ModelsCfg(
+            answerer=models.get("answerer", _FALLBACK_ANSWERER),
+            judge=models.get("judge", _FALLBACK_JUDGE),
+            extraction=models.get("extraction", _FALLBACK_EXTRACTION),
+            distill=models.get("distill", _FALLBACK_DISTILL),
+            verifier=models.get("verifier", _FALLBACK_VERIFIER),
+            planner=models.get("planner", _FALLBACK_PLANNER),
+            benchmark_default=models.get("benchmark_default", _FALLBACK_BENCHMARK),
+        ),
+        image=ImageCfg(
+            ref=image_blk.get("ref", ""),
+            api_ref_template=image_blk.get("api_ref_template", ""),
+            registries=dict(image_blk.get("registries") or {}),
+        ),
+        budget=int(stack_blk.get("budget", _FALLBACK_BUDGET)),
+        parallel=int(stack_blk.get("parallel", _FALLBACK_PARALLEL)),
+        clouds=dict(clouds_blk),
+    )
+
+
+# ─── Public surface ────────────────────────────────────────────────────
+
+_cached_stack: Optional[StackConfig] = None
+
+
+def load_stack(path: Path | str | None = None, *, strict: bool = False) -> StackConfig:
+    """Read ``configs/attestor.yaml`` (or override path) and resolve env refs.
+
+    Bypasses the cache. Most callers should use ``get_stack()`` instead.
+    """
+    if path is None:
+        path = os.environ.get("ATTESTOR_CONFIG") or DEFAULT_CONFIG
+    cfg_path = Path(path)
+    if not cfg_path.exists():
+        if strict:
+            raise SystemExit(f"[attestor.config] config not found: {cfg_path}")
+        return _build_fallback_stack()
+    return _parse_yaml(cfg_path, strict=strict)
+
+
+def get_stack(*, strict: bool = False) -> StackConfig:
+    """Return the cached stack, loading on first call.
+
+    Most production code should call this. The cache is per-process and
+    safe to call repeatedly. Use ``set_stack()`` for test injection or
+    ``reset_stack()`` to force a re-read.
+    """
+    global _cached_stack
+    if _cached_stack is None:
+        _cached_stack = load_stack(strict=strict)
+    return _cached_stack
+
+
+def set_stack(stack: StackConfig) -> None:
+    """Override the cached stack. For tests + benchmark harnesses."""
+    global _cached_stack
+    _cached_stack = stack
+
+
+def reset_stack() -> None:
+    """Drop the cache. Next ``get_stack()`` re-reads the YAML."""
+    global _cached_stack
+    _cached_stack = None
+
+
+# ─── Helpers used by scripts ─────────────────────────────────────────
+
+def configure_embedder(stack: StackConfig) -> None:
+    """Pin embedder selection via env vars so the auto-detect chain in
+    ``attestor.store.embeddings.get_embedding_provider()`` returns the
+    provider this stack asked for. Always disables Ollama auto-probe."""
+    os.environ["ATTESTOR_DISABLE_LOCAL_EMBED"] = "1"
+    if stack.embedder.provider == "voyage":
+        if not os.environ.get("VOYAGE_API_KEY"):
+            raise SystemExit(
+                "[attestor.config] embedder=voyage but VOYAGE_API_KEY not set"
+            )
+        os.environ["VOYAGE_EMBEDDING_MODEL"] = stack.embedder.model
+        os.environ["VOYAGE_EMBEDDING_DIMENSIONS"] = str(stack.embedder.dimensions)
+        os.environ["OPENAI_EMBEDDING_DIMENSIONS"] = str(stack.embedder.dimensions)
+    elif stack.embedder.provider == "openai":
+        os.environ.pop("VOYAGE_API_KEY", None)
+        os.environ["OPENAI_EMBEDDING_MODEL"] = stack.embedder.model
+        os.environ["OPENAI_EMBEDDING_DIMENSIONS"] = str(stack.embedder.dimensions)
+    else:
+        raise SystemExit(
+            f"[attestor.config] unknown embedder provider: {stack.embedder.provider!r}"
+        )
+
+
+def build_backend_config(
+    stack: StackConfig, *, no_graph: bool = False
+) -> Dict[str, Any]:
+    """``AgentMemory`` ``backend_configs`` payload for the canonical
+    PG+Neo4j stack. When ``no_graph`` is set, drops Neo4j (graph role)
+    so a Postgres-only run is possible."""
+    from urllib.parse import urlparse
+
+    parsed = urlparse(stack.postgres.url)
+    db = (parsed.path or "/").lstrip("/") or "attestor_v4_test"
+
+    backend_configs: Dict[str, Dict[str, Any]] = {
+        "postgres": {
+            "url": f"{parsed.scheme}://{parsed.hostname}:{parsed.port or 5432}",
+            "database": db,
+            "auth": {
+                "username": parsed.username or "postgres",
+                "password": parsed.password or "attestor",
+            },
+            "v4": stack.postgres.v4,
+            "skip_schema_init": stack.postgres.skip_schema_init,
+        },
+    }
+    backends = ["postgres"]
+    if not no_graph:
+        backend_configs["neo4j"] = {
+            "url": stack.neo4j.url,
+            "database": stack.neo4j.database,
+            "auth": {
+                "username": stack.neo4j.username,
+                "password": stack.neo4j.password,
+            },
+        }
+        backends.append("neo4j")
+    return {
+        "mode": "solo",
+        "backends": backends,
+        "backend_configs": backend_configs,
+    }
+
+
+def verify_neo4j_reachable(stack: StackConfig) -> None:
+    """Connect to Neo4j up-front so a benchmark that *expects* the
+    graph role doesn't fall through silently."""
+    try:
+        from neo4j import GraphDatabase
+    except ImportError as e:
+        raise SystemExit(
+            f"[attestor.config] neo4j driver not installed: {e}"
+        )
+    try:
+        with GraphDatabase.driver(
+            stack.neo4j.url, auth=(stack.neo4j.username, stack.neo4j.password)
+        ) as drv:
+            drv.verify_connectivity()
+    except Exception as e:
+        raise SystemExit(
+            f"[attestor.config] Neo4j unreachable at {stack.neo4j.url}: {e}\n"
+            "        The default stack requires Neo4j (graph role)."
+        )
+
+
+def print_stack_banner(stack: StackConfig, *, run_label: str) -> None:
+    """Print the resolved stack so users sanity-check before any
+    expensive call."""
+    print("=" * 72)
+    print(f"[{run_label}] resolved Attestor stack (configs/attestor.yaml):")
+    print(f"  document/vector  postgres @ {stack.postgres.url}")
+    print(f"  graph            neo4j    @ {stack.neo4j.url} ({stack.neo4j.database})")
+    print(f"  embedder         {stack.embedder.provider}:{stack.embedder.model}"
+          f" @ {stack.embedder.dimensions}-D")
+    print(f"  models")
+    print(f"    answerer            {stack.models.answerer}")
+    print(f"    judge               {stack.models.judge}")
+    print(f"    extraction          {stack.models.extraction}")
+    print(f"    distill             {stack.models.distill}")
+    print(f"    verifier            {stack.models.verifier}")
+    print(f"    planner             {stack.models.planner}")
+    print(f"    benchmark_default   {stack.models.benchmark_default}")
+    print(f"  budget           {stack.budget} tokens · parallel = {stack.parallel}")
+    print("=" * 72)
+
+
+def confirm_or_exit(stack: StackConfig, *, run_label: str, yes: bool) -> None:
+    """Print banner + interactive confirm (or ``--yes`` for non-interactive)."""
+    print_stack_banner(stack, run_label=run_label)
+    if yes:
+        print(f"[{run_label}] --yes supplied; proceeding without prompt")
+        return
+    if not sys.stdin.isatty():
+        raise SystemExit(
+            f"[{run_label}] non-interactive shell and --yes not supplied; aborting."
+        )
+    answer = input(f"[{run_label}] Proceed with this stack? [y/N] ").strip().lower()
+    if answer not in ("y", "yes"):
+        raise SystemExit(f"[{run_label}] aborted by user")
+
+
+@dataclass(frozen=True)
+class CloudTarget:
+    name: str
+    region: str
+    compute: str
+    postgres: str
+    neo4j: str
+    image_ref: str
+
+
+def cloud_target(
+    stack: StackConfig, name: str, *, version: Optional[str] = None
+) -> CloudTarget:
+    """Resolve the deploy plan for ``gcp`` / ``azure`` / ``aws`` with the
+    native-registry image ref already substituted."""
+    if name not in stack.clouds:
+        available = ", ".join(sorted(stack.clouds))
+        raise SystemExit(
+            f"[attestor.config] unknown cloud {name!r} (available: {available})"
+        )
+    cloud = stack.clouds[name]
+    image_ref = stack.image.native_ref(cloud["image_ref_key"], version=version)
+    return CloudTarget(
+        name=name,
+        region=cloud["region"],
+        compute=cloud["compute"],
+        postgres=cloud["postgres"],
+        neo4j=cloud["neo4j"],
+        image_ref=image_ref,
+    )

--- a/attestor/consolidation/consolidator.py
+++ b/attestor/consolidation/consolidator.py
@@ -36,9 +36,18 @@ from attestor.models import Memory
 
 logger = logging.getLogger("attestor.consolidation.consolidator")
 
-# Production runs use a stronger reasoning model here than synchronous
-# extraction. claude-opus-4-7 is the recommended default per roadmap.
-DEFAULT_CONSOLIDATION_MODEL = "openai/gpt-4o"
+def _default_consolidation_model() -> str:
+    """Resolve the consolidation model from ``configs/attestor.yaml``.
+
+    Consolidation is a heavier reasoning task than synchronous extraction
+    so we use the verifier slot (Claude Sonnet by default in the
+    canonical stack).
+    """
+    from attestor.config import get_stack
+    return get_stack().models.verifier
+
+
+DEFAULT_CONSOLIDATION_MODEL = _default_consolidation_model()
 
 
 @dataclass(frozen=True)

--- a/attestor/core.py
+++ b/attestor/core.py
@@ -1121,13 +1121,19 @@ class AgentMemory:
     def extract(
         self,
         messages: List[Dict[str, Any]],
-        model: str = "claude-haiku",
+        model: Optional[str] = None,
         use_llm: bool = False,
         namespace: str = "default",
     ) -> List[Memory]:
-        """Extract and store memories from conversation messages."""
+        """Extract and store memories from conversation messages.
+
+        ``model`` defaults to ``stack.models.extraction`` from
+        ``configs/attestor.yaml``.
+        """
         from attestor.extraction.extractor import extract_memories
 
+        # extract_memories already resolves None → stack default; pass
+        # through unchanged.
         extracted = extract_memories(messages, use_llm=use_llm, model=model)
         stored = []
         for mem in extracted:

--- a/attestor/extraction/extractor.py
+++ b/attestor/extraction/extractor.py
@@ -11,7 +11,7 @@ from attestor.models import Memory
 def extract_memories(
     messages: List[Dict[str, Any]],
     use_llm: bool = False,
-    model: str = "openai/gpt-4.1-mini",
+    model: Optional[str] = None,
 ) -> List[Memory]:
     """Extract memories from conversation messages.
 
@@ -24,6 +24,9 @@ def extract_memories(
         List of Memory objects extracted from the conversation.
     """
     if use_llm:
+        if model is None:
+            from attestor.config import get_stack
+            model = get_stack().models.extraction
         return _llm_extract(messages, model)
     return _rule_extract(messages)
 
@@ -63,7 +66,7 @@ def extract_from_session(
     speaker_a: str = "A",
     speaker_b: str = "B",
     session_date: str = "",
-    model: str = "openai/gpt-4.1-mini",
+    model: Optional[str] = None,
     api_key: Optional[str] = None,
 ) -> Tuple[List[Memory], List[Dict[str, Any]]]:
     """Extract memories and relation triples from a conversation session.
@@ -74,6 +77,9 @@ def extract_from_session(
     Returns (memories, triples) where triples are dicts with
     subject, predicate, object, event_date keys.
     """
+    if model is None:
+        from attestor.config import get_stack
+        model = get_stack().models.extraction
     try:
         from attestor.extraction.llm_extractor import llm_extract_session
 
@@ -95,7 +101,7 @@ def extract_from_session_full(
     speaker_a: str = "A",
     speaker_b: str = "B",
     session_date: str = "",
-    model: str = "openai/gpt-4.1-mini",
+    model: Optional[str] = None,
     api_key: Optional[str] = None,
 ) -> Tuple[
     List[Memory],
@@ -108,6 +114,9 @@ def extract_from_session_full(
     Returns (fact_memories, triples, entity_profiles, concept_profiles).
     Falls back to (rule_facts, [], [], []) if openai is unavailable.
     """
+    if model is None:
+        from attestor.config import get_stack
+        model = get_stack().models.extraction
     try:
         from attestor.extraction.llm_extractor import llm_extract_session_full
 

--- a/attestor/extraction/llm_extractor.py
+++ b/attestor/extraction/llm_extractor.py
@@ -9,7 +9,19 @@ from typing import Any, Dict, List, Optional, Tuple
 from attestor.models import Memory
 
 OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
-DEFAULT_EXTRACTION_MODEL = "openai/gpt-4.1-mini"
+
+
+def _default_extraction_model() -> str:
+    """Resolve the extraction model from ``configs/attestor.yaml``."""
+    from attestor.config import get_stack
+    return get_stack().models.extraction
+
+
+# Backwards-compatible attribute access — code that still references
+# this constant gets a string at import time. New code should call
+# ``_default_extraction_model()`` so config changes take effect without
+# a process restart.
+DEFAULT_EXTRACTION_MODEL = _default_extraction_model()
 
 
 def _get_client(api_key: Optional[str] = None):

--- a/attestor/extraction/round_extractor.py
+++ b/attestor/extraction/round_extractor.py
@@ -36,7 +36,13 @@ from attestor.extraction.prompts import (
 
 logger = logging.getLogger("attestor.extraction.round")
 
-DEFAULT_MODEL = "openai/gpt-4.1-mini"
+def _default_model() -> str:
+    """Resolve the extraction model from ``configs/attestor.yaml``."""
+    from attestor.config import get_stack
+    return get_stack().models.extraction
+
+
+DEFAULT_MODEL = _default_model()
 DEFAULT_MAX_TOKENS = 2048
 
 USER_FACT_CATEGORIES = {

--- a/attestor/locomo.py
+++ b/attestor/locomo.py
@@ -26,7 +26,14 @@ from attestor.core import AgentMemory
 from attestor.mab import token_f1, _upgrade_embeddings_for_benchmark
 from attestor.retrieval.planner import QueryPlan, plan_query
 
-DEFAULT_MODEL = "openai/gpt-4.1-mini"
+def _default_model() -> str:
+    """Resolve the LoCoMo benchmark default model from
+    ``configs/attestor.yaml``."""
+    from attestor.config import get_stack
+    return get_stack().models.benchmark_default
+
+
+DEFAULT_MODEL = _default_model()
 OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 
 
@@ -270,7 +277,7 @@ def ingest_conversation(
     mem: AgentMemory,
     conversation: Dict[str, Any],
     use_extraction: bool = False,
-    extraction_model: str = "openai/gpt-4.1-mini",
+    extraction_model: Optional[str] = None,
     api_key: Optional[str] = None,
     verbose: bool = False,
     graph=None,
@@ -293,6 +300,10 @@ def ingest_conversation(
     total_triples = 0
     speaker_a = conversation["speaker_a"]
     speaker_b = conversation["speaker_b"]
+
+    if extraction_model is None:
+        from attestor.config import get_stack
+        extraction_model = get_stack().models.extraction
 
     if use_extraction:
         from attestor.extraction.extractor import extract_from_session
@@ -587,9 +598,9 @@ def judge_answer(
 
 def run_locomo(
     data_path: Optional[str] = None,
-    judge_model: str = "openai/gpt-4.1-mini",
-    answer_model: str = "openai/gpt-4.1-mini",
-    extraction_model: str = "openai/gpt-4.1-mini",
+    judge_model: Optional[str] = None,
+    answer_model: Optional[str] = None,
+    extraction_model: Optional[str] = None,
     use_extraction: bool = False,
     resolve_pronouns: bool = True,
     max_conversations: Optional[int] = None,
@@ -622,6 +633,17 @@ def run_locomo(
         cache_dir.mkdir(parents=True, exist_ok=True)
         data_path = str(cache_dir / "locomo10.json")
         download_locomo(data_path)
+
+    # Resolve any unset model arg from the YAML SoT.
+    if judge_model is None or answer_model is None or extraction_model is None:
+        from attestor.config import get_stack
+        s = get_stack()
+        if judge_model is None:
+            judge_model = s.models.judge
+        if answer_model is None:
+            answer_model = s.models.answerer
+        if extraction_model is None:
+            extraction_model = s.models.extraction
 
     conversations = load_locomo(data_path)
     if max_conversations:

--- a/attestor/longmemeval.py
+++ b/attestor/longmemeval.py
@@ -48,9 +48,25 @@ from typing import Any, Callable, List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_MODEL = "openai/gpt-4.1-mini"
+def _default_model() -> str:
+    """Resolve the LME benchmark default model from
+    ``configs/attestor.yaml``."""
+    from attestor.config import get_stack
+    return get_stack().models.benchmark_default
+
+
+def _default_judges() -> tuple[str, ...]:
+    """Resolve the dual-judge panel: the primary judge from the YAML
+    plus the verifier (cross-family) — matches the canonical recommended
+    ``Judge=gpt-4.1, Verifier=claude-sonnet-4-6`` pairing."""
+    from attestor.config import get_stack
+    s = get_stack()
+    return (s.models.judge, s.models.verifier)
+
+
+DEFAULT_MODEL = _default_model()
 # Default dual-judge. Second judge anchors out answerer-judge collusion.
-DEFAULT_JUDGES = ("openai/gpt-4.1-mini", "anthropic/claude-haiku-4.5")
+DEFAULT_JUDGES = _default_judges()
 OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 DEFAULT_PARALLEL = 4
 
@@ -662,7 +678,7 @@ def distill_turn(
     role: str,
     content: str,
     session_date: str,
-    model: str = "openai/gpt-5.1",
+    model: Optional[str] = None,
     api_key: Optional[str] = None,
     max_tokens: int = 3000,
 ) -> List[DistilledFact]:
@@ -679,6 +695,9 @@ def distill_turn(
     text = (content or "").strip()
     if not text:
         return []
+    if model is None:
+        from attestor.config import get_stack
+        model = get_stack().models.distill
     fallback_speaker = _normalize_speaker(role)
     # NOTE: str.replace (not str.format) — the prompt contains JSON worked
     # examples whose literal '{...}' would otherwise be misread as format
@@ -710,9 +729,9 @@ def ingest_history(
     sample: LMESample,
     *,
     use_extraction: bool = False,
-    extraction_model: str = "openai/gpt-4.1-mini",
+    extraction_model: Optional[str] = None,
     use_distillation: bool = False,
-    distill_model: str = "openai/gpt-5.1",
+    distill_model: Optional[str] = None,
     api_key: Optional[str] = None,
     verbose: bool = False,
 ) -> IngestStats:
@@ -738,6 +757,14 @@ def ingest_history(
     Returns:
         ``IngestStats`` with turn / memory / session counts.
     """
+    if extraction_model is None or distill_model is None:
+        from attestor.config import get_stack
+        s = get_stack()
+        if extraction_model is None:
+            extraction_model = s.models.extraction
+        if distill_model is None:
+            distill_model = s.models.distill
+
     ns = namespace_for(sample)
     turns_seen = 0
     memories_added = 0
@@ -1761,7 +1788,7 @@ async def _process_sample(
     use_extraction: bool,
     max_facts: int,
     use_distillation: bool = False,
-    distill_model: str = "openai/gpt-5.1",
+    distill_model: Optional[str] = None,
     verify: bool = False,
     verify_model: Optional[str] = None,
 ) -> SampleReport:
@@ -1898,7 +1925,7 @@ async def run_async(
     budget: int = 4000,
     use_extraction: bool = False,
     use_distillation: bool = False,
-    distill_model: str = "openai/gpt-5.1",
+    distill_model: Optional[str] = None,
     max_facts: int = 40,
     parallel: int = DEFAULT_PARALLEL,
     verify: bool = False,
@@ -1935,6 +1962,13 @@ async def run_async(
     from dataclasses import asdict
 
     judge_models = list(judge_models or list(DEFAULT_JUDGES))
+    if distill_model is None or verify_model is None:
+        from attestor.config import get_stack
+        s = get_stack()
+        if distill_model is None:
+            distill_model = s.models.distill
+        if verify_model is None and verify:
+            verify_model = s.models.verifier
     started = datetime.now(timezone.utc).isoformat(timespec="seconds")
 
     semaphore = asyncio.Semaphore(max(1, parallel))
@@ -2103,7 +2137,7 @@ def run(
     budget: int = 4000,
     use_extraction: bool = False,
     use_distillation: bool = False,
-    distill_model: str = "openai/gpt-5.1",
+    distill_model: Optional[str] = None,
     max_facts: int = 40,
     parallel: int = DEFAULT_PARALLEL,
     verify: bool = False,

--- a/attestor/mab.py
+++ b/attestor/mab.py
@@ -588,11 +588,19 @@ def answer_question(
     mem: AgentMemory,
     question: str,
     budget: int = 6000,
-    model: str = "claude-haiku-4-5-20251001",
+    model: Optional[str] = None,
     api_key: Optional[str] = None,
     source: str = "",
 ) -> str:
-    """Recall from memory + LLM synthesis to answer a MAB question."""
+    """Recall from memory + LLM synthesis to answer a MAB question.
+
+    ``model`` defaults to ``stack.models.verifier`` from
+    ``configs/attestor.yaml`` (the cross-family Anthropic pick that
+    complements the gpt-4.1 judge in the canonical lineup).
+    """
+    if model is None:
+        from attestor.config import get_stack
+        model = get_stack().models.verifier
     use_exact = _is_exact_source(source)
     effective_budget = _get_budget_for_source(source, budget)
 
@@ -745,7 +753,7 @@ def run_mab(
     max_questions: Optional[int] = None,
     chunk_size: int = DEFAULT_CHUNK_SIZE,
     context_max_tokens: Optional[int] = None,
-    answer_model: str = "openai/gpt-4.1-mini",
+    answer_model: Optional[str] = None,
     recall_budget: int = 6000,
     verbose: bool = False,
     api_key: Optional[str] = None,
@@ -773,6 +781,9 @@ def run_mab(
     """
     if categories is None:
         categories = ["AR", "CR"]
+    if answer_model is None:
+        from attestor.config import get_stack
+        answer_model = get_stack().models.benchmark_default
 
     # Load data
     data = load_mab(

--- a/attestor/retrieval/planner.py
+++ b/attestor/retrieval/planner.py
@@ -25,9 +25,17 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
 OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
-DEFAULT_PLANNER_MODEL = os.environ.get(
-    "PLANNER_MODEL", "anthropic/claude-opus-4.7"
-)
+
+
+def _default_planner_model() -> str:
+    """Resolve the planner model: env override > YAML > hardcoded fallback."""
+    if env := os.environ.get("PLANNER_MODEL"):
+        return env
+    from attestor.config import get_stack
+    return get_stack().models.planner
+
+
+DEFAULT_PLANNER_MODEL = _default_planner_model()
 
 VALID_INTENTS = frozenset({
     "FACTUAL_RECALL",

--- a/attestor/retrieval/temporal_query.py
+++ b/attestor/retrieval/temporal_query.py
@@ -137,10 +137,13 @@ class TemporalQueryExpander:
         self,
         client: Optional[Any] = None,
         *,
-        model: str = "openai/gpt-4o-mini",
+        model: Optional[str] = None,
         max_tokens: int = 256,
     ) -> None:
         self._client = client
+        if model is None:
+            from attestor.config import get_stack
+            model = get_stack().models.extraction
         self._model = model
         self._max_tokens = max_tokens
 

--- a/configs/attestor.yaml
+++ b/configs/attestor.yaml
@@ -74,6 +74,17 @@ stack:
     # without burning the cost of running Sonnet for everything.
     verifier: anthropic/claude-sonnet-4-6
 
+    # Planner — query rewriting + multi-step query decomposition.
+    # Used by attestor.retrieval.planner. Claude Opus is the default
+    # because the planner's job is small but reasoning-heavy.
+    planner: anthropic/claude-opus-4.7
+
+    # Benchmark default — generic fallback for ad-hoc benchmark commands
+    # where no specific role applies (e.g. `attestor locomo` when the
+    # user doesn't pass --answer-model). Cheap by design — bench
+    # iteration happens often.
+    benchmark_default: openai/gpt-4.1-mini
+
   # ─── Retrieval budget ────────────────────────────────────────────────
   # Token budget per recall (the orchestrator MMR-packs candidates
   # under this ceiling). 4000 is the canonical benchmark default.

--- a/scripts/_attestor_config.py
+++ b/scripts/_attestor_config.py
@@ -1,362 +1,54 @@
-"""Single-source-of-truth config loader for Attestor.
+"""Back-compat shim — the canonical loader lives in ``attestor.config``.
 
-Every benchmark, smoke runner, and deploy script in `scripts/` reads
-the default stack from `configs/attestor.yaml` via this module. No
-script is allowed to hardcode model names, registry addresses, embedder
-choices, or DB URLs.
+This file used to be the loader. It was promoted into the package
+itself so production code (CLI, api server, benchmark modules) can
+import it. We keep this shim so existing scripts that still import
+from ``scripts._attestor_config`` keep working.
 
-Public surface:
+New code should import from ``attestor.config`` directly:
 
-    load_stack(path=None) -> StackConfig
-        Parse + resolve the YAML into an immutable dataclass.
-
-    configure_embedder(stack)
-        Pin the embedder selection through env vars so the auto-detect
-        chain in attestor.store.embeddings.get_embedding_provider() picks
-        what the YAML asked for.
-
-    build_backend_config(stack, *, no_graph=False)
-        AgentMemory backend_configs payload for the canonical PG+Neo4j
-        stack (or PG-only when no_graph).
-
-    verify_neo4j_reachable(stack)
-        Connect to Neo4j up-front so a benchmark that *expects* the
-        graph role doesn't fall through silently.
-
-    print_stack_banner(stack, run_label)
-    confirm_or_exit(stack, run_label, yes)
-        Loud banner of resolved values + interactive confirm (or --yes).
-        Always called BEFORE any expensive call — per
-        `feedback_canonical_stack.md`.
-
-    cloud_target(stack, name) -> CloudTarget
-        Return the resolved deploy plan for "gcp" / "azure" / "aws"
-        with the native-registry image ref already substituted.
+    from attestor.config import (
+        get_stack,
+        load_stack,
+        StackConfig,
+        configure_embedder,
+        build_backend_config,
+        verify_neo4j_reachable,
+        confirm_or_exit,
+        print_stack_banner,
+        cloud_target,
+        DEFAULT_CONFIG,
+    )
 """
 
 from __future__ import annotations
 
-import os
 import sys
-from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List, Optional
 
-import yaml
+# Make sure the repo root (and therefore the `attestor` package) is on
+# sys.path when this module is imported as `scripts._attestor_config`.
+_ROOT = Path(__file__).resolve().parent.parent
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
 
-REPO_ROOT = Path(__file__).resolve().parent.parent
-DEFAULT_CONFIG = REPO_ROOT / "configs" / "attestor.yaml"
-
-
-# ─── Dataclasses (frozen for immutability per project coding standards) ───
-
-@dataclass(frozen=True)
-class PostgresCfg:
-    url: str
-    v4: bool
-    skip_schema_init: bool
-
-
-@dataclass(frozen=True)
-class Neo4jCfg:
-    url: str
-    username: str
-    password: str
-    database: str
-
-
-@dataclass(frozen=True)
-class EmbedderCfg:
-    provider: str
-    model: str
-    dimensions: int
-
-
-@dataclass(frozen=True)
-class ModelsCfg:
-    answerer: str
-    judge: str
-    extraction: str
-    distill: str
-    verifier: str
-
-
-@dataclass(frozen=True)
-class ImageCfg:
-    ref: str
-    api_ref_template: str
-    registries: Dict[str, str] = field(default_factory=dict)
-
-    def native_ref(self, key: str, *, version: Optional[str] = None) -> str:
-        """Return the registry-specific image reference. When `version` is
-        passed we use the api_ref_template (so cloud deploys pull
-        `attestor:api-<version>` instead of the introspection-only stub).
-        """
-        base = self.registries[key]
-        tag = f"api-{version}" if version else "latest"
-        return f"{base}:{tag}"
-
-
-@dataclass(frozen=True)
-class CloudTarget:
-    name: str
-    region: str
-    compute: str
-    postgres: str
-    neo4j: str
-    image_ref: str
-
-
-@dataclass(frozen=True)
-class StackConfig:
-    postgres: PostgresCfg
-    neo4j: Neo4jCfg
-    embedder: EmbedderCfg
-    models: ModelsCfg
-    image: ImageCfg
-    budget: int
-    parallel: int
-    clouds: Dict[str, Dict[str, Any]]
-
-
-# ─── YAML resolution helpers ───
-
-def _resolve_env_password(node: Dict[str, Any]) -> str:
-    """Pull a password from `password` (literal) or `password_env` (env)."""
-    if isinstance(node, dict):
-        if node.get("password"):
-            return str(node["password"])
-        env_name = node.get("password_env")
-        if env_name:
-            value = os.environ.get(env_name)
-            if not value:
-                raise SystemExit(
-                    f"[config] required env var {env_name!r} not set "
-                    "(referenced by stack.neo4j.auth.password_env)"
-                )
-            return value
-    raise SystemExit(f"[config] could not resolve password from {node!r}")
-
-
-def _resolve_env_api_key(env_var: Optional[str]) -> Optional[str]:
-    """Resolve embedder api_key_env. Returns None when env_var is None
-    so callers can decide what to do."""
-    if not env_var:
-        return None
-    value = os.environ.get(env_var)
-    if not value:
-        raise SystemExit(
-            f"[config] required env var {env_var!r} not set "
-            "(referenced by stack.embedder.api_key_env)"
-        )
-    return value
-
-
-def load_stack(path: Path | str | None = None) -> StackConfig:
-    """Read `configs/attestor.yaml` (or override path) and resolve env
-    references. Fails loudly when required values are missing."""
-    cfg_path = Path(path) if path else DEFAULT_CONFIG
-    if not cfg_path.exists():
-        raise SystemExit(f"[config] not found: {cfg_path}")
-    raw = yaml.safe_load(cfg_path.read_text())
-
-    stack_blk = raw.get("stack") or {}
-    image_blk = raw.get("image") or {}
-    clouds_blk = raw.get("clouds") or {}
-
-    pg = stack_blk.get("postgres") or {}
-    neo = stack_blk.get("neo4j") or {}
-    emb = stack_blk.get("embedder") or {}
-    models = stack_blk.get("models") or {}
-
-    # Validate required embedder API key — fail now rather than mid-run.
-    _resolve_env_api_key(emb.get("api_key_env"))
-
-    return StackConfig(
-        postgres=PostgresCfg(
-            url=pg["url"],
-            v4=bool(pg.get("v4", True)),
-            skip_schema_init=bool(pg.get("skip_schema_init", True)),
-        ),
-        neo4j=Neo4jCfg(
-            url=neo["url"],
-            username=(neo.get("auth") or {}).get("username", "neo4j"),
-            password=_resolve_env_password(neo.get("auth") or {}),
-            database=neo.get("database", "neo4j"),
-        ),
-        embedder=EmbedderCfg(
-            provider=emb.get("provider", "voyage"),
-            model=emb.get("model", "voyage-4"),
-            dimensions=int(emb.get("dimensions", 1024)),
-        ),
-        models=ModelsCfg(
-            answerer=models["answerer"],
-            judge=models["judge"],
-            extraction=models["extraction"],
-            distill=models["distill"],
-            verifier=models["verifier"],
-        ),
-        image=ImageCfg(
-            ref=image_blk.get("ref", ""),
-            api_ref_template=image_blk.get("api_ref_template", ""),
-            registries=dict(image_blk.get("registries") or {}),
-        ),
-        budget=int(stack_blk.get("budget", 4000)),
-        parallel=int(stack_blk.get("parallel", 2)),
-        clouds=dict(clouds_blk),
-    )
-
-
-# ─── Embedder env wiring ───
-
-def configure_embedder(stack: StackConfig) -> None:
-    """Pin embedder selection via env vars so
-    attestor.store.embeddings.get_embedding_provider() returns the
-    provider the YAML asked for. Ollama auto-probe is always disabled."""
-    os.environ["ATTESTOR_DISABLE_LOCAL_EMBED"] = "1"
-    if stack.embedder.provider == "voyage":
-        if not os.environ.get("VOYAGE_API_KEY"):
-            raise SystemExit("[config] embedder=voyage but VOYAGE_API_KEY not set")
-        os.environ["VOYAGE_EMBEDDING_MODEL"] = stack.embedder.model
-        os.environ["VOYAGE_EMBEDDING_DIMENSIONS"] = str(stack.embedder.dimensions)
-        os.environ["OPENAI_EMBEDDING_DIMENSIONS"] = str(stack.embedder.dimensions)
-    elif stack.embedder.provider == "openai":
-        # Voyage key, if set, would auto-win the chain. Pop it process-locally.
-        os.environ.pop("VOYAGE_API_KEY", None)
-        os.environ["OPENAI_EMBEDDING_MODEL"] = stack.embedder.model
-        os.environ["OPENAI_EMBEDDING_DIMENSIONS"] = str(stack.embedder.dimensions)
-    else:
-        raise SystemExit(
-            f"[config] unknown embedder provider: {stack.embedder.provider!r}"
-        )
-
-
-# ─── AgentMemory factory payload ───
-
-def build_backend_config(
-    stack: StackConfig, *, no_graph: bool = False
-) -> Dict[str, Any]:
-    """AgentMemory `backend_configs` payload for the canonical PG+Neo4j
-    stack. When no_graph is set, drops Neo4j (graph role) — used for
-    isolation runs that prove whether the graph layer contributes."""
-    from urllib.parse import urlparse
-
-    parsed = urlparse(stack.postgres.url)
-    db = (parsed.path or "/").lstrip("/") or "attestor_v4_test"
-
-    backend_configs: Dict[str, Dict[str, Any]] = {
-        "postgres": {
-            "url": f"{parsed.scheme}://{parsed.hostname}:{parsed.port or 5432}",
-            "database": db,
-            "auth": {
-                "username": parsed.username or "postgres",
-                "password": parsed.password or "attestor",
-            },
-            "v4": stack.postgres.v4,
-            "skip_schema_init": stack.postgres.skip_schema_init,
-        },
-    }
-    backends = ["postgres"]
-    if not no_graph:
-        backend_configs["neo4j"] = {
-            "url": stack.neo4j.url,
-            "database": stack.neo4j.database,
-            "auth": {
-                "username": stack.neo4j.username,
-                "password": stack.neo4j.password,
-            },
-        }
-        backends.append("neo4j")
-
-    return {
-        "mode": "solo",
-        "backends": backends,
-        "backend_configs": backend_configs,
-    }
-
-
-# ─── Health checks ───
-
-def verify_neo4j_reachable(stack: StackConfig) -> None:
-    """Connect to Neo4j up front. Fail loudly with the actual error
-    rather than letting the orchestrator silently fall through to
-    affinity_map={} when graph queries explode mid-run."""
-    try:
-        from neo4j import GraphDatabase
-    except ImportError as e:
-        raise SystemExit(
-            f"[config] neo4j driver not installed: {e}. "
-            "Run `pip install neo4j` or `pip install attestor[neo4j]`."
-        )
-    try:
-        with GraphDatabase.driver(
-            stack.neo4j.url, auth=(stack.neo4j.username, stack.neo4j.password)
-        ) as drv:
-            drv.verify_connectivity()
-    except Exception as e:
-        raise SystemExit(
-            f"[config] Neo4j unreachable at {stack.neo4j.url}: {e}\n"
-            "        The default stack requires Neo4j (graph role).\n"
-            "        Bring it up: docker compose -f attestor/infra/local/docker-compose.yml up -d neo4j"
-        )
-
-
-# ─── Cloud target resolver ───
-
-def cloud_target(stack: StackConfig, name: str, *, version: Optional[str] = None) -> CloudTarget:
-    """Return the resolved deploy plan for one cloud, with the native-
-    registry image ref already substituted. `version` switches from the
-    introspection-only `:latest` tag to the api-mode `:api-<version>`."""
-    if name not in stack.clouds:
-        available = ", ".join(sorted(stack.clouds))
-        raise SystemExit(f"[config] unknown cloud {name!r} (available: {available})")
-    cloud = stack.clouds[name]
-    image_ref = stack.image.native_ref(cloud["image_ref_key"], version=version)
-    return CloudTarget(
-        name=name,
-        region=cloud["region"],
-        compute=cloud["compute"],
-        postgres=cloud["postgres"],
-        neo4j=cloud["neo4j"],
-        image_ref=image_ref,
-    )
-
-
-# ─── Banner + confirm ───
-
-def print_stack_banner(stack: StackConfig, *, run_label: str) -> None:
-    """Loud print of the resolved stack so the user can sanity-check
-    before any expensive call goes out."""
-    print("=" * 72)
-    print(f"[{run_label}] resolved Attestor stack (configs/attestor.yaml):")
-    print(f"  document/vector  postgres @ {stack.postgres.url}")
-    print(f"  graph            neo4j    @ {stack.neo4j.url} ({stack.neo4j.database})")
-    print(f"  embedder         {stack.embedder.provider}:{stack.embedder.model}"
-          f" @ {stack.embedder.dimensions}-D")
-    print(f"  models")
-    print(f"    answerer       {stack.models.answerer}")
-    print(f"    judge          {stack.models.judge}")
-    print(f"    extraction     {stack.models.extraction}")
-    print(f"    distill        {stack.models.distill}")
-    print(f"    verifier       {stack.models.verifier}")
-    print(f"  budget           {stack.budget} tokens · parallel = {stack.parallel}")
-    print("=" * 72)
-
-
-def confirm_or_exit(stack: StackConfig, *, run_label: str, yes: bool) -> None:
-    """Per `feedback_canonical_stack.md`, every benchmark or deploy run
-    either prompts the user to confirm the resolved stack or is invoked
-    with `--yes` for non-interactive use. ALWAYS called BEFORE any
-    expensive call (LLM, cloud provision, image push)."""
-    print_stack_banner(stack, run_label=run_label)
-    if yes:
-        print(f"[{run_label}] --yes supplied; proceeding without prompt")
-        return
-    if not sys.stdin.isatty():
-        raise SystemExit(
-            f"[{run_label}] non-interactive shell and --yes not supplied; "
-            "aborting to avoid running with the wrong stack."
-        )
-    answer = input(f"[{run_label}] Proceed with this stack? [y/N] ").strip().lower()
-    if answer not in ("y", "yes"):
-        raise SystemExit(f"[{run_label}] aborted by user")
+from attestor.config import (  # noqa: E402,F401
+    DEFAULT_CONFIG,
+    CloudTarget,
+    EmbedderCfg,
+    ImageCfg,
+    ModelsCfg,
+    Neo4jCfg,
+    PostgresCfg,
+    StackConfig,
+    build_backend_config,
+    cloud_target,
+    configure_embedder,
+    confirm_or_exit,
+    get_stack,
+    load_stack,
+    print_stack_banner,
+    reset_stack,
+    set_stack,
+    verify_neo4j_reachable,
+)

--- a/scripts/lme_smoke_local.py
+++ b/scripts/lme_smoke_local.py
@@ -1,45 +1,21 @@
-"""Local LongMemEval smoke — minimal, fully configurable, dual-LLM.
+"""Local LongMemEval smoke — config-driven.
 
-Default stack (override via env vars or CLI flags below):
-  - Embedder: OpenAI ``text-embedding-3-large`` (truncated to 1024-D)
-  - Answer:   ``openai/gpt-5.2``
-  - Judges:   ``openai/gpt-5.2`` + ``anthropic/claude-sonnet-4.6``  (dual)
-  - Distill:  ``openai/gpt-5.2``  (Mem0-style fact extraction enabled)
+Stack discipline:
+    DB / embedder / model choices come from ``configs/attestor.yaml`` via
+    ``attestor.config.get_stack()``. The default canonical stack is
+    PG+pgvector+Neo4j+Voyage with the four-role gpt-4.1 + claude-sonnet-4-6
+    model lineup. Override the whole stack with ``--config <path>`` or
+    individual values with the CLI flags below.
 
-Why this stack:
-  - Dual-LLM cross-family judging (one OpenAI, one Anthropic) avoids
-    same-family collusion bias on the score.
-  - text-embedding-3-large @ 1024 dims keeps schema-compat with the
-    existing v4 attestor schema (``embedding_dim=1024``) — no migration.
-  - All four model slots are env-configurable so swapping in cheaper /
-    faster models for iteration is one-line.
+Why this exists:
+    LongMemEval ``oracle`` variant is the cheapest LME run we can do for
+    a sanity-check after retrieval-pipeline edits. The smoke applies a
+    fresh schema, ingests N samples, runs answer + dual-LLM judge, and
+    prints by-judge / by-category breakdowns.
 
-Configuration (every default is overridable):
-
-  Env vars                          CLI flag                 Default
-  -------------------------------- ------------------------ -------------------
-  ANSWER_MODEL                      --answer-model            openai/gpt-5.2
-  JUDGE_MODELS  (CSV)               --judge-model (repeat)    openai/gpt-5.2,anthropic/claude-sonnet-4.6
-  DISTILL_MODEL                     --distill-model           openai/gpt-5.2
-  USE_DISTILLATION  (1/0)           --no-distill              1 (on)
-  OPENAI_EMBEDDING_MODEL            --embedding-model         text-embedding-3-large
-  OPENAI_EMBEDDING_DIMENSIONS       --embedding-dim           1024
-  PG_URL                            --pg-url                  postgresql://postgres:attestor@localhost:5432/attestor_v4_test
-  LME_VARIANT                       --variant                 oracle
-  LME_N                             --n                       2
-  LME_PARALLEL                      --parallel                2
-  LME_BUDGET                        --budget                  4000
-
-Required:
-  OPENAI_API_KEY      — used for both the LLM calls and embeddings
-                        (set OPENROUTER_API_KEY instead if you prefer
-                        the OpenRouter routing layer).
-
-Usage (from repo root):
-    OPENAI_API_KEY=... .venv/bin/python scripts/lme_smoke_local.py --n 2
-
-Quick iteration with a cheaper model:
-    ANSWER_MODEL=openai/gpt-4.1-mini .venv/bin/python scripts/lme_smoke_local.py --n 2
+Usage:
+    set -a && source .env && set +a
+    .venv/bin/python scripts/lme_smoke_local.py --n 2 --yes
 """
 
 from __future__ import annotations
@@ -51,109 +27,81 @@ import logging
 import os
 import sys
 import tempfile
+from dataclasses import replace as dc_replace
 from pathlib import Path
 
-# Force line-buffered stdout/stderr for live progress in pipes / tee / CI.
 try:
     sys.stdout.reconfigure(line_buffering=True)
     sys.stderr.reconfigure(line_buffering=True)
-except AttributeError:  # pragma: no cover — pre-3.7 fallback
+except AttributeError:  # pragma: no cover
     pass
 
 ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(ROOT))
 
+from attestor.config import (  # noqa: E402
+    DEFAULT_CONFIG,
+    StackConfig,
+    build_backend_config,
+    configure_embedder,
+    confirm_or_exit,
+    load_stack,
+)
+
 SCHEMA_PATH = ROOT / "attestor" / "store" / "schema.sql"
-
-
-# ─── Defaults (every one is overridable) ───
-DEFAULTS = {
-    "answer_model":    "openai/gpt-5.2",
-    "judge_models":    "openai/gpt-5.2,anthropic/claude-sonnet-4.6",
-    "distill_model":   "openai/gpt-5.2",
-    "use_distill":     True,
-    "embedding_model": "text-embedding-3-large",
-    "embedding_dim":   1024,
-    "pg_url":          "postgresql://postgres:attestor@localhost:5432/attestor_v4_test",
-    "variant":         "oracle",
-    "n":               2,
-    "parallel":        2,
-    "budget":          4000,
-}
-
-
-def _env_or(name: str, default):
-    """Read env var; coerce to the type of the default (bool / int / str)."""
-    raw = os.environ.get(name)
-    if raw is None:
-        return default
-    if isinstance(default, bool):
-        return raw.strip().lower() in ("1", "true", "yes", "y", "on")
-    if isinstance(default, int):
-        return int(raw)
-    return raw
+RUN_LABEL = "smoke"
 
 
 def _parse_args() -> argparse.Namespace:
-    p = argparse.ArgumentParser(prog="lme_smoke_local",
-                                description=__doc__,
-                                formatter_class=argparse.RawDescriptionHelpFormatter)
-    p.add_argument("--answer-model",
-                   default=_env_or("ANSWER_MODEL", DEFAULTS["answer_model"]))
-    p.add_argument("--judge-model", action="append", default=None,
-                   help="Repeat for multiple judges. If omitted, uses JUDGE_MODELS env (CSV) or the default pair.")
-    p.add_argument("--distill-model",
-                   default=_env_or("DISTILL_MODEL", DEFAULTS["distill_model"]))
-    p.add_argument("--no-distill", action="store_true",
-                   help="Disable distillation (default is on)")
-    p.add_argument("--embedding-model",
-                   default=_env_or("OPENAI_EMBEDDING_MODEL", DEFAULTS["embedding_model"]))
-    p.add_argument("--embedding-dim", type=int,
-                   default=_env_or("OPENAI_EMBEDDING_DIMENSIONS", DEFAULTS["embedding_dim"]))
-    p.add_argument("--pg-url",
-                   default=_env_or("PG_URL", DEFAULTS["pg_url"]))
-    p.add_argument("--variant",
-                   default=_env_or("LME_VARIANT", DEFAULTS["variant"]),
-                   help="LME variant (oracle|s|m); oracle is smallest / fastest")
-    p.add_argument("--n", type=int,
-                   default=_env_or("LME_N", DEFAULTS["n"]))
-    p.add_argument("--parallel", type=int,
-                   default=_env_or("LME_PARALLEL", DEFAULTS["parallel"]))
-    p.add_argument("--budget", type=int,
-                   default=_env_or("LME_BUDGET", DEFAULTS["budget"]))
-    p.add_argument("--skip-schema", action="store_true",
-                   help="Skip schema reapply (faster repeat runs)")
-    p.add_argument("--verbose", action="store_true")
-    args = p.parse_args()
-
-    # Resolve judge models with the documented precedence:
-    # CLI flag (repeated) > JUDGE_MODELS env (CSV) > default pair.
-    if args.judge_model:
-        judges = args.judge_model
-    else:
-        raw = os.environ.get("JUDGE_MODELS", DEFAULTS["judge_models"])
-        judges = [j.strip() for j in raw.split(",") if j.strip()]
-    args.judge_models = judges
-
-    args.use_distillation = not args.no_distill and _env_or(
-        "USE_DISTILLATION", DEFAULTS["use_distill"]
+    p = argparse.ArgumentParser(
+        prog="lme_smoke_local",
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-
-    return args
-
-
-# ─── Setup helpers ───
-
-def _force_openai_embedder(model: str, dim: int) -> None:
-    """Push attestor's embedding probe to OpenAI text-embedding-3-large.
-
-    attestor/store/embeddings.py probes Ollama first by default; we
-    disable that and pin model + dimensions so the smoke is deterministic
-    regardless of what's running on localhost:11434.
-    """
-    os.environ["ATTESTOR_DISABLE_LOCAL_EMBED"] = "1"
-    os.environ["OPENAI_EMBEDDING_MODEL"] = model
-    os.environ["OPENAI_EMBEDDING_DIMENSIONS"] = str(dim)
+    p.add_argument(
+        "--config",
+        default=str(DEFAULT_CONFIG),
+        help=f"Stack config YAML (default: {DEFAULT_CONFIG.relative_to(ROOT)})",
+    )
+    p.add_argument(
+        "--embedder",
+        choices=["voyage", "openai"],
+        default=None,
+        help="Override embedder.provider from the config file",
+    )
+    p.add_argument(
+        "--no-distill",
+        action="store_true",
+        help="Disable distillation (default is on)",
+    )
+    p.add_argument(
+        "--variant",
+        default="oracle",
+        help="LME variant (oracle|s|m); oracle is smallest / fastest",
+    )
+    p.add_argument(
+        "--n",
+        type=int,
+        default=2,
+        help="Number of samples to run (ignored when --sample-ids is given)",
+    )
+    p.add_argument(
+        "--sample-ids",
+        default="",
+        help="Comma-separated sample IDs to run; overrides --n.",
+    )
+    p.add_argument(
+        "--skip-schema",
+        action="store_true",
+        help="Skip schema reapply (faster repeat runs)",
+    )
+    p.add_argument(
+        "--yes",
+        action="store_true",
+        help="Don't prompt to confirm the resolved stack",
+    )
+    p.add_argument("--verbose", action="store_true")
+    return p.parse_args()
 
 
 def _apply_fresh_schema(pg_url: str, embedding_dim: int) -> None:
@@ -162,87 +110,104 @@ def _apply_fresh_schema(pg_url: str, embedding_dim: int) -> None:
 
     raw = SCHEMA_PATH.read_text().replace("{embedding_dim}", str(embedding_dim))
     with psycopg2.connect(pg_url) as c, c.cursor() as cur:
-        for tbl in ("deletion_audit", "user_quotas", "memories", "episodes",
-                    "sessions", "projects", "users"):
+        for tbl in (
+            "deletion_audit",
+            "user_quotas",
+            "memories",
+            "episodes",
+            "sessions",
+            "projects",
+            "users",
+        ):
             cur.execute(f"DROP TABLE IF EXISTS {tbl} CASCADE")
         cur.execute(raw)
         c.commit()
-    print(f"[smoke] schema applied (embedding_dim={embedding_dim})")
+    print(f"[{RUN_LABEL}] schema applied (embedding_dim={embedding_dim})")
 
 
-def _mem_factory(pg_url: str):
-    """Return a zero-arg callable producing fresh AgentMemory instances."""
+def _wipe_neo4j(stack: StackConfig) -> None:
+    from neo4j import GraphDatabase
+
+    with GraphDatabase.driver(
+        stack.neo4j.url, auth=(stack.neo4j.username, stack.neo4j.password)
+    ) as drv, drv.session(database=stack.neo4j.database) as s:
+        s.run("MATCH (n) DETACH DELETE n")
+
+
+def _mem_factory(stack: StackConfig):
+    """Return a zero-arg callable producing fresh AgentMemory instances —
+    each LME sample gets its own SOLO user via tempdir."""
     from attestor.core import AgentMemory
-    from urllib.parse import urlparse
 
-    parsed = urlparse(pg_url)
-    db = (parsed.path or "/").lstrip("/") or "attestor_v4_test"
+    cfg = build_backend_config(stack)
 
     def _make():
-        # Each sample gets its own SOLO user via tempdir path (LME's
-        # per-sample isolation guarantee).
         path = tempfile.mkdtemp(prefix="lme_smoke_")
-        return AgentMemory(path, config={
-            "mode": "solo",
-            "backends": ["postgres"],
-            "backend_configs": {"postgres": {
-                "url": f"{parsed.scheme}://{parsed.hostname}:{parsed.port or 5432}",
-                "database": db,
-                "auth": {
-                    "username": parsed.username or "postgres",
-                    "password": parsed.password or "attestor",
-                },
-                "v4": True,
-                "skip_schema_init": True,
-            }},
-        })
+        return AgentMemory(path, config=cfg)
 
     return _make
 
 
-# ─── Main run ───
-
-async def _run(args: argparse.Namespace) -> None:
+async def _run(args: argparse.Namespace, stack: StackConfig) -> None:
     from attestor.longmemeval import load_or_download, run_async
 
-    if not (os.environ.get("OPENAI_API_KEY") or os.environ.get("OPENROUTER_API_KEY")):
+    if not (
+        os.environ.get("OPENAI_API_KEY") or os.environ.get("OPENROUTER_API_KEY")
+    ):
         sys.stderr.write(
-            "[smoke] error: neither OPENAI_API_KEY nor OPENROUTER_API_KEY is set.\n"
-            "        Both LLM calls and the OpenAI embedder need one of these.\n"
+            f"[{RUN_LABEL}] error: neither OPENAI_API_KEY nor OPENROUTER_API_KEY is set.\n"
         )
         raise SystemExit(2)
 
-    print(f"[smoke] loading LME variant={args.variant!r}…")
+    print(f"[{RUN_LABEL}] loading LME variant={args.variant!r}…")
     samples = load_or_download(variant=args.variant)
-    print(f"[smoke] dataset has {len(samples)} samples; running first {args.n}")
 
-    print(f"[smoke] embedder  = {args.embedding_model!r} @ {args.embedding_dim}-D")
-    print(f"[smoke] answerer  = {args.answer_model!r}")
-    print(f"[smoke] judges    = {args.judge_models!r}  (dual-LLM)")
-    if args.use_distillation:
-        print(f"[smoke] distiller = {args.distill_model!r}  (distillation ON)")
+    wanted_ids = {s.strip() for s in args.sample_ids.split(",") if s.strip()}
+    if wanted_ids:
+        sample_id_attr = (
+            "question_id" if hasattr(samples[0], "question_id") else "id"
+        )
+        slice_ = [s for s in samples if getattr(s, sample_id_attr, None) in wanted_ids]
+        missing = wanted_ids - {getattr(s, sample_id_attr) for s in slice_}
+        if missing:
+            sys.stderr.write(
+                f"[{RUN_LABEL}] warning: sample_ids not found: {sorted(missing)}\n"
+            )
+        if not slice_:
+            sys.stderr.write(
+                f"[{RUN_LABEL}] error: --sample-ids matched zero samples\n"
+            )
+            raise SystemExit(2)
+        print(
+            f"[{RUN_LABEL}] dataset has {len(samples)} samples; "
+            f"running {len(slice_)} matched by --sample-ids"
+        )
     else:
-        print("[smoke] distiller = (distillation OFF)")
-    print(f"[smoke] budget    = {args.budget} tokens · parallel = {args.parallel}")
+        slice_ = samples[: args.n]
+        print(
+            f"[{RUN_LABEL}] dataset has {len(samples)} samples; running first {args.n}"
+        )
+
+    use_distillation = not args.no_distill
 
     report = await run_async(
-        samples[: args.n],
-        mem_factory=_mem_factory(args.pg_url),
-        answer_model=args.answer_model,
-        judge_models=args.judge_models,
-        distill_model=args.distill_model,
-        use_distillation=args.use_distillation,
+        slice_,
+        mem_factory=_mem_factory(stack),
+        answer_model=stack.models.answerer,
+        judge_models=[stack.models.judge, stack.models.verifier],
+        distill_model=stack.models.distill,
+        use_distillation=use_distillation,
         api_key=None,  # _get_client reads OPENAI_API_KEY / OPENROUTER_API_KEY
-        budget=args.budget,
-        parallel=args.parallel,
+        budget=stack.budget,
+        parallel=stack.parallel,
         verbose=args.verbose,
     )
 
     print()
-    print("=" * 60)
-    print(f"[smoke] DONE — {report.total} samples")
-    print(f"[smoke] by_judge: {json.dumps(report.by_judge, indent=2)}")
-    print(f"[smoke] by_category: {json.dumps(report.by_category, indent=2)}")
+    print("=" * 72)
+    print(f"[{RUN_LABEL}] DONE — {report.total} samples")
+    print(f"[{RUN_LABEL}] by_judge: {json.dumps(report.by_judge, indent=2)}")
+    print(f"[{RUN_LABEL}] by_category: {json.dumps(report.by_category, indent=2)}")
 
 
 def main() -> int:
@@ -253,12 +218,30 @@ def main() -> int:
         format="%(asctime)s %(levelname)s %(name)s: %(message)s",
     )
 
-    _force_openai_embedder(args.embedding_model, args.embedding_dim)
+    stack = load_stack(args.config)
+    if args.embedder:
+        stack = dc_replace(
+            stack,
+            embedder=dc_replace(
+                stack.embedder,
+                provider=args.embedder,
+                model=(
+                    "voyage-4" if args.embedder == "voyage" else "text-embedding-3-large"
+                ),
+            ),
+        )
+
+    confirm_or_exit(stack, run_label=RUN_LABEL, yes=args.yes)
+    configure_embedder(stack)
 
     if not args.skip_schema:
-        _apply_fresh_schema(args.pg_url, args.embedding_dim)
+        _apply_fresh_schema(stack.postgres.url, stack.embedder.dimensions)
+        try:
+            _wipe_neo4j(stack)
+        except Exception as e:
+            print(f"[{RUN_LABEL}] warning: neo4j wipe skipped — {e}")
 
-    asyncio.run(_run(args))
+    asyncio.run(_run(args, stack))
     return 0
 
 


### PR DESCRIPTION
## Summary

Until now the YAML was aspirational — `scripts/_attestor_config.py` existed but had zero call sites, every benchmark module hardcoded its own `DEFAULT_MODEL = "..."`, and `scripts/lme_smoke_local.py` still defaulted to `gpt-5.2` (lost when the `dev` branch was nuked).

This wires the YAML into the live code path with a strict layered resolution:

```
explicit CLI flag           ← highest
  ↓
explicit env var (POSTGRES_URL, VOYAGE_API_KEY, ANSWER_MODEL, …)
  ↓
configs/attestor.yaml       ← SoT
  ↓
hardcoded fallback          ← only when YAML missing AND env unset
```

## What changed

| | |
|---|---|
| **New** | `attestor/config.py` — promoted loader from `scripts/_attestor_config.py`. Public surface: `get_stack()`, `set_stack()`, `load_stack()`, `configure_embedder()`, `build_backend_config()`, `verify_neo4j_reachable()`, `confirm_or_exit()`, `cloud_target()`. Cached per-process. `ATTESTOR_CONFIG=<path>` to override default file. |
| **YAML** | `configs/attestor.yaml` adds `planner` and `benchmark_default` roles (previously hardcoded in code). |
| **Shim** | `scripts/_attestor_config.py` collapsed to a thin re-export so existing scripts keep importing from there. |
| **Refactored** | 11 production modules — every `DEFAULT_MODEL = "..."` literal replaced with a runtime `get_stack().models.<role>` lookup. Function signatures changed `model: str = "..."` to `model: Optional[str] = None`, resolving lazily inside the body. |
| **API server** | `attestor/api.py::_build_config()` now defers to the YAML when no env override is set — env-var path still works for cloud deploys. |
| **Smoke runner** | `scripts/lme_smoke_local.py` restored to config-driven version (the refactor that was lost in the dev-branch nuke). Drops the `DEFAULTS` dict and `_force_openai_embedder()`. |

## Acceptance criteria

```bash
grep -rn 'openai/gpt-\|anthropic/claude-' attestor/ scripts/ --include='*.py' \
  | grep -v 'attestor/config\.py\|scripts/_attestor_config\.py\|test_\|claude-code'
# → empty
```

→ Every production code path resolves through `configs/attestor.yaml`. The only remaining literals are in `attestor/config.py` (the hardcoded fallback used when YAML is missing) and `scripts/_attestor_config.py` (the re-export shim).

Bumping a model in the YAML — say `answerer: openai/gpt-4.1` → `openai/gpt-5.2` — now propagates to `lme_smoke_local.py`, `attestor longmemeval`, `attestor locomo`, `attestor mab`, the API server, and all extraction modules with no other edits.

## Test plan

- [x] 774 unit tests pass (`pytest tests/ -m "not live"`) — no regressions vs main
- [x] `from attestor.config import get_stack; print(get_stack().models)` returns the canonical 7-role config
- [x] All module-level `DEFAULT_*` constants resolve to YAML values at import time
- [x] CLI flag overrides still work — `attestor locomo --answer-model openai/gpt-5` overrides YAML
- [x] Env var overrides still work — `POSTGRES_URL=...` and `ANSWER_MODEL=...` beat YAML
- [x] API server continues to work with cloud env-var-only deploys (no YAML present)

## Diff size

```
attestor/config.py           +462  (new — promoted loader)
attestor/longmemeval.py       ~50
attestor/cli.py               ~55
attestor/locomo.py            ~32
attestor/api.py               ~30
attestor/mab.py               ~17
attestor/extraction/*          ~37 across 3 files
attestor/retrieval/planner.py ~14
attestor/retrieval/temporal_query.py ~5
attestor/consolidation/consolidator.py ~15
attestor/core.py              ~10
configs/attestor.yaml          +11
scripts/_attestor_config.py   -402  (collapsed to shim)
scripts/lme_smoke_local.py    full rewrite via loader
```

Net: +890 / -601, 16 files. Single PR.