### PR TITLE
feat(llm): config-driven OpenAI vs OpenRouter routing

### DIFF
--- a/attestor/config.py
+++ b/attestor/config.py
@@ -74,6 +74,25 @@ _FALLBACK_BENCHMARK = "openai/gpt-4.1-mini"
 _FALLBACK_BUDGET = 4000
 _FALLBACK_PARALLEL = 2
 
+# LLM client routing — which OpenAI-compatible endpoint we send chat
+# completion calls to. OpenRouter is the default (matches the canonical
+# benchmark stack); "openai" hits api.openai.com directly which avoids
+# OpenRouter's per-call markup when the model is an OpenAI one and you
+# already have an OpenAI key.
+_FALLBACK_LLM_PROVIDER = "openrouter"
+_OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+_OPENAI_BASE_URL = "https://api.openai.com/v1"
+LLM_PROVIDER_DEFAULTS: Dict[str, Dict[str, str]] = {
+    "openrouter": {
+        "base_url": _OPENROUTER_BASE_URL,
+        "api_key_env": "OPENROUTER_API_KEY",
+    },
+    "openai": {
+        "base_url": _OPENAI_BASE_URL,
+        "api_key_env": "OPENAI_API_KEY",
+    },
+}
+
 
 # ─── Dataclasses ──────────────────────────────────────────────────────
 
@@ -130,6 +149,44 @@ class ModelsCfg:
 
 
 @dataclass(frozen=True)
+class LLMCfg:
+    """Where chat-completion calls are routed.
+
+    ``provider`` selects an OpenAI-compatible endpoint. Two are wired:
+
+      openrouter  — base_url=https://openrouter.ai/api/v1; key=OPENROUTER_API_KEY
+                    (default; matches the canonical benchmark stack so
+                    cross-provider models like anthropic/claude-sonnet-4-6
+                    work in the same call).
+      openai      — base_url=https://api.openai.com/v1; key=OPENAI_API_KEY
+                    (no per-call OpenRouter markup; only OpenAI models work).
+
+    ``base_url`` and ``api_key_env`` override the per-provider defaults
+    when set in YAML — useful for local Ollama (set base_url to
+    http://localhost:11434/v1) or for swapping the env var name.
+    """
+
+    provider: str
+    base_url: str
+    api_key_env: str
+
+    @classmethod
+    def for_provider(cls, provider: str) -> LLMCfg:
+        """Build with the canonical defaults for a known provider."""
+        defaults = LLM_PROVIDER_DEFAULTS.get(provider)
+        if defaults is None:
+            raise ValueError(
+                f"unknown LLM provider {provider!r}; "
+                f"expected one of {sorted(LLM_PROVIDER_DEFAULTS)}"
+            )
+        return cls(
+            provider=provider,
+            base_url=defaults["base_url"],
+            api_key_env=defaults["api_key_env"],
+        )
+
+
+@dataclass(frozen=True)
 class ImageCfg:
     ref: str
     api_ref_template: str
@@ -149,6 +206,7 @@ class StackConfig:
     neo4j: Neo4jCfg
     embedder: EmbedderCfg
     models: ModelsCfg
+    llm: LLMCfg
     image: ImageCfg
     budget: int
     parallel: int
@@ -207,6 +265,7 @@ def _build_fallback_stack() -> StackConfig:
             planner=_FALLBACK_PLANNER,
             benchmark_default=_FALLBACK_BENCHMARK,
         ),
+        llm=LLMCfg.for_provider(_FALLBACK_LLM_PROVIDER),
         image=ImageCfg(ref="", api_ref_template="", registries={}),
         budget=_FALLBACK_BUDGET,
         parallel=_FALLBACK_PARALLEL,
@@ -224,6 +283,20 @@ def _parse_yaml(cfg_path: Path, *, strict: bool) -> StackConfig:
     neo = stack_blk.get("neo4j") or {}
     emb = stack_blk.get("embedder") or {}
     models = stack_blk.get("models") or {}
