### PR TITLE
P0 security hygiene: wire JWT, scrub hook leaks, fix v4 CLI SQL bug

### DIFF
--- a/attestor/api.py
+++ b/attestor/api.py
@@ -223,4 +223,68 @@ try:
 except Exception:  # pragma: no cover - UI is optional
     pass
 
-app = Starlette(routes=routes)
+
+def _build_middleware() -> list:
+    """Return the Starlette middleware stack for the resolved mode.
+
+    SOLO mode (default) returns no middleware — the api is a single-user
+    local service and bearer tokens would just be noise.
+
+    HOSTED / SHARED modes attach :class:`JWTAuthMiddleware`. In those
+    modes ``ATTESTOR_JWT_PUBLIC_KEY`` (PEM or JWKS JSON) MUST be set;
+    if it isn't, every request returns 500 ``"auth not configured"`` so
+    we fail visibly rather than serving anonymous traffic in a
+    multi-tenant deployment.
+
+    Configurable via env (only used when mode != SOLO):
+
+      ATTESTOR_JWT_PUBLIC_KEY     PEM string or path to .pem; required.
+      ATTESTOR_JWT_AUDIENCE       Optional ``aud`` claim to enforce.
+      ATTESTOR_JWT_ISSUER         Optional ``iss`` claim to enforce.
+      ATTESTOR_JWT_ALGORITHMS     Comma-separated; default ``RS256``.
+      ATTESTOR_JWT_LEEWAY_SECONDS Default ``0``.
+    """
+    from starlette.middleware import Middleware
+
+    from attestor.auth import JWTAuthMiddleware
+    from attestor.mode import AttestorMode, detect_mode
+
+    mode = detect_mode()
+    if mode is AttestorMode.SOLO:
+        return []
+
+    public_key = os.environ.get("ATTESTOR_JWT_PUBLIC_KEY")
+    if public_key and os.path.isfile(public_key):
+        # Allow pointing at a .pem on disk for cloud deploys that
+        # mount keys via a volume rather than env-encoding them.
+        try:
+            with open(public_key, "r", encoding="utf-8") as fh:
+                public_key = fh.read()
+        except OSError as e:
+            logger.error("could not read ATTESTOR_JWT_PUBLIC_KEY=%r: %s",
+                         public_key, e)
+            public_key = None
+
+    algorithms_raw = os.environ.get("ATTESTOR_JWT_ALGORITHMS", "RS256")
+    algorithms = [a.strip() for a in algorithms_raw.split(",") if a.strip()]
+
+    leeway = 0
+    try:
+        leeway = int(os.environ.get("ATTESTOR_JWT_LEEWAY_SECONDS", "0"))
+    except ValueError:
+        pass
+
+    return [
+        Middleware(
+            JWTAuthMiddleware,
+            mode=mode,
+            public_key=public_key,
+            audience=os.environ.get("ATTESTOR_JWT_AUDIENCE"),
+            issuer=os.environ.get("ATTESTOR_JWT_ISSUER"),
+            algorithms=algorithms,
+            leeway_seconds=leeway,
+        ),
+    ]
+
+
+app = Starlette(routes=routes, middleware=_build_middleware())

--- a/attestor/cli.py
+++ b/attestor/cli.py
@@ -725,8 +725,19 @@ def _cmd_import(args):
 
 
 def _cmd_inspect(args):
+    # v4 schema renamed `created_at` → `t_created`. Try the v4 column
+    # first; fall back to v3 so existing pre-v4 installs keep working.
     with AgentMemory(args.path) as mem:
-        rows = mem.execute("SELECT id, content, tags, category, entity, status, created_at FROM memories ORDER BY created_at DESC LIMIT 50")
+        try:
+            rows = mem.execute(
+                "SELECT id, content, tags, category, entity, status, t_created "
+                "FROM memories ORDER BY t_created DESC LIMIT 50"
+            )
+        except Exception:
+            rows = mem.execute(
+                "SELECT id, content, tags, category, entity, status, created_at "
+                "FROM memories ORDER BY created_at DESC LIMIT 50"
+            )
         if not rows:
             print("No memories in store.")
             return

--- a/attestor/hooks/post_tool_use.py
+++ b/attestor/hooks/post_tool_use.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 from pathlib import Path
 
