### PR TITLE
fix(v4): persist namespace through metadata in v4 schema

### DIFF
--- a/attestor/core.py
+++ b/attestor/core.py
@@ -751,6 +751,18 @@ class AgentMemory:
                 logger.debug("Dedup hit: content_hash=%s -> id=%s", chash[:8], existing.id)
                 return existing
 
+        # In v4 the schema has no `namespace` column (tenancy moved to
+        # user_id + project_id + scope). Stamp the namespace into metadata
+        # so it survives the round-trip — Memory.from_row() reads it back
+        # from metadata["_namespace"] when there's no top-level column.
+        # Without this, any caller that uses namespace as a sub-tenancy key
+        # (LME bench writes namespace="lme_<sample>"; ad-hoc multi-tenant
+        # callers passing namespace=...) silently drops 100% of recall
+        # candidates because every read returns namespace="default".
+        _final_metadata = dict(metadata or {})
+        if v4_active and namespace and namespace != "default":
+            _final_metadata.setdefault("_namespace", namespace)
+
         memory = Memory(
             content=content,
             tags=tags or [],
@@ -760,7 +772,7 @@ class AgentMemory:
             event_date=event_date,
             confidence=confidence,
             content_hash=chash,
-            metadata=metadata or {},
+            metadata=_final_metadata,
             # v4 fields (None / defaults when caller didn't pass them)
             user_id=user_id,
             project_id=project_id,

--- a/attestor/models.py
+++ b/attestor/models.py
@@ -237,13 +237,25 @@ class Memory:
         created_at = _maybe_iso(row.get("created_at")) or datetime.now(timezone.utc).isoformat()
         valid_from = _maybe_iso(row.get("valid_from")) or created_at
 
+        # Namespace resolution: v3 schema has a top-level `namespace` column;
+        # v4 dropped it (tenancy moved to user_id + project_id + scope) so a
+        # v4 read returns no namespace and the dataclass defaults to "default".
+        # That breaks any caller that uses namespace as a metadata-style key
+        # (e.g. the LME bench writes namespace="lme_<sample>" for sample
+        # isolation across the shared DB). Fall back to metadata["_namespace"]
+        # which AgentContext already stamps and which we now stamp from
+        # core.add() too. Final fallback is the legacy "default".
+        _ns_from_row = row.get("namespace")
+        if _ns_from_row is None:
+            _md_for_ns = metadata if isinstance(metadata, dict) else {}
+            _ns_from_row = _md_for_ns.get("_namespace", "default")
         return cls(
             id=str(row["id"]),
             content=row["content"],
             tags=list(tags) if tags is not None else [],
             category=row.get("category", "general"),
             entity=row.get("entity"),
-            namespace=row.get("namespace", "default"),
+            namespace=_ns_from_row,
             user_id=_maybe_str(row.get("user_id")),
             project_id=_maybe_str(row.get("project_id")),
             session_id=_maybe_str(row.get("session_id")),

--- a/tests/test_v4_namespace_roundtrip.py
+++ b/tests/test_v4_namespace_roundtrip.py
@@ -1,0 +1,122 @@
+"""v4 namespace round-trip — write w/ namespace, read it back.
+
+Background — caught by the trace PR (#76):
+    The v4 schema has no `namespace` column (replaced by user_id +
+    project_id + scope for tenancy). Pre-fix, ``Memory.from_row``
+    fell back to the dataclass default "default" for every v4 read,
+    so any caller that used namespace as a metadata-style key (the
+    LME bench writes namespace="lme_<sample>" for sample isolation)
+    saw 100% of recall candidates dropped by the orchestrator's
+    namespace filter.
+
+    Fix:
+      • core.add()  — stamp namespace into metadata["_namespace"]
+                      when v4 is active and namespace != "default"
+      • models.from_row — fall back to metadata["_namespace"] when
+                      the row has no namespace column
+
+These tests pin the round-trip without requiring a live Postgres —
+they synthesize the row dicts that ``_row_to_memory`` consumes.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from attestor.models import Memory
+
+
+@pytest.mark.unit
+def test_v4_row_with_metadata_namespace_round_trips():
+    """A v4 row (no `namespace` column) carries the namespace inside
+    metadata; from_row should recover it."""
+    row = {
+        "id": "00000000-0000-0000-0000-000000000001",
+        "content": "v4 namespaced memory",
+        "user_id": "00000000-0000-0000-0000-0000000000aa",
+        "project_id": "00000000-0000-0000-0000-0000000000bb",
+        "scope": "user",
+        # NB: no `namespace` key — that's the v4 schema reality
+        "metadata": {"_namespace": "lme_sample_42"},
+        "tags": [],
+        "category": "fact",
+    }
+    mem = Memory.from_row(row)
+    assert mem.namespace == "lme_sample_42"
+
+
+@pytest.mark.unit
+def test_v4_row_with_metadata_as_json_string_round_trips():
+    """Some Postgres drivers return jsonb columns as JSON strings (not
+    dicts). from_row must parse the string before lookup."""
+    row = {
+        "id": "00000000-0000-0000-0000-000000000002",
+        "content": "v4 string-metadata memory",
+        "user_id": "00000000-0000-0000-0000-0000000000aa",
+        "metadata": json.dumps({"_namespace": "tenant-acme"}),
+        "tags": [],
+    }
+    mem = Memory.from_row(row)
+    assert mem.namespace == "tenant-acme"
+
+
+@pytest.mark.unit
+def test_v4_row_without_namespace_metadata_falls_back_to_default():
+    """v4 row + no _namespace in metadata = legacy "default". Pre-fix
+    behavior preserved for the SOLO single-tenant happy path."""
+    row = {
+        "id": "00000000-0000-0000-0000-000000000003",
+        "content": "v4 untenanted memory",
+        "user_id": "00000000-0000-0000-0000-0000000000aa",
+        "metadata": {},
+        "tags": [],
+    }
+    mem = Memory.from_row(row)
+    assert mem.namespace == "default"
+
+
+@pytest.mark.unit
+def test_v3_row_top_level_namespace_still_wins():
+    """v3 schema kept the top-level namespace column. We must not
+    regress v3 reads — the column trumps any metadata fallback."""
+    row = {
+        "id": "v3id000000aa",
+        "content": "v3 namespaced memory",
+        "namespace": "v3-tenant",
+        "metadata": {"_namespace": "would-have-been-this-but-v3-wins"},
+        "tags": [],
+    }
+    mem = Memory.from_row(row)
+    assert mem.namespace == "v3-tenant"
+
+
+@pytest.mark.unit
+def test_v4_row_with_non_dict_metadata_falls_back_safely():
+    """If metadata happens to be a JSON string that parses to a list
+    (legacy junk data), we must not crash on .get()."""
+    row = {
+        "id": "00000000-0000-0000-0000-000000000005",
+        "content": "v4 list-metadata memory",
+        "user_id": "00000000-0000-0000-0000-0000000000aa",
+        "metadata": json.dumps(["why", "is", "this", "a", "list"]),
+        "tags": [],
+    }
+    mem = Memory.from_row(row)
+    assert mem.namespace == "default"
+
+
+@pytest.mark.unit
+def test_v4_row_with_explicit_default_namespace_in_metadata():
+    """Caller stamped metadata["_namespace"]="default" — round-trips
+    as "default" (no surprise). Same as the no-metadata case."""
+    row = {
+        "id": "00000000-0000-0000-0000-000000000006",
+        "content": "v4 explicit-default memory",
+        "user_id": "00000000-0000-0000-0000-0000000000aa",
+        "metadata": {"_namespace": "default"},
+        "tags": [],
+    }
+    mem = Memory.from_row(row)
+    assert mem.namespace == "default"


### PR DESCRIPTION
## Summary

The v4 schema dropped the top-level \`namespace\` column when tenancy moved to user_id + project_id + scope, but the API surface (\`AgentMemory.add\` / \`recall\`) and the \`Memory\` dataclass still expose \`namespace\` as a string. **Pre-fix, every v4 row rehydrated with \`namespace=\"default\"\`** because \`Memory.from_row\` defaulted on the missing column.

Any caller that used namespace as a sub-tenancy key — LME bench writes \`namespace=\"lme_<sample>\"\` for sample isolation across a shared DB, ad-hoc multi-tenant callers, the \`AgentContext.for_chat\` flow — saw **100% of recall candidates dropped** by the orchestrator's namespace filter.

## How it was hidden

Completely silent. The document path returned empty results and the bench's LLM answerer occasionally produced correct answers from training-data memory of public LongMemEval questions, **masking the failure**. Caught by PR #76's \`recall.stage.candidates\` trace event:

\`\`\`
vector_in=50  kept=0
dropped_namespace=50
sample_other_namespace='default'
filter_namespace='lme_gpt4_2655b836'
\`\`\`

## Fix

- \`core.add()\` — when v4 is active AND the caller passed a non-default namespace, stamp it into \`metadata[\"_namespace\"]\` so it survives the INSERT (which has no namespace column).
- \`Memory.from_row\` — when the row carries no top-level namespace (v4), fall back to \`metadata[\"_namespace\"]\` before defaulting to \"default\". v3 path unchanged.

## End-to-end validation

\`scripts/lme_smoke_local.py --n 1 --trace\`:

| | Before | After |
|---|---|---|
| \`recall.stage.candidates kept\` | 0 | **50** |
| \`recall.stage.mmr in/out\` | 0 / 0 | **50 / 10** |
| \`recall.done final_count\` | 0 | **10** |
| gpt-4.1 verdict | CORRECT (*) | CORRECT |
| sonnet-4-6 verdict | WRONG | CORRECT |
| inter-judge agreement | 0% | **100%** |

(*) Before-fix gpt-4.1 was only correct via training-data leak — the answerer received zero retrieved context.

## Test plan
- [x] 6 unit tests in \`tests/test_v4_namespace_roundtrip.py\`: round-trip, JSON-string metadata, missing metadata, v3 column wins, non-dict metadata, explicit-default
- [x] Full unit suite: 968 passed, 232 skipped, 0 failed
- [x] Live smoke: 1 sample → both judges CORRECT → 100% inter-judge agreement