### PR TITLE
chore(mcp): bump server.json to 4.0.0 for Registry publish

### DIFF
--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.bolnet/attestor",
   "title": "Attestor",
   "description": "Self-hosted memory for agent teams. Bi-temporal replay, deterministic retrieval, audit log.",
-  "version": "4.0.0a5",
+  "version": "4.0.0",
   "repository": {
     "url": "https://github.com/bolnet/attestor",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "attestor",
-      "version": "4.0.0a5",
+      "version": "4.0.0",
       "runtimeHint": "python",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
Mirrors PyPI 4.0.0 cut (#79). The Official MCP Registry pulls version from server.json at publish time.