### PR TITLE
feat(retrieval): expose vector_top_k + mmr_top_n via YAML

### DIFF
--- a/attestor/config.py
+++ b/attestor/config.py
@@ -151,6 +151,38 @@ class ModelsCfg:
 
 
 @dataclass(frozen=True)
+class RetrievalCfg:
+    """Knobs for the 6-step recall cascade.
+
+    The recall pipeline (vector → BM25 → RRF → graph → MMR → fit) is
+    bounded by three quantities that interact:
+
+      vector_top_k  — pgvector's ``LIMIT`` on the cosine-similarity
+                      lane. More candidates = more raw material for
+                      MMR + graph affinity to choose from. Default 50.
+
+      mmr_top_n     — cap on what MMR emits; the diversity rerank
+                      drops redundant memories. Default ``None``
+                      preserves ``mmr_rerank``'s legacy behavior
+                      (no explicit cap; it returns whatever survives
+                      the diversity trim).
+
+      budget        — token cap on the final pack sent to the
+                      answerer. Lives on StackConfig directly (legacy
+                      placement); keeping it there for back-compat.
+                      Models support 200k-1M context; ``budget`` is
+                      what we choose to actually use.
+
+    These three knobs MUST be tuned together. Raising budget alone
+    does nothing if MMR cuts to 10 first; raising vector_top_k alone
+    just gives MMR more candidates to discard.
+    """
+
+    vector_top_k: int = 50
+    mmr_top_n: Optional[int] = None
+
+
+@dataclass(frozen=True)
 class LLMCfg:
     """Where chat-completion calls are routed.
 
@@ -209,6 +241,7 @@ class StackConfig:
     embedder: EmbedderCfg
     models: ModelsCfg
     llm: LLMCfg
+    retrieval: RetrievalCfg
     image: ImageCfg
     budget: int
     parallel: int
@@ -268,6 +301,7 @@ def _build_fallback_stack() -> StackConfig:
             benchmark_default=_FALLBACK_BENCHMARK,
         ),
         llm=LLMCfg.for_provider(_FALLBACK_LLM_PROVIDER),
+        retrieval=RetrievalCfg(),
         image=ImageCfg(ref="", api_ref_template="", registries={}),
         budget=_FALLBACK_BUDGET,
         parallel=_FALLBACK_PARALLEL,
@@ -286,6 +320,13 @@ def _parse_yaml(cfg_path: Path, *, strict: bool) -> StackConfig:
     emb = stack_blk.get("embedder") or {}
     models = stack_blk.get("models") or {}
     llm_blk = stack_blk.get("llm") or {}
+    retrieval_blk = stack_blk.get("retrieval") or {}
+
+    mmr_top_raw = retrieval_blk.get("mmr_top_n")
+    retrieval_cfg = RetrievalCfg(
+        vector_top_k=int(retrieval_blk.get("vector_top_k", 50)),
+        mmr_top_n=(int(mmr_top_raw) if mmr_top_raw is not None else None),
+    )
 
     llm_provider = str(llm_blk.get("provider", _FALLBACK_LLM_PROVIDER))
     if llm_provider not in LLM_PROVIDER_DEFAULTS:
@@ -327,6 +368,7 @@ def _parse_yaml(cfg_path: Path, *, strict: bool) -> StackConfig:
             benchmark_default=models.get("benchmark_default", _FALLBACK_BENCHMARK),
         ),
         llm=llm_cfg,
+        retrieval=retrieval_cfg,
         image=ImageCfg(
             ref=image_blk.get("ref", ""),
             api_ref_template=image_blk.get("api_ref_template", ""),
@@ -489,6 +531,9 @@ def print_stack_banner(stack: StackConfig, *, run_label: str) -> None:
     print(f"    verifier            {stack.models.verifier}")
     print(f"    planner             {stack.models.planner}")
     print(f"    benchmark_default   {stack.models.benchmark_default}")
+    mmr_cap = stack.retrieval.mmr_top_n if stack.retrieval.mmr_top_n is not None else "uncapped"
+    print(f"  retrieval        vector_top_k={stack.retrieval.vector_top_k}"
+          f" · mmr_top_n={mmr_cap}")
     print(f"  budget           {stack.budget} tokens · parallel = {stack.parallel}")
     print("=" * 72)
 

--- a/attestor/core.py
+++ b/attestor/core.py
@@ -156,6 +156,19 @@ class AgentMemory:
         self._retrieval.confidence_decay_rate = self.config.confidence_decay_rate
         self._retrieval.confidence_boost_rate = self.config.confidence_boost_rate
 
+        # Wire YAML retrieval knobs (vector_top_k, mmr_top_n) onto the
+        # orchestrator. We deliberately don't make AgentMemory crash if
+        # the stack loader fails — this is a tunable, not a correctness
+        # constraint, and the orchestrator's own defaults match the
+        # historical behavior.
+        try:
+            from attestor.config import get_stack
+            _retrieval_cfg = get_stack(strict=False).retrieval
+            self._retrieval.vector_top_k = _retrieval_cfg.vector_top_k
+            self._retrieval.mmr_top_n = _retrieval_cfg.mmr_top_n
+        except Exception as _e:
+            logger.debug("retrieval cfg not applied: %s", _e)
+
         # Operation ring buffer for latency observability
         self._ops_log: Deque[Dict[str, Any]] = deque(maxlen=200)
 

--- a/attestor/retrieval/orchestrator.py
+++ b/attestor/retrieval/orchestrator.py
@@ -69,6 +69,12 @@ class RetrievalOrchestrator:
         # Retained for callers; has no effect in semantic-first pipeline.
         self.fusion_mode: str = "semantic_first"
 
+        # Vector-lane top-K + MMR cap. Defaults match the legacy
+        # constants below; AgentMemory wires the resolved YAML values
+        # post-construction so callers can also tune via Python.
+        self.vector_top_k: int = VECTOR_TOP_K
+        self.mmr_top_n: Optional[int] = None  # None = no cap
+
     # ── Helpers ──
 
     def _question_entities(self, query: str) -> List[str]:
@@ -240,18 +246,18 @@ class RetrievalOrchestrator:
                 # don't — fall back to the legacy signature on TypeError.
                 try:
                     vector_hits_raw = self.vector_store.search(
-                        query, limit=VECTOR_TOP_K, namespace=namespace,
+                        query, limit=self.vector_top_k, namespace=namespace,
                         as_of=as_of, time_window=time_window,
                     )
                 except TypeError:
                     vector_hits_raw = self.vector_store.search(
-                        query, limit=VECTOR_TOP_K, namespace=namespace,
+                        query, limit=self.vector_top_k, namespace=namespace,
                     )
             except Exception:
                 vector_hits_raw = []
         if _tr.is_enabled():
             _tr.event("recall.stage.vector",
-                      top_k=VECTOR_TOP_K, hit_count=len(vector_hits_raw),
+                      top_k=self.vector_top_k, hit_count=len(vector_hits_raw),
                       hits=[{"id": h.get("memory_id"),
                              "distance": round(float(h.get("distance", 1.0)), 4)}
                             for h in vector_hits_raw[:10]])
@@ -440,9 +446,14 @@ class RetrievalOrchestrator:
         if self.enable_mmr:
             _pre_mmr_count = len(results)
             results = mmr_rerank(results, lambda_param=self.mmr_lambda)
+            # Apply post-MMR cap if configured. None = legacy behavior
+            # (no cap; let mmr_rerank's own diversity trim decide).
+            if self.mmr_top_n is not None and len(results) > self.mmr_top_n:
+                results = results[: self.mmr_top_n]
             if _tr.is_enabled():
                 _tr.event("recall.stage.mmr",
                           lambda_=self.mmr_lambda,
+                          mmr_top_n=self.mmr_top_n,
                           in_count=_pre_mmr_count, out_count=len(results))
 
         # ── Step 5: Confidence decay ──
@@ -477,7 +488,7 @@ class RetrievalOrchestrator:
             "namespace": namespace,
             "token_budget": token_budget,
             "question_entities": question_entities,
-            "vector_top_k": VECTOR_TOP_K,
+            "vector_top_k": self.vector_top_k,
             "vector_hits": trace_hits,
             "graph_triples_injected": len(triple_strs[:20]),
             "ranked_after_blend": ranked_preview,
@@ -511,7 +522,7 @@ class RetrievalOrchestrator:
         if self.vector_store:
             try:
                 vector_hits_raw = self.vector_store.search(
-                    query, limit=VECTOR_TOP_K, namespace=namespace
+                    query, limit=self.vector_top_k, namespace=namespace
                 )
             except Exception as e:
                 vector_hits_raw = []
@@ -532,7 +543,7 @@ class RetrievalOrchestrator:
             })
         vector_layer: Dict = {
             "name": "Vector Top-K",
-            "description": f"Top {VECTOR_TOP_K} by cosine similarity",
+            "description": f"Top {self.vector_top_k} by cosine similarity",
             "count": len(candidates),
             "latency_ms": round((time.monotonic() - t) * 1000, 2),
             "results": [
@@ -656,7 +667,7 @@ class RetrievalOrchestrator:
             "warnings": warnings,
             "config": {
                 "pipeline": "semantic_first",
-                "vector_top_k": VECTOR_TOP_K,
+                "vector_top_k": self.vector_top_k,
                 "vector_weight": VECTOR_WEIGHT,
                 "graph_weight": GRAPH_WEIGHT,
                 "mmr_lambda": self.mmr_lambda,

--- a/configs/attestor.yaml
+++ b/configs/attestor.yaml
@@ -113,7 +113,28 @@ stack:
   # ─── Retrieval budget ────────────────────────────────────────────────
   # Token budget per recall (the orchestrator MMR-packs candidates
   # under this ceiling). 4000 is the canonical benchmark default.
-  budget: 4000
+  # ─── Retrieval cascade tuning ─────────────────────────────────────────
+  # Three knobs that interact — raising one without the others usually
+  # does nothing.
+  #
+  #   vector_top_k  pgvector LIMIT on the cosine-similarity lane.
+  #                 More candidates → more raw material for graph
+  #                 affinity + MMR to choose from. Default 50; bench
+  #                 runs targeting big context should raise to 200-500.
+  #
+  #   mmr_top_n     post-MMR cap. None means "no cap" (legacy behavior;
+  #                 mmr_rerank's diversity trim decides). Set when you
+  #                 want to bound how many memories actually reach the
+  #                 answerer.
+  #
+  #   budget        token cap on the final pack (below). At budget=4000
+  #                 with 10 memories surviving MMR, MMR is the binding
+  #                 constraint, not budget. Set them together.
+  retrieval:
+    vector_top_k: 50
+    # mmr_top_n: 50    # uncomment to cap; default = no cap
+
+  budget: 4000   # tokens for the pack sent to the answerer
 
   # Concurrency across samples in benchmark runs (LME / LoCoMo / BEAM).
   parallel: 2

--- a/tests/test_retrieval_config.py
+++ b/tests/test_retrieval_config.py
@@ -1,0 +1,85 @@
+"""Retrieval cascade tunables — vector_top_k + mmr_top_n via YAML."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def _yaml_with_retrieval(tmp_path, monkeypatch, **retrieval) -> Path:
+    cfg = {
+        "stack": {
+            "postgres": {"url": "postgresql://postgres@localhost/attestor"},
+            "neo4j": {
+                "url": "bolt://localhost:7687",
+                "auth": {"username": "neo4j", "password": "test"},
+                "database": "neo4j",
+            },
+            "embedder": {
+                "provider": "voyage", "model": "voyage-4", "dimensions": 1024,
+            },
+            "llm": {"provider": "openrouter"},
+            "models": {
+                "answerer": "openai/gpt-5.4-mini",
+                "judge": "openai/gpt-5.5",
+                "extraction": "openai/gpt-5.4-mini",
+                "distill": "openai/gpt-5.4-mini",
+                "verifier": "anthropic/claude-sonnet-4-6",
+                "planner": "anthropic/claude-opus-4.7",
+                "benchmark_default": "openai/gpt-5.4-mini",
+            },
+        },
+    }
+    if retrieval:
+        cfg["stack"]["retrieval"] = retrieval
+
+    p = tmp_path / "attestor.yaml"
+    p.write_text(yaml.safe_dump(cfg))
+    monkeypatch.setenv("ATTESTOR_CONFIG", str(p))
+    from attestor import config as _c
+    _c.reset_stack()
+    return p
+
+
+@pytest.mark.unit
+def test_default_retrieval_cfg_matches_legacy(tmp_path, monkeypatch):
+    """No `retrieval:` block in YAML → legacy defaults preserved."""
+    _yaml_with_retrieval(tmp_path, monkeypatch)
+    from attestor.config import get_stack
+    s = get_stack(strict=False)
+    assert s.retrieval.vector_top_k == 50
+    assert s.retrieval.mmr_top_n is None
+
+
+@pytest.mark.unit
+def test_vector_top_k_overrides_via_yaml(tmp_path, monkeypatch):
+    _yaml_with_retrieval(tmp_path, monkeypatch, vector_top_k=300)
+    from attestor.config import get_stack
+    s = get_stack(strict=False)
+    assert s.retrieval.vector_top_k == 300
+
+
+@pytest.mark.unit
+def test_mmr_top_n_overrides_via_yaml(tmp_path, monkeypatch):
+    _yaml_with_retrieval(tmp_path, monkeypatch, mmr_top_n=128)
+    from attestor.config import get_stack
+    s = get_stack(strict=False)
+    assert s.retrieval.mmr_top_n == 128
+
+
+@pytest.mark.unit
+def test_explicit_null_mmr_top_n_is_uncapped(tmp_path, monkeypatch):
+    """YAML `mmr_top_n: null` should land as None (uncapped)."""
+    p = _yaml_with_retrieval(tmp_path, monkeypatch, vector_top_k=100)
+    from attestor.config import get_stack
+    s = get_stack(strict=False)
+    assert s.retrieval.vector_top_k == 100
+    assert s.retrieval.mmr_top_n is None  # absent in YAML → uncapped


