### PR TITLE
feat(rbac): enforce role permissions at AgentContext layer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ semantic-first (vector → BM25 → RRF → graph → MMR → fit) as of 2026-04
 a separate tag-match utility lives at `attestor/retrieval/tag_matcher.py`
 but is consumed by the entity extractor, not the recall pipeline.
 
-**Multi-agent primitives:** 6 RBAC roles (ORCHESTRATOR, PLANNER, EXECUTOR, RESEARCHER, REVIEWER, MONITOR) — currently **advisory metadata** (the role enum exists in `attestor/context.py` but is not enforced at the recall layer; only `read_only` gates writes). Namespace isolation is row-level on Postgres but **not yet enforced on Neo4j** (graph entity nodes are global across namespaces). Provenance tracking, write quotas, and per-agent token budgets are wired.
+**Multi-agent primitives:** 6 RBAC roles (ORCHESTRATOR, PLANNER, EXECUTOR, RESEARCHER, REVIEWER, MONITOR) — **enforced at the AgentContext layer** via `ROLE_PERMISSIONS` in `attestor/context.py`. Matrix: ORCHESTRATOR = READ+WRITE+FORGET; PLANNER/EXECUTOR/RESEARCHER = READ+WRITE; REVIEWER/MONITOR = READ only. `read_only=True` is an independent kill switch that strips WRITE+FORGET regardless of role. Direct `AgentMemory.add()` calls (without an AgentContext) bypass the matrix — RBAC is a context-layer guarantee, not a backend one. Namespace isolation is row-level on Postgres but **not yet enforced on Neo4j** (graph entity nodes are global across namespaces). Provenance tracking, write quotas, and per-agent token budgets are wired.
 
 **Temporal:** Contradiction detection auto-supersedes older facts; nothing is deleted. Every fact has a validity window; `recall(as_of=...)` replays the past.
 

--- a/attestor/__init__.py
+++ b/attestor/__init__.py
@@ -1,6 +1,12 @@
 """Attestor — Embedded memory for AI agents."""
 
