### PR TITLE
feat(trace): exhaustive end-to-end pipeline tracing

### DIFF
--- a/attestor/core.py
+++ b/attestor/core.py
@@ -777,6 +777,13 @@ class AgentMemory:
         t0 = time.monotonic()
         self._store.insert(memory)
         store_timings["document_ms"] = round((time.monotonic() - t0) * 1000, 2)
+        from attestor import trace as _tr
+        if _tr.is_enabled():
+            _tr.event("ingest.write.pg",
+                      memory_id=memory.id, namespace=namespace,
+                      content_len=len(content), tags=list(tags or []),
+                      category=category, entity=entity,
+                      latency_ms=store_timings["document_ms"])
 
         # v4 provenance signing (Phase 8.1) — sign AFTER insert so the
         # canonical payload includes the DB-generated id + t_created.
@@ -806,12 +813,20 @@ class AgentMemory:
                 t0 = time.monotonic()
                 self._vector_store.add(memory.id, content, namespace=namespace)
                 store_timings["vector_ms"] = round((time.monotonic() - t0) * 1000, 2)
+                if _tr.is_enabled():
+                    _tr.event("ingest.write.vector",
+                              memory_id=memory.id, namespace=namespace,
+                              latency_ms=store_timings["vector_ms"], ok=True)
             except Exception as e:
                 store_timings["vector_ms"] = -1  # failed
                 logger.warning(
                     "vector add failed for memory %s: %s: %s",
                     memory.id, type(e).__name__, e,
                 )
+                if _tr.is_enabled():
+                    _tr.event("ingest.write.vector",
+                              memory_id=memory.id, namespace=namespace,
+                              ok=False, error=f"{type(e).__name__}: {e}")
 
         # Update entity graph (also non-fatal; surface exceptions for the
         # same reason — silent drops here mean recall layer 2 returns
@@ -824,6 +839,11 @@ class AgentMemory:
                     content, tags or [], entity, category,
                     namespace=namespace,
                 )
+                if _tr.is_enabled():
+                    _tr.event("ingest.extract",
+                              memory_id=memory.id, namespace=namespace,
+                              entity_count=len(nodes), relation_count=len(edges),
+                              entity_names=[n["name"] for n in nodes][:10])
                 # Tag every entity / relation with the writer's namespace
                 # so the graph layer enforces tenancy alongside Postgres.
                 # Older graph backends without the kwarg still accept the
@@ -859,12 +879,21 @@ class AgentMemory:
                             metadata=edge.get("metadata"),
                         )
                 store_timings["graph_ms"] = round((time.monotonic() - t0) * 1000, 2)
+                if _tr.is_enabled():
+                    _tr.event("ingest.write.graph",
+                              memory_id=memory.id, namespace=namespace,
+                              entity_count=len(nodes), relation_count=len(edges),
+                              latency_ms=store_timings["graph_ms"], ok=True)
             except Exception as e:
                 store_timings["graph_ms"] = -1  # failed
                 logger.warning(
                     "graph add failed for memory %s: %s: %s",
                     memory.id, type(e).__name__, e,
                 )
+                if _tr.is_enabled():
+                    _tr.event("ingest.write.graph",
+                              memory_id=memory.id, namespace=namespace,
+                              ok=False, error=f"{type(e).__name__}: {e}")
 
         total_ms = round((time.monotonic() - t_total) * 1000, 2)
         store_timings["total_ms"] = total_ms

