### PR TITLE
CI builds Dockerfile.api + drop phantom Terraform refs

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,12 +1,19 @@
 name: Build & Push Docker Image
 
-# Multi-arch (amd64 + arm64) container build that publishes the Attestor
-# MCP image to GitHub Container Registry on every push to main / tagged
-# release, and to Docker Hub when DOCKERHUB_USERNAME + DOCKERHUB_TOKEN
-# secrets are present (gracefully skips Hub push when missing).
+# Multi-arch (amd64 + arm64) container build that publishes BOTH:
 #
-# Source: ./Dockerfile (introspection-only profile — see file header for
-# why this is the registry-listing artifact, not the production image).
+#   1. ./Dockerfile         — introspection-only MCP image, the artifact
+#                             external registries (Glama, Smithery) verify.
+#                             Pushed with the canonical version tags
+#                             (e.g. 4.0.0a5, latest, v4).
+#   2. ./Dockerfile.api     — full HTTP API image, the artifact cloud
+#                             deploys actually pull. Pushed with `api-`
+#                             prefixed tags (e.g. api-4.0.0a5, api-latest).
+#
+# Targets GHCR + Docker Hub + Quay (when the relevant secrets are set —
+# missing secrets are skipped gracefully). Manual pushes to AWS ECR
+# Public + GCP Artifact Registry + Azure ACR are no longer needed once
+# this workflow runs on a release.
 
 on:
   push:
@@ -96,7 +103,7 @@ jobs:
             echo 'EOF'
           } >> "$GITHUB_OUTPUT"
 
-      - name: Extract metadata
+      - name: Extract metadata — MCP introspection image
         id: meta
         uses: docker/metadata-action@v5
         with:
@@ -115,7 +122,23 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
             type=raw,value=latest,enable=${{ github.event_name == 'release' }}
 
-      - name: Build and push
+      - name: Extract metadata — full API image
+        id: meta_api
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ steps.image_list.outputs.images }}
+          # The api image gets `api-` prefixed tags so it can coexist with
+          # the introspection image in the same repo without collision.
+          # docs/install/{aws,gcp,azure}.md and configs/attestor.yaml's
+          # `image.api_ref_template` both reference :api-<version>.
+          tags: |
+            type=semver,pattern=api-{{version}}
+            type=semver,pattern=api-{{major}}.{{minor}}
+            type=sha,format=short,prefix=api-sha-
+            type=raw,value=api-latest,enable={{is_default_branch}}
+            type=raw,value=api-latest,enable=${{ github.event_name == 'release' }}
+
+      - name: Build and push — MCP introspection image
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -124,5 +147,20 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=mcp
+          cache-to: type=gha,mode=max,scope=mcp
+
+      - name: Build and push — full API image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile.api
+          # API image is currently amd64-only. The published Dockerfile.api
+          # uses pinned wheels that ship for amd64; arm64 multi-arch is a
+          # follow-up (matches the linux/amd64 caveat in docs/install/).
+          platforms: linux/amd64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta_api.outputs.tags }}
+          labels: ${{ steps.meta_api.outputs.labels }}
+          cache-from: type=gha,scope=api
+          cache-to: type=gha,mode=max,scope=api

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Distribution: this release also mirrors the image to **5 Docker registries** sim
 
 Introspection-only fallback for the MCP server so external registries (Glama, Smithery) can verify the listing without provisioning Postgres + Neo4j. When `ATTESTOR_MCP_TOLERATE_INIT_FAILURE=1` is set, `attestor mcp` swallows backend connection errors at startup and continues to advertise its 8 tools via `tools/list`. Any `tools/call` against a non-initialized server returns a clear "configure backends to enable execution" error instead of crashing. Production deployments leave the env var unset and behave as before — strict, fail-closed init.
 
-Also adds a top-level `Dockerfile` that builds an introspection-only image (~150 MB, single layer over `python:3.12-slim`) for use as the registry-listing artifact. Real production deployments continue to use `attestor/infra/local/docker-compose.yml` or one of the cloud Terraform stacks under `attestor/infra/{aws_arango,azure,gcp_alloydb}`.
+Also adds a top-level `Dockerfile` that builds an introspection-only image (~150 MB, single layer over `python:3.12-slim`) for use as the registry-listing artifact. Real production deployments continue to use `attestor/infra/local/docker-compose.yml` for the local stack, or the imperative cloud-deploy guides under `docs/install/{aws,gcp,azure}.md` for managed-service deploys.
 
 ## [4.0.0a3] — 2026-04-27
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,9 @@
 # "configure backends to enable execution" error.
 #
 # Real production deployment uses attestor/infra/local/docker-compose.yml
-# (Postgres + Neo4j + Attestor) or one of the cloud Terraform stacks under
-# attestor/infra/{aws_arango,azure,gcp_alloydb}.
+# (Postgres + Neo4j + Attestor). For cloud deploys see docs/install/{aws,gcp,
+# azure}.md (imperative, validated 2026-04-28). The companion Dockerfile.api
+# builds the full HTTP API image and is what cloud deploys actually pull.
 
 FROM python:3.12-slim
 


### PR DESCRIPTION
## Summary

Two P1 audit items in one small PR.

### 1. CI now builds Dockerfile.api alongside Dockerfile

Before: only `./Dockerfile` (MCP introspection stub) was built in CI. The full HTTP API image at `./Dockerfile.api` — which all 5 public registries serve as `:api-4.0.0a5`, and which `docs/install/{aws,gcp,azure}.md` + `configs/attestor.yaml` reference — was pushed manually by hand. Drift waiting to happen.

After: the workflow builds both images on every release tag.

| File | Tags | Cache scope |
|------|------|-------------|
| `./Dockerfile` (MCP stub) | `4.0.0a5`, `4.0`, `v4`, `latest`, `sha-…`, `main` | `scope=mcp` |
| `./Dockerfile.api` (full API) | `api-4.0.0a5`, `api-4.0`, `api-latest`, `api-sha-…` | `scope=api` |

API image is `linux/amd64` only (matches the caveat already in the install guides).

### 2. Drop phantom Terraform references

`Dockerfile:14` and `CHANGELOG.md:17` claimed Terraform stacks exist at `attestor/infra/{aws_arango,azure,gcp_alloydb}`. Only `aws_arango/` actually exists — and it's an ArangoDB-on-ECS recipe, not the canonical PG+Neo4j stack. References replaced with pointers to `docs/install/{aws,gcp,azure}.md` (the imperative deploy guides validated 2026-04-28).

## Test plan

- [x] YAML syntax-valid (`yaml.safe_load(open(...))` clean)
- [x] 773 unit tests pass; 1 pre-existing registry flake unaffected
- [ ] Next release tag will trigger the two-image build — verify by checking GHCR for both `<sha>:latest` and `<sha>:api-latest` after the next push to `main`