-from attestor.context import AgentContext, AgentRole, Visibility
+from attestor.context import (
+    ROLE_PERMISSIONS,
+    AgentContext,
+    AgentRole,
+    RolePermission,
+    Visibility,
+)
 from attestor.core import AgentMemory
 from attestor.models import (
     Memory,
@@ -15,6 +21,8 @@ __all__ = [
     "AgentMemory",
     "AgentContext",
     "AgentRole",
+    "RolePermission",
+    "ROLE_PERMISSIONS",
     "Memory",
     "MemoryScope",
     "Project",

--- a/attestor/context.py
+++ b/attestor/context.py
@@ -33,7 +33,7 @@ import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, FrozenSet, List, Optional, Union
 
 from attestor.models import Memory, MemoryScope, RetrievalResult
 
@@ -54,6 +54,37 @@ class AgentRole(str, Enum):
     RESEARCHER = "researcher"
     REVIEWER = "reviewer"
     MONITOR = "monitor"
+
+
+class RolePermission(str, Enum):
+    """Capabilities granted by a role.
+
+    READ      -- recall / search / timeline (always granted; recall path
+                 stays open so a misconfigured role never blinds an agent)
+    WRITE     -- add_memory
+    FORGET    -- forget (archival; admin-tier capability)
+    """
+
+    READ = "read"
+    WRITE = "write"
+    FORGET = "forget"
+
+
+# Role -> capability matrix. ORCHESTRATOR is the admin tier (full perms).
+# REVIEWER + MONITOR are read-only by intent: a reviewer that writes
+# contaminates the evidence trail; a monitor that writes is a feedback
+# loop. PLANNER / EXECUTOR / RESEARCHER need write but not forget --
+# immutability is a feature, only the orchestrator can archive.
+ROLE_PERMISSIONS: Dict[AgentRole, FrozenSet[RolePermission]] = {
+    AgentRole.ORCHESTRATOR: frozenset(
+        {RolePermission.READ, RolePermission.WRITE, RolePermission.FORGET}
+    ),
+    AgentRole.PLANNER:   frozenset({RolePermission.READ, RolePermission.WRITE}),
+    AgentRole.EXECUTOR:  frozenset({RolePermission.READ, RolePermission.WRITE}),
+    AgentRole.RESEARCHER: frozenset({RolePermission.READ, RolePermission.WRITE}),
+    AgentRole.REVIEWER:  frozenset({RolePermission.READ}),
+    AgentRole.MONITOR:   frozenset({RolePermission.READ}),
+}
 
 
 @dataclass
@@ -262,6 +293,28 @@ class AgentContext:
             "or use ATTESTOR_PATH / ATTESTOR_URL env vars."
         )
 
+    # ------------------------------------------------------------------ #
+    #  RBAC                                                                #
+    # ------------------------------------------------------------------ #
+
+    def _require_permission(self, perm: RolePermission) -> None:
+        """Raise PermissionError if the current role lacks ``perm``.
+
+        Looks up the role in ROLE_PERMISSIONS. ``read_only=True`` is an
+        independent gate -- it strips WRITE/FORGET regardless of role
+        (so an ORCHESTRATOR with read_only=True still cannot write).
+        """
+        granted = ROLE_PERMISSIONS.get(self.role, frozenset())
+        if self.read_only and perm in (RolePermission.WRITE, RolePermission.FORGET):
+            raise PermissionError(
+                f"Agent '{self.agent_id}' is read-only in this context"
+            )
+        if perm not in granted:
+            raise PermissionError(
+                f"Agent '{self.agent_id}' (role={self.role.value}) "
+                f"lacks permission '{perm.value}'"
+            )
+
     def add_memory(
         self,
         content: str,
@@ -276,12 +329,9 @@ class AgentContext:
         """Add a memory with full provenance tracking.
 
         Attaches agent_id, session_id, namespace, and visibility to metadata.
-        Enforces write quota and read_only constraints.
+        Enforces role permissions, write quota, and read_only constraints.
         """
-        if self.read_only:
-            raise PermissionError(
-                f"Agent '{self.agent_id}' is read-only in this context"
-            )
+        self._require_permission(RolePermission.WRITE)
 
         writes_by_me = sum(
             1 for mid in self.memories_written
@@ -382,11 +432,8 @@ class AgentContext:
         return mem.timeline(entity, namespace=self.namespace)
 
     def forget(self, memory_id: str) -> bool:
-        """Archive a memory. Requires write access."""
-        if self.read_only:
-            raise PermissionError(
-                f"Agent '{self.agent_id}' is read-only in this context"
-            )
+        """Archive a memory. Requires the FORGET capability (admin-tier)."""
+        self._require_permission(RolePermission.FORGET)
         mem = self._get_memory()
         return mem.forget(memory_id)
 

--- a/tests/test_rbac.py
+++ b/tests/test_rbac.py
@@ -1,0 +1,188 @@
+"""RBAC enforcement at the AgentContext layer.
+
+Until 2026-04-28 ``AgentRole`` was advisory metadata -- the role enum
+was set on the context, recorded in memory metadata, and otherwise
+ignored. This module pins the actual enforcement matrix introduced in
+``attestor/context.py`` (ROLE_PERMISSIONS):
+
+    ORCHESTRATOR        : READ + WRITE + FORGET
+    PLANNER / EXECUTOR /
+        RESEARCHER      : READ + WRITE
+    REVIEWER / MONITOR  : READ only
+
+The tests use a small in-memory fake of the Attestor memory backend
+because we only need to verify the permission gate fires *before* the
+backend is touched. This keeps the suite hermetic (no Postgres / Neo4j
+required) and catches regressions where a future refactor removes the
+``_require_permission`` call.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+import pytest
+
+from attestor.context import (
+    ROLE_PERMISSIONS,
+    AgentContext,
+    AgentRole,
+    RolePermission,
+)
+from attestor.models import Memory
+
+
+@dataclass
+class _FakeMem:
+    """Minimal stand-in for AgentMemory used to assert RBAC fires first."""
+
+    added: List[str] = field(default_factory=list)
+    forgotten: List[str] = field(default_factory=list)
+
+    def add(self, content: str, **kwargs) -> Memory:
+        self.added.append(content)
+        return Memory(
+            id=f"mem-{len(self.added)}",
+            content=content,
+            namespace=kwargs.get("namespace", "default"),
+        )
+
+    def forget(self, memory_id: str) -> bool:
+        self.forgotten.append(memory_id)
+        return True
+
+    def recall(self, query: str, **kwargs):
+        return []
+
+    def health(self):  # pragma: no cover - unused in these tests
+        return {"ok": True}
+
+    def close(self):  # pragma: no cover
+        pass
+
+
+def _ctx(role: AgentRole, *, read_only: bool = False) -> tuple[AgentContext, _FakeMem]:
+    fake = _FakeMem()
+    ctx = AgentContext(
+        agent_id=f"agent-{role.value}",
+        role=role,
+        memory=fake,
+        read_only=read_only,
+    )
+    return ctx, fake
+
+
+# ---------------------------------------------------------------------------
+# Matrix completeness
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_role_permissions_matrix_covers_every_role():
+    """A new AgentRole without a matrix entry would silently default to
+    `frozenset()` (deny-all). That is safe but surprising -- this guards
+    against forgetting to update the table when adding a role."""
+    for role in AgentRole:
+        assert role in ROLE_PERMISSIONS, f"Role {role} missing from ROLE_PERMISSIONS"
+        assert (
+            RolePermission.READ in ROLE_PERMISSIONS[role]
+        ), f"Role {role} cannot READ -- recall path would be blinded"
+
+
+# ---------------------------------------------------------------------------
+# Write enforcement
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "role",
+    [AgentRole.ORCHESTRATOR, AgentRole.PLANNER, AgentRole.EXECUTOR, AgentRole.RESEARCHER],
+)
+def test_write_allowed_roles_can_add_memory(role: AgentRole):
+    ctx, fake = _ctx(role)
+    ctx.add_memory("hello", category="note")
+    assert fake.added == ["hello"]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("role", [AgentRole.REVIEWER, AgentRole.MONITOR])
+def test_write_denied_roles_cannot_add_memory(role: AgentRole):
+    ctx, fake = _ctx(role)
+    with pytest.raises(PermissionError, match=role.value):
+        ctx.add_memory("should be blocked", category="note")
+    assert fake.added == [], "backend should not be touched after a deny"
+
+
+@pytest.mark.unit
+def test_default_executor_add_still_works():
+    """Backwards-compat smoke: the default role is EXECUTOR, and the
+    pre-existing add() call shape must continue to work without changes."""
+    fake = _FakeMem()
+    ctx = AgentContext(agent_id="a", memory=fake)
+    ctx.add_memory("default-role write")
+    assert fake.added == ["default-role write"]
+
+
+# ---------------------------------------------------------------------------
+# Forget enforcement
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_forget_allowed_for_orchestrator():
+    ctx, fake = _ctx(AgentRole.ORCHESTRATOR)
+    assert ctx.forget("mem-x") is True
+    assert fake.forgotten == ["mem-x"]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "role",
+    [
+        AgentRole.PLANNER,
+        AgentRole.EXECUTOR,
+        AgentRole.RESEARCHER,
+        AgentRole.REVIEWER,
+        AgentRole.MONITOR,
+    ],
+)
+def test_forget_denied_for_non_orchestrators(role: AgentRole):
+    ctx, fake = _ctx(role)
+    with pytest.raises(PermissionError, match="forget"):
+        ctx.forget("mem-x")
+    assert fake.forgotten == []
+
+
+# ---------------------------------------------------------------------------
+# read_only flag is independent of role and always wins
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_read_only_flag_strips_write_even_for_orchestrator():
+    """An ORCHESTRATOR with read_only=True still cannot write -- the
+    flag is a hard kill switch, not a role override."""
+    ctx, fake = _ctx(AgentRole.ORCHESTRATOR, read_only=True)
+    with pytest.raises(PermissionError, match="read-only"):
+        ctx.add_memory("blocked")
+    assert fake.added == []
+
+
+@pytest.mark.unit
+def test_read_only_flag_strips_forget_even_for_orchestrator():
+    ctx, fake = _ctx(AgentRole.ORCHESTRATOR, read_only=True)
+    with pytest.raises(PermissionError, match="read-only"):
+        ctx.forget("mem-x")
+    assert fake.forgotten == []
+
+
+@pytest.mark.unit
+def test_read_only_flag_does_not_affect_recall():
+    """READ stays available regardless of read_only -- otherwise an
+    auditor sub-context could not read what it is auditing."""
+    ctx, _ = _ctx(AgentRole.MONITOR, read_only=True)
+    # Should not raise. The fake returns [] but we are testing the gate,
+    # not the retrieval pipeline.
+    assert ctx.recall("anything") == []


### PR DESCRIPTION
## Summary

`AgentRole` was advisory metadata until now — the role enum was set on the context, recorded in memory metadata, and otherwise ignored. Only `read_only` gated writes. This PR wires actual enforcement.

**Permission matrix** (`ROLE_PERMISSIONS` in `attestor/context.py`):

| Role | READ | WRITE | FORGET |
|---|---|---|---|
| ORCHESTRATOR | ✓ | ✓ | ✓ |
| PLANNER, EXECUTOR, RESEARCHER | ✓ | ✓ | ✗ |
| REVIEWER, MONITOR | ✓ | ✗ | ✗ |

`read_only=True` remains an independent kill switch that strips WRITE+FORGET regardless of role.

## Scope notes

- Enforcement lives at the `AgentContext` layer only. Direct `AgentMemory.add()` calls bypass the matrix — this matches the pre-existing `read_only` pattern and is now documented in CLAUDE.md.
- Neo4j-layer namespace enforcement is still pending (separate backlog item).
- New public exports: `RolePermission`, `ROLE_PERMISSIONS` (added to `attestor.__init__`).

## Test plan

- [x] 17 new tests in `tests/test_rbac.py` cover the full role × permission matrix
- [x] Backwards-compat: default EXECUTOR `add()` still works without changes
- [x] Full unit suite: 933 passed, 232 skipped, 0 failed
- [x] CLAUDE.md updated to reflect enforcement