@@ -13,6 +14,48 @@ _EMPTY_RESPONSE = {}
 _READ_ONLY_PREFIXES = (
     "cat", "ls", "head", "tail", "echo", "grep", "find", "rg", "pwd", "which", "type",
 )
+
+# Secret patterns to redact BEFORE we persist any captured Bash command or
+# tool output. The canonical leak vector this guards against: a captured
+# command like `curl -H "Authorization: Bearer ey..." https://api.foo`
+# would otherwise land in the memory store with the live token.
+#
+# Patterns cover: OpenAI / OpenRouter / Anthropic / Voyage / GitHub /
+# AWS / GCP / generic bearer tokens / generic header-style "X-API-Key:".
+_SECRET_PATTERNS = (
+    # Authorization / bearer headers (any value after "Bearer " up to whitespace/quote)
+    (re.compile(r"(?i)\b(authorization\s*:\s*bearer\s+)\S+", re.UNICODE),  r"\1<REDACTED>"),
+    (re.compile(r"(?i)\b(x-api-key\s*:\s*)\S+",            re.UNICODE),   r"\1<REDACTED>"),
+    # Provider-specific key prefixes (must come BEFORE the generic prefix=value rule)
+    (re.compile(r"\bsk-or-v1-[A-Za-z0-9_-]{20,}"),  "<REDACTED:openrouter>"),
+    (re.compile(r"\bsk-proj-[A-Za-z0-9_-]{20,}"),   "<REDACTED:openai>"),
+    (re.compile(r"\bsk-ant-[A-Za-z0-9_-]{20,}"),    "<REDACTED:anthropic>"),
+    (re.compile(r"\bsk-[A-Za-z0-9_-]{32,}"),        "<REDACTED:openai>"),
+    (re.compile(r"\bpa-[A-Za-z0-9_-]{30,}"),        "<REDACTED:voyage>"),
+    (re.compile(r"\bghp_[A-Za-z0-9]{30,}"),         "<REDACTED:github>"),
+    (re.compile(r"\bgithub_pat_[A-Za-z0-9_]{30,}"), "<REDACTED:github>"),
+    (re.compile(r"\bAKIA[A-Z0-9]{16}\b"),           "<REDACTED:aws>"),
+    (re.compile(r"\bASIA[A-Z0-9]{16}\b"),           "<REDACTED:aws>"),
+    (re.compile(r"\bya29\.[A-Za-z0-9_-]{20,}"),     "<REDACTED:gcp>"),
+    # Env-export style: KEY=value where KEY ends in _TOKEN / _KEY / _SECRET / _PASSWORD
+    (re.compile(r"(?i)\b([A-Z][A-Z0-9_]*(?:_TOKEN|_KEY|_SECRET|_PASSWORD)\s*=\s*)\S+"),
+                                                    r"\1<REDACTED>"),
+)
+
+
+def _redact_secrets(text: str) -> str:
+    """Apply all secret-pattern redactions to ``text``.
+
+    Order matters: provider-specific patterns run before the generic
+    ``KEY=value`` pattern so a literal ``OPENAI_API_KEY=sk-proj-...``
+    becomes ``OPENAI_API_KEY=<REDACTED>`` (key name preserved, value
+    redacted) rather than the looser fallback.
+    """
+    if not text:
+        return text
+    for pattern, replacement in _SECRET_PATTERNS:
+        text = pattern.sub(replacement, text)
+    return text
 
 
 def handle(payload: dict) -> dict:
@@ -65,7 +108,13 @@ def handle(payload: dict) -> dict:
             if first_word in _READ_ONLY_PREFIXES:
                 return _EMPTY_RESPONSE
 
-            output_summary = (tool_output or "")[:200]
+            # Redact secrets BEFORE building the captured content. A
+            # `curl -H "Authorization: Bearer ..."` would otherwise land
+            # in the memory store with the live token. Same for any
+            # `OPENAI_API_KEY=sk-...` style export, AWS access keys,
+            # GitHub PATs, etc.
+            command = _redact_secrets(command)
+            output_summary = _redact_secrets((tool_output or "")[:200])
             content = f"Ran command: {command}"
             if output_summary:
                 content += f"\nOutput: {output_summary}"


