### PR TITLE
feat(neo4j): scope graph entities and edges by namespace

### DIFF
--- a/attestor/core.py
+++ b/attestor/core.py
@@ -810,20 +810,42 @@ class AgentMemory:
                 t0 = time.monotonic()
                 nodes, edges = extract_entities_and_relations(
                     content, tags or [], entity, category,
+                    namespace=namespace,
                 )
+                # Tag every entity / relation with the writer's namespace
+                # so the graph layer enforces tenancy alongside Postgres.
+                # Older graph backends without the kwarg still accept the
+                # call via the TypeError fallback below.
                 for node in nodes:
-                    self._graph.add_entity(
-                        node["name"],
-                        entity_type=node.get("type", "general"),
-                        attributes=node.get("attributes"),
-                    )
+                    try:
+                        self._graph.add_entity(
+                            node["name"],
+                            entity_type=node.get("type", "general"),
+                            attributes=node.get("attributes"),
+                            namespace=namespace,
+                        )
+                    except TypeError:
+                        self._graph.add_entity(
+                            node["name"],
+                            entity_type=node.get("type", "general"),
+                            attributes=node.get("attributes"),
+                        )
                 for edge in edges:
-                    self._graph.add_relation(
-                        edge["from"],
-                        edge["to"],
-                        relation_type=edge.get("type", "related_to"),
-                        metadata=edge.get("metadata"),
-                    )
+                    try:
+                        self._graph.add_relation(
+                            edge["from"],
+                            edge["to"],
+                            relation_type=edge.get("type", "related_to"),
+                            metadata=edge.get("metadata"),
+                            namespace=namespace,
+                        )
+                    except TypeError:
+                        self._graph.add_relation(
+                            edge["from"],
+                            edge["to"],
+                            relation_type=edge.get("type", "related_to"),
+                            metadata=edge.get("metadata"),
+                        )
                 store_timings["graph_ms"] = round((time.monotonic() - t0) * 1000, 2)
             except Exception as e:
                 store_timings["graph_ms"] = -1  # failed

--- a/attestor/graph/extractor.py
+++ b/attestor/graph/extractor.py
@@ -36,43 +36,52 @@ def extract_entities_and_relations(
     tags: List[str],
     entity: Optional[str],
     category: str,
+    namespace: Optional[str] = None,
 ) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
     """Extract entities and relations from a memory's content and metadata.
 
     Returns (nodes, edges) where:
-      - nodes: [{"name": str, "type": str, "attributes": dict}, ...]
-      - edges: [{"from": str, "to": str, "type": str, "metadata": dict}, ...]
+      - nodes: [{"name": str, "type": str, "namespace": str, "attributes": dict}, ...]
+      - edges: [{"from": str, "to": str, "type": str, "namespace": str, "metadata": dict}, ...]
+
+    Every produced node/edge carries the writer's ``namespace`` so the
+    graph backend can enforce tenancy without additional plumbing. When
+    ``namespace`` is ``None`` the field is omitted from each dict (the
+    backend treats absent values as ``"default"`` via coalesce on read).
     """
     nodes: List[Dict[str, Any]] = []
     edges: List[Dict[str, Any]] = []
 
