### PR TITLE
fix(identity): race-safe ensure_inbox + get_or_create_daily

### DIFF
--- a/attestor/identity/projects.py
+++ b/attestor/identity/projects.py
@@ -49,16 +49,54 @@ class ProjectRepo:
         return Project.from_row(dict(row))
 
     def ensure_inbox(self, user_id: str) -> Project:
-        """Idempotent: returns the user's Inbox, creating on first call."""
+        """Idempotent: returns the user's Inbox, creating on first call.
+
+        Race-safe under parallel callers. Schema has UNIQUE (user_id,
+        name) on the projects table — we attempt the INSERT and re-SELECT
+        on conflict. Without this, two threads on cold cache would both
+        find no existing inbox and both INSERT; the loser would crash
+        with psycopg2.errors.UniqueViolation. Common path on LME parallel
+        runs where every sample shares the SOLO user.
+        """
+        # Fast path: already exists.
         existing = self.find_by_name(user_id, INBOX_NAME)
         if existing is not None:
             return existing
-        return self.create(
-            user_id=user_id,
-            name=INBOX_NAME,
-            description="Conversations not assigned to a project",
-            metadata={INBOX_FLAG: True, "created_by": "auto"},
-        )
+
+        # Race-safe insert: ON CONFLICT DO NOTHING returns no row when
+        # another thread won; we then re-SELECT to pick up that thread's
+        # winning row.
+        with self._conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            cur.execute(
+                """
+                INSERT INTO projects (user_id, name, description, metadata)
+                VALUES (%s, %s, %s, %s::jsonb)
+                ON CONFLICT (user_id, name) DO NOTHING
+                RETURNING *
+                """,
+                (
+                    user_id,
+                    INBOX_NAME,
+                    "Conversations not assigned to a project",
+                    json.dumps({INBOX_FLAG: True, "created_by": "auto"}),
+                ),
+            )
+            row = cur.fetchone()
+        self._conn.commit()
+        if row is not None:
+            # We won the race.
+            return Project.from_row(dict(row))
+        # Lost the race — pick up the winner's row.
+        existing = self.find_by_name(user_id, INBOX_NAME)
+        if existing is None:
+            # Should be impossible: ON CONFLICT triggered means a row
+            # exists, but we couldn't find it. Defend with a clear error.
+            raise RuntimeError(
+                f"ensure_inbox: ON CONFLICT fired for user_id={user_id} "
+                "but follow-up SELECT returned no row — likely a "
+                "transaction-isolation issue."
+            )
+        return existing
 
     # ── Read ──────────────────────────────────────────────────────────────
 

--- a/attestor/identity/sessions.py
+++ b/attestor/identity/sessions.py
@@ -51,8 +51,33 @@ class SessionRepo:
         self, user_id: str, project_id: str, day: str,
     ) -> Session:
         """SOLO-mode helper: one session per (user, day). ``day`` is an ISO
-        date string (e.g. '2026-04-25'). Returns existing if found."""
+        date string (e.g. '2026-04-25'). Returns existing if found.
+
+        Race-safe under parallel callers: serializes the SELECT-then-
+        INSERT critical section via a Postgres transactional advisory
+        lock keyed on (user_id, day). Without this, two parallel LME
+        samples sharing the SOLO user (the common case) would both see
+        no daily session and both INSERT — silent duplicate sessions
+        for the same day.
+
+        The lock is transactional (auto-releases on commit/rollback)
+        so we don't leak locks even if an exception fires mid-flight.
+        Schema has no UNIQUE constraint on (user_id, daily_key) so the
+        advisory lock IS the only protection here.
+        """
+        # Hash the (user, day) key into a 32-bit lock id. abs() so the
+        # value fits the postgres int4 range; collision risk is
+        # negligible at this volume (lock space is 2**31).
+        import hashlib
+        digest = hashlib.sha256(
+            f"daily:{user_id}:{day}".encode("utf-8"),
+        ).digest()
+        lock_id = int.from_bytes(digest[:4], "big") & 0x7FFFFFFF
+
         with self._conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            # Acquire the transactional advisory lock — blocks if
+            # another thread already holds it for this (user, day).
+            cur.execute("SELECT pg_advisory_xact_lock(%s)", (lock_id,))
             cur.execute(
                 """
                 SELECT * FROM sessions
@@ -65,13 +90,31 @@ class SessionRepo:
             )
             row = cur.fetchone()
             if row:
+                self._conn.commit()  # release advisory lock
                 return Session.from_row(dict(row))
-        return self.create(
-            user_id=user_id,
-            project_id=project_id,
-            title=f"Local — {day}",
-            metadata={"daily_key": f"solo-daily-{day}", "created_by": "solo_daily"},
-        )
+
+            # Still inside the lock — INSERT now is exclusive for this
+            # (user, day) pair. Other threads block on the lock until
+            # we commit.
+            cur.execute(
+                """
+                INSERT INTO sessions (user_id, project_id, title, metadata)
+                VALUES (%s, %s, %s, %s::jsonb)
+                RETURNING *
+                """,
+                (
+                    user_id,
+                    project_id,
+                    f"Local — {day}",
+                    json.dumps({
+                        "daily_key": f"solo-daily-{day}",
+                        "created_by": "solo_daily",
+                    }),
+                ),
+            )
+            row = cur.fetchone()
+        self._conn.commit()  # releases advisory lock
+        return Session.from_row(dict(row))
 
     # ── Read ──────────────────────────────────────────────────────────────
 

