### PR TITLE
feat(safety): assert embedder dim matches pgvector schema at startup

### DIFF
--- a/attestor/core.py
+++ b/attestor/core.py
@@ -96,6 +96,18 @@ class AgentMemory:
         doc_backend = role_assignments["document"]
         self._store: DocumentStore = _get_or_create(doc_backend)
 
+        # Embedder/schema dim guard — fail-fast if the embedder produces
+        # D-dim vectors but the pgvector schema declares vector(N) with
+        # N != D. Without this guard, every UPDATE on memories.embedding
+        # silently no-ops (the doc-write path swallows non-fatal vector
+        # errors) and Attestor accepts writes that store nothing in the
+        # vector lane. Skips on non-Postgres stores, on first-init
+        # (table not created yet), and on introspection errors.
+        from attestor.store.embedder_dim_check import (
+            assert_embedder_dim_matches_schema,
+        )
+        assert_embedder_dim_matches_schema(self._store)
+
         # Initialize vector store (optional — graceful degradation)
         self._vector_store: Optional[VectorStore] = None
         if "vector" in role_assignments:

--- a/attestor/store/embedder_dim_check.py
+++ b/attestor/store/embedder_dim_check.py
@@ -1,0 +1,140 @@
+"""Embedder/schema dimension assertion — fail-fast guard.
+
+Bug class: pgvector declares ``embedding vector(N)`` at table-create time.
+If the active embedder produces D-dim vectors and ``D != N``, every UPDATE
+that sets the embedding column is silently no-op'd because the document
+write path swallows non-fatal vector errors (`attestor/core.py::add`).
+The result is an Attestor that "accepts" writes but stores nothing in the
+vector lane — invisible until recall returns zero hits.
+
+This guard runs once at ``AgentMemory.__init__``:
+  - reads ``memories.embedding`` typmod from ``pg_attribute`` to learn the
+    schema's declared dim,
+  - compares to the embedder's ``.dimension``,
+  - raises ``EmbedderDimMismatchError`` with both numbers + remediation
+    when they diverge,
+  - skips when the table doesn't exist yet (greenfield first init: the
+    backend is about to CREATE TABLE at the embedder's dim, no schema to
+    check against),
+  - skips when the introspection query errors (e.g. role lacks
+    ``SELECT`` on system catalogs) — diagnostic checks should never break
+    a startup that was otherwise viable.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+logger = logging.getLogger("attestor")
+
+
+# pgvector encodes the vector(N) dimension into ``pg_attribute.atttypmod``.
+# As of pgvector 0.5+, ``atttypmod`` IS the dimension itself (no "+ 4"
+# adjustment like varchar). The canonical query is to read it directly
+# off the column — ``format_type(atttypid, atttypmod)`` returns e.g.
+# ``"vector(1024)"`` and is brittle to parse, so we use atttypmod.
+_DIM_LOOKUP_SQL = """
+    SELECT atttypmod
+    FROM pg_attribute
+    WHERE attrelid = to_regclass('public.memories')
+      AND attname  = 'embedding'
+      AND NOT attisdropped
+"""
+
+
+class EmbedderDimMismatchError(RuntimeError):
+    """Raised when the embedder's output dim doesn't match the pgvector
+    schema's declared dim. Carries both numbers + the provider name so
+    the user can diagnose without re-running.
+
+    Inherits ``RuntimeError`` so legacy ``except (ValueError, RuntimeError)``
+    clauses around init still see the failure as fatal."""
+
+
+def get_schema_embedding_dim(conn: Any) -> Optional[int]:
+    """Return the declared dim of ``memories.embedding`` in the active DB.
+
+    Returns:
+        int  — the column's vector dim
+        None — when the table/column doesn't exist, OR when the
+               introspection query errors (caller treats both as
+               "skip the check").
+
+    The query is read-only and runs against ``pg_attribute``; it does
+    not need RLS to be set up (system catalogs are not RLS-scoped). It
+    only fails on hardened deployments where the runtime role has been
+    denied SELECT on ``pg_attribute`` — extremely rare; in that case
+    we return None and skip rather than block startup.
+    """
+    try:
+        with conn.cursor() as cur:
+            cur.execute(_DIM_LOOKUP_SQL)
+            row = cur.fetchone()
+    except Exception as e:
+        # Diagnostic check; never blow up startup. Logged so it's visible
+        # in operator logs without becoming a hard error.
+        logger.debug("schema dim introspection failed: %s", e)
+        return None
+
+    if row is None:
+        # Table or column doesn't exist yet — greenfield first init.
+        return None
+
+    # row is a 1-tuple (atttypmod,). atttypmod < 0 means "no typmod set"
+    # which would be a corrupted schema; treat as unknown and skip.
+    dim = row[0]
+    if dim is None or dim < 0:
+        return None
+    return int(dim)
+
+
+def assert_embedder_dim_matches_schema(backend: Any) -> None:
+    """Validate that ``backend._embedder.dimension`` equals the schema's
+    declared dim for ``memories.embedding``. Raises on mismatch; no-ops
+    on every "can't tell" case.
+
+    Skip conditions (no raise):
+      - backend has no ``_conn`` attribute (non-Postgres store)
+      - backend has no ``_embedder`` attribute (e.g. embedding_dim
+        passed explicitly without probing an embedder)
+      - schema dim is None (table not created yet, OR query error)
+      - embedder.dimension is None / not an int (defensive)
+
+    Raises:
+        EmbedderDimMismatchError: schema_dim != embedder_dim
+    """
+    conn = getattr(backend, "_conn", None)
+    if conn is None:
+        return
+
+    embedder = getattr(backend, "_embedder", None)
+    if embedder is None:
+        return
+
+    embedder_dim = getattr(embedder, "dimension", None)
+    if not isinstance(embedder_dim, int) or embedder_dim <= 0:
+        return
+
+    schema_dim = get_schema_embedding_dim(conn)
+    if schema_dim is None:
+        # Table missing or unable to introspect — skip the check. The
+        # backend's own _init_schema path will create the column at the
+        # embedder's dim.
+        return
+
+    if schema_dim == embedder_dim:
+        return
+
+    provider_name = getattr(embedder, "provider_name", "unknown")
+    raise EmbedderDimMismatchError(
+        f"Embedder dimension mismatch: embedder={provider_name}({embedder_dim}-D) "
+        f"but schema=vector({schema_dim}). "
+        f"Either reconfigure the embedder (configs/attestor.yaml -> embedder.model "
+        f"to one that emits {schema_dim}-D vectors) or migrate the schema:\n"
+        f"  TRUNCATE memories;\n"
+        f"  ALTER TABLE memories DROP COLUMN embedding;\n"
+        f"  ALTER TABLE memories ADD COLUMN embedding vector({embedder_dim});\n"
+        f"  CREATE INDEX idx_memories_embedding_hnsw "
+        f"ON memories USING hnsw (embedding vector_cosine_ops);"
+    )

--- a/tests/test_embedder_dim_check.py
+++ b/tests/test_embedder_dim_check.py
@@ -1,0 +1,316 @@
+"""Startup-time assertion that the embedder's output dim matches the
+pgvector schema dim.
+
+The pgvector schema column `embedding vector(N)` is fixed at table-create
+time. If the embedder produces D-dim vectors and N != D, every UPDATE on
+the embedding column silently no-ops because the doc path swallows
+non-fatal vector errors. We've been bitten by this before — switching
+from text-embedding-3-large (3072-D) to voyage-4 (1024-D) without
+migrating the schema gave us an Attestor that "accepted" writes but
+stored nothing.
+
+The check fires during ``AgentMemory.__init__`` once the document store
+is up. It MUST raise (not warn) on mismatch and tell the user both
+numbers plus the two remediation paths (reconfigure embedder, or migrate
+schema). When the table doesn't exist yet (greenfield first init), the
+check is skipped — the schema will get created at the right dim by the
+backend's own init path.
+
+These tests are hermetic: a synthetic backend stub returns the schema dim
+we want, the embedder's dim is forced via ``backend_configs``, and no
+real Postgres / embedding provider is required.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from attestor.store.embedder_dim_check import (
+    EmbedderDimMismatchError,
+    assert_embedder_dim_matches_schema,
+    get_schema_embedding_dim,
+)
+
+
+# ───────────────────────────────────────────────────────────────────────
+# Stubs — mimic the parts of PostgresBackend we touch
+# ───────────────────────────────────────────────────────────────────────
+
+
+class _StubCursor:
+    """psycopg2-style cursor that returns one canned row per execute()."""
+
+    def __init__(self, rows_per_call: list) -> None:
+        # rows_per_call is a queue: each execute() pops the next row.
+        # Use None for "no row" (empty result).
+        self._queue = list(rows_per_call)
+        self._last_row: Optional[tuple] = None
+        self.executed: list[str] = []
+
+    def __enter__(self) -> "_StubCursor":
+        return self
+
+    def __exit__(self, *exc) -> None:
+        return None
+
+    def execute(self, sql: str, params=None) -> None:
+        self.executed.append(sql)
+        if self._queue:
+            self._last_row = self._queue.pop(0)
+        else:
+            self._last_row = None
+
+    def fetchone(self):
+        return self._last_row
+
+
+class _StubConn:
+    """psycopg2-style connection that hands out _StubCursors."""
+
+    def __init__(self, rows_per_call: list) -> None:
+        self._rows = rows_per_call
+
+    def cursor(self, cursor_factory=None) -> _StubCursor:
+        return _StubCursor(self._rows)
+
+
+def _make_backend(schema_dim: Optional[int], embedder_dim: int):
+    """Construct a PostgresBackend-shaped stub.
+
+    schema_dim:
+        - int  → the memories.embedding column has vector(schema_dim)
+        - None → the memories table does not exist (or column missing)
+
+    embedder_dim:
+        - the dimension we'll claim our embedder produces.
+    """
+    # The introspection query is structured to return either a single-row
+    # tuple of (dim,) or None when the table/column is absent.
+    rows = [(schema_dim,)] if schema_dim is not None else [None]
+    conn = _StubConn(rows)
+
+    embedder = MagicMock()
+    embedder.dimension = embedder_dim
+    embedder.provider_name = f"stub:{embedder_dim}d"
+
+    backend = MagicMock()
+    backend._conn = conn
+    backend._embedder = embedder
+    backend._embedding_dim = embedder_dim
+
+    return backend
+
+
+# ───────────────────────────────────────────────────────────────────────
+# get_schema_embedding_dim
+# ───────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_get_schema_dim_returns_int_when_column_exists() -> None:
+    backend = _make_backend(schema_dim=1024, embedder_dim=1024)
+    assert get_schema_embedding_dim(backend._conn) == 1024
+
+
+@pytest.mark.unit
+def test_get_schema_dim_returns_none_when_column_missing() -> None:
+    backend = _make_backend(schema_dim=None, embedder_dim=1024)
+    # No row → no column / no table → None
+    assert get_schema_embedding_dim(backend._conn) is None
+
+
+@pytest.mark.unit
+def test_get_schema_dim_returns_none_on_query_error() -> None:
+    """If the introspection query raises (e.g. permissions, search path),
+    treat as 'unknown' and skip rather than blowing up startup."""
+
+    class _ExplodingConn:
+        def cursor(self, cursor_factory=None):
+            raise RuntimeError("permission denied for pg_attribute")
+
+    assert get_schema_embedding_dim(_ExplodingConn()) is None
+
+
+# ───────────────────────────────────────────────────────────────────────
+# assert_embedder_dim_matches_schema — match path
+# ───────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_match_does_not_raise() -> None:
+    backend = _make_backend(schema_dim=1024, embedder_dim=1024)
+    # Should be a no-op (no exception, no return value contract).
+    assert_embedder_dim_matches_schema(backend)
+
+
+@pytest.mark.unit
+def test_match_with_3072_dim_does_not_raise() -> None:
+    """Different but matching dim — still fine."""
+    backend = _make_backend(schema_dim=3072, embedder_dim=3072)
+    assert_embedder_dim_matches_schema(backend)
+
+
+# ───────────────────────────────────────────────────────────────────────
+# Mismatch path — must raise with both numbers + remediation
+# ───────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_mismatch_raises_with_both_dims_in_message() -> None:
+    """The classic failure mode: embedder=1024, schema=1536."""
+    backend = _make_backend(schema_dim=1536, embedder_dim=1024)
+    with pytest.raises(
+        (EmbedderDimMismatchError, ValueError, RuntimeError),
+    ) as excinfo:
+        assert_embedder_dim_matches_schema(backend)
+    msg = str(excinfo.value)
+    # Both numbers must appear so the user can immediately see the gap.
+    assert "1024" in msg
+    assert "1536" in msg
+
+
+@pytest.mark.unit
+def test_mismatch_message_mentions_remediation_paths() -> None:
+    """The error has to point at the two remediation paths so the user
+    isn't left guessing — reconfigure the embedder OR migrate the schema."""
+    backend = _make_backend(schema_dim=1536, embedder_dim=1024)
+    with pytest.raises(
+        (EmbedderDimMismatchError, ValueError, RuntimeError),
+    ) as excinfo:
+        assert_embedder_dim_matches_schema(backend)
+    msg = str(excinfo.value).lower()
+    # Reconfigure path
+    assert "embedder" in msg
+    # Migrate path
+    assert (
+        "alter table" in msg
+        or "migrate" in msg
+        or "drop column" in msg
+    )
+
+
+@pytest.mark.unit
+def test_mismatch_message_includes_provider_name() -> None:
+    """When the embedder exposes a provider_name, surface it so the user
+    knows which embedder produced the mismatch (e.g. 'voyage:voyage-4')."""
+    backend = _make_backend(schema_dim=1536, embedder_dim=1024)
+    backend._embedder.provider_name = "voyage:voyage-4"
+    with pytest.raises(
+        (EmbedderDimMismatchError, ValueError, RuntimeError),
+    ) as excinfo:
+        assert_embedder_dim_matches_schema(backend)
+    msg = str(excinfo.value)
+    assert "voyage" in msg.lower()
+
+
+# ───────────────────────────────────────────────────────────────────────
+# Table missing — must NOT raise (greenfield first init)
+# ───────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_table_missing_skips_check() -> None:
+    """When memories.embedding doesn't exist yet, this is the very first
+    init and the table is about to be created at the embedder's dim. Skip
+    the check rather than rejecting the bootstrap."""
+    backend = _make_backend(schema_dim=None, embedder_dim=1024)
+    # Should not raise.
+    assert_embedder_dim_matches_schema(backend)
+
+
+@pytest.mark.unit
+def test_query_error_skips_check() -> None:
+    """When the introspection query raises (e.g. RLS denies pg_attribute,
+    role lacks SELECT on system catalogs), don't break startup over a
+    diagnostic check. Skip silently — recall errors will surface the real
+    issue, and the doctor command can re-run the check explicitly."""
+
+    class _ExplodingConn:
+        def cursor(self, cursor_factory=None):
+            raise RuntimeError("permission denied")
+
+    embedder = MagicMock()
+    embedder.dimension = 1024
+    embedder.provider_name = "stub"
+
+    backend = MagicMock()
+    backend._conn = _ExplodingConn()
+    backend._embedder = embedder
+    backend._embedding_dim = 1024
+
+    # Should not raise.
+    assert_embedder_dim_matches_schema(backend)
+
+
+# ───────────────────────────────────────────────────────────────────────
+# Backend without an embedder — skip (e.g. embedding_dim was passed
+# explicitly, no embedder probed)
+# ───────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_backend_without_embedder_skips_check() -> None:
+    """If the backend has no _embedder attribute (e.g. a non-Postgres
+    document store, or a Postgres backend booted with embedding_dim
+    pre-set + skip_schema_init), there's nothing to compare. Skip."""
+    backend = MagicMock(spec=[])  # no attributes
+    # spec=[] → any attribute access raises AttributeError
+    # Should not raise.
+    assert_embedder_dim_matches_schema(backend)
+
+
+@pytest.mark.unit
+def test_backend_without_conn_skips_check() -> None:
+    """Non-Postgres backends (Arango, AWS, Cosmos) don't expose _conn;
+    the check only fires for the Postgres backend. Skip on absence."""
+    embedder = MagicMock()
+    embedder.dimension = 1024
+    backend = MagicMock(spec=["_embedder"])
+    backend._embedder = embedder
+    # Should not raise.
+    assert_embedder_dim_matches_schema(backend)
+
+
+# ───────────────────────────────────────────────────────────────────────
+# Wired into AgentMemory.__init__: a constructed AgentMemory whose store
+# would mismatch must raise at construction time, not later at recall.
+# ───────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_agent_memory_init_raises_on_dim_mismatch(tmp_path) -> None:
+    """End-to-end: when AgentMemory wires a Postgres-shaped store whose
+    schema dim != embedder dim, construction itself must blow up.
+
+    We patch out the heavy bits (registry, config layering) so this stays
+    a pure unit test."""
+    from attestor.core import AgentMemory
+
+    # A backend stub that satisfies the duck-typed surface AgentMemory
+    # touches in __init__: stats(), close(), _v4 attribute, _conn
+    # (introspection target), _embedder (dim source).
+    schema_dim = 1536
+    embedder_dim = 1024
+    backend = _make_backend(schema_dim=schema_dim, embedder_dim=embedder_dim)
+    # AgentMemory checks this attribute to gate v4 features.
+    backend._v4 = False
+
+    # Patch the registry's instantiate_backend so AgentMemory wires our stub.
+    with patch(
+        "attestor.core.instantiate_backend", return_value=backend,
+    ), patch(
+        "attestor.core.resolve_backends",
+        return_value={"document": "postgres", "vector": "postgres", "graph": "postgres"},
+    ), patch(
+        "attestor.core.DEFAULT_BACKENDS", ["postgres"],
+    ):
+        with pytest.raises(
+            (EmbedderDimMismatchError, ValueError, RuntimeError),
+        ) as excinfo:
+            AgentMemory(tmp_path / "mem")
+    msg = str(excinfo.value)
+    assert str(schema_dim) in msg
+    assert str(embedder_dim) in msg

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -37,6 +37,13 @@ class TestGetEmbeddingProvider:
     def setup_method(self):
         clear_embedding_cache()
 
