### PR TITLE
fix(client): forward namespace in recall + map QuotaExceeded to 429

### DIFF
--- a/attestor/api.py
+++ b/attestor/api.py
@@ -132,16 +132,24 @@ async def add_memory(request: Request) -> JSONResponse:
     if not content:
         return _err("content is required")
     mem = _get_mem()
-    m = mem.add(
-        content=content,
-        tags=body.get("tags", []),
-        category=body.get("category", "general"),
-        entity=body.get("entity"),
-        namespace=body.get("namespace", "default"),
-        event_date=body.get("event_date"),
-        confidence=body.get("confidence", 1.0),
-        metadata=body.get("metadata", {}),
-    )
+    # Import lazily — quotas is Postgres-specific and may pull psycopg2.
+    from attestor.quotas import QuotaExceeded
+
+    try:
+        m = mem.add(
+            content=content,
+            tags=body.get("tags", []),
+            category=body.get("category", "general"),
+            entity=body.get("entity"),
+            namespace=body.get("namespace", "default"),
+            event_date=body.get("event_date"),
+            confidence=body.get("confidence", 1.0),
+            metadata=body.get("metadata", {}),
+        )
+    except QuotaExceeded as e:
+        # 429 Too Many Requests — include the limit field name so clients
+        # can show a useful error (e.g. "max_writes_per_day reached").
+        return _err(f"quota exceeded: {e}", status=429)
     return _ok(m.to_dict())
 
 

--- a/attestor/client.py
+++ b/attestor/client.py
@@ -99,12 +99,21 @@ class MemoryClient:
     # -- Read --
 
     def recall(
-        self, query: str, budget: Optional[int] = None
+        self,
+        query: str,
+        budget: Optional[int] = None,
+        namespace: Optional[str] = None,
     ) -> List[RetrievalResult]:
-        """Recall memories via the HTTP API."""
+        """Recall memories via the HTTP API.
+
+        ``namespace`` is forwarded to the server so namespace-scoped recall
+        works over HTTP (parity with the embedded ``AgentMemory.recall``).
+        """
         body: Dict[str, Any] = {"query": query}
         if budget:
             body["budget"] = budget
+        if namespace is not None:
+            body["namespace"] = namespace
 
         data = self._post("/recall", body)
         results = []
@@ -118,10 +127,13 @@ class MemoryClient:
         return results
 
     def recall_as_context(
-        self, query: str, budget: Optional[int] = None
+        self,
+        query: str,
+        budget: Optional[int] = None,
+        namespace: Optional[str] = None,
     ) -> str:
         """Recall and format as context string."""
-        results = self.recall(query, budget=budget)
+        results = self.recall(query, budget=budget, namespace=namespace)
         if not results:
             return ""
         lines = []

