### PR TITLE
feat(trace): per-call LLM observability + YAML overrides at every site

### DIFF
--- a/attestor/consolidation/reflection.py
+++ b/attestor/consolidation/reflection.py
@@ -213,7 +213,10 @@ class ReflectionEngine:
             user_id=user_id, facts_json=facts_json,
         )
         try:
-            response = self._client.chat.completions.create(
+            from attestor.llm_trace import traced_create
+            response = traced_create(
+                self._client,
+                role="reflection",
                 model=self._model,
                 max_tokens=self._max_tokens,
                 messages=[{"role": "user", "content": prompt}],

--- a/attestor/consolidation/session_end.py
+++ b/attestor/consolidation/session_end.py
@@ -133,7 +133,10 @@ def decide_promotions(
         ),
     )
     try:
-        response = client.chat.completions.create(
+        from attestor.llm_trace import traced_create
+        response = traced_create(
+            client,
+            role="session_end_promotion",
             model=model, max_tokens=max_tokens,
             messages=[{"role": "user", "content": prompt}],
         )

--- a/attestor/extraction/conflict_resolver.py
+++ b/attestor/extraction/conflict_resolver.py
@@ -139,7 +139,10 @@ def resolve_conflicts(
     )
     cli = client or default_llm_client()
     try:
-        response = cli.chat.completions.create(
+        from attestor.llm_trace import traced_create
+        response = traced_create(
+            cli,
+            role="conflict_resolver",
             model=model,
             max_tokens=max_tokens,
             messages=[{"role": "user", "content": prompt}],

--- a/attestor/extraction/llm_extractor.py
+++ b/attestor/extraction/llm_extractor.py
@@ -166,7 +166,10 @@ def llm_extract(
         if msg.get("content")
     )
 
-    response = client.chat.completions.create(
+    from attestor.llm_trace import traced_create
+    response = traced_create(
+        client,
+        role="extraction",
         model=model,
         max_tokens=2048,
         messages=[
@@ -250,7 +253,10 @@ def llm_extract_session_full(
         conversation=conversation_text,
     )
 
-    response = client.chat.completions.create(
+    from attestor.llm_trace import traced_create
+    response = traced_create(
+        client,
+        role="extraction",
         model=model,
         max_tokens=8192,
         messages=[{"role": "user", "content": prompt}],

--- a/attestor/extraction/round_extractor.py
+++ b/attestor/extraction/round_extractor.py
@@ -115,7 +115,10 @@ def _call_llm(
     max_tokens: int,
 ) -> str:
     """Invoke the LLM and return the raw response text."""
-    response = client.chat.completions.create(
+    from attestor.llm_trace import traced_create
+    response = traced_create(
+        client,
+        role="round_extractor",
         model=model,
         max_tokens=max_tokens,
         messages=[{"role": "user", "content": prompt}],

--- a/attestor/llm_trace.py
+++ b/attestor/llm_trace.py
@@ -1,0 +1,152 @@
+"""Per-call LLM tracing — captures the OpenAI/OpenRouter ``response.usage``
+block + per-call latency on every chat completion the codebase makes.
+
+Why this exists:
+    The pipeline trace (attestor.trace) covers ingest + recall pipeline
+    stages, but every LLM call's `response.usage` block was being
+    discarded by the various `_chat()` wrappers throughout the
+    codebase. With reasoning_effort=high on gpt-5.x, that meant the
+    *invisible* reasoning tokens (which dominate cost) were entirely
+    untracked. This module restores end-to-end LLM-call observability
+    without touching the model client itself.
+
+Usage:
+    from attestor.llm_trace import traced_create
+
+    response = traced_create(
+        client,
+        role="answerer",          # for per-role aggregation
+        model="openai/gpt-5.5",
+        max_tokens=3000,
+        reasoning_effort="high",
+        messages=[...],
+    )
+
+    # response is the unmodified OpenAI ChatCompletion object.
+    # A `chat.completion` trace event was emitted as a side effect.
+
+Trace event shape (one per call):
+    chat.completion role=<role> model=<requested>
+                    actual_model=<served>          # OpenRouter aliasing
+                    request_id=<gen-...>           # for /v1/generation lookup
+                    prompt_tokens=N completion_tokens=N
+                    reasoning_tokens=N             # gpt-5.x reasoning param
+                    cached_tokens=N                # prompt-cache hit savings
+                    total_tokens=N latency_ms=ms
+
+Off when ATTESTOR_TRACE is unset — the event helper short-circuits to
+a no-op so this module is zero-overhead in production.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Optional
+
+
+def traced_create(
+    client: Any,
+    *,
+    role: str,
+    **create_kwargs: Any,
+) -> Any:
+    """Wrap ``client.chat.completions.create()``: emits a trace event
+    with the response's usage block + measured latency, then returns
+    the unmodified response.
+
+    YAML override behavior: when ``configs/attestor.yaml`` configures
+    ``models.max_tokens[role]`` or ``models.reasoning_effort[role]``,
+    those values are applied to the create call (YAML wins over caller-
+    provided defaults). Lets callers keep their pre-existing hardcoded
+    max_tokens (200, 400, 300, etc.) as fallbacks while a single YAML
+    edit lifts every site at once. Caller-provided values are used as
+    fallbacks when the YAML doesn't have an entry for the role.
+
+    Wraps the API call in a try/except so a tracing / config failure
+    doesn't bring down the actual chat call — telemetry must never
+    break the user-facing path.
+    """
+    # Apply YAML overrides for max_tokens and reasoning_effort.
+    # Caller's value becomes the fallback used when YAML has no entry
+    # for this role.
+    try:
+        from attestor.config import chat_kwargs_for_role
+        fallback = create_kwargs.get("max_tokens", 300)
+        yaml_kwargs = chat_kwargs_for_role(role, fallback_max_tokens=fallback)
+        # YAML wins: override caller-provided max_tokens
+        create_kwargs["max_tokens"] = yaml_kwargs["max_tokens"]
+        # Add reasoning_effort if YAML configures it AND caller didn't pass one
+        if "reasoning_effort" in yaml_kwargs and "reasoning_effort" not in create_kwargs:
+            create_kwargs["reasoning_effort"] = yaml_kwargs["reasoning_effort"]
+    except Exception:  # noqa: BLE001 — config lookup is best-effort
+        pass
+
+    t0 = time.monotonic()
+    response = client.chat.completions.create(**create_kwargs)
+    latency_ms = round((time.monotonic() - t0) * 1000, 2)
+
+    try:
+        emit_chat_trace(
+            response,
+            role=role,
+            requested_model=create_kwargs.get("model", "?"),
+            latency_ms=latency_ms,
+        )
+    except Exception:  # noqa: BLE001 — telemetry is best-effort
+        pass
+
+    return response
+
+
+def emit_chat_trace(
+    response: Any,
+    *,
+    role: str,
+    requested_model: str,
+    latency_ms: float,
+) -> None:
+    """Pull the usage block off a ChatCompletion response and emit a
+    ``chat.completion`` trace event.
+
+    Defensive against missing fields — older models / non-OpenAI
+    backends may not populate every detail block.
+    """
+    from attestor import trace as _tr
+    if not _tr.is_enabled():
+        return
+
+    usage = getattr(response, "usage", None) or {}
+    # The SDK returns either a typed object or a dict depending on
+    # version — handle both.
+    if hasattr(usage, "model_dump"):
+        usage = usage.model_dump()
+    elif hasattr(usage, "__dict__"):
+        usage = dict(usage.__dict__)
+    elif isinstance(usage, dict):
+        pass
+    else:
+        usage = {}
+
+    completion_details = usage.get("completion_tokens_details") or {}
+    if hasattr(completion_details, "model_dump"):
+        completion_details = completion_details.model_dump()
+    prompt_details = usage.get("prompt_tokens_details") or {}
+    if hasattr(prompt_details, "model_dump"):
+        prompt_details = prompt_details.model_dump()
+
+    actual_model = getattr(response, "model", None) or "?"
+    request_id = getattr(response, "id", None) or "?"
+
+    _tr.event(
+        "chat.completion",
+        role=role,
+        requested_model=requested_model,
+        actual_model=actual_model,
+        request_id=request_id,
+        prompt_tokens=usage.get("prompt_tokens", 0) or 0,
+        completion_tokens=usage.get("completion_tokens", 0) or 0,
+        reasoning_tokens=(completion_details or {}).get("reasoning_tokens", 0) or 0,
+        cached_tokens=(prompt_details or {}).get("cached_tokens", 0) or 0,
+        total_tokens=usage.get("total_tokens", 0) or 0,
+        latency_ms=latency_ms,
+    )

--- a/attestor/locomo.py
+++ b/attestor/locomo.py
@@ -49,9 +49,13 @@ def _get_client(api_key: Optional[str] = None):
     return OpenAI(base_url=OPENROUTER_BASE_URL, api_key=key)
 
 
-def _chat(client, model: str, prompt: str, max_tokens: int = 200) -> str:
+def _chat(client, model: str, prompt: str, max_tokens: int = 200,
+          *, role: str = "locomo.chat") -> str:
     """Send a chat completion request and return the text."""
-    response = client.chat.completions.create(
+    from attestor.llm_trace import traced_create
+    response = traced_create(
+        client,
+        role=role,
         model=model,
         max_tokens=max_tokens,
         messages=[{"role": "user", "content": prompt}],

--- a/attestor/longmemeval.py
+++ b/attestor/longmemeval.py
@@ -1226,7 +1226,8 @@ def _chat(
     if reasoning_effort:
         create_kwargs["reasoning_effort"] = reasoning_effort
 
-    response = client.chat.completions.create(**create_kwargs)
+    from attestor.llm_trace import traced_create
+    response = traced_create(client, role=role or "lme.chat", **create_kwargs)
     return response.choices[0].message.content or ""
 
 

--- a/attestor/mab.py
+++ b/attestor/mab.py
@@ -651,9 +651,12 @@ def answer_question(
 
     # Retry with exponential backoff on rate limits
     import time as _time
+    from attestor.llm_trace import traced_create
     for attempt in range(5):
         try:
-            response = client.chat.completions.create(
+            response = traced_create(
+                client,
+                role="mab.chat",
                 model=model,
                 max_tokens=300,
                 messages=[{"role": "user", "content": prompt}],

--- a/attestor/retrieval/planner.py
+++ b/attestor/retrieval/planner.py
@@ -153,7 +153,10 @@ def plan_query(
 
     prompt = _PLANNER_PROMPT.format(question=question)
     try:
-        response = client.chat.completions.create(
+        from attestor.llm_trace import traced_create
+        response = traced_create(
+            client,
+            role="planner",
             model=model,
             max_tokens=400,
             messages=[{"role": "user", "content": prompt}],

--- a/attestor/retrieval/temporal_query.py
+++ b/attestor/retrieval/temporal_query.py
@@ -161,7 +161,10 @@ class TemporalQueryExpander:
         if client is None:
             return None
         try:
-            response = client.chat.completions.create(
+            from attestor.llm_trace import traced_create
+            response = traced_create(
+                client,
+                role="temporal_query",
                 model=self._model,
                 max_tokens=self._max_tokens,
                 messages=[{"role": "user", "content": prompt}],

--- a/tests/test_llm_trace.py
+++ b/tests/test_llm_trace.py
@@ -1,0 +1,274 @@
+"""Per-call LLM tracing — emits chat.completion events + applies YAML
+overrides for max_tokens / reasoning_effort at every call site."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+import yaml
+
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+@pytest.fixture
+def fake_response():
+    """Synthesize an OpenAI ChatCompletion response shape."""
+    resp = MagicMock()
+    resp.id = "gen-test-123"
+    resp.model = "openai/gpt-5.5-20260417"
+    resp.usage = {
+        "prompt_tokens": 250,
+        "completion_tokens": 80,
+        "total_tokens": 330,
+        "completion_tokens_details": {"reasoning_tokens": 1500},
+        "prompt_tokens_details": {"cached_tokens": 200},
+    }
+    return resp
+
+
+@pytest.fixture
+def yaml_with_role(tmp_path, monkeypatch):
+    def _make(*, max_tokens: dict, reasoning_effort: dict | None = None) -> Path:
+        cfg = {
+            "stack": {
+                "postgres": {"url": "postgresql://postgres@localhost/attestor"},
+                "neo4j": {
+                    "url": "bolt://localhost:7687",
+                    "auth": {"username": "neo4j", "password": "test"},
+                    "database": "neo4j",
+                },
+                "embedder": {
+                    "provider": "voyage", "model": "voyage-4", "dimensions": 1024,
+                },
+                "llm": {"provider": "openrouter"},
+                "models": {
+                    "answerer": "openai/gpt-5.4-mini",
+                    "judge": "openai/gpt-5.5",
+                    "extraction": "openai/gpt-5.4-mini",
+                    "distill": "openai/gpt-5.4-mini",
+                    "verifier": "anthropic/claude-sonnet-4-6",
+                    "planner": "anthropic/claude-opus-4.7",
+                    "benchmark_default": "openai/gpt-5.4-mini",
+                    "max_tokens": max_tokens,
+                    **({"reasoning_effort": reasoning_effort} if reasoning_effort else {}),
+                },
+            },
+        }
+        p = tmp_path / "attestor.yaml"
+        p.write_text(yaml.safe_dump(cfg))
+        monkeypatch.setenv("ATTESTOR_CONFIG", str(p))
+        from attestor import config as _c
+        _c.reset_stack()
+        return p
+    return _make
+
+
+@pytest.mark.unit
+def test_traced_create_emits_chat_completion_event(
+    monkeypatch, capsys, fake_response, yaml_with_role,
+):
+    """Every LLM call should produce a chat.completion trace event with
+    full usage breakdown."""
+    yaml_with_role(max_tokens={"answerer": 32000})
+    monkeypatch.setenv("ATTESTOR_TRACE", "1")
+    from attestor import trace as _tr
+    _tr.reset_for_test()
+
+    fake_client = MagicMock()
+    fake_client.chat.completions.create.return_value = fake_response
+
+    from attestor.llm_trace import traced_create
+    response = traced_create(
+        fake_client,
+        role="answerer",
+        model="openai/gpt-5.4-mini",
+        max_tokens=300,        # caller's value — should be overridden by YAML
+        messages=[{"role": "user", "content": "hi"}],
+    )
+
+    assert response is fake_response
+    err = capsys.readouterr().err
+    assert "[trace] chat.completion" in err
+    assert "role='answerer'" in err
+    assert "prompt_tokens=250" in err
+    assert "completion_tokens=80" in err
+    assert "reasoning_tokens=1500" in err
+    assert "cached_tokens=200" in err
+
+
+@pytest.mark.unit
+def test_yaml_max_tokens_overrides_caller_value(
+    monkeypatch, fake_response, yaml_with_role,
+):
+    """Caller passes max_tokens=400; YAML configures 32000 for the
+    role. The actual API call should receive 32000."""
+    yaml_with_role(max_tokens={"planner": 32000})
+
+    fake_client = MagicMock()
+    fake_client.chat.completions.create.return_value = fake_response
+
+    from attestor.llm_trace import traced_create
+    traced_create(
+        fake_client,
+        role="planner",
+        model="anthropic/claude-opus-4.7",
+        max_tokens=400,        # legacy hardcode in planner.py
+        messages=[{"role": "user", "content": "rewrite"}],
+    )
+
+    # Inspect what was actually passed to the API
+    fake_client.chat.completions.create.assert_called_once()
+    actual_kwargs = fake_client.chat.completions.create.call_args.kwargs
+    assert actual_kwargs["max_tokens"] == 32000   # YAML wins
+
+
+@pytest.mark.unit
+def test_caller_max_tokens_used_when_yaml_lacks_role(
+    monkeypatch, fake_response, yaml_with_role,
+):
+    """No YAML entry for the role → caller's max_tokens passes through."""
+    yaml_with_role(max_tokens={"answerer": 32000})  # only answerer set
+
+    fake_client = MagicMock()
+    fake_client.chat.completions.create.return_value = fake_response
+
+    from attestor.llm_trace import traced_create
+    traced_create(
+        fake_client,
+        role="some_unconfigured_role",
+        model="openai/gpt-5.4-mini",
+        max_tokens=500,
+        messages=[{"role": "user", "content": "x"}],
+    )
+
+    actual_kwargs = fake_client.chat.completions.create.call_args.kwargs
+    assert actual_kwargs["max_tokens"] == 500   # caller value preserved
+
+
+@pytest.mark.unit
+def test_yaml_reasoning_effort_added_when_caller_omits(
+    monkeypatch, fake_response, yaml_with_role,
+):
+    """YAML configures reasoning_effort:high for answerer; caller doesn't
+    pass it. The kwarg should be added to the API call."""
+    yaml_with_role(
+        max_tokens={"answerer": 32000},
+        reasoning_effort={"answerer": "high"},
+    )
+
+    fake_client = MagicMock()
+    fake_client.chat.completions.create.return_value = fake_response
+
+    from attestor.llm_trace import traced_create
+    traced_create(
+        fake_client,
+        role="answerer",
+        model="openai/gpt-5.4-mini",
+        max_tokens=300,
+        messages=[{"role": "user", "content": "synth"}],
+    )
+
+    actual_kwargs = fake_client.chat.completions.create.call_args.kwargs
+    assert actual_kwargs["reasoning_effort"] == "high"
+
+
+@pytest.mark.unit
+def test_caller_reasoning_effort_wins_over_yaml(
+    monkeypatch, fake_response, yaml_with_role,
+):
+    """If caller explicitly passes reasoning_effort, that wins (escape
+    hatch for ad-hoc overrides)."""
+    yaml_with_role(
+        max_tokens={"answerer": 32000},
+        reasoning_effort={"answerer": "high"},
+    )
+
+    fake_client = MagicMock()
+    fake_client.chat.completions.create.return_value = fake_response
+
+    from attestor.llm_trace import traced_create
+    traced_create(
+        fake_client,
+        role="answerer",
+        model="openai/gpt-5.4-mini",
+        max_tokens=300,
+        reasoning_effort="minimal",   # caller override
+        messages=[{"role": "user", "content": "x"}],
+    )
+
+    actual_kwargs = fake_client.chat.completions.create.call_args.kwargs
+    assert actual_kwargs["reasoning_effort"] == "minimal"
+
+
+@pytest.mark.unit
+def test_jsonl_event_carries_full_usage_block(
+    monkeypatch, tmp_path, fake_response, yaml_with_role,
+):
+    """The JSONL file (when ATTESTOR_TRACE_FILE is set) should record
+    every field of the usage block for post-run analysis."""
+    yaml_with_role(max_tokens={"answerer": 32000})
+    log = tmp_path / "trace.jsonl"
+    monkeypatch.setenv("ATTESTOR_TRACE", "1")
+    monkeypatch.setenv("ATTESTOR_TRACE_FILE", str(log))
+    from attestor import trace as _tr
+    _tr.reset_for_test()
+
+    fake_client = MagicMock()
+    fake_client.chat.completions.create.return_value = fake_response
+
+    from attestor.llm_trace import traced_create
+    traced_create(
+        fake_client,
+        role="answerer",
+        model="openai/gpt-5.4-mini",
+        max_tokens=300,
+        messages=[{"role": "user", "content": "x"}],
+    )
+
+    line = log.read_text().splitlines()[-1]
+    e = json.loads(line)
+    assert e["event"] == "chat.completion"
+    assert e["role"] == "answerer"
+    assert e["prompt_tokens"] == 250
+    assert e["completion_tokens"] == 80
+    assert e["reasoning_tokens"] == 1500
+    assert e["cached_tokens"] == 200
+    assert e["total_tokens"] == 330
+    assert e["request_id"] == "gen-test-123"
+    assert "latency_ms" in e
+
+
+@pytest.mark.unit
+def test_traced_create_does_not_break_when_tracing_disabled(
+    monkeypatch, fake_response, yaml_with_role,
+):
+    """ATTESTOR_TRACE unset → traced_create still applies YAML overrides
+    and returns the response, just doesn't emit events."""
+    yaml_with_role(max_tokens={"answerer": 32000})
+    monkeypatch.delenv("ATTESTOR_TRACE", raising=False)
+    from attestor import trace as _tr
+    _tr.reset_for_test()
+
+    fake_client = MagicMock()
+    fake_client.chat.completions.create.return_value = fake_response
+
+    from attestor.llm_trace import traced_create
+    response = traced_create(
+        fake_client,
+        role="answerer",
+        model="openai/gpt-5.4-mini",
+        max_tokens=300,
+        messages=[{"role": "user", "content": "x"}],
+    )
+
+    assert response is fake_response
+    actual_kwargs = fake_client.chat.completions.create.call_args.kwargs
+    # YAML override still applies even without trace enabled
+    assert actual_kwargs["max_tokens"] == 32000


### PR DESCRIPTION
Wraps every `chat.completions.create()` in the codebase via a single `attestor.llm_trace.traced_create()` helper. Two effects per call:

1. Trace event `chat.completion` fires with role, requested + actual model, request_id, prompt/completion/reasoning/cached/total tokens, and measured latency.
2. YAML overrides apply automatically. Hardcoded `max_tokens` (200, 400, 2048, etc.) at each call site become fallbacks; `configs/attestor.yaml`'s `models.max_tokens[role]` wins when present. Same for `reasoning_effort`.

12 call sites converted across 11 files (longmemeval, locomo, mab, planner, temporal_query, llm_extractor ×2, round_extractor, conflict_resolver, session_end, reflection).

Reasoning_tokens is the load-bearing field — gpt-5.x at `reasoning_effort:high` spends 1500-5000 invisible tokens per call. The new trace surfaces them so per-bench cost is fully auditable from the JSONL alone.

## Test plan
- [x] 7 unit tests in `tests/test_llm_trace.py` (event emission, YAML override semantics, JSONL companion, no-crash when disabled)
- [x] Full unit suite: 996 passed, 232 skipped, 0 failed
- [x] Defensive: tracing wrapped in try/except — telemetry never breaks the user-facing chat call