+    llm_blk = stack_blk.get("llm") or {}
+
+    llm_provider = str(llm_blk.get("provider", _FALLBACK_LLM_PROVIDER))
+    if llm_provider not in LLM_PROVIDER_DEFAULTS:
+        raise SystemExit(
+            f"[attestor.config] unknown LLM provider {llm_provider!r}; "
+            f"expected one of {sorted(LLM_PROVIDER_DEFAULTS)}"
+        )
+    llm_defaults = LLM_PROVIDER_DEFAULTS[llm_provider]
+    llm_cfg = LLMCfg(
+        provider=llm_provider,
+        base_url=str(llm_blk.get("base_url", llm_defaults["base_url"])),
+        api_key_env=str(llm_blk.get("api_key_env", llm_defaults["api_key_env"])),
+    )
 
     return StackConfig(
         postgres=PostgresCfg(
@@ -251,6 +324,7 @@ def _parse_yaml(cfg_path: Path, *, strict: bool) -> StackConfig:
             planner=models.get("planner", _FALLBACK_PLANNER),
             benchmark_default=models.get("benchmark_default", _FALLBACK_BENCHMARK),
         ),
+        llm=llm_cfg,
         image=ImageCfg(
             ref=image_blk.get("ref", ""),
             api_ref_template=image_blk.get("api_ref_template", ""),
@@ -403,6 +477,8 @@ def print_stack_banner(stack: StackConfig, *, run_label: str) -> None:
     print(f"  graph            neo4j    @ {stack.neo4j.url} ({stack.neo4j.database})")
     print(f"  embedder         {stack.embedder.provider}:{stack.embedder.model}"
           f" @ {stack.embedder.dimensions}-D")
+    print(f"  llm              {stack.llm.provider} → {stack.llm.base_url}"
+          f" (key from ${stack.llm.api_key_env})")
     print(f"  models")
     print(f"    answerer            {stack.models.answerer}")
     print(f"    judge               {stack.models.judge}")

--- a/attestor/longmemeval.py
+++ b/attestor/longmemeval.py
@@ -1120,11 +1120,20 @@ JUDGE_PROMPT = (
 def _get_client(api_key: Optional[str] = None) -> Any:
     """Instantiate an OpenAI-compatible client.
 
-    Default target is OpenRouter. Override with ``LME_LLM_BASE_URL`` to
-    point at any OpenAI-compatible endpoint — most importantly local
-    Ollama at ``http://localhost:11434/v1`` for offline / no-key runs.
-    When the base URL points at localhost, ``OPENROUTER_API_KEY`` is
-    optional (Ollama accepts any non-empty key).
+    Resolution order (top wins):
+      1. ``LME_LLM_BASE_URL`` env — explicit ad-hoc override; mostly
+         used to point at local Ollama (``http://localhost:11434/v1``).
+         When the URL points at localhost, the API key is optional.
+      2. ``configs/attestor.yaml`` ``stack.llm.provider`` — picks the
+         base URL and the env var name for the API key. Two providers
+         wired today: ``openrouter`` (default; multi-vendor model names
+         like ``anthropic/claude-sonnet-4-6``) and ``openai`` (no
+         OpenRouter markup, OpenAI models only).
+      3. Hardcoded fallback to OpenRouter — only if YAML is missing.
+
+    The chosen provider's API key env var is required unless the base
+    URL is local. A clear error names the env var that was missing
+    rather than the generic "OPENROUTER_API_KEY".
     """
     try:
         from openai import OpenAI
@@ -1134,19 +1143,46 @@ def _get_client(api_key: Optional[str] = None) -> Any:
             "`poetry add --group dev openai`."
         ) from e
 
-    base_url = os.environ.get("LME_LLM_BASE_URL", OPENROUTER_BASE_URL)
+    # 2 — resolve provider via stack
+    try:
+        from attestor.config import get_stack
+        llm_cfg = get_stack().llm
+    except Exception:
+        # Stack load can fail in stripped-checkout / no-YAML test scenarios;
+        # fall back to the legacy OpenRouter shape so existing callers
+        # don't crash before they even get to the API call.
+        llm_cfg = None
+
+    # 1 — explicit env override wins
+    env_base_url = os.environ.get("LME_LLM_BASE_URL")
+    if env_base_url:
+        base_url = env_base_url
+        # When user set the URL explicitly, default the key env to the
+        # configured provider's; the request itself will surface a 401
+        # if the key is mismatched.
+        key_env = (llm_cfg.api_key_env if llm_cfg else "OPENROUTER_API_KEY")
+    elif llm_cfg is not None:
+        base_url = llm_cfg.base_url
+        key_env = llm_cfg.api_key_env
+    else:
+        base_url = OPENROUTER_BASE_URL
+        key_env = "OPENROUTER_API_KEY"
+
     is_local = "localhost" in base_url or "127.0.0.1" in base_url
 
-    key = api_key or os.environ.get("OPENROUTER_API_KEY")
+    key = api_key or os.environ.get(key_env)
     if not key:
         if is_local:
             key = "ollama"  # placeholder; Ollama ignores the key
         else:
+            provider_name = (llm_cfg.provider if llm_cfg else "openrouter")
             raise RuntimeError(
-                "OPENROUTER_API_KEY not set — required for LongMemEval "
-                "answer/judge against a remote endpoint. Set "
-                "LME_LLM_BASE_URL=http://localhost:11434/v1 to run "
-                "against local Ollama instead."
+                f"{key_env} not set — required for LongMemEval "
+                f"answer/judge against {base_url} "
+                f"(llm.provider={provider_name!r}). Either export "
+                f"{key_env}, switch llm.provider in configs/attestor.yaml, "
+                f"or set LME_LLM_BASE_URL=http://localhost:11434/v1 to "
+                f"run against local Ollama instead."
             )
     return OpenAI(base_url=base_url, api_key=key)
 

--- a/configs/attestor.yaml
+++ b/configs/attestor.yaml
@@ -48,6 +48,23 @@ stack:
     dimensions: 1024
     api_key_env: VOYAGE_API_KEY        # resolved from environment
 
+  # ─── LLM client routing ───────────────────────────────────────────────
+  # Where chat-completion calls land. Two providers wired:
+  #
+  #   openrouter  — default. Multi-vendor catalog so cross-provider
+  #                 model strings like `anthropic/claude-sonnet-4-6`
+  #                 work in the same call shape. Requires OPENROUTER_API_KEY.
+  #   openai      — direct to api.openai.com. No OpenRouter per-call
+  #                 markup; only OpenAI models. Requires OPENAI_API_KEY.
+  #
+  # `base_url` and `api_key_env` are auto-defaulted from the provider —
+  # override them to point at local Ollama (base_url=http://localhost:11434/v1)
+  # or to swap the env-var name. The runtime helper `_get_client` honors
+  # `LME_LLM_BASE_URL` env first when set, so ad-hoc local runs still work
+  # without editing this file.
+  llm:
+    provider: openrouter
+
   # ─── Models (per-role assignment) ────────────────────────────────────
   # All four roles use distinct models tuned to their job. See
   # `project_lme_4models_20260428.md` for the benchmark numbers that

--- a/scripts/lme_smoke_local.py
+++ b/scripts/lme_smoke_local.py
@@ -157,11 +157,15 @@ def _mem_factory(stack: StackConfig):
 async def _run(args: argparse.Namespace, stack: StackConfig) -> None:
     from attestor.longmemeval import load_or_download, run_async
 
-    if not (
-        os.environ.get("OPENAI_API_KEY") or os.environ.get("OPENROUTER_API_KEY")
-    ):
+    # Pre-flight: the runtime LLM client picks its key env from the
+    # resolved llm.provider in the stack. Surface a clear error here
+    # rather than letting the first chat call fail with 401.
+    expected_key_env = stack.llm.api_key_env
+    if not os.environ.get(expected_key_env):
         sys.stderr.write(
-            f"[{RUN_LABEL}] error: neither OPENAI_API_KEY nor OPENROUTER_API_KEY is set.\n"
+            f"[{RUN_LABEL}] error: {expected_key_env} not set — required "
+            f"for llm.provider={stack.llm.provider!r}. Either export the "
+            f"env var or switch llm.provider in configs/attestor.yaml.\n"
         )
         raise SystemExit(2)
 

--- a/tests/test_llm_provider_config.py
+++ b/tests/test_llm_provider_config.py
@@ -1,0 +1,186 @@
+"""LLM provider routing — config + runtime client wiring.
+
+Confirms the new ``stack.llm.provider`` knob actually flips the base
+URL + API-key env on the OpenAI client. Two providers wired today:
+``openrouter`` (default; matches the canonical bench stack) and
+``openai`` (direct, no per-call markup).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+# Make sure the repo root is on the path so `import attestor` works
+# regardless of how pytest is invoked.
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+@pytest.fixture
+def yaml_with_llm(tmp_path, monkeypatch):
+    """Factory for a tmp YAML stack with the LLM block set."""
+
+    def _make(provider: str, *, base_url: str | None = None,
+              api_key_env: str | None = None) -> Path:
+        cfg = {
+            "stack": {
+                "postgres": {"url": "postgresql://postgres@localhost/attestor"},
+                "neo4j": {
+                    "url": "bolt://localhost:7687",
+                    "auth": {"username": "neo4j", "password": "test"},
+                    "database": "neo4j",
+                },
+                "embedder": {
+                    "provider": "voyage", "model": "voyage-4", "dimensions": 1024,
+                },
+                "llm": {"provider": provider},
+                "models": {
+                    "answerer": "openai/gpt-4.1",
+                    "judge": "openai/gpt-4.1",
+                    "extraction": "openai/gpt-4.1-mini",
+                    "distill": "openai/gpt-4.1-mini",
+                    "verifier": "anthropic/claude-sonnet-4-6",
+                    "planner": "anthropic/claude-opus-4.7",
+                    "benchmark_default": "openai/gpt-4.1-mini",
+                },
+            },
+        }
+        if base_url is not None:
+            cfg["stack"]["llm"]["base_url"] = base_url
+        if api_key_env is not None:
+            cfg["stack"]["llm"]["api_key_env"] = api_key_env
+
+        path = tmp_path / "attestor.yaml"
+        path.write_text(yaml.safe_dump(cfg))
+        # Test isolation: force the loader to re-read this file every test
+        monkeypatch.setenv("ATTESTOR_CONFIG", str(path))
+        from attestor import config as _c
+        _c.reset_stack()
+        return path
+
+    return _make
+
+
+# ---------------------------------------------------------------------------
+# YAML parsing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_default_llm_provider_is_openrouter(yaml_with_llm):
+    yaml_with_llm("openrouter")
+    from attestor.config import get_stack
+    s = get_stack(strict=False)
+    assert s.llm.provider == "openrouter"
+    assert s.llm.base_url == "https://openrouter.ai/api/v1"
+    assert s.llm.api_key_env == "OPENROUTER_API_KEY"
+
+
+@pytest.mark.unit
+def test_openai_provider_uses_native_base_and_key(yaml_with_llm):
+    yaml_with_llm("openai")
+    from attestor.config import get_stack
+    s = get_stack(strict=False)
+    assert s.llm.provider == "openai"
+    assert s.llm.base_url == "https://api.openai.com/v1"
+    assert s.llm.api_key_env == "OPENAI_API_KEY"
+
+
+@pytest.mark.unit
+def test_unknown_provider_raises_at_load(yaml_with_llm):
+    yaml_with_llm("anthropic-direct")  # not wired
+    from attestor.config import get_stack
+    with pytest.raises(SystemExit, match="unknown LLM provider"):
+        get_stack(strict=False)
+
+
+@pytest.mark.unit
+def test_yaml_overrides_take_precedence(yaml_with_llm):
+    """Pointing base_url at local Ollama via YAML should round-trip."""
+    yaml_with_llm(
+        "openai",
+        base_url="http://localhost:11434/v1",
+        api_key_env="LOCAL_OLLAMA_TOKEN",
+    )
+    from attestor.config import get_stack
+    s = get_stack(strict=False)
+    assert s.llm.base_url == "http://localhost:11434/v1"
+    assert s.llm.api_key_env == "LOCAL_OLLAMA_TOKEN"
+
+
+# ---------------------------------------------------------------------------
+# Runtime client construction
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_get_client_uses_openrouter_by_default(yaml_with_llm, monkeypatch):
+    yaml_with_llm("openrouter")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-v1-test")
+    monkeypatch.delenv("LME_LLM_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    from attestor.longmemeval import _get_client
+    client = _get_client()
+    assert "openrouter.ai" in str(client.base_url)
+
+
+@pytest.mark.unit
+def test_get_client_routes_to_openai_when_provider_openai(yaml_with_llm, monkeypatch):
+    yaml_with_llm("openai")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.delenv("LME_LLM_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    from attestor.longmemeval import _get_client
+    client = _get_client()
+    assert "api.openai.com" in str(client.base_url)
+
+
+@pytest.mark.unit
+def test_get_client_env_base_url_overrides_yaml(yaml_with_llm, monkeypatch):
+    """LME_LLM_BASE_URL env wins over YAML — preserves the
+    ad-hoc local-Ollama escape hatch even when YAML pins openai."""
+    yaml_with_llm("openai")
+    monkeypatch.setenv("LME_LLM_BASE_URL", "http://localhost:11434/v1")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    from attestor.longmemeval import _get_client
+    client = _get_client()
+    assert "localhost:11434" in str(client.base_url)
+
+
+@pytest.mark.unit
+def test_get_client_missing_key_names_the_specific_env(yaml_with_llm, monkeypatch):
+    """Error must name the YAML-configured env var, not 'OPENROUTER_API_KEY'
+    when the provider is openai. Saves debugging time."""
+    yaml_with_llm("openai")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("LME_LLM_BASE_URL", raising=False)
+
+    from attestor.longmemeval import _get_client
+    with pytest.raises(RuntimeError, match="OPENAI_API_KEY"):
+        _get_client()
+
+
+@pytest.mark.unit
+def test_get_client_local_ollama_works_keyless(yaml_with_llm, monkeypatch):
+    """Local Ollama base URL ignores the missing key (same as before
+    this PR — back-compat path stays intact)."""
+    yaml_with_llm("openai")
+    monkeypatch.setenv("LME_LLM_BASE_URL", "http://127.0.0.1:11434/v1")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    from attestor.longmemeval import _get_client
+    client = _get_client()  # must not raise
+    assert "127.0.0.1" in str(client.base_url)


### PR DESCRIPTION
## Summary

The bench client was hardwired to OpenRouter (\`https://openrouter.ai/api/v1\` + \`OPENROUTER_API_KEY\`). Adds a YAML knob so users with only an OpenAI key — or who want to skip OpenRouter's per-call markup when the model is OpenAI's — can flip the route without code edits.

\`\`\`yaml
# configs/attestor.yaml
stack:
  llm:
    provider: openrouter   # default — multi-vendor catalog; needed for
                           # cross-provider model strings like
                           # anthropic/claude-sonnet-4-6
    # provider: openai     # direct to api.openai.com; no markup;
                           # OpenAI models only
\`\`\`

## Resolution order (in \`_get_client\`)

1. \`LME_LLM_BASE_URL\` env — preserves the ad-hoc local-Ollama escape hatch
2. \`stack.llm.provider\` — config-driven default
3. Hardcoded OpenRouter — only if YAML is missing entirely

The chosen provider's API key env var is required unless the URL is local. Error message **names the specific env var** that's missing (\`OPENAI_API_KEY\` when provider=openai, \`OPENROUTER_API_KEY\` when provider=openrouter), instead of always saying \"OPENROUTER_API_KEY\".

## What else changed

- \`attestor/config.py\` — new \`LLMCfg\` frozen dataclass on \`StackConfig\`. \`LLM_PROVIDER_DEFAULTS\` table holds the canonical (base_url, api_key_env) per provider; YAML can override either.
- \`print_stack_banner\` now shows the LLM provider, base URL, and key-env name. The smoke runner sanity-check surfaces this before any tokens are spent.
- \`scripts/lme_smoke_local.py\` pre-flight check is now keyed off the resolved provider — fails loudly if the right env var isn't set.

## Test plan

- [x] 9 unit tests in \`tests/test_llm_provider_config.py\` covering: default provider, openai routing, unknown-provider rejection, YAML override precedence, env override over YAML, specific-error messaging, local Ollama back-compat
- [x] Full unit suite: **977 passed**, 232 skipped, 0 failed
- [x] Banner verified: smoke run prints \`llm  openrouter → https://openrouter.ai/api/v1 (key from \$OPENROUTER_API_KEY)\`