+    def _node(name: str, type_: str, attributes: Dict[str, Any]) -> Dict[str, Any]:
+        out: Dict[str, Any] = {"name": name, "type": type_, "attributes": attributes}
+        if namespace is not None:
+            out["namespace"] = namespace
+        return out
+
+    def _edge(
+        from_: str, to: str, type_: str, metadata: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        out: Dict[str, Any] = {
+            "from": from_, "to": to, "type": type_, "metadata": metadata,
+        }
+        if namespace is not None:
+            out["namespace"] = namespace
+        return out
+
     # Primary entity from the memory
     if entity:
         entity_type = _CATEGORY_TYPE_MAP.get(category, "concept")
-        nodes.append({
-            "name": entity,
-            "type": entity_type,
-            "attributes": {"category": category},
-        })
+        nodes.append(_node(entity, entity_type, {"category": category}))
 
     # Extract entities from tags (proper nouns / meaningful keywords)
     for tag in tags:
         if tag and len(tag) > 1:
             # Tags that look like proper nouns or tool names
             if tag[0].isupper() or tag in _KNOWN_TOOLS:
-                nodes.append({
-                    "name": tag,
-                    "type": _guess_type(tag),
-                    "attributes": {},
-                })
+                nodes.append(_node(tag, _guess_type(tag), {}))
                 # Create relation from primary entity to tag entity
                 if entity and tag.lower() != entity.lower():
-                    edges.append({
-                        "from": entity,
-                        "to": tag,
-                        "type": "related_to",
-                        "metadata": {"source": "tag"},
-                    })
+                    edges.append(_edge(entity, tag, "related_to", {"source": "tag"}))
 
     # Extract relations from content via patterns
     content_lower = content.lower()
@@ -83,18 +92,11 @@ def extract_entities_and_relations(
             # Clean up the target
             target = target.split(",")[0].strip()  # Take first item if list
             if len(target) > 1 and len(target) < 50:
-                nodes.append({
-                    "name": target,
-                    "type": _guess_type(target),
-                    "attributes": {},
-                })
+                nodes.append(_node(target, _guess_type(target), {}))
                 source = entity or "user"
-                edges.append({
-                    "from": source,
-                    "to": target,
-                    "type": rel_type,
-                    "metadata": {"source": "content_pattern"},
-                })
+                edges.append(
+                    _edge(source, target, rel_type, {"source": "content_pattern"})
+                )
 
     return nodes, edges
 

--- a/attestor/retrieval/orchestrator.py
+++ b/attestor/retrieval/orchestrator.py
@@ -96,22 +96,38 @@ class RetrievalOrchestrator:
         return entities
 
     def _graph_affinity_map(
-        self, question_entities: List[str]
+        self,
+        question_entities: List[str],
+        namespace: Optional[str] = None,
     ) -> Dict[str, int]:
         """Map lowercased candidate-entity → min hop distance to any question entity.
 
         Empty map when no graph is available or the question has no entities.
+        ``namespace`` scopes the BFS — without it, a recall in tenant A could
+        pull a graph affinity bonus from tenant B's entities. Backends that
+        don't accept ``namespace`` (e.g. v3 graph stores) silently ignore it
+        via the TypeError fallback below.
         """
         affinity: Dict[str, int] = {}
         if not self.graph or not question_entities:
             return affinity
+
+        def _related(entity: str, depth: int) -> List[str]:
+            # Try namespace-aware signature first; fall back for backends
+            # that haven't adopted the kwarg yet.
+            try:
+                return self.graph.get_related(
+                    entity, depth=depth, namespace=namespace,
+                )
+            except TypeError:
+                return self.graph.get_related(entity, depth=depth)
 
         for q_ent in question_entities:
             q_key = q_ent.lower()
             affinity[q_key] = min(affinity.get(q_key, 0), 0)
 
             try:
-                d1 = self.graph.get_related(q_ent, depth=1)
+                d1 = _related(q_ent, 1)
             except Exception:
                 d1 = []
             for name in d1:
@@ -120,7 +136,7 @@ class RetrievalOrchestrator:
                     affinity[k] = 1
 
             try:
-                d2 = self.graph.get_related(q_ent, depth=GRAPH_MAX_DEPTH)
+                d2 = _related(q_ent, GRAPH_MAX_DEPTH)
             except Exception:
                 d2 = []
             for name in d2:
@@ -130,16 +146,25 @@ class RetrievalOrchestrator:
         return affinity
 
     def _graph_context_triples(
-        self, question_entities: List[str]
+        self,
+        question_entities: List[str],
+        namespace: Optional[str] = None,
     ) -> List[str]:
-        """Render typed edges incident to question entities as inline strings."""
+        """Render typed edges incident to question entities as inline strings.
+
+        Filters edges by ``namespace`` so synthetic-triple injection can't
+        leak relationships from other tenants into the recall context.
+        """
         triples: List[str] = []
         if not self.graph or not hasattr(self.graph, "get_edges"):
             return triples
         seen = set()
         for ent in question_entities:
             try:
-                edges = self.graph.get_edges(ent)
+                try:
+                    edges = self.graph.get_edges(ent, namespace=namespace)
+                except TypeError:
+                    edges = self.graph.get_edges(ent)
             except Exception:
                 continue
             for edge in edges[:30]:
@@ -300,7 +325,12 @@ class RetrievalOrchestrator:
                     )
 
         # ── Step 2: Graph narrow ──
-        affinity_map = self._graph_affinity_map(question_entities)
+        # Pass namespace through so the BFS can't pull affinity from
+        # entities written by another tenant. Pre-namespace nodes still
+        # recall under namespace="default" via coalesce in the backend.
+        affinity_map = self._graph_affinity_map(
+            question_entities, namespace=namespace,
+        )
         trace_hits = []
         for c in candidates:
             mem = c["memory"]
@@ -334,7 +364,9 @@ class RetrievalOrchestrator:
         ]
 
         # ── Step 3: Inject synthetic triple memories ──
