### PR TITLE
feat(answerer): PR-B self-consistency K-sample (+3-6% LME-S)

### DIFF
--- a/attestor/config.py
+++ b/attestor/config.py
@@ -197,6 +197,46 @@ class MultiQueryCfg:
 
 
 @dataclass(frozen=True)
+class SelfConsistencyCfg:
+    """Answerer-side self-consistency knobs (Phase 3 PR-B, +3-6%).
+
+    When ``enabled`` is True, the LME answerer draws K independent
+    samples at non-zero temperature and elects the consensus answer
+    via majority vote (default) or a judge LLM. Lives on
+    ``StackConfig`` directly because this is answerer behavior, NOT
+    retrieval behavior — peer of ``stack.retrieval``, not nested
+    inside it.
+
+    Disabled by default — flip per bench run via this YAML, or via
+    ``ATTESTOR_SELF_CONSISTENCY_ENABLED=1`` for ad-hoc smokes if
+    callers want to add an env override later.
+
+    Cost: K × answerer cost per sample. K=5 means 5x answerer spend;
+    gate carefully.
+
+    Configuration:
+      enabled       — master switch
+      k             — number of samples (5 is the sweet spot per
+                      Wang et al. 2022; diminishing returns past ~10)
+      temperature   — per-sample temperature; 0.7 is the standard
+                      value from the paper
+      voter         — ``majority`` (normalized-fingerprint vote) or
+                      ``judge_pick`` (LLM picks best of K)
+      judge_model   — model id for ``judge_pick``; null falls back
+                      to ``models.judge``
+    """
+
+    enabled: bool = False
+    k: int = 5
+    temperature: float = 0.7
+    voter: str = "majority"
+    judge_model: Optional[str] = None
+
+
+_VALID_SC_VOTERS = ("majority", "judge_pick")
+
+
+@dataclass(frozen=True)
 class RetrievalCfg:
     """Knobs for the 6-step recall cascade.
 
@@ -297,6 +337,7 @@ class StackConfig:
     budget: int
     parallel: int
     clouds: Dict[str, Dict[str, Any]]
+    self_consistency: SelfConsistencyCfg = field(default_factory=SelfConsistencyCfg)
 
 
 # ─── YAML helpers ─────────────────────────────────────────────────────
@@ -357,6 +398,7 @@ def _build_fallback_stack() -> StackConfig:
         budget=_FALLBACK_BUDGET,
         parallel=_FALLBACK_PARALLEL,
         clouds={},
+        self_consistency=SelfConsistencyCfg(),
     )
 
 
@@ -388,6 +430,21 @@ def _parse_yaml(cfg_path: Path, *, strict: bool) -> StackConfig:
         vector_top_k=int(retrieval_blk.get("vector_top_k", 50)),
         mmr_top_n=(int(mmr_top_raw) if mmr_top_raw is not None else None),
         multi_query=mq_cfg,
+    )
+
+    sc_blk = stack_blk.get("self_consistency") or {}
+    sc_voter = str(sc_blk.get("voter", "majority"))
+    if sc_voter not in _VALID_SC_VOTERS:
+        raise SystemExit(
+            f"[attestor.config] unknown self_consistency voter "
+            f"{sc_voter!r}; expected one of {list(_VALID_SC_VOTERS)}"
+        )
+    sc_cfg = SelfConsistencyCfg(
+        enabled=bool(sc_blk.get("enabled", False)),
+        k=int(sc_blk.get("k", 5)),
+        temperature=float(sc_blk.get("temperature", 0.7)),
+        voter=sc_voter,
+        judge_model=sc_blk.get("judge_model"),
     )
 
     llm_provider = str(llm_blk.get("provider", _FALLBACK_LLM_PROVIDER))
@@ -441,6 +498,7 @@ def _parse_yaml(cfg_path: Path, *, strict: bool) -> StackConfig:
         budget=int(stack_blk.get("budget", _FALLBACK_BUDGET)),
         parallel=int(stack_blk.get("parallel", _FALLBACK_PARALLEL)),
         clouds=dict(clouds_blk),
+        self_consistency=sc_cfg,
     )
 
 

--- a/attestor/longmemeval.py
+++ b/attestor/longmemeval.py
@@ -1359,6 +1359,59 @@ def _strip_reasoning(raw: str) -> Tuple[str, str]:
     return reasoning, after
 
 
+def _answerer_call(
+    *,
+    client: Any,
+    model: str,
+    prompt: str,
+    max_tokens: int,
+) -> str:
+    """Produce the answerer's raw response, applying self-consistency
+    when ``stack.self_consistency.enabled`` is True.
+
+    Single-sample path (default): one greedy ``_chat`` call. Identical
+    behavior to the legacy code site.
+
+    Self-consistency path: K independent samples at non-zero
+    temperature, reduced via majority vote (or judge_pick) to one
+    final answer. Cost is K × answerer cost.
+
+    On any error in the self-consistency path, falls back to the
+    single-sample path so the LME run never breaks because of a
+    config knob.
+    """
+    try:
+        from attestor.config import get_stack
+        stack = get_stack()
+        sc = getattr(stack, "self_consistency", None)
+    except Exception:  # noqa: BLE001 — config errors must not break answerer
+        sc = None
+
+    if sc is not None and sc.enabled and sc.k > 1:
+        try:
+            from attestor.longmemeval_consistency import (
+                answer_with_self_consistency,
+            )
+            judge_model = sc.judge_model or stack.models.judge
+            result = answer_with_self_consistency(
+                client=client,
+                model=model,
+                messages=[{"role": "user", "content": prompt}],
+                k=sc.k,
+                temperature=sc.temperature,
+                voter=sc.voter,
+                judge_model=judge_model,
+            )
+            if result.chosen:
+                return result.chosen
+            # Empty consensus → fall through to single-sample retry.
+        except Exception:  # noqa: BLE001
+            # Self-consistency layer failed; degrade to single-sample.
+            pass
+
+    return _chat(client, model, prompt, max_tokens=max_tokens, role="answerer")
+
+
 def answer_question(
     mem: Any,
     sample: LMESample,
@@ -1423,7 +1476,12 @@ def answer_question(
         context=context,
     )
     client = _get_client(api_key)
-    raw = _chat(client, model, prompt, max_tokens=max_tokens, role="answerer").strip()
+    raw = _answerer_call(
+        client=client,
+        model=model,
+        prompt=prompt,
+        max_tokens=max_tokens,
+    ).strip()
     reasoning, first_answer = _strip_reasoning(raw)
 
     final_answer = first_answer

--- a/attestor/longmemeval_consistency.py
+++ b/attestor/longmemeval_consistency.py
@@ -1,0 +1,389 @@
+"""Self-consistency K-sample answerer (Phase 3 PR-B, +3-6% LME-S).
+
+A single greedy decode from the answerer model can lock onto a wrong
+answer when the question is ambiguous or the retrieved context is
+noisy. K independent samples drawn at non-zero temperature plus a
+tie-break heuristic (majority vote on a normalized fingerprint, or a
+delegated judge LLM) almost always elects the correct answer when the
+corpus contains it. Classic technique from Wang et al. 2022.
+
+This module is answerer-side only — it does NOT touch the retrieval
+pipeline or ``RetrievalCfg``. The orchestrator runs unchanged; we
+just call the answerer K times instead of once and reduce the K
+samples to one final answer.
+
+Configuration lives in ``configs/attestor.yaml`` under the
+top-level ``stack.self_consistency`` block (peer of ``stack.retrieval``,
+not nested inside it):
+
+    stack:
+      self_consistency:
+        enabled: false
+        k: 5
+        temperature: 0.7
+        voter: majority           # majority | judge_pick
+        judge_model: null         # null → models.judge
+
+Trace events emitted (when ``ATTESTOR_TRACE=1``):
+
+  - ``answer.self_consistency.samples`` — k, model, temperature,
+    sample_lengths
+  - ``answer.self_consistency.elected`` — voter, chosen_fingerprint,
+    vote_breakdown
+
+Cost: K × answerer cost. Disabled by default — gate behind the YAML
+knob and flip per bench run only.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger("attestor.longmemeval_consistency")
+
+# Strategies the loader + dispatcher accept. New entries added here
+# automatically flow into the YAML validator.
+VALID_VOTERS = ("majority", "judge_pick")
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Result shape
+# ──────────────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class ConsistencyResult:
+    """K answerer samples + the elected final answer.
+
+    Immutable per the project coding-style rules. ``vote_breakdown``
+    keys are normalized fingerprints (see ``_fingerprint``); values are
+    raw counts. ``voter`` records which strategy actually produced
+    ``chosen`` — judge_pick can fall back to majority on judge failure,
+    in which case ``voter`` is reported as ``"majority"``.
+    """
+
+    samples: List[str]                       # all K raw answers (post-strip)
+    chosen: str                              # the elected final answer
+    voter: str                               # "majority" | "judge_pick"
+    vote_breakdown: Dict[str, int] = field(default_factory=dict)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Fingerprinting
+# ──────────────────────────────────────────────────────────────────────
+
+# Trailing punctuation we strip before fingerprinting so "Bob." and "Bob"
+# collapse. Internal punctuation (e.g. "Bob, the CTO") is left intact.
+_TRAILING_PUNCT_RE = re.compile(r"[\s\.,;:!?\-—–'\"`]+$")
+_LEADING_PUNCT_RE = re.compile(r"^[\s\.,;:!?\-—–'\"`]+")
+_WS_COLLAPSE_RE = re.compile(r"\s+")
+
+
+def _fingerprint(answer: str) -> str:
+    """Canonicalize an answer string for majority-vote bucketing.
+
+    Steps: lowercase → strip leading/trailing punctuation+whitespace →
+    collapse internal whitespace → return. Two answers that differ
+    only in casing, surrounding punctuation, or whitespace collapse to
+    the same fingerprint.
+
+    Empty strings (after canonicalization) return ``""`` — callers
+    should treat the empty fingerprint as "no answer".
+    """
+    if not answer:
+        return ""
+    s = answer.lower()
+    s = _LEADING_PUNCT_RE.sub("", s)
+    s = _TRAILING_PUNCT_RE.sub("", s)
+    s = _WS_COLLAPSE_RE.sub(" ", s).strip()
+    return s
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Sampling
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _sample_once(
+    *,
+    client: Any,
+    model: str,
+    messages: List[Dict[str, Any]],
+    temperature: float,
+) -> str:
+    """Draw a single answerer sample. Returns the stripped content text,
+    or ``""`` on any error. Wrapped in ``traced_create`` so each draw
+    emits a ``chat.completion`` event for cost tracking."""
+    from attestor.llm_trace import traced_create
+
+    response = traced_create(
+        client,
+        role="answerer",
+        model=model,
+        temperature=temperature,
+        messages=messages,
+    )
+    text = response.choices[0].message.content or ""
+    return text.strip()
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Voters
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _majority_choice(samples: List[str]) -> tuple[str, Dict[str, int]]:
+    """Pick the most-frequent fingerprint; tiebreak by first-seen.
+
+    Returns ``(chosen_surface_form, vote_breakdown)``. The chosen
+    surface form is the first sample whose fingerprint matched the
+    winning bucket — preserves user-facing capitalization/punctuation.
+    """
+    if not samples:
+        return "", {}
+
+    # Count fingerprints in stable insertion order (first-seen wins
+    # tiebreaks via dict ordering on Python 3.7+).
+    counts: Dict[str, int] = {}
+    first_surface: Dict[str, str] = {}
+    for s in samples:
+        fp = _fingerprint(s)
+        if not fp:
+            continue
+        counts[fp] = counts.get(fp, 0) + 1
+        if fp not in first_surface:
+            first_surface[fp] = s
+
+    if not counts:
+        return "", {}
+
+    # max() on dict.items() with a key is stable on first-seen — Python
+    # iterates in insertion order, and max returns the first item with
+    # the maximum value. That's exactly the tiebreak we want.
+    winning_fp, _ = max(counts.items(), key=lambda kv: kv[1])
+    return first_surface[winning_fp], counts
+
+
+_JUDGE_PROMPT = (
+    "You are picking the best of {n} candidate answers to the question below. "
+    "Output a single integer 0..{n_minus_1} indicating the index of the best "
+    "candidate — nothing else, no explanation, no punctuation.\n\n"
+    "Question:\n{question}\n\n"
+    "Candidates:\n{candidates}\n\n"
+    "Best index:"
+)
+
+
+def _judge_choice(
+    *,
+    samples: List[str],
+    question: str,
+    judge_client: Any,
+    judge_model: str,
+) -> int:
+    """Ask a judge LLM to pick the best of K candidate samples by index.
+
+    Returns the chosen index. Raises on judge error or unparseable
+    output — callers handle the fallback to majority.
+    """
+    from attestor.llm_trace import traced_create
+
+    candidates = "\n".join(f"[{i}] {s}" for i, s in enumerate(samples))
+    prompt = _JUDGE_PROMPT.format(
+        n=len(samples),
+        n_minus_1=len(samples) - 1,
+        question=question,
+        candidates=candidates,
+    )
+    response = traced_create(
+        judge_client,
+        role="self_consistency_judge",
+        model=judge_model,
+        max_tokens=8,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    text = (response.choices[0].message.content or "").strip()
+    # Extract the first integer from the response.
+    m = re.search(r"-?\d+", text)
+    if not m:
+        raise ValueError(f"judge returned unparseable index: {text!r}")
+    idx = int(m.group(0))
+    if idx < 0 or idx >= len(samples):
+        raise ValueError(f"judge index {idx} out of range [0, {len(samples)})")
+    return idx
+
+
+def _question_from_messages(messages: List[Dict[str, Any]]) -> str:
+    """Best-effort extraction of the user's question from the chat
+    messages — used only for the judge prompt context. Defensive: if
+    the schema doesn't match, falls back to a generic placeholder."""
+    if not messages:
+        return "(no question available)"
+    # Last user message wins.
+    for m in reversed(messages):
+        if m.get("role") == "user":
+            content = m.get("content", "")
+            if isinstance(content, str):
+                return content[:4000]  # cap to keep judge prompt bounded
+    return str(messages[-1].get("content", ""))[:4000]
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Public entry point
+# ──────────────────────────────────────────────────────────────────────
+
+
+def answer_with_self_consistency(
+    *,
+    client: Any,
+    model: str,
+    messages: List[Dict[str, Any]],
+    k: int = 5,
+    temperature: float = 0.7,
+    voter: str = "majority",
+    judge_client: Optional[Any] = None,
+    judge_model: Optional[str] = None,
+) -> ConsistencyResult:
+    """Run the answerer model K times and elect the consensus answer.
+
+    Args:
+        client: OpenAI-compatible chat-completions client (the answerer
+            client). Each of the K samples calls
+            ``client.chat.completions.create``.
+        model: Answerer model id.
+        messages: Messages list passed verbatim to every sample call.
+        k: Number of independent samples to draw. K=0 returns an empty
+            result without making any LLM call. K=1 effectively reduces
+            to a single greedy decode.
+        temperature: Per-sample temperature. Non-zero temperature is
+            essential — at T=0 every sample collapses to the greedy
+            decode and the vote degenerates.
+        voter: "majority" (default) buckets samples by normalized
+            fingerprint and picks the most-frequent answer with a
+            first-sample tiebreak. "judge_pick" delegates to a judge
+            LLM that picks the best of the K candidates by index;
+            judge failures fall back to majority.
+        judge_client: Optional judge LLM client for ``voter="judge_pick"``.
+            Defaults to ``client`` (reuse the answerer client).
+        judge_model: Required when ``voter="judge_pick"``. Should
+            normally come from ``stack.models.judge``.
+
+    Returns:
+        ``ConsistencyResult`` with the K raw samples, the elected
+        ``chosen`` answer, the actual voter strategy that produced it
+        (judge_pick can fall back to "majority" on judge error), and
+        the vote breakdown for diagnostics.
+
+    Defensive contract: on any error (K=0, all samples empty, model
+    unreachable, all samples fail), returns an empty ``chosen`` with
+    whatever samples did succeed. Never raises — except for invalid
+    voter strategies, which surface as ``ValueError`` because they're
+    a programming error.
+    """
+    if voter not in VALID_VOTERS:
+        raise ValueError(
+            f"unknown voter strategy {voter!r}; expected one of {VALID_VOTERS}"
+        )
+
+    if k <= 0:
+        return ConsistencyResult(samples=[], chosen="", voter=voter, vote_breakdown={})
+
+    samples: List[str] = []
+    for i in range(k):
+        try:
+            text = _sample_once(
+                client=client,
+                model=model,
+                messages=messages,
+                temperature=temperature,
+            )
+        except Exception as exc:  # noqa: BLE001 — sampling errors must not abort the loop
+            logger.debug("self_consistency sample %d failed: %s", i, exc)
+            continue
+        if text:
+            samples.append(text)
+
+    # Telemetry: emit a samples event regardless of whether we found a
+    # winner. Useful for cost accounting + debugging when all samples
+    # came back empty.
+    _emit_samples_event(
+        k=k, model=model, temperature=temperature, samples=samples,
+    )
+
+    if not samples:
+        return ConsistencyResult(samples=[], chosen="", voter=voter, vote_breakdown={})
+
+    if voter == "judge_pick" and judge_model:
+        try:
+            idx = _judge_choice(
+                samples=samples,
+                question=_question_from_messages(messages),
+                judge_client=judge_client or client,
+                judge_model=judge_model,
+            )
+            chosen = samples[idx]
+            breakdown = {_fingerprint(s): 1 for s in samples}
+            _emit_elected_event(
+                voter="judge_pick", chosen=chosen, breakdown=breakdown,
+            )
+            return ConsistencyResult(
+                samples=samples, chosen=chosen,
+                voter="judge_pick", vote_breakdown=breakdown,
+            )
+        except Exception as exc:  # noqa: BLE001 — fall back to majority
+            logger.debug("self_consistency judge_pick failed; falling back: %s", exc)
+            # Fall through to majority path below.
+
+    # Majority vote path (default + judge_pick fallback).
+    chosen, breakdown = _majority_choice(samples)
+    _emit_elected_event(
+        voter="majority", chosen=chosen, breakdown=breakdown,
+    )
+    return ConsistencyResult(
+        samples=samples, chosen=chosen,
+        voter="majority", vote_breakdown=breakdown,
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Trace events (best-effort, no-ops when ATTESTOR_TRACE is unset)
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _emit_samples_event(
+    *, k: int, model: str, temperature: float, samples: List[str],
+) -> None:
+    try:
+        from attestor import trace as _tr
+        if not _tr.is_enabled():
+            return
+        _tr.event(
+            "answer.self_consistency.samples",
+            k=k,
+            model=model,
+            temperature=temperature,
+            sample_lengths=[len(s) for s in samples],
+            sample_count=len(samples),
+        )
+    except Exception:  # noqa: BLE001 — telemetry must never break the call
+        pass
+
+
+def _emit_elected_event(
+    *, voter: str, chosen: str, breakdown: Dict[str, int],
+) -> None:
+    try:
+        from attestor import trace as _tr
+        if not _tr.is_enabled():
+            return
+        _tr.event(
+            "answer.self_consistency.elected",
+            voter=voter,
+            chosen_fingerprint=_fingerprint(chosen),
+            vote_breakdown=dict(breakdown),
+        )
+    except Exception:  # noqa: BLE001
+        pass

--- a/configs/attestor.yaml
+++ b/configs/attestor.yaml
@@ -182,6 +182,19 @@ stack:
   # Concurrency across samples in benchmark runs (LME / LoCoMo / BEAM).
   parallel: 2
 
+  # Self-consistency answerer (Phase 3 PR-B, +3-6% on LME-S).
+  # When enabled, the LME answerer draws K independent samples at
+  # non-zero temperature and elects the consensus answer (most-
+  # frequent normalized fingerprint by default; optional judge_pick
+  # mode delegates to a judge LLM). 5x answerer cost — gate behind
+  # this YAML knob; flip per bench run.
+  self_consistency:
+    enabled: false
+    k: 5
+    temperature: 0.7
+    voter: majority           # majority | judge_pick
+    judge_model: null         # null → models.judge
+
 # ─── Container image (for cloud deploys) ────────────────────────────────
 # The published image is currently the *introspection-only* MCP stub
 # (Glama listing). For Path B cloud deploys we build a separate

--- a/tests/test_self_consistency.py
+++ b/tests/test_self_consistency.py
@@ -1,0 +1,339 @@
+"""Unit tests for the self-consistency K-sample answerer (Phase 3 PR-B).
+
+The answerer LLM client is mocked — we verify the K-sample loop,
+fingerprint-based majority vote, judge_pick election, and the
+defensive fallbacks deterministically. End-to-end testing happens via
+the LME smoke once the module is wired into ``answer_question``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any, List
+from unittest.mock import MagicMock
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+from attestor.longmemeval_consistency import (  # noqa: E402
+    ConsistencyResult,
+    _fingerprint,
+    answer_with_self_consistency,
+)
+
+
+# ── Helpers ───────────────────────────────────────────────────────────
+
+
+def _mk_response(text: str) -> Any:
+    """Build a minimal OpenAI-shaped chat-completion response object."""
+    response = MagicMock()
+    msg = MagicMock()
+    msg.content = text
+    choice = MagicMock()
+    choice.message = msg
+    response.choices = [choice]
+    response.model = "test/model"
+    response.id = "gen-test"
+    response.usage = None
+    return response
+
+
+def _client_returning(answers: List[str]) -> MagicMock:
+    """Build a MagicMock OpenAI client whose chat.completions.create
+    returns successive answers from ``answers`` on each call."""
+    client = MagicMock()
+    client.chat.completions.create.side_effect = [_mk_response(a) for a in answers]
+    return client
+
+
+# ── _fingerprint ──────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_fingerprint_collapses_case_punct_and_whitespace() -> None:
+    """Three answers that differ only in capitalization, trailing
+    punctuation, and internal whitespace must hash to the same key."""
+    assert _fingerprint("Bob Patel.") == _fingerprint("bob patel")
+    assert _fingerprint("Bob Patel.") == _fingerprint("Bob Patel")
+    assert _fingerprint("  Bob   Patel  ") == _fingerprint("Bob Patel")
+
+
+@pytest.mark.unit
+def test_fingerprint_distinct_for_distinct_answers() -> None:
+    assert _fingerprint("Alice") != _fingerprint("Bob")
+    assert _fingerprint("42") != _fingerprint("43")
+
+
+@pytest.mark.unit
+def test_fingerprint_empty_string_is_stable() -> None:
+    assert _fingerprint("") == _fingerprint("   ")
+    assert _fingerprint("") == ""
+
+
+# ── answer_with_self_consistency — majority vote ─────────────────────
+
+
+@pytest.mark.unit
+def test_majority_vote_unanimous() -> None:
+    client = _client_returning(["Bob", "Bob", "Bob", "Bob", "Bob"])
+    result = answer_with_self_consistency(
+        client=client,
+        model="test/model",
+        messages=[{"role": "user", "content": "who?"}],
+        k=5,
+        temperature=0.7,
+        voter="majority",
+    )
+    assert result.chosen == "Bob"
+    assert result.voter == "majority"
+    assert len(result.samples) == 5
+    assert sum(result.vote_breakdown.values()) == 5
+
+
+@pytest.mark.unit
+def test_majority_vote_3_1_1_distribution() -> None:
+    """Three samples agree on 'Alice', two outliers split — 'Alice' wins."""
+    client = _client_returning(["Alice", "Alice", "Alice", "Bob", "Carol"])
+    result = answer_with_self_consistency(
+        client=client,
+        model="test/model",
+        messages=[{"role": "user", "content": "q"}],
+        k=5,
+        temperature=0.7,
+        voter="majority",
+    )
+    assert result.chosen == "Alice"
+    assert result.vote_breakdown[_fingerprint("Alice")] == 3
+
+
+@pytest.mark.unit
+def test_majority_vote_tie_picks_first_sample() -> None:
+    """2-2-1 tie: two distinct answers share the top count. Stable
+    tiebreak picks the first sample's answer."""
+    client = _client_returning(["Bob", "Alice", "Alice", "Bob", "Carol"])
+    result = answer_with_self_consistency(
+        client=client,
+        model="test/model",
+        messages=[{"role": "user", "content": "q"}],
+        k=5,
+        temperature=0.7,
+        voter="majority",
+    )
+    # Bob and Alice both have 2 votes; first sample is "Bob" → Bob wins.
+    assert result.chosen == "Bob"
+
+
+@pytest.mark.unit
+def test_majority_vote_normalizes_fingerprints() -> None:
+    """Answers that differ only in casing/punctuation merge into one
+    bucket and win with their combined count."""
+    client = _client_returning(["Bob Patel.", "bob patel", "Bob Patel", "Alice", "Alice"])
+    result = answer_with_self_consistency(
+        client=client,
+        model="test/model",
+        messages=[{"role": "user", "content": "q"}],
+        k=5,
+        temperature=0.7,
+        voter="majority",
+    )
+    # Three Bob variants merge to 3 votes → beats Alice's 2.
+    # Chosen is the first-seen surface form.
+    assert result.chosen == "Bob Patel."
+    assert result.vote_breakdown[_fingerprint("Bob Patel")] == 3
+
+
+# ── answer_with_self_consistency — defensive paths ───────────────────
+
+
+@pytest.mark.unit
+def test_k_zero_returns_empty_string() -> None:
+    client = MagicMock()
+    result = answer_with_self_consistency(
+        client=client,
+        model="test/model",
+        messages=[{"role": "user", "content": "q"}],
+        k=0,
+        temperature=0.7,
+    )
+    assert result.chosen == ""
+    assert result.samples == []
+    # No LLM calls should fire when k=0.
+    client.chat.completions.create.assert_not_called()
+
+
+@pytest.mark.unit
+def test_all_samples_empty_returns_empty() -> None:
+    client = _client_returning(["", "  ", "\n", "", ""])
+    result = answer_with_self_consistency(
+        client=client,
+        model="test/model",
+        messages=[{"role": "user", "content": "q"}],
+        k=5,
+        temperature=0.7,
+    )
+    assert result.chosen == ""
+
+
+@pytest.mark.unit
+def test_one_nonempty_among_empties_is_chosen() -> None:
+    """If 4 of 5 samples are empty, the lone non-empty one wins."""
+    client = _client_returning(["", "Alice", "", "", ""])
+    result = answer_with_self_consistency(
+        client=client,
+        model="test/model",
+        messages=[{"role": "user", "content": "q"}],
+        k=5,
+        temperature=0.7,
+    )
+    assert result.chosen == "Alice"
+
+
+@pytest.mark.unit
+def test_sampler_failure_skipped_remaining_samples_continue() -> None:
+    """A single sample raising should not abort the K-sample loop —
+    the survivors still vote."""
+    client = MagicMock()
+
+    def flaky_create(**kwargs: Any) -> Any:
+        n = client.chat.completions.create.call_count
+        if n == 2:
+            raise RuntimeError("transient outage")
+        return _mk_response("Alice")
+
+    client.chat.completions.create.side_effect = flaky_create
+    result = answer_with_self_consistency(
+        client=client,
+        model="test/model",
+        messages=[{"role": "user", "content": "q"}],
+        k=5,
+        temperature=0.7,
+    )
+    # Four "Alice" samples, one failure → "Alice" still wins.
+    assert result.chosen == "Alice"
+    assert len(result.samples) == 4
+
+
+# ── answer_with_self_consistency — judge_pick ────────────────────────
+
+
+@pytest.mark.unit
+def test_judge_pick_calls_judge_and_returns_choice() -> None:
+    answerer_client = _client_returning(["Alice", "Bob", "Carol", "Dan", "Eve"])
+    judge_client = MagicMock()
+    judge_client.chat.completions.create.return_value = _mk_response("3")
+
+    result = answer_with_self_consistency(
+        client=answerer_client,
+        model="test/model",
+        messages=[{"role": "user", "content": "q"}],
+        k=5,
+        temperature=0.7,
+        voter="judge_pick",
+        judge_client=judge_client,
+        judge_model="judge/test",
+    )
+    # Judge picked sample index 3 → "Dan"
+    assert result.chosen == "Dan"
+    assert result.voter == "judge_pick"
+    judge_client.chat.completions.create.assert_called_once()
+
+
+@pytest.mark.unit
+def test_judge_pick_falls_back_to_majority_on_judge_failure() -> None:
+    answerer_client = _client_returning(["Alice", "Alice", "Alice", "Bob", "Carol"])
+    judge_client = MagicMock()
+    judge_client.chat.completions.create.side_effect = RuntimeError("judge offline")
+
+    result = answer_with_self_consistency(
+        client=answerer_client,
+        model="test/model",
+        messages=[{"role": "user", "content": "q"}],
+        k=5,
+        temperature=0.7,
+        voter="judge_pick",
+        judge_client=judge_client,
+        judge_model="judge/test",
+    )
+    # Falls back to majority: 3x Alice wins.
+    assert result.chosen == "Alice"
+    assert result.voter == "majority"  # fallback voter is recorded
+
+
+@pytest.mark.unit
+def test_judge_pick_without_judge_client_uses_answerer_client() -> None:
+    """When judge_client is None, we reuse the answerer client (and
+    then the K+1th call is the judge call)."""
+    # K=3 sample answers + 1 judge response.
+    client = _client_returning(["Alice", "Bob", "Carol", "1"])
+
+    result = answer_with_self_consistency(
+        client=client,
+        model="test/model",
+        messages=[{"role": "user", "content": "q"}],
+        k=3,
+        temperature=0.7,
+        voter="judge_pick",
+        judge_client=None,
+        judge_model="judge/test",
+    )
+    # Judge picked index 1 → "Bob"
+    assert result.chosen == "Bob"
+    assert result.voter == "judge_pick"
+
+
+@pytest.mark.unit
+def test_judge_pick_invalid_index_falls_back_to_majority() -> None:
+    """Judge returning a non-numeric or out-of-range answer should
+    fall back to majority instead of crashing."""
+    answerer_client = _client_returning(["Alice", "Alice", "Alice", "Bob", "Carol"])
+    judge_client = MagicMock()
+    judge_client.chat.completions.create.return_value = _mk_response("not a number")
+
+    result = answer_with_self_consistency(
+        client=answerer_client,
+        model="test/model",
+        messages=[{"role": "user", "content": "q"}],
+        k=5,
+        temperature=0.7,
+        voter="judge_pick",
+        judge_client=judge_client,
+        judge_model="judge/test",
+    )
+    assert result.chosen == "Alice"
+    assert result.voter == "majority"
+
+
+# ── ConsistencyResult shape ──────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_consistency_result_is_frozen_dataclass() -> None:
+    """ConsistencyResult is immutable per coding-style.md."""
+    result = ConsistencyResult(
+        samples=["a", "b"], chosen="a", voter="majority", vote_breakdown={"a": 2},
+    )
+    with pytest.raises((AttributeError, Exception)):  # frozen dataclass error
+        result.chosen = "x"  # type: ignore[misc]
+
+
+@pytest.mark.unit
+def test_invalid_voter_raises() -> None:
+    """An unrecognized voter strategy is a programming error — surface
+    it loudly rather than silently falling through."""
+    client = _client_returning(["a", "b", "c"])
+    with pytest.raises(ValueError, match="voter"):
+        answer_with_self_consistency(
+            client=client,
+            model="test/model",
+            messages=[{"role": "user", "content": "q"}],
+            k=3,
+            temperature=0.7,
+            voter="not_a_real_strategy",
+        )

--- a/tests/test_self_consistency_config.py
+++ b/tests/test_self_consistency_config.py
@@ -1,0 +1,146 @@
+"""Self-consistency YAML loader tests (Phase 3 PR-B).
+
+Confirms the top-level ``stack.self_consistency`` block lands on
+``StackConfig.self_consistency``, defaults are applied when the block
+is omitted, and an invalid ``voter`` value fails loudly.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+import yaml
+
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def _yaml_with(tmp_path, monkeypatch, **stack_extra: Any) -> Path:
+    """Write a minimal valid YAML to ``tmp_path`` and point the loader at it."""
+    cfg: Dict[str, Any] = {
+        "stack": {
+            "postgres": {"url": "postgresql://postgres@localhost/attestor"},
+            "neo4j": {
+                "url": "bolt://localhost:7687",
+                "auth": {"username": "neo4j", "password": "test"},
+                "database": "neo4j",
+            },
+            "embedder": {
+                "provider": "voyage", "model": "voyage-4", "dimensions": 1024,
+            },
+            "llm": {"provider": "openrouter"},
+            "models": {
+                "answerer": "openai/gpt-5.4-mini",
+                "judge": "openai/gpt-5.5",
+                "extraction": "openai/gpt-5.4-mini",
+                "distill": "openai/gpt-5.4-mini",
+                "verifier": "anthropic/claude-sonnet-4-6",
+                "planner": "anthropic/claude-opus-4.7",
+                "benchmark_default": "openai/gpt-5.4-mini",
+            },
+            **stack_extra,
+        },
+    }
+    p = tmp_path / "attestor.yaml"
+    p.write_text(yaml.safe_dump(cfg))
+    monkeypatch.setenv("ATTESTOR_CONFIG", str(p))
+    from attestor import config as _c
+    _c.reset_stack()
+    return p
+
+
+@pytest.mark.unit
+def test_self_consistency_defaults_when_block_omitted(tmp_path, monkeypatch):
+    """No `self_consistency` block → safe defaults: disabled, k=5, t=0.7,
+    voter='majority', judge_model=None."""
+    _yaml_with(tmp_path, monkeypatch)
+    from attestor.config import get_stack
+    s = get_stack(strict=False)
+    sc = s.self_consistency
+    assert sc.enabled is False
+    assert sc.k == 5
+    assert sc.temperature == pytest.approx(0.7)
+    assert sc.voter == "majority"
+    assert sc.judge_model is None
+
+
+@pytest.mark.unit
+def test_self_consistency_block_is_parsed(tmp_path, monkeypatch):
+    _yaml_with(
+        tmp_path, monkeypatch,
+        self_consistency={
+            "enabled": True,
+            "k": 7,
+            "temperature": 0.5,
+            "voter": "judge_pick",
+            "judge_model": "openai/gpt-5.5",
+        },
+    )
+    from attestor.config import get_stack
+    s = get_stack(strict=False)
+    sc = s.self_consistency
+    assert sc.enabled is True
+    assert sc.k == 7
+    assert sc.temperature == pytest.approx(0.5)
+    assert sc.voter == "judge_pick"
+    assert sc.judge_model == "openai/gpt-5.5"
+
+
+@pytest.mark.unit
+def test_self_consistency_invalid_voter_raises(tmp_path, monkeypatch):
+    """Loader must reject unknown voter strategies with a clear message."""
+    _yaml_with(
+        tmp_path, monkeypatch,
+        self_consistency={"enabled": True, "voter": "coin_flip"},
+    )
+    from attestor.config import load_stack
+    with pytest.raises(SystemExit, match="voter"):
+        load_stack(strict=False)
+
+
+@pytest.mark.unit
+def test_self_consistency_majority_voter_accepted(tmp_path, monkeypatch):
+    """Both supported voters parse cleanly."""
+    for voter in ("majority", "judge_pick"):
+        _yaml_with(
+            tmp_path, monkeypatch,
+            self_consistency={"enabled": True, "voter": voter},
+        )
+        from attestor.config import get_stack
+        s = get_stack(strict=False)
+        assert s.self_consistency.voter == voter
+
+
+@pytest.mark.unit
+def test_self_consistency_partial_block_uses_defaults_for_missing(tmp_path, monkeypatch):
+    """Only `enabled: true` set → other fields take their defaults."""
+    _yaml_with(
+        tmp_path, monkeypatch,
+        self_consistency={"enabled": True},
+    )
+    from attestor.config import get_stack
+    s = get_stack(strict=False)
+    sc = s.self_consistency
+    assert sc.enabled is True
+    assert sc.k == 5
+    assert sc.temperature == pytest.approx(0.7)
+    assert sc.voter == "majority"
+    assert sc.judge_model is None
+
+
+@pytest.mark.unit
+def test_self_consistency_no_yaml_falls_back_to_defaults(monkeypatch):
+    """Stripped checkout / no YAML → fallback stack still has a
+    valid SelfConsistencyCfg (disabled by default)."""
+    monkeypatch.setenv("ATTESTOR_CONFIG", "/tmp/nonexistent_attestor.yaml")
+    from attestor import config as _c
+    _c.reset_stack()
+    s = _c.get_stack(strict=False)
+    assert s.self_consistency.enabled is False
+    assert s.self_consistency.k == 5
+    assert s.self_consistency.voter == "majority"


### PR DESCRIPTION
## Summary

- **Phase 3 PR-B** implements answerer-side self-consistency: K independent samples at non-zero temperature, reduced to one final answer via majority vote (default) or a judge LLM (`judge_pick`). Classic Wang et al. 2022 technique; expected lift +3-6% on LME-S.
- **Disabled by default.** Flip `stack.self_consistency.enabled: true` in `configs/attestor.yaml` per bench run — K=5 means 5x answerer cost, so this is gated, not on-by-default.
- **Retrieval pipeline untouched.** Lives entirely on the answerer side (`longmemeval._answerer_call` dispatcher + new `attestor/longmemeval_consistency.py`). `RetrievalCfg` and `orchestrator.py` are not modified.

## What landed

- `attestor/longmemeval_consistency.py` — new module with `answer_with_self_consistency(...) -> ConsistencyResult`. Frozen dataclass for the result; `_fingerprint()` canonicalizes answers (lowercase + strip leading/trailing punctuation + collapse whitespace) for majority-vote bucketing; `traced_create` wraps every LLM call.
- `attestor/config.py` — new `SelfConsistencyCfg` (frozen dataclass), wired as a top-level `StackConfig` field. YAML loader rejects unknown `voter` strings via `SystemExit`.
- `attestor/longmemeval.py` — single call-site change: `_chat(...)` for the answerer is now routed through `_answerer_call`, which dispatches to the K-sample path when enabled and falls back to the legacy single-sample path otherwise (and on any error in the consistency layer — defensive contract).
- `configs/attestor.yaml` — top-level `stack.self_consistency` block (peer of `stack.retrieval`).
- `tests/test_self_consistency.py` — 17 unit tests covering fingerprinting, majority vote (unanimous, 3-1-1, tie, normalized-collision), defensive paths (K=0, all-empty, sampler failure), judge_pick (success, judge failure → majority, no judge_client → reuse answerer, invalid judge index → majority), and the frozen-dataclass invariant.
- `tests/test_self_consistency_config.py` — 6 YAML loader tests covering defaults, full-block parse, invalid-voter rejection, partial-block fill-in, and the no-YAML fallback path.

## Trace events

When `ATTESTOR_TRACE=1`:

- `answer.self_consistency.samples` — `k`, `model`, `temperature`, `sample_lengths`
- `answer.self_consistency.elected` — `voter`, `chosen_fingerprint`, `vote_breakdown`

## Test plan

- [x] `pytest tests/test_self_consistency.py tests/test_self_consistency_config.py -v` → 23/23 pass
- [x] Full unit suite no regressions: 894 pass (the lone `test_registry::test_conflict_raises` failure is a pre-existing test-isolation flake — passes alone, fails interleaved; reproduced on `main` without my changes)
- [x] LME-related tests: 102 pass
- [ ] Live LME-S smoke run with `enabled: true` (deferred — gated behind YAML; `pytest`-level coverage is the gate for landing the PR)
- [ ] Cost-tracking verification on a `traced_create` event capture during a real K=5 run

## Configuration

```yaml
stack:
  self_consistency:
    enabled: false              # flip per bench run
    k: 5
    temperature: 0.7
    voter: majority             # majority | judge_pick
    judge_model: null           # null → models.judge
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)