--- a/attestor/retrieval/orchestrator.py
+++ b/attestor/retrieval/orchestrator.py
@@ -222,7 +222,14 @@ class RetrievalOrchestrator:
         when both are None.
         """
         t_total = time.monotonic()
+        from attestor import trace as _tr
         question_entities = self._question_entities(query)
+        if _tr.is_enabled():
+            _tr.event("recall.start", query=query[:200], namespace=namespace,
+                      token_budget=token_budget,
+                      question_entities=question_entities,
+                      as_of=str(as_of) if as_of else None,
+                      time_window=str(time_window) if time_window else None)
 
         # ── Step 1: Vector top-K ──
         vector_hits_raw: List[Dict] = []
@@ -242,6 +249,12 @@ class RetrievalOrchestrator:
                     )
             except Exception:
                 vector_hits_raw = []
+        if _tr.is_enabled():
+            _tr.event("recall.stage.vector",
+                      top_k=VECTOR_TOP_K, hit_count=len(vector_hits_raw),
+                      hits=[{"id": h.get("memory_id"),
+                             "distance": round(float(h.get("distance", 1.0)), 4)}
+                            for h in vector_hits_raw[:10]])
 
         # ── Step 1b: BM25 lane (Phase 4.3) ──
         # Runs alongside the vector lane; fused via RRF below. When the
@@ -261,6 +274,13 @@ class RetrievalOrchestrator:
                 )
             except Exception:
                 bm25_hits_raw = []
+        if _tr.is_enabled():
+            _tr.event("recall.stage.bm25",
+                      enabled=self.bm25_lane is not None,
+                      hit_count=len(bm25_hits_raw),
+                      hits=[{"id": h.memory_id,
+                             "rank": getattr(h, "rank", None)}
+                            for h in bm25_hits_raw[:10]])
 
         # ── Step 2: Materialise vector candidates with preliminary vector_sim
         # status='active' is current-state filtering. When as_of is set,
@@ -323,6 +343,11 @@ class RetrievalOrchestrator:
                     c["vector_sim"] = max(
                         c["vector_sim"], 1.0 - (pos / n),
                     )
+            if _tr.is_enabled():
+                _tr.event("recall.stage.rrf",
+                          fused_count=len(fused),
+                          top_fused=[{"id": mid, "rank": i}
+                                     for i, mid in enumerate(fused[:10])])
 
         # ── Step 2: Graph narrow ──
         # Pass namespace through so the BFS can't pull affinity from
@@ -331,6 +356,12 @@ class RetrievalOrchestrator:
         affinity_map = self._graph_affinity_map(
             question_entities, namespace=namespace,
         )
+        if _tr.is_enabled():
+            _tr.event("recall.stage.graph",
+                      query_entities=question_entities,
+                      reachable_entity_count=len(affinity_map),
+                      affinity_sample={k: v for k, v in
+                                       list(affinity_map.items())[:10]})
         trace_hits = []
         for c in candidates:
             mem = c["memory"]
@@ -386,7 +417,12 @@ class RetrievalOrchestrator:
 
         # ── Step 4: MMR diversity ──
         if self.enable_mmr:
+            _pre_mmr_count = len(results)
             results = mmr_rerank(results, lambda_param=self.mmr_lambda)
+            if _tr.is_enabled():
+                _tr.event("recall.stage.mmr",
+                          lambda_=self.mmr_lambda,
+                          in_count=_pre_mmr_count, out_count=len(results))
 
         # ── Step 5: Confidence decay ──
         results = confidence_decay_boost(
@@ -397,7 +433,22 @@ class RetrievalOrchestrator:
         )
 
         # ── Step 6: Fit to budget ──
+        _pre_pack_count = len(results)
         final = fit_to_budget(results, token_budget)
+        if _tr.is_enabled():
+            _tr.event("recall.stage.pack",
+                      token_budget=token_budget,
+                      in_count=_pre_pack_count, out_count=len(final))
+            _tr.event("recall.done",
+                      query=query[:120],
+                      final_count=len(final),
+                      latency_ms=round((time.monotonic() - t_total) * 1000, 2),
+                      final_ids=[
+                          {"id": r.memory.id, "score": round(r.score, 4),
+                           "source": r.match_source,
+                           "preview": r.memory.content[:80]}
+                          for r in final[:20]
+                      ])
 
         trace_write({
             "kind": "recall",

--- a/attestor/retrieval/orchestrator.py
+++ b/attestor/retrieval/orchestrator.py
@@ -291,16 +291,25 @@ class RetrievalOrchestrator:
         require_active = (as_of is None and time_window is None)
         candidates: List[Dict] = []
         seen_ids: set = set()
+        _drop = {"missing": 0, "inactive": 0, "namespace": 0, "kept": 0,
+                 "first_drop_status": None, "first_drop_namespace": None}
         for vr in vector_hits_raw:
             mid = vr["memory_id"]
             if mid in seen_ids:
                 continue
             memory = self.store.get(mid)
             if not memory:
+                _drop["missing"] += 1
                 continue
             if require_active and memory.status != "active":
+                _drop["inactive"] += 1
+                if _drop["first_drop_status"] is None:
+                    _drop["first_drop_status"] = memory.status
                 continue
             if namespace and memory.namespace != namespace:
+                _drop["namespace"] += 1
+                if _drop["first_drop_namespace"] is None:
+                    _drop["first_drop_namespace"] = memory.namespace
                 continue
             distance = float(vr.get("distance", 1.0))
             vector_sim = max(0.0, 1.0 - distance)
@@ -308,6 +317,18 @@ class RetrievalOrchestrator:
                 {"memory": memory, "distance": distance, "vector_sim": vector_sim}
             )
             seen_ids.add(mid)
+            _drop["kept"] += 1
+        if _tr.is_enabled():
+            _tr.event("recall.stage.candidates",
+                      vector_in=len(vector_hits_raw),
+                      kept=_drop["kept"],
+                      dropped_missing=_drop["missing"],
+                      dropped_inactive=_drop["inactive"],
+                      dropped_namespace=_drop["namespace"],
+                      sample_inactive_status=_drop["first_drop_status"],
+                      sample_other_namespace=_drop["first_drop_namespace"],
+                      require_active=require_active,
+                      filter_namespace=namespace)
 
         # Pull BM25-only hits into the candidate set (vector_sim=0 for those).
         # The RRF-style boost below rewards them based on their BM25 rank.

--- a/attestor/store/postgres_backend.py
+++ b/attestor/store/postgres_backend.py
@@ -585,7 +585,21 @@ class PostgresBackend(DocumentStore, VectorStore, GraphStore):
     def _embed(self, text: str) -> List[float]:
         """Generate embedding using the shared provider."""
         self._ensure_embedding_fn()
-        return self._embedder.embed(text)
+        from attestor import trace as _tr
+        if not _tr.is_enabled():
+            return self._embedder.embed(text)
+        import time as _time
+        t0 = _time.monotonic()
+        vec = self._embedder.embed(text)
+        _tr.event(
+            "ingest.embed",
+            provider=getattr(self._embedder, "provider", type(self._embedder).__name__),
+            model=getattr(self._embedder, "model", "?"),
+            dim=len(vec),
+            text_len=len(text),
+            latency_ms=round((_time.monotonic() - t0) * 1000, 2),
+        )
+        return vec
 
     def _build_embedding_text(self, memory_id: str, content: str) -> str:
         """Build the text used for embedding (Phase 4.1, roadmap §B.1).