--- a/tests/test_client_api_parity.py
+++ b/tests/test_client_api_parity.py
@@ -1,0 +1,133 @@
+"""HTTP client / ASGI server parity tests.
+
+Pinpoints two known drift bugs and locks the parity contract:
+
+1. ``MemoryClient.recall(namespace=...)`` MUST forward ``namespace`` in
+   the JSON body so namespace-scoped recall works over HTTP just like
+   it does in the embedded ``AgentMemory``.
+
+2. The ASGI ``/add`` endpoint MUST translate
+   :class:`attestor.quotas.QuotaExceeded` to **HTTP 429** with the
+   standard ``{"ok": false, "error": "quota exceeded: ..."}`` body so
+   clients can distinguish quota breaches from other failures.
+
+Both tests are hermetic — no Postgres / Neo4j required.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from typing import Any, Dict, List
+from unittest.mock import patch
+
+import pytest
+from starlette.testclient import TestClient
+
+from attestor import api as attestor_api
+from attestor.client import MemoryClient
+from attestor.models import Memory
+from attestor.quotas import QuotaExceeded
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Fix 1 — MemoryClient.recall() forwards `namespace`
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class _FakeResponse:
+    """Minimal urllib response object compatible with the client's reader."""
+
+    def __init__(self, payload: Dict[str, Any]) -> None:
+        self._buf = io.BytesIO(json.dumps(payload).encode())
+
+    def read(self) -> bytes:
+        return self._buf.read()
+
+    def __enter__(self) -> "_FakeResponse":
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        self._buf.close()
+
+
+@pytest.mark.unit
+def test_recall_forwards_namespace_in_body() -> None:
+    """``recall(namespace="ns1")`` must put ``namespace`` in the POST body."""
+    captured: Dict[str, Any] = {}
+
+    def fake_urlopen(req: Any, timeout: float = 0) -> _FakeResponse:
+        captured["url"] = req.full_url
+        captured["body"] = json.loads(req.data.decode())
+        return _FakeResponse({"ok": True, "data": []})
+
+    client = MemoryClient("http://memory.test", agent_id="planner-01")
+
+    with patch("attestor.client.urllib.request.urlopen", fake_urlopen):
+        results: List[Any] = client.recall(query="x", namespace="ns1")
+
+    assert results == []
+    assert captured["url"] == "http://memory.test/recall"
+    assert captured["body"]["query"] == "x"
+    assert captured["body"]["namespace"] == "ns1"
+
+
+@pytest.mark.unit
+def test_recall_omits_namespace_when_not_set() -> None:
+    """Back-compat: callers without ``namespace`` must keep working."""
+    captured: Dict[str, Any] = {}
+
+    def fake_urlopen(req: Any, timeout: float = 0) -> _FakeResponse:
+        captured["body"] = json.loads(req.data.decode())
+        return _FakeResponse({"ok": True, "data": []})
+
+    client = MemoryClient("http://memory.test")
+
+    with patch("attestor.client.urllib.request.urlopen", fake_urlopen):
+        client.recall(query="x")
+
+    assert "namespace" not in captured["body"]
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Fix 2 — QuotaExceeded → HTTP 429
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class _FakeMem:
+    """Tiny stand-in for AgentMemory that raises QuotaExceeded on add()."""
+
+    def add(self, **kwargs: Any) -> Memory:
+        raise QuotaExceeded(
+            field="max_writes_per_day", limit=100, current=100,
+        )
+
+
+@pytest.mark.unit
+def test_add_endpoint_returns_429_on_quota_exceeded() -> None:
+    """/add must surface QuotaExceeded as 429 with a quota error body."""
+    fake = _FakeMem()
+    with patch.object(attestor_api, "_get_mem", return_value=fake):
+        client = TestClient(attestor_api.app)
+        resp = client.post("/add", json={"content": "hello"})
+
+    assert resp.status_code == 429, resp.text
+    body = resp.json()
+    assert body["ok"] is False
+    assert "quota" in body["error"].lower()
+    # Limit type should be surfaced so callers can build a useful message.
+    assert "max_writes_per_day" in body["error"]
+
+
+@pytest.mark.unit
+def test_add_endpoint_400_when_content_missing() -> None:
+    """Sanity check: pre-existing 400 on missing content still works."""
+    fake = _FakeMem()
+    with patch.object(attestor_api, "_get_mem", return_value=fake):
+        client = TestClient(attestor_api.app)
+        resp = client.post("/add", json={})
+
+    assert resp.status_code == 400
+    body = resp.json()
+    assert body["ok"] is False
+    assert "content" in body["error"]


### PR DESCRIPTION
## Summary

Two API/client parity drifts between the embedded `AgentMemory` and the `MemoryClient` HTTP shim.

### Fix 1: `MemoryClient.recall()` namespace forwarding
The HTTP server (`attestor/api.py`) accepts and uses `namespace` in `/recall` request bodies. The HTTP client did not pass it. Result: namespace-scoped recall worked embedded, silently broke over HTTP. Adds optional `namespace` parameter to `MemoryClient.recall()` (and `recall_as_context()`); forwards it in the JSON body when set; back-compat preserved (no `namespace` key when caller doesn't pass one).

### Fix 2: `QuotaExceeded` → HTTP 429
`AgentMemory.add()` raises `attestor.quotas.QuotaExceeded` when a user/project hits write quota. Over HTTP this surfaced as 500. Now returns **429 Too Many Requests** with `{"ok": false, "error": "quota exceeded: <field> (limit=..., current=...)"}` so callers can build useful retry logic. The exception import is lazy inside `add_memory()` to keep `api.py` importable in non-Postgres deploys (matches existing pattern).

## Test plan
- [x] 4 new tests in `tests/test_client_api_parity.py`:
  - recall body contains `namespace` when set
  - recall body omits `namespace` when not set (back-compat)
  - `/add` returns 429 on `QuotaExceeded` with the field name in the error
  - `/add` 400 path for missing `content` unchanged
- [x] Full unit suite: 916 passed, 236 skipped