--- a/tests/test_repos_race.py
+++ b/tests/test_repos_race.py
@@ -1,0 +1,154 @@
+"""Concurrency stress for ProjectRepo.ensure_inbox + SessionRepo.get_or_create_daily.
+
+Both repos had a classic SELECT-then-INSERT race that would fire under
+parallel LME runs (every sample shares the SOLO user). Asserting the
+fixes hold:
+
+  • ensure_inbox: schema UNIQUE(user_id, name) backs ON CONFLICT DO NOTHING.
+    16 threads racing → exactly 1 inbox row, 16 callers all return that
+    same row.
+  • get_or_create_daily: pg_advisory_xact_lock(hash(user_id, day))
+    serializes the get-or-create critical section. 16 threads racing →
+    exactly 1 daily session, 16 callers all return that same row.
+
+Marked ``live`` — needs a real Postgres at POSTGRES_URL with the v4
+schema applied. Run with::
+
+    POSTGRES_URL=postgresql://... .venv/bin/python -m pytest \
+        tests/test_repos_race.py -v
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import uuid
+
+import pytest
+
+
+POSTGRES_URL = os.environ.get("POSTGRES_URL")
+pytestmark = pytest.mark.skipif(
+    not POSTGRES_URL,
+    reason="repos race tests need POSTGRES_URL set to a live v4 Postgres",
+)
+
+
+@pytest.fixture
+def fresh_user(tmp_path):
+    """Create a brand-new user for each test so previous-run state
+    doesn't pollute the race test."""
+    import psycopg2
+    from attestor.identity.users import UserRepo
+
+    conn = psycopg2.connect(POSTGRES_URL)
+    conn.autocommit = True
+    repo = UserRepo(conn)
+    ext_id = f"race-test-{uuid.uuid4().hex[:8]}"
+    user = repo.create_or_get(
+        external_id=ext_id, display_name="race-test", metadata={},
+    )
+    yield conn, user
+    # Cleanup: cascade-delete the test user (drops projects+sessions).
+    with conn.cursor() as cur:
+        cur.execute("DELETE FROM users WHERE id = %s", (user.id,))
+    conn.close()
+
+
+@pytest.mark.live
+def test_ensure_inbox_is_race_safe(fresh_user):
+    conn, user = fresh_user
+    from attestor.identity.projects import ProjectRepo
+
+    N_THREADS = 16
+    results: list = [None] * N_THREADS
+    errors: list = []
+
+    def worker(i: int) -> None:
+        try:
+            # Each thread gets its own connection — that's how parallel
+            # LME samples work in practice.
+            import psycopg2
+            c = psycopg2.connect(POSTGRES_URL)
+            c.autocommit = False
+            try:
+                results[i] = ProjectRepo(c).ensure_inbox(user.id)
+            finally:
+                c.close()
+        except Exception as e:  # noqa: BLE001
+            errors.append((i, e))
+
+    threads = [threading.Thread(target=worker, args=(i,))
+               for i in range(N_THREADS)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert errors == [], f"unexpected errors: {errors}"
+
+    # All 16 callers should have returned the SAME inbox project.
+    ids = {p.id for p in results if p is not None}
+    assert len(ids) == 1, f"expected 1 inbox, got {len(ids)} distinct ids: {ids}"
+
+    # And the DB should hold exactly one inbox row for this user.
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT COUNT(*) FROM projects WHERE user_id = %s "
+            "AND COALESCE(metadata->>'is_inbox','false') = 'true'",
+            (user.id,),
+        )
+        count = cur.fetchone()[0]
+    assert count == 1, f"expected 1 inbox row, got {count}"
+
+
+@pytest.mark.live
+def test_get_or_create_daily_is_race_safe(fresh_user):
+    conn, user = fresh_user
+    from attestor.identity.projects import ProjectRepo
+    from attestor.identity.sessions import SessionRepo
+
+    # Need a project to anchor the session
+    project = ProjectRepo(conn).ensure_inbox(user.id)
+    day = "2099-12-31"   # far future date so no collision with real sessions
+
+    N_THREADS = 16
+    results: list = [None] * N_THREADS
+    errors: list = []
+
+    def worker(i: int) -> None:
+        try:
+            import psycopg2
+            c = psycopg2.connect(POSTGRES_URL)
+            c.autocommit = False
+            try:
+                results[i] = SessionRepo(c).get_or_create_daily(
+                    user_id=user.id,
+                    project_id=project.id,
+                    day=day,
+                )
+            finally:
+                c.close()
+        except Exception as e:  # noqa: BLE001
+            errors.append((i, e))
+
+    threads = [threading.Thread(target=worker, args=(i,))
+               for i in range(N_THREADS)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert errors == [], f"unexpected errors: {errors}"
+
+    ids = {s.id for s in results if s is not None}
+    assert len(ids) == 1, f"expected 1 daily session, got {len(ids)}"
+
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT COUNT(*) FROM sessions WHERE user_id = %s "
+            "AND metadata->>'daily_key' = %s",
+            (user.id, f"solo-daily-{day}"),
+        )
+        count = cur.fetchone()[0]
+    assert count == 1, f"expected 1 daily session row, got {count}"


### PR DESCRIPTION
Both repos had SELECT-then-INSERT races that fired under parallel LME runs. `ensure_inbox` now uses ON CONFLICT DO NOTHING (schema already has the unique constraint); `get_or_create_daily` uses a Postgres transactional advisory lock keyed on (user_id, day).

## Test plan
- [x] 2 live stress tests (16 threads each) in `tests/test_repos_race.py`
- [x] Both tests pass empirically against the local Postgres
- [x] Full unit suite green
- [x] No behavior change in non-concurrent paths