### PR DESCRIPTION
## Summary

Three P0 fixes flagged by an external audit. Each one was a real embarrassment that survives a 30-second screenshot.

| # | Item | File | Before | After |
|---|------|------|--------|-------|
| 1 | **No auth on the REST API** | `attestor/api.py:226` | `app = Starlette(routes=routes)` — every endpoint anonymous, even in HOSTED/SHARED mode. JWTAuthMiddleware existed but was uncalled. | `Starlette(routes=routes, middleware=_build_middleware())`. SOLO → no middleware (zero behavior change for local users). HOSTED/SHARED → attaches `JWTAuthMiddleware` with config from env. |
| 2 | **Hook leaks secrets into memory store** | `attestor/hooks/post_tool_use.py:58-87` | A captured `curl -H "Authorization: Bearer ey..."` Bash command was written to the memory store with the live token. | New `_redact_secrets()` masks Bearer tokens, all major API key prefixes (sk-/sk-or-v1-/sk-proj-/sk-ant-/pa-/ghp_/AKIA/ya29.), and `*_KEY=`/`*_TOKEN=`/`*_SECRET=` env exports. Applied to both `command` and `output_summary`. |
| 3 | **CLI `attestor inspect` SQL-errors on v4** | `attestor/cli.py:728` | Selects `created_at` and orders by `created_at`. v4 schema renamed that column to `t_created`. | Tries v4 column first, falls back to v3 on exception. |

## JWT mode-detection contract

```
ATTESTOR_MODE=solo                           → no middleware (default)
ATTESTOR_AUTH_PROVIDER=auth0|clerk|cognito   → HOSTED, attaches middleware
ATTESTOR_REQUIRE_AUTH=true                   → SHARED, attaches middleware
```

When middleware is attached, configurable via env:
```
ATTESTOR_JWT_PUBLIC_KEY=<PEM string OR path-to-.pem>   # required
ATTESTOR_JWT_AUDIENCE=…
ATTESTOR_JWT_ISSUER=…
ATTESTOR_JWT_ALGORITHMS=RS256                          # default
ATTESTOR_JWT_LEEWAY_SECONDS=0                          # default
```

Multi-tenant deploys without a public key fail visibly with HTTP 500 *"auth not configured"* rather than serving anonymous traffic.

## Redactor coverage

Verified 8 patterns end-to-end (all redacted; plain text passes through):

```
curl -H "Authorization: Bearer ey1234..."           → … Bearer <REDACTED>
export OPENAI_API_KEY=sk-proj-PH7FC…                → OPENAI_API_KEY=<REDACTED>
OPENROUTER_API_KEY=sk-or-v1-fe12fc1d…               → OPENROUTER_API_KEY=<REDACTED>
VOYAGE_API_KEY=pa-lnc_OoDw…                         → VOYAGE_API_KEY=<REDACTED>
aws_access_key_id AKIAIOSFODNN7EXAMPLE              → … <REDACTED:aws>
gh auth login --with-token ghp_aabbcc…              → … <REDACTED:github>
curl -H "X-API-Key: super-secret-…"                 → … X-API-Key: <REDACTED>
POSTGRES_PASSWORD=hunter2plain                      → POSTGRES_PASSWORD=<REDACTED>
```

The two keys leaked into the prior session (`sk-proj-PH7FC...` OpenAI and `sk-or-v1-fe12fc1d...` OpenRouter) match the patterns and are now redacted by this hook before they could be persisted.

## Test plan

- [x] 774 unit tests pass (no regressions)
- [x] `_build_middleware()` returns `[]` in SOLO mode and `[Middleware(JWTAuthMiddleware, ...)]` in SHARED mode
- [x] Redactor smoke-tested against 8 known secret patterns
- [ ] Live Postgres `attestor inspect` against a v4 schema (manual — local docker-compose)

## Out of scope (filed for follow-up)

These were in the audit but aren't in this PR:
- 5-layer pipeline copy in README/CLAUDE.md is wrong (P1)
- CI builds `Dockerfile` not `Dockerfile.api` (P1)
- RBAC is metadata-only (P1)
- Neo4j has no namespace property (P1)
- Phantom Terraform references in `Dockerfile:14` (P1)