### PR TITLE
docs(readme): promote ContextPack envelope; deprecate tag_search

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,13 +244,22 @@ The "do not auto-resolve" stance is the load-bearing piece for regulated chat sy
 
 ### Chain-of-Note reading
 
+`recall()` returns a list. `recall_as_pack()` returns a **typed retrieval envelope** an agent can actually reason about — every field a Chain-of-Note flow needs to cite, abstain, or pick the right validity window when memories conflict:
+
 ```python
 pack = mem.recall_as_pack(query="who runs engineering?", context=ctx)
-# pack.memories : list of {id, content, validity_window, confidence, source_episode_id}
-# pack.prompt   : default Chain-of-Note prompt with NOTES → SYNTHESIS → CITE → ABSTAIN → CONFLICT structure
+
+for entry in pack.memories:
+    print(entry.id,                    # cite this in the answer
+          entry.confidence,            # weight or abstain
+          entry.valid_from,            # bi-temporal window for conflict resolution
+          entry.valid_until,
+          entry.source_episode_id)     # provenance back to the round it came from
+
+agent.send(pack.render_prompt())       # Chain-of-Note prompt, memories interpolated as JSON
 ```
 
-The default prompt has explicit `ABSTAIN` and `CONFLICT` clauses — every frontier model defaults to confabulation otherwise.
+`ContextPack` is `frozen=True`, hashable, JSON-serializable. It drops cleanly into a tool call. The default prompt has explicit `ABSTAIN` and `CONFLICT` clauses — every frontier model defaults to confabulation otherwise.
 
 ---
 
@@ -258,7 +267,10 @@ The default prompt has explicit `ABSTAIN` and `CONFLICT` clauses — every front
 
 ### Six roles
 
-`AgentRole`: `ORCHESTRATOR`, `PLANNER`, `EXECUTOR`, `RESEARCHER`, `REVIEWER`, `MONITOR` (`attestor/context.py:49-56`). The role flows onto every memory's metadata for provenance. Access enforcement happens at the Postgres RLS layer (see §Tenant isolation).
+`AgentRole`: `ORCHESTRATOR`, `PLANNER`, `EXECUTOR`, `RESEARCHER`, `REVIEWER`, `MONITOR` (`attestor/context.py:49-56`). The role flows onto every memory's metadata for provenance. **Access enforcement is two-layer:**
+
+- **AgentContext layer** — `ROLE_PERMISSIONS` matrix gates writes / forgets per role. Matrix: `ORCHESTRATOR = R+W+F`; `PLANNER` / `EXECUTOR` / `RESEARCHER` = `R+W`; `REVIEWER` / `MONITOR` = `R` only. `read_only=True` is an independent kill switch.
+- **Postgres RLS layer** — row-level filter on `user_id` (see §Tenant isolation).
 
 ### AgentContext — handoff, scratchpad, trail
 

--- a/attestor/store/base.py
+++ b/attestor/store/base.py
@@ -37,6 +37,12 @@ class DocumentStore(ABC):
         limit: int = 100,
     ) -> List[Memory]: ...
 
+    # NOTE: tag_search predates the semantic-first cascade and is no longer
+    # called by the canonical recall pipeline (vector → BM25 → RRF → graph
+    # → MMR → fit). It is kept on the interface for direct admin/UI lookup
+    # by tag-set on backends that have a cheap tag index, and for backwards
+    # compat with v3 callers. New callers should prefer recall() / search()
+    # — those are what the orchestrator routes through.
     @abstractmethod
     def tag_search(
         self,


### PR DESCRIPTION
## Summary

Three small follow-ups from an external code-review pass.

### 1. \`attestor/store/base.py\` — flag \`tag_search\` as superseded

\`DocumentStore.tag_search\` predates the semantic-first cascade and is no longer called by the canonical recall pipeline (vector → BM25 → RRF → graph → MMR → fit). Kept on the interface for direct admin / UI tag lookup and v3-caller compat, but now flagged with a comment so new callers route through \`recall()\` / \`search()\` instead.

No code removal — this is a craft-signal, not a refactor.

### 2. README — promote the \`ContextPack\` envelope

\`recall()\` returns a list. \`recall_as_pack()\` returns a typed envelope an agent can actually reason about — and that's the part of the API most worth advertising. New snippet iterates \`pack.memories\` and prints every field an agent uses (\`id\`, \`confidence\`, \`valid_from\`, \`valid_until\`, \`source_episode_id\`). Three lines of code that land the *"they actually thought about how the agent consumes this"* signal.

### 3. README — fix RBAC drift

The Multi-agent primitives section described RBAC as Postgres-RLS-only. PR #72 (this branch's history) added AgentContext-layer enforcement via the \`ROLE_PERMISSIONS\` matrix. Now correctly described as two-layer (context-layer permission gate + RLS row filter).

## Test plan
- [x] No code paths changed; no new tests required
- [x] Sanity-ran existing units for the touched components: 40 passed (rbac, trace, embedder dim, namespace round-trip)