### PR TITLE
feat(retrieval): RC4 temporal pre-filter (+1.5% LME-S)

### DIFF
--- a/attestor/config.py
+++ b/attestor/config.py
@@ -197,6 +197,33 @@ class MultiQueryCfg:
 
 
 @dataclass(frozen=True)
+class TemporalPrefilterCfg:
+    """Regex-only temporal pre-filter knobs (Phase 3 RC4 — +1.5% LME-S).
+
+    When ``enabled`` is True and the question contains a relative
+    time phrase ("two weeks ago", "yesterday", "last Monday"), the
+    orchestrator builds a ``TimeWindow`` around the implied event date
+    and passes it through the existing ``time_window`` kwarg to the
+    vector + BM25 lanes — narrowing recall to memories that are
+    plausibly contemporaneous with the question.
+
+    Caller-supplied ``time_window`` always wins; this only fires when
+    no explicit bound was passed. Disabled by default so legacy
+    callers see no behavior change.
+
+    Configuration:
+      enabled         — master switch
+      tolerance_days  — half-width of the window in days. People say
+                        "last week" when they mean 8 days ago; the
+                        tolerance absorbs that drift so the filter
+                        doesn't false-negative.
+    """
+
+    enabled: bool = False
+    tolerance_days: int = 3
+
+
+@dataclass(frozen=True)
 class RetrievalCfg:
     """Knobs for the 6-step recall cascade.
 
@@ -226,11 +253,18 @@ class RetrievalCfg:
     ``multi_query`` extends the cascade with a query-rewrite +
     RRF-merge lane in front of the vector step. Disabled by default
     so legacy callers see no behavior change.
+
+    ``temporal_prefilter`` (RC4) detects relative time phrases in the
+    question and tightens the event-time window passed to the vector
+    + BM25 lanes. Disabled by default; flip per bench run.
     """
 
     vector_top_k: int = 50
     mmr_top_n: Optional[int] = None
     multi_query: MultiQueryCfg = field(default_factory=MultiQueryCfg)
+    temporal_prefilter: TemporalPrefilterCfg = field(
+        default_factory=TemporalPrefilterCfg,
+    )
 
 
 @dataclass(frozen=True)
@@ -384,10 +418,16 @@ def _parse_yaml(cfg_path: Path, *, strict: bool) -> StackConfig:
         ),
         merge=str(mq_blk.get("merge", "rrf")),
     )
+    tp_blk = retrieval_blk.get("temporal_prefilter") or {}
+    tp_cfg = TemporalPrefilterCfg(
+        enabled=bool(tp_blk.get("enabled", False)),
+        tolerance_days=int(tp_blk.get("tolerance_days", 3)),
+    )
     retrieval_cfg = RetrievalCfg(
         vector_top_k=int(retrieval_blk.get("vector_top_k", 50)),
         mmr_top_n=(int(mmr_top_raw) if mmr_top_raw is not None else None),
         multi_query=mq_cfg,
+        temporal_prefilter=tp_cfg,
     )
 
     llm_provider = str(llm_blk.get("provider", _FALLBACK_LLM_PROVIDER))

--- a/attestor/core.py
+++ b/attestor/core.py
@@ -167,6 +167,9 @@ class AgentMemory:
             self._retrieval.vector_top_k = _retrieval_cfg.vector_top_k
             self._retrieval.mmr_top_n = _retrieval_cfg.mmr_top_n
             self._retrieval.multi_query_cfg = _retrieval_cfg.multi_query
+            self._retrieval.temporal_prefilter_cfg = (
+                _retrieval_cfg.temporal_prefilter
+            )
         except Exception as _e:
             logger.debug("retrieval cfg not applied: %s", _e)
 

--- a/attestor/retrieval/orchestrator.py
+++ b/attestor/retrieval/orchestrator.py
@@ -83,6 +83,15 @@ class RetrievalOrchestrator:
         # them via RRF before the rest of the cascade.
         self.multi_query_cfg = None  # type: ignore[assignment]
 
+        # Temporal pre-filter (Phase 3 RC4). Defaults to None — no
+        # behavior change. AgentMemory wires the resolved
+        # TemporalPrefilterCfg post-construction. When
+        # ``temporal_prefilter_cfg.enabled`` is True and the question
+        # contains a relative time phrase, recall() builds a
+        # ``TimeWindow`` and passes it through the existing
+        # ``time_window`` kwarg before Step 1 runs.
+        self.temporal_prefilter_cfg = None  # type: ignore[assignment]
+
     # ── Helpers ──
 
     def _question_entities(self, query: str) -> List[str]:
@@ -244,6 +253,38 @@ class RetrievalOrchestrator:
                       question_entities=question_entities,
                       as_of=str(as_of) if as_of else None,
                       time_window=str(time_window) if time_window else None)
+
+        # ── Step 0: Temporal pre-filter (RC4) ──
+        # When enabled and the question contains a relative time phrase,
+        # tighten the event-time window passed to subsequent lanes. Caller-
+        # supplied time_window takes precedence — never override an explicit
+        # bound. Falls through silently when no phrase matches.
+        tp_cfg = getattr(self, "temporal_prefilter_cfg", None)
+        if (
+            tp_cfg is not None
+            and getattr(tp_cfg, "enabled", False)
+            and time_window is None
+        ):
+            from attestor.retrieval.temporal_prefilter import detect_window
+            detected = detect_window(
+                query, tolerance_days=int(tp_cfg.tolerance_days),
+            )
+            if detected is not None:
+                time_window = detected.window
+                if _tr.is_enabled():
+                    _tr.event(
+                        "recall.stage.temporal_prefilter",
+                        matched_phrase=detected.matched_text,
+                        target=detected.target.isoformat(),
+                        window_start=(
+                            detected.window.start.isoformat()
+                            if detected.window.start else None
+                        ),
+                        window_end=(
+                            detected.window.end.isoformat()
+                            if detected.window.end else None
+                        ),
+                    )
 
         # ── Step 1: Vector top-K ──
         # When multi_query is enabled, this step fans out: rewrite the