--- a/attestor/trace.py
+++ b/attestor/trace.py
@@ -1,0 +1,139 @@
+"""Pipeline tracing — env-gated, stderr + JSONL output.
+
+Off by default. Enable with ATTESTOR_TRACE=1.
+
+Why this exists:
+    The smoke runner needs end-to-end visibility: where did my message
+    go (ingest path) and how was it retrieved (retrieval path). The
+    project's degradation pattern catches non-fatal vector/graph
+    errors silently to keep the document path always green -- which
+    is correct for production but blinds you when you're debugging.
+    This module is the diagnostic eyepiece.
+
+Usage in code:
+    import attestor.trace as tr
+
+    tr.event("ingest.embed", provider="voyage", model="voyage-4",
+             dim=1024, latency_ms=42)
+
+When ATTESTOR_TRACE is unset, ``tr.event`` is a fast no-op (one env
+lookup cached at module load) so trace points can sit in hot paths
+without measurable overhead.
+
+Output format:
+    Stderr: ``[trace] ingest.embed provider=voyage model=voyage-4 dim=1024 latency_ms=42``
+    JSONL (when ATTESTOR_TRACE_FILE=path): one event per line, full fields,
+    parseable for post-run analysis.
+
+Conventions:
+    - event names are dotted: <area>.<step>[.<sub>]
+    - field names are snake_case
+    - never include raw secrets in trace fields (we redact via the
+      same patterns as hooks/post_tool_use.py if a field looks
+      key-shaped, but the cleanest fix is "don't pass secrets")
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import threading
+from datetime import datetime, timezone
+from typing import Any, Optional, TextIO
+
+_ENABLED: bool = bool(os.environ.get("ATTESTOR_TRACE"))
+_FILE_PATH: Optional[str] = os.environ.get("ATTESTOR_TRACE_FILE") or None
+_FH: Optional[TextIO] = None
+_LOCK = threading.Lock()
+
+
+# Defensive redactor: lifted from hooks/post_tool_use.py. If a trace
+# field accidentally carries a key-shaped string we still scrub it.
+_SECRET_PATTERNS = (
+    (re.compile(r"\bsk-or-v1-[A-Za-z0-9_-]{20,}"),  "<REDACTED:openrouter>"),
+    (re.compile(r"\bsk-proj-[A-Za-z0-9_-]{20,}"),   "<REDACTED:openai>"),
+    (re.compile(r"\bsk-ant-[A-Za-z0-9_-]{20,}"),    "<REDACTED:anthropic>"),
+    (re.compile(r"\bsk-[A-Za-z0-9_-]{32,}"),        "<REDACTED:openai>"),
+    (re.compile(r"\bpa-[A-Za-z0-9_-]{30,}"),        "<REDACTED:voyage>"),
+    (re.compile(r"\bghp_[A-Za-z0-9]{30,}"),         "<REDACTED:github>"),
+    (re.compile(r"\bAKIA[A-Z0-9]{16}\b"),           "<REDACTED:aws>"),
+)
+
+
+def _scrub(value: Any) -> Any:
+    if not isinstance(value, str):
+        return value
+    out = value
+    for pat, repl in _SECRET_PATTERNS:
+        out = pat.sub(repl, out)
+    return out
+
+
+def _open_file() -> Optional[TextIO]:
+    global _FH
+    if _FH is not None or not _FILE_PATH:
+        return _FH
+    try:
+        os.makedirs(os.path.dirname(os.path.abspath(_FILE_PATH)), exist_ok=True)
+        _FH = open(_FILE_PATH, "a", buffering=1, encoding="utf-8")
+    except OSError as e:
+        sys.stderr.write(f"[trace] could not open {_FILE_PATH!r}: {e}\n")
+        _FH = None
+    return _FH
+
+
+def is_enabled() -> bool:
+    """Cheap check; lets callers skip building expensive payloads."""
+    return _ENABLED
+
+
+def event(name: str, **fields: Any) -> None:
+    """Emit a single trace event.
+
+    Args:
+        name: Dotted event name (e.g. ``recall.stage.vector``).
+        **fields: Structured key/value pairs. Values must be JSON-encodable.
+                  String values are scrubbed for known key prefixes.
+    """
+    if not _ENABLED:
+        return
+
+    scrubbed = {k: _scrub(v) for k, v in fields.items()}
+    payload = {
+        "ts": datetime.now(timezone.utc).isoformat(timespec="milliseconds"),
+        "event": name,
+        **scrubbed,
+    }
+
+    pretty = " ".join(f"{k}={v!r}" if isinstance(v, str) else f"{k}={v}"
+                      for k, v in scrubbed.items())
+    line = f"[trace] {name} {pretty}".rstrip()
+
+    with _LOCK:
+        sys.stderr.write(line + "\n")
+        sys.stderr.flush()
+        fh = _open_file()
+        if fh is not None:
+            try:
+                fh.write(json.dumps(payload, default=str) + "\n")
+            except (TypeError, ValueError) as e:
+                sys.stderr.write(f"[trace] could not serialize event {name!r}: {e}\n")
+
+
+def reset_for_test() -> None:
+    """Test helper: re-read env vars and reopen the file handle.
+
+    Module-level _ENABLED is captured at import; tests that toggle the
+    env var need to call this to take effect.
+    """
+    global _ENABLED, _FILE_PATH, _FH
+    if _FH is not None:
+        try:
+            _FH.close()
+        except OSError:
+            pass
+    _ENABLED = bool(os.environ.get("ATTESTOR_TRACE"))
+    _FILE_PATH = os.environ.get("ATTESTOR_TRACE_FILE") or None
+    _FH = None

--- a/scripts/lme_smoke_local.py
+++ b/scripts/lme_smoke_local.py
@@ -101,6 +101,12 @@ def _parse_args() -> argparse.Namespace:
         help="Don't prompt to confirm the resolved stack",
     )
     p.add_argument("--verbose", action="store_true")
+    p.add_argument(
+        "--trace",
+        action="store_true",
+        help="Exhaustive per-stage trace (sets ATTESTOR_TRACE=1; writes "
+             "JSONL to logs/lme_smoke_<ts>.jsonl)",
+    )
     return p.parse_args()
 
 
@@ -212,6 +218,20 @@ async def _run(args: argparse.Namespace, stack: StackConfig) -> None:
 
 def main() -> int:
     args = _parse_args()
+
+    if args.trace:
+        from datetime import datetime as _dt
+        ts = _dt.now().strftime("%Y%m%d_%H%M%S")
+        trace_path = ROOT / "logs" / f"lme_smoke_{ts}.jsonl"
+        trace_path.parent.mkdir(parents=True, exist_ok=True)
+        os.environ["ATTESTOR_TRACE"] = "1"
+        os.environ["ATTESTOR_TRACE_FILE"] = str(trace_path)
+        # Re-read env after setting it; module load happens later but the
+        # smoke imports attestor.* below — make sure trace.py picks it up.
+        import attestor.trace as _tr
+        _tr.reset_for_test()
+        print(f"[{RUN_LABEL}] trace ON — events stream to stderr; "
+              f"jsonl → {trace_path}")
 
     logging.basicConfig(
         level=logging.INFO if args.verbose else logging.WARNING,

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -1,0 +1,92 @@
+"""Unit tests for the env-gated pipeline tracer."""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+import attestor.trace as tr
+
+
+@pytest.fixture(autouse=True)
+def _reset_trace_env(monkeypatch, tmp_path):
+    """Each test starts with a known-clean tracer state."""
+    monkeypatch.delenv("ATTESTOR_TRACE", raising=False)
+    monkeypatch.delenv("ATTESTOR_TRACE_FILE", raising=False)
+    tr.reset_for_test()
+    yield
+    tr.reset_for_test()
+
+
+@pytest.mark.unit
+def test_disabled_by_default(capsys):
+    assert tr.is_enabled() is False
+    tr.event("ingest.embed", model="voyage-4", dim=1024)
+    captured = capsys.readouterr()
+    # When disabled, NO output anywhere.
+    assert captured.err == ""
+    assert captured.out == ""
+
+
+@pytest.mark.unit
+def test_enabled_writes_to_stderr(capsys, monkeypatch):
+    monkeypatch.setenv("ATTESTOR_TRACE", "1")
+    tr.reset_for_test()
+    assert tr.is_enabled() is True
+
+    tr.event("ingest.embed", model="voyage-4", dim=1024, latency_ms=42)
+
+    captured = capsys.readouterr()
+    assert "[trace] ingest.embed" in captured.err
+    assert "model='voyage-4'" in captured.err
+    assert "dim=1024" in captured.err
+
+
+@pytest.mark.unit
+def test_enabled_writes_to_jsonl(capsys, monkeypatch, tmp_path):
+    log = tmp_path / "trace.jsonl"
+    monkeypatch.setenv("ATTESTOR_TRACE", "1")
+    monkeypatch.setenv("ATTESTOR_TRACE_FILE", str(log))
+    tr.reset_for_test()
+
+    tr.event("recall.start", query="hello", namespace="ns-a", token_budget=2000)
+    tr.event("recall.done", final_count=3, latency_ms=15.5)
+
+    lines = log.read_text().splitlines()
+    assert len(lines) == 2
+    e1 = json.loads(lines[0])
+    e2 = json.loads(lines[1])
+    assert e1["event"] == "recall.start"
+    assert e1["query"] == "hello"
+    assert e1["namespace"] == "ns-a"
+    assert e2["event"] == "recall.done"
+    assert e2["final_count"] == 3
+
+
+@pytest.mark.unit
+def test_secrets_are_redacted_in_event_fields(capsys, monkeypatch):
+    """If a trace field accidentally carries a key-shaped string we still
+    scrub it. The cleanest fix is "don't pass secrets" -- this is belt
+    and suspenders against an authorization header sneaking into a
+    trace field via e.g. a request-dump."""
+    monkeypatch.setenv("ATTESTOR_TRACE", "1")
+    tr.reset_for_test()
+
+    tr.event(
+        "demo",
+        # Made-up key shapes that match the patterns. None of these are
+        # real keys; the test asserts we redact based on prefix shape.
+        openai_key="sk-proj-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        voyage_key="pa-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        bearer_header="Bearer sk-or-v1-AAAAAAAAAAAAAAAAAAAAAA",
+    )
+
+    err = capsys.readouterr().err
+    assert "sk-proj-A" not in err
+    assert "pa-A" not in err
+    assert "<REDACTED:openai>" in err
+    assert "<REDACTED:voyage>" in err
+    # NB: "Bearer ..." gets the openrouter prefix replaced inside
+    assert "<REDACTED:openrouter>" in err


### PR DESCRIPTION
## Summary

Off-by-default end-to-end pipeline tracing for ingest + retrieval. Enabled with \`ATTESTOR_TRACE=1\` or via the new \`--trace\` flag on \`scripts/lme_smoke_local.py\`. Output: structured one-line stderr events plus optional JSONL companion at \`ATTESTOR_TRACE_FILE\`.

Surfaces every step so an operator can answer **"where did my message go and how was it retrieved"** without guessing.

### Ingest events
- \`ingest.write.pg\` — memory_id, namespace, len, tags, latency
- \`ingest.embed\` — provider, model, dim, text_len, latency
- \`ingest.write.vector\` — memory_id, ok, latency, error?
- \`ingest.extract\` — entity_count, relation_count, sample names
- \`ingest.write.graph\` — entity_count, relation_count, ok, latency

### Retrieval events (one per stage of the 6-step cascade)
- \`recall.start\` — query, namespace, budget, query_entities
- \`recall.stage.vector\` — top_k, hits[id, distance]
- \`recall.stage.bm25\` — enabled, hits
- \`recall.stage.rrf\` — fused_count, top_fused
- \`recall.stage.candidates\` — vector_in, kept, dropped_missing/inactive/namespace, sample reasons
- \`recall.stage.graph\` — query_entities, reachable_count, affinity_sample
- \`recall.stage.mmr\` — lambda, in_count, out_count
- \`recall.stage.pack\` — token_budget, in_count, out_count
- \`recall.done\` — final_count, latency, final_ids[id, score, preview]

## Real bugs caught on first run

The trace surfaced two real issues during a 1-question validation smoke:

1. **OpenRouter 401 across all distill / answerer / judge calls** — invalid key in \`.env\`. Trace surfaced 8 distill failures + answerer fallback in seconds. Fixed by rotating the key.
2. **v4 namespace tenancy mismatch — 50→0 silent drop in recall** — the v4 schema has no \`namespace\` column (uses user_id + project_id + scope), but \`orchestrator.py\` still filters on \`memory.namespace\`. Every v4 row rehydrates with \`namespace='default'\`, so every recall that passes a namespace string drops 100% of candidates. **This was completely silent before this PR.** Trace event \`recall.stage.candidates\` shows the bucket now: \`dropped_namespace=50, sample_other_namespace='default', filter_namespace='lme_gpt4_2655b836'\`. Fix is a separate PR.

## Defensive secret redaction

Lifted from \`hooks/post_tool_use.py\` (PR #69). If a trace field accidentally carries a key-shaped string we still scrub it (sk-*, pa-*, AKIA*, ghp_*, ya29.*, Bearer / X-API-Key headers).

## Test plan

- [x] 4 unit tests in \`tests/test_trace.py\`: disabled-by-default no-op, stderr output, JSONL file output, secret redactor.
- [x] Full unit suite: 962 passed, 232 skipped, 0 failed.
- [x] Validated end-to-end on \`scripts/lme_smoke_local.py --n 1 --trace\`: every event fires correctly; JSONL written to \`logs/lme_smoke_<ts>.jsonl\`.