### PR DESCRIPTION
## Summary

Three knobs control how many memories actually reach the answerer: \`vector_top_k\` (vector lane LIMIT), \`mmr_top_n\` (post-MMR cap), and \`budget\` (token cap on the pack). Until now only \`budget\` was YAML-tunable; the other two were hardcoded constants in \`orchestrator.py\`. Result: callers who tried to expand recall by raising \`budget\` saw no effect — MMR was the binding constraint.

\`\`\`yaml
stack:
  retrieval:
    vector_top_k: 50    # was: hardcoded VECTOR_TOP_K = 50
    mmr_top_n: null     # was: not exposed; null = legacy uncapped
\`\`\`

\`RetrievalCfg\` is a new frozen dataclass on \`StackConfig\`; defaults match the historical constants so no behavior change for unmigrated YAML.

## Honest scope note

**Bumping any one of the three knobs alone usually does nothing — they interact.** Set them together when targeting big context (e.g. \`budget=256000 + vector_top_k=500 + mmr_top_n=null\`). This PR makes that tuning *possible*; it does NOT change the defaults. A separate run is needed to validate that bigger context actually helps accuracy on the LME bench (lost-in-the-middle effects can degrade results past ~32k even on 1M-context models).

## What else changed

- \`AgentMemory.__init__\` now wires the resolved retrieval cfg onto the orchestrator post-construction.
- \`print_stack_banner\` shows the retrieval line: \`vector_top_k=50 · mmr_top_n=uncapped\`.

## Test plan

- [x] 4 unit tests in \`tests/test_retrieval_config.py\` (legacy defaults preserved, vector_top_k override, mmr_top_n override, explicit-null case)
- [x] Full unit suite: 981 passed, 232 skipped, 0 failed