+    def teardown_method(self):
+        # Clear the module-level cached provider so MagicMock embedders
+        # used in these tests don't leak into subsequent suites that
+        # boot a real PostgresBackend (where the embedder/schema dim
+        # guard would otherwise fire against a leaked stub).
+        clear_embedding_cache()
+
     def test_raises_without_any_key(self):
         """No local ollama, no cloud creds, no OpenAI key → explicit error."""
         with patch.dict("os.environ", {}, clear=True):

--- a/tests/test_gdpr.py
+++ b/tests/test_gdpr.py
@@ -46,7 +46,19 @@ def admin_conn():
 
 @pytest.fixture
 def fresh_schema(admin_conn):
-    raw = SCHEMA_PATH.read_text().replace("{embedding_dim}", "16")
+    # 1024-D matches Ollama bge-m3 (the default local embedder used by the
+    # AgentMemory round-trip test below). If you change the embedder, keep
+    # this in sync — the embedder/schema dim assertion in
+    # AgentMemory.__init__ will reject the mismatch at startup.
+    #
+    # Clear the module-level embedder cache so a real Ollama probe runs
+    # for the AgentMemory init below. Some prior tests (e.g.
+    # test_embeddings.py) leave a MagicMock embedder with dim=1536 cached
+    # after their `with patch(...)` blocks tear down; without this clear
+    # the dim guard would fire against the leaked mock instead of Ollama.
+    from attestor.store.embeddings import clear_embedding_cache
+    clear_embedding_cache()
+    raw = SCHEMA_PATH.read_text().replace("{embedding_dim}", "1024")
     with admin_conn.cursor() as cur:
         for tbl in ("deletion_audit", "user_quotas", "memories", "episodes",
                     "sessions", "projects", "users"):

