### PR TITLE
chore(yaml): downgrade answerer to openai/gpt-5.4-mini

### DIFF
--- a/attestor/config.py
+++ b/attestor/config.py
@@ -64,7 +64,7 @@ _FALLBACK_NEO4J_USER = "neo4j"
 _FALLBACK_EMBEDDER_PROVIDER = "voyage"
 _FALLBACK_EMBEDDER_MODEL = "voyage-4"
 _FALLBACK_EMBEDDER_DIM = 1024
-_FALLBACK_ANSWERER = "openai/gpt-5.5"
+_FALLBACK_ANSWERER = "openai/gpt-5.4-mini"
 _FALLBACK_JUDGE = "openai/gpt-5.5"
 # Note: OpenRouter has no gpt-5.5-mini SKU; the -mini roles use 5.4-mini
 # (cheapest current 5.x mini) until a 5.5-mini variant ships.

--- a/configs/attestor.yaml
+++ b/configs/attestor.yaml
@@ -81,7 +81,7 @@ stack:
     # Answerer — synthesises the final reply from retrieved context.
     # gpt-4.1 won overall on LongMemEval, especially on temporal +
     # multi-session reasoning.
-    answerer: openai/gpt-5.5
+    answerer: openai/gpt-5.4-mini
 
     # Judge — single-judge panel. gpt-4.1 was the strongest standalone
     # judge in the 4-model run.


### PR DESCRIPTION
Answerer joins the mini-tier alongside extraction/distill/benchmark_default. Judge stays at gpt-5.5. Cost-optimized for volume-heavy bench runs.