### PR TITLE
docs(hire-me): link author byline + AI-infra-led framing + spec drift fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ pip install attestor
 | **Repo** | <https://github.com/bolnet/attestor> |
 | **License** | MIT |
 
+> Designed and built by **[Surendra Singh](https://www.linkedin.com/in/singhsurendra/)** — building auditable infrastructure for multi-agent AI, with fifteen years of production-systems discipline brought to the memory layer. Companion projects: [`claude-finance`](https://github.com/bolnet/finance) (Claude-powered financial analytics) · [`private-equity`](https://bolnet.github.io/private-equity/) (PE × AI workshop). [Reach out](https://www.linkedin.com/in/singhsurendra/) if you're hiring senior IC for AI infrastructure.
+
 ---
 
 ## What it is

--- a/docs/index.html
+++ b/docs/index.html
@@ -1468,7 +1468,7 @@ footer.colophon {
     <div class="hero-dateline">
       <span class="filing">&sect; 00 &middot; Masthead</span>
       <span>Filed under Infrastructure</span>
-      <span>By Surendra Singh</span>
+      <span>By <a href="https://www.linkedin.com/in/singhsurendra/" target="_blank" rel="noopener" style="color:inherit;text-decoration:underline;text-decoration-thickness:1px;text-underline-offset:3px;">Surendra Singh</a></span>
       <span class="accent">&mdash; For publication &mdash;</span>
     </div>
 
@@ -1505,8 +1505,8 @@ footer.colophon {
           <span class="hero-spec-value">Python &middot; REST &middot; MCP</span>
         </div>
         <div class="hero-spec-row">
-          <span class="hero-spec-label">Retrieval Layers</span>
-          <span class="hero-spec-value">5</span>
+          <span class="hero-spec-label">Pipeline Steps</span>
+          <span class="hero-spec-value">6</span>
         </div>
         <div class="hero-spec-row">
           <span class="hero-spec-label">RBAC Roles</span>
@@ -1535,7 +1535,7 @@ footer.colophon {
       <span><b>STACK</b>Postgres &middot; pgvector &middot; Neo4j</span>
       <span><b>CLOUD</b>PostgreSQL &middot; ArangoDB &middot; Cosmos &middot; AlloyDB</span>
       <span><b>DEPLOY</b>AWS &middot; Azure &middot; GCP</span>
-      <span><b>RETRIEVAL</b>RRF &middot; PageRank &middot; MMR</span>
+      <span><b>RETRIEVAL</b>Vector &middot; BM25 &middot; RRF &middot; MMR</span>
       <span><b>LICENSE</b>MIT</span>
       <!-- duplicate -->
       <span><b>MULTI-AGENT</b>NAMESPACE</span>
@@ -1547,7 +1547,7 @@ footer.colophon {
       <span><b>STACK</b>Postgres &middot; pgvector &middot; Neo4j</span>
       <span><b>CLOUD</b>PostgreSQL &middot; ArangoDB &middot; Cosmos &middot; AlloyDB</span>
       <span><b>DEPLOY</b>AWS &middot; Azure &middot; GCP</span>
-      <span><b>RETRIEVAL</b>RRF &middot; PageRank &middot; MMR</span>
+      <span><b>RETRIEVAL</b>Vector &middot; BM25 &middot; RRF &middot; MMR</span>
       <span><b>LICENSE</b>MIT</span>
     </div>
   </div>
@@ -2996,7 +2996,7 @@ results = executor.<span class="fn">recall</span>(<span class="string">"order se
       <a href="https://registry.modelcontextprotocol.io/servers/io.github.bolnet/attestor" class="btn btn-ghost" target="_blank" rel="noopener">MCP Registry</a>
     </div>
 
-    <p class="closing-byline reveal">MIT. Self&#8209;hosted. Deterministic. Production deploy in one command. Designed and built by <a href="https://www.linkedin.com/in/singhsurendra/" target="_blank" rel="noopener">Surendra Singh</a> &mdash; fifteen years architecting production systems in financial services. <em>Thank you.</em></p>
+    <p class="closing-byline reveal">MIT. Self&#8209;hosted. Deterministic. Production deploy in one command. Designed and built by <a href="https://www.linkedin.com/in/singhsurendra/" target="_blank" rel="noopener">Surendra Singh</a> &mdash; building auditable infrastructure for multi-agent AI, with fifteen years of production-systems discipline brought to the memory layer. <em>Thank you.</em></p>
   </div>
 </section>
 


### PR DESCRIPTION
## Summary
- README and `docs/index.html` retuned for the senior-IC-AI-infra hiring-manager 30-second scan
- Author byline now links to LinkedIn within the first scroll-screen on both surfaces
- Closing byline reframed: leads with *"building auditable infrastructure for multi-agent AI"* — finance depth supports rather than ledes
- Two factual drift fixes in the landing page that a careful reviewer would catch (Pipeline Steps count, ticker)

## Changes

**`README.md` (+2 lines, line 25)** — new blockquote under the version table linking [Surendra Singh](https://www.linkedin.com/in/singhsurendra/) + companion projects (`claude-finance`, `private-equity`) + a *"Reach out"* CTA aimed at AI-infra hiring managers.

**`docs/index.html` (+6/-6 lines)**:
- `line 1471` — hero dateline `By Surendra Singh` linked to LinkedIn (top-of-fold).
- `line 2999` — closing byline rewritten: *"…building auditable infrastructure for multi-agent AI, with fifteen years of production-systems discipline brought to the memory layer."* (was *"…fifteen years architecting production systems in financial services."*)
- `line 1508` — spec sheet `Retrieval Layers · 5` → `Pipeline Steps · 6`. Code is six-step semantic-first per `attestor/retrieval/orchestrator.py`; the marketing copy was stale.
- `lines 1538 + 1550` — ticker `RETRIEVAL · RRF · PageRank · MMR` → `RETRIEVAL · Vector · BM25 · RRF · MMR`. PageRank exists in `Neo4jBackend.pagerank` but is not invoked from `recall()`; the actual recall lanes are vector + BM25.

## Test plan
- [ ] `git diff main...docs/hire-me-byline` — confirm only README + index.html touched, exactly 8 line additions / 6 deletions
- [ ] Open `docs/index.html` locally — hero shows linked author byline + spec sheet `PIPELINE STEPS · 6`; closing byline reads "building auditable infrastructure for multi-agent AI"
- [ ] Click the LinkedIn link from each of: hero masthead, closing byline, footer colophon, README author line — all four route to `/in/singhsurendra/`
- [ ] No code paths affected — docs-only change