### PR TITLE
feat(models): per-role reasoning_effort + 10× max_tokens

### DIFF
--- a/attestor/config.py
+++ b/attestor/config.py
@@ -140,6 +140,16 @@ class ModelsCfg:
                     (retrieval.planner)
       benchmark_default — generic fallback for ad-hoc bench commands
                           where no specific role applies
+
+    ``reasoning_effort`` (gpt-5.x reasoning models only): role → effort
+        level (none|minimal|low|medium|high|xhigh). Models that don't
+        support this param ignore it silently (Anthropic, older OpenAI).
+        Default empty dict = don't pass the param = legacy behavior.
+
+    ``max_tokens``: role → completion-token cap. Reasoning tokens count
+        against this, so high-effort roles need real headroom (3000 is
+        a typical target on the answerer; 1000 on judge). Default empty
+        dict = use a per-role legacy default (300 for most roles).
     """
     answerer: str
     judge: str
@@ -148,6 +158,8 @@ class ModelsCfg:
     verifier: str
     planner: str
     benchmark_default: str
+    reasoning_effort: Dict[str, str] = field(default_factory=dict)
+    max_tokens: Dict[str, int] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -366,6 +378,8 @@ def _parse_yaml(cfg_path: Path, *, strict: bool) -> StackConfig:
             verifier=models.get("verifier", _FALLBACK_VERIFIER),
             planner=models.get("planner", _FALLBACK_PLANNER),
             benchmark_default=models.get("benchmark_default", _FALLBACK_BENCHMARK),
+            reasoning_effort=dict(models.get("reasoning_effort") or {}),
+            max_tokens={k: int(v) for k, v in (models.get("max_tokens") or {}).items()},
         ),
         llm=llm_cfg,
         retrieval=retrieval_cfg,
@@ -512,6 +526,36 @@ def verify_neo4j_reachable(stack: StackConfig) -> None:
         )
 
 
+def chat_kwargs_for_role(
+    role: str,
+    *,
+    fallback_max_tokens: int = 300,
+) -> Dict[str, Any]:
+    """Build the kwargs dict to pass to OpenAI chat.completions.create()
+    for a given role, sourced from the resolved stack.
+
+    Returns at minimum ``{"max_tokens": int}``; adds ``reasoning_effort``
+    when the YAML configures one for this role. Models that don't support
+    reasoning_effort (Anthropic, older OpenAI) silently ignore it via
+    OpenRouter's API surface — no client-side filtering needed.
+
+    Stack load failures (no YAML, missing keys) fall back to safe
+    defaults: ``max_tokens=fallback_max_tokens``, no reasoning_effort.
+    Callers don't crash on stripped-checkout / test scenarios.
+    """
+    out: Dict[str, Any] = {"max_tokens": fallback_max_tokens}
+    try:
+        m = get_stack(strict=False).models
+    except Exception:
+        return out
+
+    if role in m.max_tokens:
+        out["max_tokens"] = m.max_tokens[role]
+    if role in m.reasoning_effort:
+        out["reasoning_effort"] = m.reasoning_effort[role]
+    return out
+
+
 def print_stack_banner(stack: StackConfig, *, run_label: str) -> None:
     """Print the resolved stack so users sanity-check before any
     expensive call."""
@@ -531,6 +575,12 @@ def print_stack_banner(stack: StackConfig, *, run_label: str) -> None:
     print(f"    verifier            {stack.models.verifier}")
     print(f"    planner             {stack.models.planner}")
     print(f"    benchmark_default   {stack.models.benchmark_default}")
+    if stack.models.reasoning_effort:
+        ef = ", ".join(f"{r}={v}" for r, v in stack.models.reasoning_effort.items())
+        print(f"  reasoning_effort {ef}")
+    if stack.models.max_tokens:
+        mt = ", ".join(f"{r}={v}" for r, v in stack.models.max_tokens.items())
+        print(f"  max_tokens       {mt}")
     mmr_cap = stack.retrieval.mmr_top_n if stack.retrieval.mmr_top_n is not None else "uncapped"
     print(f"  retrieval        vector_top_k={stack.retrieval.vector_top_k}"
           f" · mmr_top_n={mmr_cap}")

--- a/attestor/longmemeval.py
+++ b/attestor/longmemeval.py
@@ -710,7 +710,7 @@ def distill_turn(
     )
     try:
         client = _get_client(api_key)
-        raw = _chat(client, model, prompt, max_tokens=max_tokens)
+        raw = _chat(client, model, prompt, max_tokens=max_tokens, role="distill")
     except Exception as e:  # noqa: BLE001 — distillation is best-effort
         logger.warning("distill_turn failed (%s); falling back to raw turn", e)
         return [
@@ -1187,13 +1187,46 @@ def _get_client(api_key: Optional[str] = None) -> Any:
     return OpenAI(base_url=base_url, api_key=key)
 
 
-def _chat(client: Any, model: str, prompt: str, *, max_tokens: int = 300) -> str:
-    """One-shot chat completion; returns content text."""
-    response = client.chat.completions.create(
-        model=model,
-        max_tokens=max_tokens,
-        messages=[{"role": "user", "content": prompt}],
-    )
+def _chat(
+    client: Any,
+    model: str,
+    prompt: str,
+    *,
+    max_tokens: int = 300,
+    reasoning_effort: Optional[str] = None,
+    role: Optional[str] = None,
+) -> str:
+    """One-shot chat completion; returns content text.
+
+    When ``role`` is provided, look up per-role overrides for
+    ``reasoning_effort`` and ``max_tokens`` from the YAML stack
+    (``models.reasoning_effort[role]`` and ``models.max_tokens[role]``).
+    Explicit kwargs win over YAML; YAML wins over the legacy default.
+
+    ``reasoning_effort`` is a gpt-5.x param. Models that don't support
+    it ignore it silently via OpenRouter's API surface; no need to
+    filter client-side.
+    """
+    if role is not None:
+        from attestor.config import chat_kwargs_for_role
+        role_kwargs = chat_kwargs_for_role(role, fallback_max_tokens=max_tokens)
+        # Explicit caller args override YAML
+        if max_tokens != 300:  # legacy sentinel — caller passed an explicit value
+            role_kwargs["max_tokens"] = max_tokens
+        else:
+            max_tokens = role_kwargs["max_tokens"]
+        if reasoning_effort is None and "reasoning_effort" in role_kwargs:
+            reasoning_effort = role_kwargs["reasoning_effort"]
+
+    create_kwargs: Dict[str, Any] = {
+        "model": model,
+        "max_tokens": max_tokens,
+        "messages": [{"role": "user", "content": prompt}],
+    }
+    if reasoning_effort:
+        create_kwargs["reasoning_effort"] = reasoning_effort
+
+    response = client.chat.completions.create(**create_kwargs)
     return response.choices[0].message.content or ""
 
 
@@ -1361,7 +1394,7 @@ def answer_question(
         context=context,
     )
     client = _get_client(api_key)
-    raw = _chat(client, model, prompt, max_tokens=max_tokens).strip()
+    raw = _chat(client, model, prompt, max_tokens=max_tokens, role="answerer").strip()
     reasoning, first_answer = _strip_reasoning(raw)
 
     final_answer = first_answer
@@ -1375,7 +1408,8 @@ def answer_question(
             first_answer=first_answer,
         )
         verified_text = _chat(
-            client, verify_model or model, verify_prompt, max_tokens=150
+            client, verify_model or model, verify_prompt,
+            max_tokens=150, role="verifier",
         ).strip()
         # Only accept the verifier's output if it is a non-empty single line
         # that differs from the first answer. Preserve the verified=True flag
@@ -1516,7 +1550,7 @@ def judge_personalization(
         context=context,
     )
     client = _get_client(api_key)
-    raw = _chat(client, model, prompt, max_tokens=max_tokens)
+    raw = _chat(client, model, prompt, max_tokens=max_tokens, role="judge")
     label, reasoning = _parse_judge_response(raw)
     return JudgeResult(
         label=label,
@@ -1548,7 +1582,7 @@ def judge_answer(
         generated=generated,
     )
     client = _get_client(api_key)
-    raw = _chat(client, model, prompt, max_tokens=max_tokens)
+    raw = _chat(client, model, prompt, max_tokens=max_tokens, role="judge")
     label, reasoning = _parse_judge_response(raw)
     return JudgeResult(
         label=label,

--- a/configs/attestor.yaml
+++ b/configs/attestor.yaml
@@ -110,6 +110,34 @@ stack:
     # iteration happens often.
     benchmark_default: openai/gpt-5.4-mini
 
+    # ─── Reasoning effort (gpt-5.x reasoning-model param) ──────────────
+    # Higher effort = more internal CoT tokens spent before the visible
+    # answer. The `mini` base + `high` effort combination matches the
+    # o1-mini pattern: cheap base model "punches up" via deeper internal
+    # reasoning. Anthropic models silently ignore this param.
+    reasoning_effort:
+      answerer:    high      # mini base + deep reasoning = punches up
+      judge:       high      # verdict accuracy is the headline
+      extraction:  low       # ingest workhorse; speed > deep reasoning
+      distill:     low
+      verifier:    medium    # second-pass cross-check
+      planner:     medium    # query rewriting
+      benchmark_default: low
+
+    # ─── Output budget per role (10× the legacy 300-token cap) ──────────
+    # Reasoning tokens count against this, so high-effort roles need
+    # real headroom (3000 = ~1500 reasoning + ~500 visible + slack).
+    # Lifting this without raising reasoning_effort just gives the model
+    # more room to ramble — set them together.
+    max_tokens:
+      answerer:    3000      # was 300 → 10×; fits effort:high
+      judge:       3000      # was 300 → 10×
+      extraction:  5000      # was 500 → 10×
+      distill:     5000      # was 500 → 10×
+      verifier:    2000      # was 200 → 10×
+      planner:     3000      # was 300 → 10×
+      benchmark_default: 3000
+
   # ─── Retrieval budget ────────────────────────────────────────────────
   # Token budget per recall (the orchestrator MMR-packs candidates
   # under this ceiling). 4000 is the canonical benchmark default.

--- a/tests/test_reasoning_effort_config.py
+++ b/tests/test_reasoning_effort_config.py
@@ -1,0 +1,144 @@
+"""Per-role reasoning_effort + max_tokens — config + chat-kwargs builder.
+
+Confirms the YAML knobs land on `ModelsCfg`, the kwargs builder
+returns the right dict per role, and missing roles fall through to
+the legacy default (300 max_tokens, no reasoning_effort).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def _yaml_with_models(tmp_path, monkeypatch, **models_extra) -> Path:
+    cfg = {
+        "stack": {
+            "postgres": {"url": "postgresql://postgres@localhost/attestor"},
+            "neo4j": {
+                "url": "bolt://localhost:7687",
+                "auth": {"username": "neo4j", "password": "test"},
+                "database": "neo4j",
+            },
+            "embedder": {
+                "provider": "voyage", "model": "voyage-4", "dimensions": 1024,
+            },
+            "llm": {"provider": "openrouter"},
+            "models": {
+                "answerer": "openai/gpt-5.4-mini",
+                "judge": "openai/gpt-5.5",
+                "extraction": "openai/gpt-5.4-mini",
+                "distill": "openai/gpt-5.4-mini",
+                "verifier": "anthropic/claude-sonnet-4-6",
+                "planner": "anthropic/claude-opus-4.7",
+                "benchmark_default": "openai/gpt-5.4-mini",
+                **models_extra,
+            },
+        },
+    }
+    p = tmp_path / "attestor.yaml"
+    p.write_text(yaml.safe_dump(cfg))
+    monkeypatch.setenv("ATTESTOR_CONFIG", str(p))
+    from attestor import config as _c
+    _c.reset_stack()
+    return p
+
+
+@pytest.mark.unit
+def test_default_reasoning_and_max_tokens_are_empty(tmp_path, monkeypatch):
+    """No `reasoning_effort` / `max_tokens` block → empty dicts.
+    Production behavior preserved (back-compat)."""
+    _yaml_with_models(tmp_path, monkeypatch)
+    from attestor.config import get_stack
+    s = get_stack(strict=False)
+    assert s.models.reasoning_effort == {}
+    assert s.models.max_tokens == {}
+
+
+@pytest.mark.unit
+def test_reasoning_effort_block_is_parsed(tmp_path, monkeypatch):
+    _yaml_with_models(
+        tmp_path, monkeypatch,
+        reasoning_effort={"answerer": "high", "judge": "high", "extraction": "low"},
+    )
+    from attestor.config import get_stack
+    s = get_stack(strict=False)
+    assert s.models.reasoning_effort == {
+        "answerer": "high", "judge": "high", "extraction": "low",
+    }
+
+
+@pytest.mark.unit
+def test_max_tokens_block_is_parsed_as_ints(tmp_path, monkeypatch):
+    _yaml_with_models(
+        tmp_path, monkeypatch,
+        max_tokens={"answerer": 3000, "judge": "1000", "verifier": 500},
+    )
+    from attestor.config import get_stack
+    s = get_stack(strict=False)
+    assert s.models.max_tokens == {"answerer": 3000, "judge": 1000, "verifier": 500}
+
+
+@pytest.mark.unit
+def test_chat_kwargs_for_role_returns_legacy_default_when_unset(tmp_path, monkeypatch):
+    """No YAML override for the role → just max_tokens=fallback."""
+    _yaml_with_models(tmp_path, monkeypatch)
+    from attestor.config import chat_kwargs_for_role
+    out = chat_kwargs_for_role("answerer", fallback_max_tokens=300)
+    assert out == {"max_tokens": 300}
+
+
+@pytest.mark.unit
+def test_chat_kwargs_for_role_picks_up_yaml_overrides(tmp_path, monkeypatch):
+    _yaml_with_models(
+        tmp_path, monkeypatch,
+        reasoning_effort={"answerer": "high"},
+        max_tokens={"answerer": 3000},
+    )
+    from attestor.config import chat_kwargs_for_role
+    out = chat_kwargs_for_role("answerer", fallback_max_tokens=300)
+    assert out == {"max_tokens": 3000, "reasoning_effort": "high"}
+
+
+@pytest.mark.unit
+def test_chat_kwargs_for_role_only_max_tokens_set(tmp_path, monkeypatch):
+    """max_tokens override without reasoning_effort — common for
+    non-reasoning roles like extraction or planner."""
+    _yaml_with_models(
+        tmp_path, monkeypatch,
+        max_tokens={"extraction": 2000},
+    )
+    from attestor.config import chat_kwargs_for_role
+    out = chat_kwargs_for_role("extraction", fallback_max_tokens=300)
+    assert out == {"max_tokens": 2000}
+
+
+@pytest.mark.unit
+def test_chat_kwargs_for_role_handles_unknown_role(tmp_path, monkeypatch):
+    """Roles not present in either dict get the fallback."""
+    _yaml_with_models(
+        tmp_path, monkeypatch,
+        reasoning_effort={"answerer": "high"},
+        max_tokens={"answerer": 3000},
+    )
+    from attestor.config import chat_kwargs_for_role
+    out = chat_kwargs_for_role("nonexistent_role", fallback_max_tokens=500)
+    assert out == {"max_tokens": 500}
+
+
+@pytest.mark.unit
+def test_chat_kwargs_for_role_survives_no_yaml(monkeypatch):
+    """Stripped checkout / no YAML — return safe defaults, don't crash."""
+    monkeypatch.setenv("ATTESTOR_CONFIG", "/tmp/nonexistent.yaml")
+    from attestor import config as _c
+    _c.reset_stack()
+    out = _c.chat_kwargs_for_role("answerer", fallback_max_tokens=300)
+    assert out == {"max_tokens": 300}


### PR DESCRIPTION
Adds two YAML knobs (`models.reasoning_effort` + `models.max_tokens`) and lifts the canonical `configs/attestor.yaml` to use them. The combination — cheap base model + reasoning_effort:high + 10× max_tokens — is the o1-mini pattern: small model that punches up via internal CoT.

Single YAML, no separate bench file (per `project_default_config_file.md`).

## Test plan
- [x] 8 unit tests in `tests/test_reasoning_effort_config.py`
- [x] Full unit suite: 989 passed, 232 skipped, 0 failed
- [x] Stack banner verified to print effort + max_tokens blocks

## Bench-drift
Disk 500-q results used the prior non-reasoning answerer. New YAML needs a fresh canonical run before any headline citation.