--- a/tests/test_quotas.py
+++ b/tests/test_quotas.py
@@ -54,7 +54,15 @@ def admin_conn():
 
 @pytest.fixture
 def fresh_schema(admin_conn):
-    raw = SCHEMA_PATH.read_text().replace("{embedding_dim}", "16")
+    # 1024-D matches Ollama bge-m3 (the default local embedder used by the
+    # AgentMemory enforcement test below). The embedder/schema dim
+    # assertion in AgentMemory.__init__ rejects mismatches at startup.
+    #
+    # Clear the module-level embedder cache (see test_gdpr.py for the
+    # same rationale — prior tests can leak a MagicMock embedder).
+    from attestor.store.embeddings import clear_embedding_cache
+    clear_embedding_cache()
+    raw = SCHEMA_PATH.read_text().replace("{embedding_dim}", "1024")
     with admin_conn.cursor() as cur:
         for tbl in ("user_quotas", "memories", "episodes",
                     "sessions", "projects", "users"):


### PR DESCRIPTION
## Summary

Guards the silent-no-op write failure documented in `project_pgvector_dim_lesson.md`: pgvector's `vector(N)` is fixed-dim; if the embedder produces D-dim vectors and N ≠ D, every write silently no-ops because the doc-path swallows non-fatal vector errors per the project's degradation pattern. We've been bitten — switching from text-embedding-3-large (3072-D) to voyage-4 (1024-D) without migrating the schema produced an Attestor that accepted writes but stored nothing retrievable.