--- a/attestor/retrieval/temporal_prefilter.py
+++ b/attestor/retrieval/temporal_prefilter.py
@@ -1,0 +1,319 @@
+"""Regex-only temporal pre-filter for the recall pipeline (Phase 3 RC4).
+
+Detects relative time phrases in a user question ("two weeks ago",
+"yesterday", "last Monday") and computes the implied event-date
+window. The orchestrator passes that window through the existing
+``time_window`` kwarg to the vector + BM25 lanes, so retrieval narrows
+to memories whose ``event_date`` is plausibly contemporaneous with
+what the question is asking about.
+
+Why this exists
+---------------
+Per-RCA evidence on LongMemEval-S, the embedder collapses the
+temporal context of "what did I think TWO WEEKS AGO" into noise — the
+content keywords dominate the cosine. Hard-pre-filtering the candidate
+set by event-time recovers the +1.5% the dense lane was leaving on
+the floor.
+
+Pure regex; no LLM. A separate LLM-based ``TemporalQueryExpander``
+exists at ``attestor.retrieval.temporal_query`` for harder cases
+("before I had kids", "back when I lived in Seattle"). The two are
+orthogonal — this module returns ``None`` and the LLM lane can still
+fire downstream.
+
+Public API
+----------
+
+    detect_window(
+        question: str,
+        *,
+        question_date: Optional[datetime] = None,
+        tolerance_days: int = 3,
+    ) -> Optional[DetectedPhrase]
+
+Returns ``None`` when no phrase matches. When multiple phrases match,
+the FIRST (left-to-right) wins — so "Yesterday I thought about last
+week" anchors to yesterday, not last week.
+
+Configuration lives in ``configs/attestor.yaml`` under
+``retrieval.temporal_prefilter``:
+
+    retrieval:
+      temporal_prefilter:
+        enabled: false        # default off — flip per bench run
+        tolerance_days: 3     # half-width of the window in days
+
+Trace event emitted (when ATTESTOR_TRACE=1):
+
+  - ``recall.stage.temporal_prefilter`` — matched phrase + computed
+    target + window bounds
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import List, Optional, Tuple
+
+from attestor.retrieval.temporal_query import TimeWindow
+
+logger = logging.getLogger("attestor.retrieval.temporal_prefilter")
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Public dataclass
+# ──────────────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class DetectedPhrase:
+    """Diagnostic record of which phrase was matched + the computed window.
+
+    ``matched_text`` is the literal substring from the question that
+    triggered the detection — useful for trace logs and audit. ``target``
+    is the implied event date (single point), and ``window`` is the
+    ``[target - tolerance, target + tolerance]`` interval that's actually
+    handed to the retrieval lanes.
+    """
+
+    matched_text: str
+    target: datetime
+    window: TimeWindow
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Number-word + unit lookups
+# ──────────────────────────────────────────────────────────────────────
+
+_NUMBER_WORDS: dict[str, int] = {
+    "a": 1, "an": 1, "one": 1,
+    "two": 2, "three": 3, "four": 4, "five": 5,
+    "six": 6, "seven": 7, "eight": 8, "nine": 9, "ten": 10,
+}
+
+# 1 month ≈ 30 days, 1 year ≈ 365 days. Calendar-accurate math would
+# need ``dateutil.relativedelta`` (an extra dep we don't pull in for
+# a soft pre-filter — the tolerance window absorbs the drift).
+_UNIT_DAYS: dict[str, int] = {
+    "day": 1, "days": 1,
+    "week": 7, "weeks": 7,
+    "month": 30, "months": 30,
+    "year": 365, "years": 365,
+}
+
+_WEEKDAYS: dict[str, int] = {
+    # Python: Monday=0, Sunday=6
+    "monday": 0, "tuesday": 1, "wednesday": 2, "thursday": 3,
+    "friday": 4, "saturday": 5, "sunday": 6,
+}
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Regex catalogue
+# ──────────────────────────────────────────────────────────────────────
+#
+# Order matters. We compile each pattern, scan the question, and pick
+# the match with the SMALLEST start offset — i.e. the leftmost phrase
+# wins when two patterns both match. Inside a single pattern, longer
+# phrases must come before shorter ones (e.g. "the day before
+# yesterday" before "yesterday") so the regex engine doesn't collapse
+# the longer phrase into the shorter one.
+
+_NUMBER_RE = r"(?:\d+|a|an|one|two|three|four|five|six|seven|eight|nine|ten)"
+_UNIT_RE = r"(?:day|week|month|year)s?"
+_WEEKDAY_RE = r"(?:monday|tuesday|wednesday|thursday|friday|saturday|sunday)"
+
+# 1. N units ago
+_RE_N_UNITS_AGO = re.compile(
+    rf"\b({_NUMBER_RE})\s+({_UNIT_RE})\s+ago\b",
+    re.IGNORECASE,
+)
+
+# 2. the day before yesterday — must be tried BEFORE plain yesterday
+_RE_DAY_BEFORE_YESTERDAY = re.compile(
+    r"\bthe\s+day\s+before\s+yesterday\b",
+    re.IGNORECASE,
+)
+
+# 3. yesterday
+_RE_YESTERDAY = re.compile(r"\byesterday\b", re.IGNORECASE)
+
+# 4. last week|month|year
+_RE_LAST_UNIT = re.compile(
+    r"\blast\s+(week|month|year)\b",
+    re.IGNORECASE,
+)
+
+# 5. last <weekday>
+_RE_LAST_WEEKDAY = re.compile(
+    rf"\blast\s+({_WEEKDAY_RE})\b",
+    re.IGNORECASE,
+)
+
+# 6. this morning|afternoon|evening
+_RE_THIS_PART_OF_DAY = re.compile(
+    r"\bthis\s+(morning|afternoon|evening)\b",
+    re.IGNORECASE,
+)
+
+# 7. Forward-looking: N units later|after|hence
+_RE_N_UNITS_FORWARD = re.compile(
+    rf"\b({_NUMBER_RE})\s+({_UNIT_RE})\s+(later|after|hence)\b",
+    re.IGNORECASE,
+)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Public entry point
+# ──────────────────────────────────────────────────────────────────────
+
+
+def detect_window(
+    question: str,
+    *,
+    question_date: Optional[datetime] = None,
+    tolerance_days: int = 3,
+) -> Optional[DetectedPhrase]:
+    """Return a ``DetectedPhrase`` when ``question`` contains a
+    relative time phrase, else ``None``.
+
+    ``question_date`` defaults to ``datetime.now(timezone.utc)``.
+    ``tolerance_days`` widens the window symmetrically — people say
+    "last week" when they mean 8 days ago, and the tolerance absorbs
+    that drift so the lane filter doesn't false-negative.
+
+    Defensive: returns None on empty/whitespace input. Never raises.
+    """
+    if not question or not question.strip():
+        return None
+    if question_date is None:
+        question_date = datetime.now(timezone.utc)
+
+    try:
+        match = _earliest_match(question, question_date)
+    except Exception as e:  # noqa: BLE001
+        # Belt-and-braces: regex matching is the only thing here that
+        # could plausibly raise (catastrophic backtracking on
+        # adversarial input). Degrade silently.
+        logger.debug("temporal_prefilter.detect_window: matcher raised: %s", e)
+        return None
+
+    if match is None:
+        return None
+
+    matched_text, target = match
+    window = _build_window(target, tolerance_days=tolerance_days)
+    return DetectedPhrase(
+        matched_text=matched_text,
+        target=target,
+        window=window,
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Internals
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _earliest_match(
+    question: str, question_date: datetime,
+) -> Optional[Tuple[str, datetime]]:
+    """Run every pattern, pick the leftmost hit, return (matched_text, target).
+
+    Returns ``None`` when no pattern matches.
+    """
+    candidates: List[Tuple[int, str, datetime]] = []
+
+    # Pattern 1: N units ago
+    for m in _RE_N_UNITS_AGO.finditer(question):
+        n = _word_to_int(m.group(1))
+        days = _UNIT_DAYS[m.group(2).lower()]
+        target = question_date - timedelta(days=n * days)
+        candidates.append((m.start(), m.group(0), target))
+
+    # Pattern 2: the day before yesterday
+    for m in _RE_DAY_BEFORE_YESTERDAY.finditer(question):
+        candidates.append(
+            (m.start(), m.group(0), question_date - timedelta(days=2)),
+        )
+
+    # Pattern 3: yesterday
+    for m in _RE_YESTERDAY.finditer(question):
+        candidates.append(
+            (m.start(), m.group(0), question_date - timedelta(days=1)),
+        )
+
+    # Pattern 4: last <unit>
+    for m in _RE_LAST_UNIT.finditer(question):
+        unit = m.group(1).lower()
+        days = _UNIT_DAYS[unit]
+        candidates.append(
+            (m.start(), m.group(0), question_date - timedelta(days=days)),
+        )
+
+    # Pattern 5: last <weekday>
+    for m in _RE_LAST_WEEKDAY.finditer(question):
+        wd = _WEEKDAYS[m.group(1).lower()]
+        delta = _days_back_to_previous_weekday(question_date.weekday(), wd)
+        candidates.append(
+            (m.start(), m.group(0), question_date - timedelta(days=delta)),
+        )
+
+    # Pattern 6: this morning|afternoon|evening — same calendar day
+    for m in _RE_THIS_PART_OF_DAY.finditer(question):
+        candidates.append((m.start(), m.group(0), question_date))
+
+    # Pattern 7: forward-looking N units later|after|hence
+    for m in _RE_N_UNITS_FORWARD.finditer(question):
+        n = _word_to_int(m.group(1))
+        days = _UNIT_DAYS[m.group(2).lower()]
+        target = question_date + timedelta(days=n * days)
+        candidates.append((m.start(), m.group(0), target))
+
+    if not candidates:
+        return None
+
+    # Leftmost wins; on tie (same start, e.g. "the day before
+    # yesterday" overlaps "yesterday" if both patterns matched), prefer
+    # the LONGER substring so we honor the more specific phrase.
+    candidates.sort(key=lambda c: (c[0], -len(c[1])))
+    _, matched_text, target = candidates[0]
+    return matched_text, target
+
+
+def _word_to_int(token: str) -> int:
+    """Convert a number token (digit string OR word) to int."""
+    t = token.strip().lower()
+    if t.isdigit():
+        return int(t)
+    return _NUMBER_WORDS[t]
+
+
+def _days_back_to_previous_weekday(today_wd: int, target_wd: int) -> int:
+    """Days from today back to the most recent occurrence of target_wd
+    that is STRICTLY BEFORE today.
+
+    When today_wd == target_wd, returns 7 (the previous occurrence,
+    not today). Otherwise returns ``(today_wd - target_wd) mod 7``,
+    falling back to 7 if that would be 0.
+    """
+    delta = (today_wd - target_wd) % 7
+    return delta if delta != 0 else 7
+
+
+def _build_window(target: datetime, *, tolerance_days: int) -> TimeWindow:
+    """Symmetric window around ``target`` of half-width ``tolerance_days``.
+
+    ``tolerance_days=0`` collapses to a point (start == end == target),
+    which is valid per ``TimeWindow``'s invariants (start ≤ end).
+    Negative tolerance is treated as 0 — we never invert the window.
+    """
+    half = max(0, int(tolerance_days))
+    delta = timedelta(days=half)
+    return TimeWindow(
+        start=target - delta,
+        end=target + delta,
+        interpretation=f"temporal_prefilter ±{half}d",
+    )

--- a/configs/attestor.yaml
+++ b/configs/attestor.yaml
@@ -177,6 +177,17 @@ stack:
       rewriter_reasoning_effort: low
       merge: rrf                         # rrf | union
 
+    # Temporal pre-filter (Phase 3 RC4 — +1.5% on LME-S).
+    # When enabled, detects relative time phrases ("two weeks ago",
+    # "yesterday", "last Monday") in the question and tightens the
+    # vector + BM25 candidate window to memories with event_date
+    # within tolerance_days of the implied target. Caller-supplied
+    # time_window always wins; this only fires when no explicit
+    # bound was passed. Disabled by default.
+    temporal_prefilter:
+      enabled: false
+      tolerance_days: 3
+
   budget: 4000   # tokens for the pack sent to the answerer
 
   # Concurrency across samples in benchmark runs (LME / LoCoMo / BEAM).

--- a/tests/test_temporal_prefilter.py
+++ b/tests/test_temporal_prefilter.py
@@ -1,0 +1,433 @@
+"""Unit tests for ``attestor.retrieval.temporal_prefilter.detect_window``.
+
+Pure regex behavior — no LLM, no I/O. Every test pins ``question_date``
+explicitly so we don't depend on freezegun being installed and so the
+test is reproducible across machines/timezones.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Fixtures
+# ──────────────────────────────────────────────────────────────────────
+
+# A Wednesday — 2026-04-29 14:00 UTC. Convenient anchor for weekday
+# math (chosen so "last Monday" = -2 days, "last Friday" = -5 days).
+WEDNESDAY = datetime(2026, 4, 29, 14, 0, 0, tzinfo=timezone.utc)
+# A Monday — 2026-04-27 09:00 UTC, used for the "last Monday on a
+# Monday" edge case.
+MONDAY = datetime(2026, 4, 27, 9, 0, 0, tzinfo=timezone.utc)
+
+
+def _expect_target(
+    *, question: str, question_date: datetime, target: datetime,
+    tolerance_days: int = 3,
+) -> None:
+    """Assert detect_window returns the expected target + symmetric window."""
+    from attestor.retrieval.temporal_prefilter import detect_window
+
+    detected = detect_window(
+        question, question_date=question_date, tolerance_days=tolerance_days,
+    )
+    assert detected is not None, f"no phrase matched in {question!r}"
+    # Allow up to 1-second drift (datetime constructions in implementation
+    # may use replace(microsecond=0) etc.).
+    delta = abs((detected.target - target).total_seconds())
+    assert delta < 1.0, (
+        f"target mismatch for {question!r}: "
+        f"expected {target.isoformat()}, got {detected.target.isoformat()}"
+    )
+    # Window symmetry: end - start == 2 * tolerance_days
+    assert detected.window.start is not None
+    assert detected.window.end is not None
+    span = (detected.window.end - detected.window.start).total_seconds()
+    expected_span = 2 * tolerance_days * 86400
+    assert abs(span - expected_span) < 1.0, (
+        f"window span mismatch: expected {expected_span}s, got {span}s"
+    )
+    # Target sits in the middle of the window (± 1s).
+    mid = detected.window.start + (detected.window.end - detected.window.start) / 2
+    assert abs((mid - detected.target).total_seconds()) < 1.0
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Numeric N units ago
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_two_weeks_ago() -> None:
+    _expect_target(
+        question="What did I think two weeks ago?",
+        question_date=WEDNESDAY,
+        target=WEDNESDAY - timedelta(weeks=2),
+    )
+
+
+@pytest.mark.unit
+def test_five_days_ago() -> None:
+    _expect_target(
+        question="Anything notable 5 days ago?",
+        question_date=WEDNESDAY,
+        target=WEDNESDAY - timedelta(days=5),
+    )
+
+
+@pytest.mark.unit
+def test_ten_years_ago() -> None:
+    _expect_target(
+        question="What was I doing ten years ago?",
+        question_date=WEDNESDAY,
+        target=WEDNESDAY - timedelta(days=365 * 10),
+    )
+
+
+@pytest.mark.unit
+def test_one_month_ago_uses_30_day_approximation() -> None:
+    _expect_target(
+        question="Status one month ago?",
+        question_date=WEDNESDAY,
+        target=WEDNESDAY - timedelta(days=30),
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Number-word forms (a/an/one/.../ten)
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_a_week_ago_means_one_week() -> None:
+    _expect_target(
+        question="A week ago I changed jobs.",
+        question_date=WEDNESDAY,
+        target=WEDNESDAY - timedelta(weeks=1),
+    )
+
+
+@pytest.mark.unit
+def test_an_hour_does_not_match_units_only_dwmy() -> None:
+    """The detector only handles day/week/month/year — 'an hour ago'
+    must NOT match (no support for sub-day granularity)."""
+    from attestor.retrieval.temporal_prefilter import detect_window
+
+    result = detect_window("an hour ago", question_date=WEDNESDAY)
+    assert result is None
+
+
+@pytest.mark.unit
+def test_three_days_ago_word_form() -> None:
+    _expect_target(
+        question="Three days ago we shipped",
+        question_date=WEDNESDAY,
+        target=WEDNESDAY - timedelta(days=3),
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# yesterday / day before yesterday
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_yesterday() -> None:
+    _expect_target(
+        question="What happened yesterday?",
+        question_date=WEDNESDAY,
+        target=WEDNESDAY - timedelta(days=1),
+    )
+
+
+@pytest.mark.unit
+def test_day_before_yesterday() -> None:
+    _expect_target(
+        question="Did I work the day before yesterday?",
+        question_date=WEDNESDAY,
+        target=WEDNESDAY - timedelta(days=2),
+    )
+
+
+@pytest.mark.unit
+def test_day_before_yesterday_picked_over_yesterday() -> None:
+    """When 'the day before yesterday' appears, the longer phrase
+    must win — never collapse to a 1-day match on the trailing
+    'yesterday'."""
+    from attestor.retrieval.temporal_prefilter import detect_window
+
+    detected = detect_window(
+        "the day before yesterday I noted X",
+        question_date=WEDNESDAY,
+    )
+    assert detected is not None
+    delta_days = round((WEDNESDAY - detected.target).total_seconds() / 86400)
+    assert delta_days == 2, f"expected 2 days back, got {delta_days}"
+
+
+# ──────────────────────────────────────────────────────────────────────
+# last <unit>
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_last_week() -> None:
+    _expect_target(
+        question="What did we ship last week?",
+        question_date=WEDNESDAY,
+        target=WEDNESDAY - timedelta(weeks=1),
+    )
+
+
+@pytest.mark.unit
+def test_last_month_30_day_approximation() -> None:
+    _expect_target(
+        question="Last month's revenue?",
+        question_date=WEDNESDAY,
+        target=WEDNESDAY - timedelta(days=30),
+    )
+
+
+@pytest.mark.unit
+def test_last_year() -> None:
+    _expect_target(
+        question="Was I sick last year?",
+        question_date=WEDNESDAY,
+        target=WEDNESDAY - timedelta(days=365),
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# last <weekday>
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_last_monday_on_wednesday_points_two_days_back() -> None:
+    """Wednesday → previous Monday is 2 days back."""
+    _expect_target(
+        question="Notes from last Monday?",
+        question_date=WEDNESDAY,
+        target=WEDNESDAY - timedelta(days=2),
+    )
+
+
+@pytest.mark.unit
+def test_last_friday_on_wednesday_points_five_days_back() -> None:
+    _expect_target(
+        question="What did I commit last Friday?",
+        question_date=WEDNESDAY,
+        target=WEDNESDAY - timedelta(days=5),
+    )
+
+
+@pytest.mark.unit
+def test_last_monday_on_a_monday_means_seven_days_back() -> None:
+    """Edge case: when question_date IS a Monday, 'last Monday' must
+    mean the PREVIOUS Monday (7 days back), not 0 days."""
+    _expect_target(
+        question="Recall last Monday's review.",
+        question_date=MONDAY,
+        target=MONDAY - timedelta(days=7),
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# this morning|afternoon|evening
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_this_morning_targets_today() -> None:
+    """'this morning' should target the same calendar day as
+    question_date — exact target time is implementation-defined but
+    should be within the same UTC day."""
+    from attestor.retrieval.temporal_prefilter import detect_window
+
+    detected = detect_window(
+        "What did I think this morning?", question_date=WEDNESDAY,
+    )
+    assert detected is not None
+    assert detected.target.date() == WEDNESDAY.date()
+
+
+@pytest.mark.unit
+def test_this_evening_targets_today() -> None:
+    from attestor.retrieval.temporal_prefilter import detect_window
+
+    detected = detect_window(
+        "Plan for this evening?", question_date=WEDNESDAY,
+    )
+    assert detected is not None
+    assert detected.target.date() == WEDNESDAY.date()
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Forward-looking
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_two_weeks_later_is_forward() -> None:
+    _expect_target(
+        question="Two weeks later we shipped.",
+        question_date=WEDNESDAY,
+        target=WEDNESDAY + timedelta(weeks=2),
+    )
+
+
+@pytest.mark.unit
+def test_three_days_after_is_forward() -> None:
+    _expect_target(
+        question="Three days after that meeting?",
+        question_date=WEDNESDAY,
+        target=WEDNESDAY + timedelta(days=3),
+    )
+
+
+@pytest.mark.unit
+def test_one_year_hence_is_forward() -> None:
+    _expect_target(
+        question="One year hence I'll review.",
+        question_date=WEDNESDAY,
+        target=WEDNESDAY + timedelta(days=365),
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# No match / negative cases
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_no_phrase_returns_none() -> None:
+    from attestor.retrieval.temporal_prefilter import detect_window
+
+    assert detect_window("What is my favorite color?", question_date=WEDNESDAY) is None
+    assert detect_window("", question_date=WEDNESDAY) is None
+    assert detect_window("    ", question_date=WEDNESDAY) is None
+
+
+@pytest.mark.unit
+def test_unrelated_word_last_does_not_match() -> None:
+    """'last' alone (without week/month/year/<weekday>) should not
+    match — e.g. 'the last time' is not a temporal anchor."""
+    from attestor.retrieval.temporal_prefilter import detect_window
+
+    assert detect_window("the last time we spoke", question_date=WEDNESDAY) is None
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Multiple matches → pick the FIRST (left-to-right)
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_multiple_phrases_picks_first() -> None:
+    """When 'yesterday' appears before 'last week', the detector picks
+    yesterday (1 day back), not last week (7 days back)."""
+    from attestor.retrieval.temporal_prefilter import detect_window
+
+    detected = detect_window(
+        "Yesterday I thought about last week's review",
+        question_date=WEDNESDAY,
+    )
+    assert detected is not None
+    delta_days = round((WEDNESDAY - detected.target).total_seconds() / 86400)
+    assert delta_days == 1, f"expected yesterday (1d back), got {delta_days}d"
+
+
+@pytest.mark.unit
+def test_multiple_phrases_first_two_weeks_then_yesterday() -> None:
+    from attestor.retrieval.temporal_prefilter import detect_window
+
+    detected = detect_window(
+        "Two weeks ago I started the project; yesterday I shipped it.",
+        question_date=WEDNESDAY,
+    )
+    assert detected is not None
+    delta_days = round((WEDNESDAY - detected.target).total_seconds() / 86400)
+    assert delta_days == 14, f"expected two weeks (14d back), got {delta_days}d"
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Tolerance window
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_custom_tolerance_widens_window() -> None:
+    from attestor.retrieval.temporal_prefilter import detect_window
+
+    detected = detect_window(
+        "yesterday", question_date=WEDNESDAY, tolerance_days=10,
+    )
+    assert detected is not None
+    span = (detected.window.end - detected.window.start).total_seconds()
+    assert abs(span - 20 * 86400) < 1.0, (
+        f"expected 20-day span at tolerance=10, got {span/86400:.2f}d"
+    )
+
+
+@pytest.mark.unit
+def test_zero_tolerance_collapses_window_to_target() -> None:
+    from attestor.retrieval.temporal_prefilter import detect_window
+
+    detected = detect_window(
+        "yesterday", question_date=WEDNESDAY, tolerance_days=0,
+    )
+    assert detected is not None
+    assert detected.window.start == detected.target
+    assert detected.window.end == detected.target
+
+
+# ──────────────────────────────────────────────────────────────────────
+# matched_text — the literal substring
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_matched_text_is_literal_substring() -> None:
+    from attestor.retrieval.temporal_prefilter import detect_window
+
+    q = "What happened YESTERDAY at the meeting?"
+    detected = detect_window(q, question_date=WEDNESDAY)
+    assert detected is not None
+    assert detected.matched_text.lower() in q.lower()
+    # Case-insensitive match preserves original casing in the question.
+    assert "YESTERDAY" in q
+
+
+@pytest.mark.unit
+def test_matched_text_for_two_weeks_ago() -> None:
+    from attestor.retrieval.temporal_prefilter import detect_window
+
+    detected = detect_window(
+        "Two weeks ago we shipped",
+        question_date=WEDNESDAY,
+    )
+    assert detected is not None
+    assert "two weeks ago" in detected.matched_text.lower()
+
+
+# ──────────────────────────────────────────────────────────────────────
+# question_date defaults to "now"
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_default_question_date_is_now() -> None:
+    """When question_date is omitted, detect_window should use
+    datetime.now(UTC). We verify the window is centered close to now."""
+    from attestor.retrieval.temporal_prefilter import detect_window
+
+    now = datetime.now(timezone.utc)
+    detected = detect_window("yesterday")
+    assert detected is not None
+    # Target should be ~1 day before now (allow 5s slack for clock drift
+    # between the call and the assertion).
+    expected = now - timedelta(days=1)
+    assert abs((detected.target - expected).total_seconds()) < 5.0

--- a/tests/test_temporal_prefilter_orchestrator.py
+++ b/tests/test_temporal_prefilter_orchestrator.py
@@ -1,0 +1,302 @@
+"""Integration tests for the temporal pre-filter wired into the orchestrator.
+
+Pure regex unit behavior is covered by ``test_temporal_prefilter.py``.
+This file checks that the orchestrator opens Step 0 only when
+``temporal_prefilter_cfg.enabled`` is True, that the computed
+``TimeWindow`` flows through to the vector lane via the existing
+``time_window`` kwarg, and that a caller-supplied ``time_window``
+always wins.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from attestor.config import TemporalPrefilterCfg
+from attestor.retrieval.temporal_query import TimeWindow
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Test doubles — same shape as test_multi_query_orchestrator.py
+# ──────────────────────────────────────────────────────────────────────
+
+
+class FakeVectorStore:
+    """Records the time_window kwarg passed on each search call."""
+
+    def __init__(self, hits_per_query: Optional[Dict[str, List[Dict]]] = None):
+        self.hits_per_query = hits_per_query or {}
+        self.calls: List[Dict[str, Any]] = []
+
+    def search(
+        self,
+        query: str,
+        *,
+        limit: int = 50,
+        namespace: Optional[str] = None,
+        as_of: Any = None,
+        time_window: Any = None,
+        **kwargs: Any,
+    ) -> List[Dict]:
+        self.calls.append({
+            "query": query,
+            "limit": limit,
+            "namespace": namespace,
+            "as_of": as_of,
+            "time_window": time_window,
+        })
+        return list(self.hits_per_query.get(query, []))
+
+
+class FakeStore:
+    """Minimal DocumentStore stub returning real Memory objects."""
+
+    def __init__(self) -> None:
+        self._mems: Dict[str, Any] = {}
+
+    def add_memory(self, memory_id: str, content: str = "x") -> None:
+        from attestor.models import Memory
+
+        self._mems[memory_id] = Memory(id=memory_id, content=content)
+
+    def get(self, memory_id: str):
+        return self._mems.get(memory_id)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Default behavior — disabled
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_disabled_by_default_no_time_window_override() -> None:
+    """Out of the box (no cfg wired) the orchestrator must not touch
+    time_window — caller's None stays None on the vector call."""
+    from attestor.retrieval.orchestrator import RetrievalOrchestrator
+
+    store = FakeStore()
+    store.add_memory("a")
+    vec = FakeVectorStore({"yesterday I shipped": [
+        {"memory_id": "a", "distance": 0.1},
+    ]})
+
+    orch = RetrievalOrchestrator(store=store, vector_store=vec)
+    assert orch.temporal_prefilter_cfg is None
+
+    orch.recall("yesterday I shipped")
+
+    assert len(vec.calls) == 1
+    assert vec.calls[0]["time_window"] is None
+
+
+@pytest.mark.unit
+def test_cfg_present_but_disabled_no_override() -> None:
+    """A TemporalPrefilterCfg(enabled=False) must behave the same as
+    cfg=None — even on a question that contains a relative phrase."""
+    from attestor.retrieval.orchestrator import RetrievalOrchestrator
+
+    store = FakeStore()
+    store.add_memory("a")
+    vec = FakeVectorStore({"yesterday I shipped": [
+        {"memory_id": "a", "distance": 0.1},
+    ]})
+
+    orch = RetrievalOrchestrator(store=store, vector_store=vec)
+    orch.temporal_prefilter_cfg = TemporalPrefilterCfg(enabled=False)
+
+    orch.recall("yesterday I shipped")
+
+    assert vec.calls[0]["time_window"] is None
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Enabled — phrase present
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_enabled_with_phrase_passes_time_window_to_vector_lane() -> None:
+    """enabled=True + question with phrase → vector_store.search receives
+    a TimeWindow centered on the implied target."""
+    from attestor.retrieval.orchestrator import RetrievalOrchestrator
+
+    store = FakeStore()
+    store.add_memory("a")
+    vec = FakeVectorStore({"what did I think yesterday": [
+        {"memory_id": "a", "distance": 0.1},
+    ]})
+
+    orch = RetrievalOrchestrator(store=store, vector_store=vec)
+    orch.temporal_prefilter_cfg = TemporalPrefilterCfg(
+        enabled=True, tolerance_days=3,
+    )
+
+    orch.recall("what did I think yesterday")
+
+    assert len(vec.calls) == 1
+    tw = vec.calls[0]["time_window"]
+    assert isinstance(tw, TimeWindow), (
+        f"expected TimeWindow on vector lane, got {type(tw).__name__}"
+    )
+    # Yesterday ± 3 days → a 6-day span.
+    assert tw.start is not None and tw.end is not None
+    span_days = (tw.end - tw.start).total_seconds() / 86400
+    assert abs(span_days - 6.0) < 0.01, f"expected 6-day span, got {span_days}"
+
+
+@pytest.mark.unit
+def test_enabled_no_phrase_no_override() -> None:
+    """enabled=True but the question has no relative phrase → no
+    time_window override (None passes through to the lane)."""
+    from attestor.retrieval.orchestrator import RetrievalOrchestrator
+
+    store = FakeStore()
+    store.add_memory("a")
+    vec = FakeVectorStore({"what is my favorite color": [
+        {"memory_id": "a", "distance": 0.1},
+    ]})
+
+    orch = RetrievalOrchestrator(store=store, vector_store=vec)
+    orch.temporal_prefilter_cfg = TemporalPrefilterCfg(enabled=True)
+
+    orch.recall("what is my favorite color")
+
+    assert vec.calls[0]["time_window"] is None
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Caller wins
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_caller_supplied_time_window_is_preserved() -> None:
+    """When the caller passes an explicit time_window, the pre-filter
+    must NOT override it — even if the question would have triggered
+    a different window."""
+    from attestor.retrieval.orchestrator import RetrievalOrchestrator
+
+    store = FakeStore()
+    store.add_memory("a")
+    vec = FakeVectorStore({"yesterday's commit": [
+        {"memory_id": "a", "distance": 0.1},
+    ]})
+
+    orch = RetrievalOrchestrator(store=store, vector_store=vec)
+    orch.temporal_prefilter_cfg = TemporalPrefilterCfg(enabled=True)
+
+    # Caller's window is far in the past — clearly distinguishable
+    # from anything yesterday-based.
+    caller_window = TimeWindow(
+        start=datetime(2020, 1, 1, tzinfo=timezone.utc),
+        end=datetime(2020, 1, 31, tzinfo=timezone.utc),
+        interpretation="caller-supplied",
+    )
+
+    orch.recall("yesterday's commit", time_window=caller_window)
+
+    tw = vec.calls[0]["time_window"]
+    assert tw is caller_window, (
+        f"caller's TimeWindow should pass through unchanged; got {tw!r}"
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Tolerance flows through
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_custom_tolerance_flows_through_to_window() -> None:
+    """tolerance_days=10 on the cfg → 20-day window span on the vector
+    lane (target ± 10 days)."""
+    from attestor.retrieval.orchestrator import RetrievalOrchestrator
+
+    store = FakeStore()
+    store.add_memory("a")
+    vec = FakeVectorStore({"yesterday": [
+        {"memory_id": "a", "distance": 0.1},
+    ]})
+
+    orch = RetrievalOrchestrator(store=store, vector_store=vec)
+    orch.temporal_prefilter_cfg = TemporalPrefilterCfg(
+        enabled=True, tolerance_days=10,
+    )
+
+    orch.recall("yesterday")
+
+    tw = vec.calls[0]["time_window"]
+    assert tw is not None and tw.start is not None and tw.end is not None
+    span_days = (tw.end - tw.start).total_seconds() / 86400
+    assert abs(span_days - 20.0) < 0.01, (
+        f"expected 20-day span at tolerance=10, got {span_days}"
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# YAML loader
+# ──────────────────────────────────────────────────────────────────────
+
+
+_BASE_YAML = """
+stack:
+  postgres:
+    url: postgresql://x/y
+  neo4j:
+    url: bolt://localhost:7687
+    auth: {{ username: neo4j, password: pw }}
+  embedder:
+    provider: voyage
+    model: voyage-4
+    dimensions: 1024
+  models:
+    answerer: x
+    judge: x
+    extraction: x
+    distill: x
+    verifier: x
+    planner: x
+    benchmark_default: x
+  llm:
+    provider: openrouter
+  retrieval:
+    vector_top_k: 50
+{extra}
+"""
+
+
+@pytest.mark.unit
+def test_yaml_loader_parses_temporal_prefilter_block(tmp_path) -> None:
+    """retrieval.temporal_prefilter.* in YAML flows through to
+    RetrievalCfg.temporal_prefilter."""
+    from attestor.config import load_stack
+
+    yaml_path = tmp_path / "test_attestor.yaml"
+    yaml_path.write_text(_BASE_YAML.format(extra="""
+    temporal_prefilter:
+      enabled: true
+      tolerance_days: 7
+"""))
+
+    stack = load_stack(yaml_path)
+    tp = stack.retrieval.temporal_prefilter
+    assert tp.enabled is True
+    assert tp.tolerance_days == 7
+
+
+@pytest.mark.unit
+def test_yaml_loader_defaults_temporal_prefilter_when_missing(tmp_path) -> None:
+    """When retrieval.temporal_prefilter is omitted, the default cfg
+    (enabled=False, tolerance_days=3) applies."""
+    from attestor.config import load_stack
+
+    yaml_path = tmp_path / "test_attestor.yaml"
+    yaml_path.write_text(_BASE_YAML.format(extra=""))
+
+    stack = load_stack(yaml_path)
+    tp = stack.retrieval.temporal_prefilter
+    assert tp.enabled is False
+    assert tp.tolerance_days == 3


### PR DESCRIPTION
## Summary

- **What:** Step 0 of the recall cascade now detects relative time phrases ("two weeks ago", "yesterday", "last Monday") in the user's question and tightens the event-time window passed to the vector + BM25 lanes — narrowing recall to memories whose `event_date` is plausibly contemporaneous with what the question is asking about.
- **Why:** Per RCA on LongMemEval-S, the embedder collapses temporal context into noise — content keywords dominate the cosine and time-bounded questions return ~zero hits. Hard-pre-filtering by event-time recovers the +1.5% the dense lane was leaving on the floor.
- **How:** Pure regex; no LLM cost. Disabled by default; flip per bench run via `configs/attestor.yaml`'s `retrieval.temporal_prefilter.enabled`. Caller-supplied `time_window` always wins. Follows the exact shape of the multi-query lane shipped in #94.

## Phrase catalogue

1. `\b(\d+|a|an|one|...|ten)\s+(day|week|month|year)s?\s+ago\b` — N units before now
2. `\bthe\s+day\s+before\s+yesterday\b` — 2 days back
3. `\byesterday\b` — 1 day back
4. `\blast\s+(week|month|year)\b` — 1 week/month/year back (30-day month approximation)
5. `\blast\s+<weekday>\b` — most recent occurrence STRICTLY BEFORE today (so "last Monday" on a Monday = 7 days back, not 0)
6. `\bthis\s+(morning|afternoon|evening)\b` — same calendar day
7. `\b(\d+|a|an|...|ten)\s+(day|week|month|year)s?\s+(later|after|hence)\b` — forward-looking N units after now

When multiple phrases match, the leftmost wins; ties break by longer substring (so `the day before yesterday` doesn't collapse to the trailing `yesterday`).

## Files

- `attestor/retrieval/temporal_prefilter.py` (new) — `detect_window()` + `DetectedPhrase` (reuses `TimeWindow` from `temporal_query.py`)
- `attestor/config.py` — `TemporalPrefilterCfg` dataclass + YAML loader hook next to `MultiQueryCfg`
- `attestor/retrieval/orchestrator.py` — Step 0 wiring + `recall.stage.temporal_prefilter` trace event
- `attestor/core.py` — `AgentMemory` wires the cfg onto the orchestrator
- `configs/attestor.yaml` — default `enabled: false`, `tolerance_days: 3`

## Test plan

- [x] 30 unit tests in `tests/test_temporal_prefilter.py` covering every regex pattern, number-words, weekday math (including the "last Monday on a Monday" edge case), forward-looking phrases, multi-match leftmost-wins, custom tolerance, and `matched_text` literal substring
- [x] 8 integration tests in `tests/test_temporal_prefilter_orchestrator.py` covering disabled (default + cfg present), enabled with phrase, enabled without phrase, caller-supplied `time_window` wins, custom tolerance flows through, YAML loader (with + without the block)
- [x] Full unit suite: 870 baseline → 908 with the new tests (all 38 green); pre-existing flaky `test_conflict_raises` (set-iteration order, unrelated to this PR) excluded from the baseline count
- [ ] Live LME-S bench run with `temporal_prefilter.enabled: true` to confirm the +1.5% lift before merging