-        triple_strs = self._graph_context_triples(question_entities)
+        triple_strs = self._graph_context_triples(
+            question_entities, namespace=namespace,
+        )
         for triple_str in triple_strs[:20]:
             results.append(
                 RetrievalResult(
@@ -450,7 +482,9 @@ class RetrievalOrchestrator:
 
         # Graph narrow
         t = time.monotonic()
-        affinity_map = self._graph_affinity_map(question_entities)
+        affinity_map = self._graph_affinity_map(
+            question_entities, namespace=namespace,
+        )
         results: List[RetrievalResult] = []
         narrowed: List[Dict] = []
         for c in candidates:
@@ -487,7 +521,9 @@ class RetrievalOrchestrator:
 
         # Triples + boosts + MMR + budget
         t = time.monotonic()
-        triple_strs = self._graph_context_triples(question_entities)
+        triple_strs = self._graph_context_triples(
+            question_entities, namespace=namespace,
+        )
         for triple_str in triple_strs[:20]:
             results.append(
                 RetrievalResult(

--- a/attestor/store/azure_backend.py
+++ b/attestor/store/azure_backend.py
@@ -41,6 +41,16 @@ class AzureBackend(DocumentStore, VectorStore, GraphStore):
         cosmos_database: Database name (default "attestor")
 
     When no cosmos_key is provided, falls back to DefaultAzureCredential.
+
+    Tenancy note:
+        The graph role is an in-process NetworkX MultiDiGraph and this
+        deploy mode is single-tenant by assumption (one Azure account ==
+        one tenant). The orchestrator's ``namespace`` kwarg is ignored
+        here intentionally — adding multi-tenancy would require splitting
+        the in-memory graph per namespace and re-loading from Cosmos on
+        every recall. If a multi-tenant Azure deploy is needed, switch
+        the graph role to the Neo4j backend, which enforces namespace
+        scoping at the Cypher layer.
     """
 
     ROLES: Set[str] = {"document", "vector", "graph"}

--- a/attestor/store/neo4j_backend.py
+++ b/attestor/store/neo4j_backend.py
@@ -1,9 +1,17 @@
 """Neo4j backend — graph role only (Layer 0 stack: Postgres+pgvector + Neo4j).
 
 Uses the official Neo4j Python driver (Bolt). Entity nodes are stored as
-`(:Entity {key, display_name, entity_type, ...})`. Relationships use the
-sanitized `relation_type` as the Neo4j relationship type. PageRank is
-delegated to the Graph Data Science (GDS) plugin when available.
+`(:Entity {key, namespace, display_name, entity_type, ...})`. Relationships
+use the sanitized `relation_type` as the Neo4j relationship type. PageRank
+is delegated to the Graph Data Science (GDS) plugin when available.
+
+Namespace tenancy (multi-tenant isolation):
+    Entity nodes and edges carry a ``namespace`` property; every read
+    operation in the recall path filters on it. New writes always carry the
+    property. Pre-namespace nodes (without the property) are treated as
+    ``namespace="default"`` on read via ``coalesce(e.namespace, 'default')``;
+    no migration is required. Closes a cross-tenant graph-affinity leak
+    where a recall in one namespace could pull bonuses from another.
 """
 
 from __future__ import annotations
@@ -22,6 +30,15 @@ logger = logging.getLogger("attestor")
 _REL_TYPE_RE = re.compile(r"[^A-Za-z0-9_]")
 _NAME_PUNCT_RE = re.compile(r"[^\w\s-]", re.UNICODE)
 _WS_RE = re.compile(r"\s+")
+
+# Namespace assigned to writes when the caller passes ``None`` AND used as
+# the read fallback for pre-namespace nodes via ``coalesce(...)``.
+_DEFAULT_NAMESPACE = "default"
+
+
+def _ns(namespace: Optional[str]) -> str:
+    """Return the effective namespace, defaulting to ``default``."""
+    return namespace or _DEFAULT_NAMESPACE
 
 
 def _sanitize_rel_type(rel_type: str) -> str:
@@ -67,9 +84,18 @@ class Neo4jBackend(GraphStore):
 
     def _init_schema(self) -> None:
         with self._session() as s:
+            # Drop the legacy single-property constraint if present — it
+            # blocks the new composite (key, namespace) constraint.
+            # ``IF EXISTS`` makes this idempotent on fresh installs.
+            try:
+                s.run("DROP CONSTRAINT entity_key_unique IF EXISTS")
+            except Exception as e:
+                logger.debug("legacy constraint drop skipped: %s", e)
+            # Composite uniqueness lets the same display-name live in
+            # different namespaces without colliding.
             s.run(
-                "CREATE CONSTRAINT entity_key_unique IF NOT EXISTS "
-                "FOR (e:Entity) REQUIRE e.key IS UNIQUE"
+                "CREATE CONSTRAINT entity_key_namespace_unique IF NOT EXISTS "
+                "FOR (e:Entity) REQUIRE (e.key, e.namespace) IS UNIQUE"
             )
 
     # ── GraphStore interface ──
@@ -79,13 +105,21 @@ class Neo4jBackend(GraphStore):
         name: str,
         entity_type: str = "general",
         attributes: Optional[Dict[str, Any]] = None,
+        namespace: Optional[str] = None,
     ) -> None:
+        """Upsert an entity scoped by namespace.
+
+        New writes always carry ``namespace`` as a node property. Callers
+        that pass ``None`` get the ``"default"`` tenant — same bucket the
+        read path uses for pre-namespace nodes via ``coalesce``.
+        """
         key = _normalize_name(name)
+        ns = _ns(namespace)
         attrs = dict(attributes) if attributes else {}
         with self._session() as s:
             s.run(
                 """
-                MERGE (e:Entity {key: $key})
+                MERGE (e:Entity {key: $key, namespace: $namespace})
                 ON CREATE SET e.display_name = $name, e.entity_type = $etype
                 ON MATCH SET e.display_name = $name,
                              e.entity_type = CASE
@@ -93,7 +127,8 @@ class Neo4jBackend(GraphStore):
                                  THEN $etype ELSE e.entity_type END
                 SET e += $attrs
                 """,
-                key=key, name=name, etype=entity_type, attrs=attrs,
+                key=key, namespace=ns, name=name,
+                etype=entity_type, attrs=attrs,
             )
 
     def add_relation(
@@ -102,55 +137,91 @@ class Neo4jBackend(GraphStore):
         to_entity: str,
         relation_type: str = "related_to",
         metadata: Optional[Dict[str, Any]] = None,
+        namespace: Optional[str] = None,
     ) -> None:
+        """Upsert an edge between two namespace-scoped entities.
+
+        Both endpoints AND the edge itself carry ``namespace``. We do not
+        support cross-namespace edges by design: if ``from_entity`` and
+        ``to_entity`` legitimately belong to different tenants, callers
+        must merge them at the document layer first.
+        """
         from_key = _normalize_name(from_entity)
         to_key = _normalize_name(to_entity)
         rel = _sanitize_rel_type(relation_type)
         meta = dict(metadata) if metadata else {}
+        # Edge namespace == its endpoints' namespace; record explicitly so
+        # the read filter doesn't need to traverse to a node to gate.
+        ns = _ns(namespace)
+        meta["namespace"] = ns
         event_date = meta.get("event_date", "")
         with self._session() as s:
             s.run(
                 f"""
-                MERGE (a:Entity {{key: $from_key}})
+                MERGE (a:Entity {{key: $from_key, namespace: $namespace}})
                   ON CREATE SET a.display_name = $from_name, a.entity_type = 'general'
-                MERGE (b:Entity {{key: $to_key}})
+                MERGE (b:Entity {{key: $to_key, namespace: $namespace}})
                   ON CREATE SET b.display_name = $to_name, b.entity_type = 'general'
-                MERGE (a)-[r:`{rel}` {{event_date: $event_date}}]->(b)
+                MERGE (a)-[r:`{rel}` {{event_date: $event_date, namespace: $namespace}}]->(b)
                 SET r += $meta, r.relation_type = $rel
                 """,
                 from_key=from_key, from_name=from_entity,
                 to_key=to_key, to_name=to_entity,
+                namespace=ns,
                 meta=meta, rel=rel, event_date=event_date,
             )
 
-    def get_related(self, entity: str, depth: int = 2) -> List[str]:
+    def get_related(
+        self,
+        entity: str,
+        depth: int = 2,
+        namespace: Optional[str] = None,
+    ) -> List[str]:
+        """BFS traversal restricted to a single namespace.
+
+        ``coalesce(n.namespace, 'default')`` keeps pre-namespace nodes
+        recallable under ``namespace="default"`` without a backfill step.
+        """
         start = _normalize_name(entity)
         d = max(1, int(depth))
+        ns = _ns(namespace)
         with self._session() as s:
             result = s.run(
                 f"""
                 MATCH (start:Entity {{key: $start}})
+                WHERE coalesce(start.namespace, 'default') = $namespace
                 MATCH (start)-[*1..{d}]-(other:Entity)
+                WHERE coalesce(other.namespace, 'default') = $namespace
                 RETURN DISTINCT other.display_name AS name
                 """,
-                start=start,
+                start=start, namespace=ns,
             )
             return [row["name"] for row in result if row["name"]]
 
-    def get_subgraph(self, entity: str, depth: int = 2) -> Dict[str, Any]:
+    def get_subgraph(
+        self,
+        entity: str,
+        depth: int = 2,
+        namespace: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Fetch a namespace-scoped subgraph rooted at ``entity``."""
         start = _normalize_name(entity)
         d = max(1, int(depth))
+        ns = _ns(namespace)
         with self._session() as s:
             nodes_rows = list(s.run(
                 f"""
                 MATCH (start:Entity {{key: $start}})
+                WHERE coalesce(start.namespace, 'default') = $namespace
                 OPTIONAL MATCH (start)-[*0..{d}]-(n:Entity)
+                WHERE n IS NULL
+                   OR coalesce(n.namespace, 'default') = $namespace
                 RETURN DISTINCT
                     coalesce(n.key, start.key) AS key,
                     coalesce(n.display_name, start.display_name) AS name,
                     coalesce(n.entity_type, start.entity_type, 'general') AS etype
                 """,
-                start=start,
+                start=start, namespace=ns,
             ))
             if not nodes_rows or all(r["key"] is None for r in nodes_rows):
                 return {"entity": entity, "nodes": [], "edges": []}
@@ -162,13 +233,17 @@ class Neo4jBackend(GraphStore):
             edges_rows = list(s.run(
                 f"""
                 MATCH (start:Entity {{key: $start}})
+                WHERE coalesce(start.namespace, 'default') = $namespace
                 MATCH (start)-[*0..{d}]-(n:Entity)
+                WHERE coalesce(n.namespace, 'default') = $namespace
                 WITH collect(DISTINCT n.key) AS keys
                 MATCH (a:Entity)-[r]->(b:Entity)
                 WHERE a.key IN keys AND b.key IN keys
+                  AND coalesce(a.namespace, 'default') = $namespace
+                  AND coalesce(b.namespace, 'default') = $namespace
                 RETURN a.key AS source, b.key AS target, type(r) AS type
                 """,
-                start=start,
+                start=start, namespace=ns,
             ))
             edges = [
                 {"source": r["source"], "target": r["target"], "type": r["type"]}
@@ -177,6 +252,9 @@ class Neo4jBackend(GraphStore):
         return {"entity": entity, "nodes": nodes, "edges": edges}
 
     def get_entities(self, entity_type: Optional[str] = None) -> List[Dict[str, Any]]:
+        # Admin/UI surface — not on the recall hot path. Returns entities
+        # across all namespaces by design (operator visibility). The recall
+        # path uses get_related/get_subgraph/get_edges which DO filter.
         if entity_type:
             cypher = "MATCH (n:Entity {entity_type: $etype}) RETURN n"
             params: Dict[str, Any] = {"etype": entity_type}
@@ -199,10 +277,16 @@ class Neo4jBackend(GraphStore):
                 })
         return result
 
-    def get_edges(self, entity: str) -> List[Dict[str, Any]]:
+    def get_edges(
+        self, entity: str, namespace: Optional[str] = None
+    ) -> List[Dict[str, Any]]:
+        """Return all edges incident to ``entity`` within the namespace."""
         key = _normalize_name(entity)
+        ns = _ns(namespace)
         cypher = """
             MATCH (a:Entity {key: $key})-[r]-(b:Entity)
+            WHERE coalesce(a.namespace, 'default') = $namespace
+              AND coalesce(b.namespace, 'default') = $namespace
             RETURN a.display_name AS subject,
                    type(r) AS predicate,
                    b.display_name AS object,
@@ -212,7 +296,7 @@ class Neo4jBackend(GraphStore):
         seen: set = set()
         result: List[Dict[str, Any]] = []
         with self._session() as s:
-            for row in s.run(cypher, key=key):
+            for row in s.run(cypher, key=key, namespace=ns):
                 triple = (row["subject"], row["predicate"], row["object"])
                 if triple in seen:
                     continue

--- a/tests/test_neo4j_namespace.py
+++ b/tests/test_neo4j_namespace.py
@@ -1,0 +1,314 @@
+"""Unit tests for Neo4j namespace tenancy.
+
+The Neo4j Python driver and a live database are NOT required — every test
+patches ``neo4j.GraphDatabase.driver`` with a recording stub that captures
+the Cypher and parameters passed to ``session.run`` so we can assert:
+
+* upserts MERGE on ``(key, namespace)`` so the same entity name in two
+  namespaces produces two distinct nodes
+* edges carry ``namespace`` on the relationship as well as on both endpoints
+* every read in the recall hot path adds a
+  ``coalesce(<n>.namespace, 'default') = $namespace`` clause and binds
+  ``namespace`` as a parameter
+* the orchestrator forwards ``namespace`` from a tenant-scoped recall
+  through the graph step
+
+These checks close the cross-tenant graph affinity leak documented in
+``attestor/store/neo4j_backend.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Tuple
+
+import pytest
+
+from attestor.retrieval.orchestrator import RetrievalOrchestrator
+
+
+# ── Driver / session stub ────────────────────────────────────────────────
+
+
+class _PermissiveRow:
+    """Row stand-in that returns a benign default for any column lookup.
+
+    The backend's read methods reach into rows with mixed schemas across
+    queries (``key``, ``name``, ``subject``, ``etype``, …); rather than
+    hand-shape per-query rows in the stub, we return ``""`` for unknown
+    columns and ``"placeholder"`` for the well-known identity columns.
+    The assertions only inspect captured Cypher / parameters, never the
+    return shape, so this is safe.
+    """
+
+    def __getitem__(self, key: str) -> str:
+        if key in {"key", "subject", "object", "name"}:
+            return "placeholder"
+        return ""
+
+
+class _RecordingResult:
+    """Iterable / .single() shim — most calls in the backend ignore the value.
+
+    We feed back a single synthetic row by default so the backend's
+    ``get_subgraph`` doesn't bail out on the first empty MATCH and still
+    issues its second (edge-fetching) Cypher call.
+    """
+
+    def __init__(self, rows: Optional[List[Any]] = None) -> None:
+        self._rows = rows if rows is not None else [_PermissiveRow()]
+
+    def __iter__(self):
+        return iter(self._rows)
+
+    def single(self) -> Any:
+        return self._rows[0] if self._rows else _PermissiveRow()
+
+
+class _RecordingSession:
+    """Captures every ``run(cypher, **params)`` call into a shared list."""
+
+    def __init__(self, sink: List[Tuple[str, Dict[str, Any]]]) -> None:
+        self._sink = sink
+
+    def __enter__(self) -> "_RecordingSession":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    def run(self, cypher: str, **params: Any) -> _RecordingResult:
+        self._sink.append((cypher, dict(params)))
+        return _RecordingResult()
+
+
+class _RecordingDriver:
+    """Stand-in for ``neo4j.Driver`` — opens recording sessions on demand."""
+
+    def __init__(self) -> None:
+        self.calls: List[Tuple[str, Dict[str, Any]]] = []
+
+    def session(self, database: Optional[str] = None) -> _RecordingSession:
+        return _RecordingSession(self.calls)
+
+    def verify_connectivity(self) -> None:
+        return None
+
+    def close(self) -> None:
+        return None
+
+
+@pytest.fixture
+def neo4j_backend(monkeypatch):
+    """Build a Neo4jBackend bound to a recording driver — no live DB needed."""
+    from attestor.store import neo4j_backend as backend_mod
+
+    driver = _RecordingDriver()
+    monkeypatch.setattr(
+        backend_mod.GraphDatabase, "driver",
+        lambda *args, **kwargs: driver,
+    )
+
+    config = {
+        "neo4j_uri": "bolt://stub:7687",
+        "neo4j_user": "neo4j",
+        "neo4j_password": "stub",
+    }
+    instance = backend_mod.Neo4jBackend(config)
+    # Reset call log so schema-init noise doesn't pollute assertions
+    driver.calls.clear()
+    return instance, driver
+
+
+def _last_call(driver: _RecordingDriver) -> Tuple[str, Dict[str, Any]]:
+    assert driver.calls, "expected at least one Cypher call"
+    return driver.calls[-1]
+
+
+# ── add_entity ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_add_entity_merges_on_name_and_namespace(neo4j_backend):
+    backend, driver = neo4j_backend
+    backend.add_entity("Caroline", entity_type="person", namespace="acme")
+
+    cypher, params = _last_call(driver)
+    # MERGE must scope by BOTH key AND namespace — that is the whole
+    # contract of this change.
+    assert "MERGE (e:Entity {key: $key, namespace: $namespace})" in cypher
+    assert params["namespace"] == "acme"
+    # ``key`` is the normalized form of the display name
+    assert params["key"] == "caroline"
+
+
+@pytest.mark.unit
+def test_add_entity_defaults_to_default_namespace(neo4j_backend):
+    backend, driver = neo4j_backend
+    backend.add_entity("Caroline", entity_type="person")  # no namespace kwarg
+
+    _, params = _last_call(driver)
+    # Backend-level fallback mirrors the read-side coalesce so legacy
+    # callers that haven't been plumbed through with namespace still land
+    # in a single, well-known tenant.
+    assert params["namespace"] == "default"
+
+
+# ── add_relation ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_add_relation_tags_endpoints_and_edge_with_namespace(neo4j_backend):
+    backend, driver = neo4j_backend
+    backend.add_relation(
+        "Caroline", "Acme",
+        relation_type="works_at",
+        metadata={"event_date": "2026-04-28"},
+        namespace="acme",
+    )
+
+    cypher, params = _last_call(driver)
+    # Both endpoint MERGEs scope by (key, namespace) and the edge itself
+    # carries namespace so a future query can gate on r.namespace without
+    # traversing back to a node.
+    assert "MERGE (a:Entity {key: $from_key, namespace: $namespace})" in cypher
+    assert "MERGE (b:Entity {key: $to_key, namespace: $namespace})" in cypher
+    assert "namespace: $namespace" in cypher  # edge-level
+    assert params["namespace"] == "acme"
+    # Metadata is also stamped — useful for graph_stats / debugging queries
+    assert params["meta"]["namespace"] == "acme"
+
+
+# ── Read filters ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_get_related_filters_by_namespace(neo4j_backend):
+    backend, driver = neo4j_backend
+    backend.get_related("Caroline", depth=2, namespace="acme")
+
+    cypher, params = _last_call(driver)
+    # The coalesce clause is the back-compat bridge — pre-namespace nodes
+    # still recall under namespace="default" without a migration script.
+    assert "coalesce(start.namespace, 'default') = $namespace" in cypher
+    assert "coalesce(other.namespace, 'default') = $namespace" in cypher
+    assert params["namespace"] == "acme"
+
+
+@pytest.mark.unit
+def test_get_subgraph_filters_by_namespace(neo4j_backend):
+    backend, driver = neo4j_backend
+    backend.get_subgraph("Caroline", depth=2, namespace="acme")
+
+    # Two queries are issued (nodes + edges); both must filter.
+    nodes_cypher, nodes_params = driver.calls[0]
+    edges_cypher, edges_params = driver.calls[1]
+    assert "coalesce(start.namespace, 'default') = $namespace" in nodes_cypher
+    assert "coalesce(a.namespace, 'default') = $namespace" in edges_cypher
+    assert "coalesce(b.namespace, 'default') = $namespace" in edges_cypher
+    assert nodes_params["namespace"] == "acme"
+    assert edges_params["namespace"] == "acme"
+
+
+@pytest.mark.unit
+def test_get_edges_filters_by_namespace(neo4j_backend):
+    backend, driver = neo4j_backend
+    backend.get_edges("Caroline", namespace="acme")
+
+    cypher, params = _last_call(driver)
+    assert "coalesce(a.namespace, 'default') = $namespace" in cypher
+    assert "coalesce(b.namespace, 'default') = $namespace" in cypher
+    assert params["namespace"] == "acme"
+
+
+@pytest.mark.unit
+def test_read_defaults_to_default_namespace(neo4j_backend):
+    backend, driver = neo4j_backend
+    backend.get_related("Caroline", depth=1)
+
+    _, params = _last_call(driver)
+    # Symmetric to writes — None at the API surface means "default" tenant.
+    assert params["namespace"] == "default"
+
+
+# ── Schema init ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_init_schema_uses_composite_constraint(monkeypatch):
+    """Fresh backends drop the legacy key-only constraint and create the composite one."""
+    from attestor.store import neo4j_backend as backend_mod
+
+    driver = _RecordingDriver()
+    monkeypatch.setattr(
+        backend_mod.GraphDatabase, "driver",
+        lambda *args, **kwargs: driver,
+    )
+    backend_mod.Neo4jBackend({
+        "neo4j_uri": "bolt://stub:7687",
+        "neo4j_user": "neo4j",
+        "neo4j_password": "stub",
+    })
+
+    cyphers = [c for c, _ in driver.calls]
+    assert any("DROP CONSTRAINT entity_key_unique" in c for c in cyphers), (
+        "must drop the legacy single-property constraint to make room for "
+        "the composite (key, namespace) one"
+    )
+    assert any(
+        "CREATE CONSTRAINT entity_key_namespace_unique" in c
+        and "REQUIRE (e.key, e.namespace) IS UNIQUE" in c
+        for c in cyphers
+    )
+
+
+# ── Orchestrator integration ─────────────────────────────────────────────
+
+
+class _FakeGraph:
+    """Captures namespace forwarded by the orchestrator's graph step."""
+
+    def __init__(self) -> None:
+        self.related_calls: List[Dict[str, Any]] = []
+        self.edges_calls: List[Dict[str, Any]] = []
+
+    def get_related(self, entity: str, depth: int = 2,
+                    namespace: Optional[str] = None) -> List[str]:
+        self.related_calls.append(
+            {"entity": entity, "depth": depth, "namespace": namespace}
+        )
+        return []
+
+    def get_edges(self, entity: str,
+                  namespace: Optional[str] = None) -> List[Dict[str, Any]]:
+        self.edges_calls.append({"entity": entity, "namespace": namespace})
+        return []
+
+
+class _NoopStore:
+    """Just enough of DocumentStore to let recall() short-circuit cleanly."""
+
+    def get(self, memory_id: str):
+        return None
+
+
+@pytest.mark.unit
+def test_orchestrator_forwards_namespace_to_graph_step():
+    graph = _FakeGraph()
+    orch = RetrievalOrchestrator(
+        store=_NoopStore(),
+        vector_store=None,  # bypass the vector lane entirely
+        graph=graph,
+    )
+    # Capitalised token so _question_entities picks it up; the orchestrator
+    # then calls graph.get_related / get_edges in the narrow + triple-injection
+    # steps.
+    orch.recall("Where does Caroline work?", namespace="acme")
+
+    assert graph.related_calls, "graph affinity step did not fire"
+    for call in graph.related_calls:
+        assert call["namespace"] == "acme", (
+            "orchestrator must forward the active tenant's namespace "
+            "into the BFS — otherwise tenant A pulls bonuses from tenant B"
+        )
+    for call in graph.edges_calls:
+        assert call["namespace"] == "acme"


### PR DESCRIPTION
## Summary

Closes the cross-tenant leak in the graph layer: Postgres has row-level namespace isolation but Neo4j entity nodes were global. A recall in `namespace="acme"` could pull a graph affinity bonus from entities written by `namespace="globex"`.

**Now enforced:**
- Composite `(key, namespace)` constraint replaces the legacy single-prop one.
- `add_entity` / `add_relation` MERGE on `(key, namespace)`; `namespace` is stamped on edges too.
- `get_related` / `get_subgraph` / `get_edges` filter via `WHERE coalesce(<n>.namespace, 'default') = \$namespace` — the `coalesce` is the back-compat bridge so pre-namespace data still recalls under `namespace="default"`.
- Namespace threaded through `retrieval/orchestrator.py` (graph step), `graph/extractor.py`, and `core.py` write path. `TypeError` fallback preserves back-compat for non-namespace `GraphStore` implementations (Arango, AGE, Neptune).

## Honest call-outs (left as follow-ups)

1. **`Neo4jBackend.pagerank()` is NOT namespace-filtered.** It runs over the full graph projection. Not on the recall hot path (only `core.pagerank()` for UI surfaces calls it). Future tenant-scoped PageRank usage would leak.
2. **`get_entities()` and `graph_stats()` intentionally return cross-namespace data** — for admin/UI visibility. Inline comment added.
3. **No migration script.** Per project convention (no ceremonial docs / config-driven greenfield), the legacy `entity_key_unique` constraint is dropped on connect; pre-namespace nodes are read-compatible via `coalesce`. **First write that targets a key existing only in pre-namespace state will create a new `namespace="default"` row**, leaving the old orphaned. Greenfield-acceptable; document if anyone runs this against a DB with real prior data.
4. **`attestor/locomo.py` (eval ingest)** calls `add_entity`/`add_relation` without `namespace=` — lands in `"default"` via fallback. Not on recall hot path; eval data is single-tenant by convention.
5. **Other `GraphStore` ABC implementations** (Arango, AGE, Neptune) unchanged. Orchestrator's `TypeError` fallback keeps them working unfiltered.

## Test plan
- [x] 9 new tests in `tests/test_neo4j_namespace.py` (hermetic; no live Neo4j needed)
- [x] Graph/orchestrator tests in isolation: 44 passed, 20 skipped
- [x] Full unit suite: 902 passed, 236 skipped (pre-existing live-Postgres flakes unrelated to this change)