**This PR makes that failure mode loud.**

## How it works

- `attestor/store/embedder_dim_check.py` (new):
  - `get_schema_embedding_dim(conn)` reads `atttypmod` from `pg_attribute` for `memories.embedding`. Returns `None` for missing column / query error.
  - `assert_embedder_dim_matches_schema(backend)` raises `EmbedderDimMismatchError` (subclass of `RuntimeError`) when `embedder.dimension != schema_dim`. Skips silently on missing `_conn` / `_embedder` / column / query error.
- Wired into `AgentMemory.__init__` (12 lines) immediately after the document store comes up.
- Error message names both numbers, the embedder provider, and gives both remediation paths: reconfigure the embedder OR `TRUNCATE` + `ALTER TABLE` + recreate index.

## What broke and what that tells us

Two pre-existing tests were passing **only** because of the bug this PR catches:
- `test_gdpr::test_agent_memory_purge_user_round_trip`
- `test_quotas::test_agent_memory_set_quota_then_add_blocks`

Both built their schema at `vector(16)` but called `AgentMemory` against a real Ollama bge-m3 embedder (1024-D). The silent vector-write failure was masking the inconsistency — exactly the bug class this PR exists to catch. Fixed by bumping the fixture schema dim to 1024.

A third test (`test_embeddings.py`) was leaking a MagicMock embedder (dim=1536) into the module-level `_cached_provider` between tests. Fixed with a `teardown_method` calling `clear_embedding_cache()`.

## Test plan
- [x] 13 new tests in `tests/test_embedder_dim_check.py` covering: match → no raise; mismatch → raises with both numbers; missing column → no raise; missing `_conn` → no raise; query error → no raise (fail-soft); error message contains remediation steps
- [x] Full suite: 925 passed, 236 skipped (one pre-existing flaky `test_registry::test_conflict_raises` unrelated)