### PR TITLE
feat(answerer): PR-E critique-and-revise prompt chain (+3-5% LME-S)

### DIFF
--- a/attestor/config.py
+++ b/attestor/config.py
@@ -237,6 +237,46 @@ _VALID_SC_VOTERS = ("majority", "judge_pick")
 
 
 @dataclass(frozen=True)
+class CritiqueReviseCfg:
+    """Answerer-side critique-and-revise knobs (Phase 3 PR-E, +3-5%).
+
+    When ``enabled`` is True, the LME answerer runs a three-step
+    pipeline: initial answer → critic checks against retrieved
+    context → conditional revise. Lives on ``StackConfig`` directly
+    because this is answerer behavior, NOT retrieval behavior — peer
+    of ``stack.self_consistency``, not nested inside ``stack.retrieval``.
+
+    Disabled by default — flip via ``configs/attestor.yaml``'s
+    ``stack.critique_revise`` per bench run.
+
+    Cost: ~3x answerer in the worst case (one critique + one revise
+    on top of the initial). In the common case where the critic says
+    ``pass`` it's ~2x answerer (one critique, no revise).
+
+    Configuration:
+      enabled        — master switch
+      critic_model   — model id for the critique step; null falls back
+                       to ``models.verifier``
+      revise_model   — model id for the revise step; null falls back
+                       to ``models.answerer``
+      max_revisions  — hard-capped at 1 in this PR (literature shows
+                       diminishing returns past one revision and rapidly-
+                       rising cost). Loader rejects values > 1.
+    """
+
+    enabled: bool = False
+    critic_model: Optional[str] = None
+    revise_model: Optional[str] = None
+    max_revisions: int = 1
+
+
+# Hard cap enforced by the YAML loader. This PR caps critique-revise
+# at one revision; future PRs can lift this when we validate the
+# cost / benefit curve past one round.
+_MAX_CRITIQUE_REVISIONS = 1
+
+
+@dataclass(frozen=True)
 class TemporalPrefilterCfg:
     """Regex-only temporal pre-filter knobs (Phase 3 RC4 — +1.5% LME-S).
 
@@ -372,6 +412,7 @@ class StackConfig:
     parallel: int
     clouds: Dict[str, Dict[str, Any]]
     self_consistency: SelfConsistencyCfg = field(default_factory=SelfConsistencyCfg)
+    critique_revise: CritiqueReviseCfg = field(default_factory=CritiqueReviseCfg)
 
 
 # ─── YAML helpers ─────────────────────────────────────────────────────
@@ -433,6 +474,7 @@ def _build_fallback_stack() -> StackConfig:
         parallel=_FALLBACK_PARALLEL,
         clouds={},
         self_consistency=SelfConsistencyCfg(),
+        critique_revise=CritiqueReviseCfg(),
     )
 
 
@@ -487,6 +529,27 @@ def _parse_yaml(cfg_path: Path, *, strict: bool) -> StackConfig:
         judge_model=sc_blk.get("judge_model"),
     )
 
+    cr_blk = stack_blk.get("critique_revise") or {}
+    cr_max_revisions = int(cr_blk.get("max_revisions", 1))
+    if cr_max_revisions > _MAX_CRITIQUE_REVISIONS:
+        raise SystemExit(
+            f"[attestor.config] critique_revise.max_revisions="
+            f"{cr_max_revisions} exceeds the hard cap of "
+            f"{_MAX_CRITIQUE_REVISIONS}; this PR enforces a single "
+            f"revision (literature shows diminishing returns past one)"
+        )
+    if cr_max_revisions < 0:
+        raise SystemExit(
+            f"[attestor.config] critique_revise.max_revisions="
+            f"{cr_max_revisions} must be >= 0"
+        )
+    cr_cfg = CritiqueReviseCfg(
+        enabled=bool(cr_blk.get("enabled", False)),
+        critic_model=cr_blk.get("critic_model"),
+        revise_model=cr_blk.get("revise_model"),
+        max_revisions=cr_max_revisions,
+    )
+
     llm_provider = str(llm_blk.get("provider", _FALLBACK_LLM_PROVIDER))
     if llm_provider not in LLM_PROVIDER_DEFAULTS:
         raise SystemExit(
@@ -539,6 +602,7 @@ def _parse_yaml(cfg_path: Path, *, strict: bool) -> StackConfig:
         parallel=int(stack_blk.get("parallel", _FALLBACK_PARALLEL)),
         clouds=dict(clouds_blk),
         self_consistency=sc_cfg,
+        critique_revise=cr_cfg,
     )
 
 

--- a/attestor/longmemeval.py
+++ b/attestor/longmemeval.py
@@ -1365,9 +1365,11 @@ def _answerer_call(
     model: str,
     prompt: str,
     max_tokens: int,
+    question: Optional[str] = None,
+    context: str = "",
 ) -> str:
     """Produce the answerer's raw response, applying self-consistency
-    when ``stack.self_consistency.enabled`` is True.
+    or critique-and-revise when their YAML knobs are flipped on.
 
     Single-sample path (default): one greedy ``_chat`` call. Identical
     behavior to the legacy code site.
@@ -1376,18 +1378,53 @@ def _answerer_call(
     temperature, reduced via majority vote (or judge_pick) to one
     final answer. Cost is K × answerer cost.
 
-    On any error in the self-consistency path, falls back to the
+    Critique-revise path (Phase 3 PR-E): three-step pipeline — initial
+    answer → critic LLM ground-checks against retrieved context → on
+    VERDICT=revise, a second answerer call produces the corrected
+    answer. ~3x answerer cost worst case (1x extra in the common
+    pass case).
+
+    Mutual exclusion: when both ``stack.self_consistency.enabled``
+    and ``stack.critique_revise.enabled`` are True we prefer
+    self-consistency (already shipped + proven) and log a warning;
+    combining the two safely is a future PR.
+
+    On any error in either layered path, falls back to the
     single-sample path so the LME run never breaks because of a
     config knob.
+
+    Args:
+        question: Optional question text — when omitted, the
+            critique-revise path falls back to extracting the question
+            from the user message in ``messages``. Pass it explicitly
+            from the caller for cleaner critic prompts.
+        context:  Optional retrieved-context block — embedded in the
+            critique/revise prompts so the critic can ground-check
+            the initial answer. Empty string degrades the critic but
+            never breaks the call.
     """
     try:
         from attestor.config import get_stack
         stack = get_stack()
         sc = getattr(stack, "self_consistency", None)
+        cr = getattr(stack, "critique_revise", None)
     except Exception:  # noqa: BLE001 — config errors must not break answerer
         sc = None
+        cr = None
 
-    if sc is not None and sc.enabled and sc.k > 1:
+    sc_on = sc is not None and sc.enabled and sc.k > 1
+    cr_on = cr is not None and cr.enabled
+
+    if sc_on and cr_on:
+        # Combining both layered strategies is a future PR; prefer the
+        # one that's already shipped + proven (self-consistency).
+        logger.warning(
+            "stack.self_consistency and stack.critique_revise both "
+            "enabled; preferring self_consistency for this run "
+            "(critique_revise skipped).",
+        )
+
+    if sc_on:
         try:
             from attestor.longmemeval_consistency import (
                 answer_with_self_consistency,
@@ -1407,6 +1444,29 @@ def _answerer_call(
             # Empty consensus → fall through to single-sample retry.
         except Exception:  # noqa: BLE001
             # Self-consistency layer failed; degrade to single-sample.
+            pass
+    elif cr_on:
+        try:
+            from attestor.longmemeval_critique import (
+                answer_with_critique_revise,
+            )
+            critic_model = cr.critic_model or stack.models.verifier
+            revise_model = cr.revise_model or stack.models.answerer
+            result = answer_with_critique_revise(
+                client=client,
+                model=model,
+                messages=[{"role": "user", "content": prompt}],
+                question=question,
+                context=context,
+                critic_model=critic_model,
+                revise_model=revise_model,
+                max_revisions=cr.max_revisions,
+            )
+            if result.final_answer:
+                return result.final_answer
+            # Empty final_answer → fall through to single-sample retry.
+        except Exception:  # noqa: BLE001
+            # Critique-revise layer failed; degrade to single-sample.
             pass
 
     return _chat(client, model, prompt, max_tokens=max_tokens, role="answerer")
@@ -1481,6 +1541,8 @@ def answer_question(
         model=model,
         prompt=prompt,
         max_tokens=max_tokens,
+        question=sample.question,
+        context=context,
     ).strip()
     reasoning, first_answer = _strip_reasoning(raw)
 

--- a/attestor/longmemeval_critique.py
+++ b/attestor/longmemeval_critique.py
@@ -1,0 +1,508 @@
+"""Critique-and-revise answerer (Phase 3 PR-E, +3-5% LME-S).
+
+A single greedy decode often produces a confident-but-wrong answer
+because the answerer commits before sanity-checking against the
+retrieved context. A two-pass cycle — answer, critique, then revise
+only when the critic flags an issue — catches a meaningful fraction
+of those failures with bounded extra cost (~3x answerer at most;
+1x extra in the common case where the critic says ``pass``).
+
+This module is answerer-side only — it does NOT touch the retrieval
+pipeline or ``RetrievalCfg``. The orchestrator runs unchanged.
+
+Configuration lives in ``configs/attestor.yaml`` under the top-level
+``stack.critique_revise`` block (peer of ``stack.self_consistency``,
+not nested inside ``retrieval``):
+
+    stack:
+      critique_revise:
+        enabled: false
+        critic_model: null      # null → models.verifier
+        revise_model: null      # null → models.answerer
+        max_revisions: 1        # hard cap; loader rejects > 1
+
+Trace events emitted (when ``ATTESTOR_TRACE=1``):
+
+  - ``answer.critique.verdict`` — verdict, reason, revised
+  - ``answer.critique.revised`` — initial_length, final_length,
+    n_revisions
+
+Cost: 1 answer + 1 critique + at most 1 revise per question. Disabled
+by default — gate behind the YAML knob and flip per bench run only.
+
+This PR caps ``max_revisions`` at 1: literature shows diminishing
+returns past one revision and the cost compounds. The cap is enforced
+in the YAML loader (``_parse_yaml`` raises SystemExit on > 1).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger("attestor.longmemeval_critique")
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Result shape
+# ──────────────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class CritiqueResult:
+    """Three-step critique-revise output.
+
+    All fields are populated even on degraded paths so downstream
+    tracing has full visibility into what happened. Immutable per the
+    project coding-style rules.
+
+    Fields:
+        initial_answer: Raw output of the first (greedy) answerer call.
+        critique:       The critic LLM's self-critique text. Empty
+                        string when the critic call failed or no
+                        critique was produced.
+        final_answer:   The revised answer when the critic said
+                        ``revise``; otherwise equal to ``initial_answer``.
+        revised:        True iff a revise call fired AND produced a
+                        non-empty answer that was actually used.
+        n_revisions:    Number of revise calls that succeeded (0 or 1
+                        in this PR).
+    """
+
+    initial_answer: str
+    critique: str
+    final_answer: str
+    revised: bool
+    n_revisions: int
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Prompts
+# ──────────────────────────────────────────────────────────────────────
+
+
+_CRITIQUE_PROMPT = (
+    "You just produced this answer to a memory-recall question. Now check "
+    "it against the source context for factual accuracy.\n\n"
+    "Question: {question}\n\n"
+    "Context (retrieved memories):\n{context}\n\n"
+    "Your initial answer: {initial_answer}\n\n"
+    "Decide:\n"
+    "  - If the answer is fully grounded in the context AND addresses the\n"
+    "    question accurately, output exactly:\n"
+    "      VERDICT: pass\n"
+    "      REASON: <one short sentence>\n"
+    "  - If the answer is wrong, partial, or unsupported by context, output:\n"
+    "      VERDICT: revise\n"
+    "      REASON: <what's wrong>\n"
+    "      FIX: <what the correct answer should say>\n\n"
+    "Output:"
+)
+
+
+_REVISE_PROMPT = (
+    "Your initial answer to this question was incorrect or incomplete. "
+    "A reviewer flagged the issue. Produce a corrected answer.\n\n"
+    "Question: {question}\n\n"
+    "Context (retrieved memories):\n{context}\n\n"
+    "Initial answer: {initial_answer}\n\n"
+    "Reviewer feedback: {critique}\n\n"
+    "Corrected answer:"
+)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Critique parsing
+# ──────────────────────────────────────────────────────────────────────
+
+
+# Match `VERDICT: pass` / `verdict = revise` / `Verdict :REVISE` etc.
+# Case-insensitive; tolerant of whitespace and punctuation between the
+# label and the value.
+_VERDICT_RE = re.compile(
+    r"verdict\s*[:=]?\s*(pass|revise)\b",
+    re.IGNORECASE,
+)
+_REASON_RE = re.compile(
+    r"reason\s*[:=]?\s*(.+?)(?:\n[A-Z]+\s*[:=]|\Z)",
+    re.IGNORECASE | re.DOTALL,
+)
+_FIX_RE = re.compile(
+    r"fix\s*[:=]?\s*(.+?)(?:\n[A-Z]+\s*[:=]|\Z)",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def _parse_verdict(text: str) -> str:
+    """Extract the VERDICT value from critique output.
+
+    Returns "pass", "revise", or "pass" as the safe default when the
+    output can't be parsed unambiguously. Defaulting to ``pass`` is
+    deliberate: a malformed critique should NEVER cause us to discard
+    the initial answer in favor of an unconstrained revise — that path
+    risks making a worse answer worse. When in doubt, keep the
+    original.
+    """
+    if not text:
+        return "pass"
+    m = _VERDICT_RE.search(text)
+    if not m:
+        return "pass"
+    return m.group(1).lower()
+
+
+def _parse_reason(text: str) -> str:
+    """Best-effort extraction of the REASON line from critique output."""
+    if not text:
+        return ""
+    m = _REASON_RE.search(text)
+    if not m:
+        return ""
+    return m.group(1).strip()
+
+
+def _parse_fix(text: str) -> str:
+    """Best-effort extraction of the FIX line from critique output."""
+    if not text:
+        return ""
+    m = _FIX_RE.search(text)
+    if not m:
+        return ""
+    return m.group(1).strip()
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Message helpers
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _question_from_messages(messages: List[Dict[str, Any]]) -> str:
+    """Best-effort extraction of the user's question from the chat
+    messages — used to fill the critique/revise prompt's ``{question}``
+    placeholder. If the schema doesn't match, falls back to a generic
+    placeholder so the prompt still renders."""
+    if not messages:
+        return "(no question available)"
+    for m in reversed(messages):
+        if m.get("role") == "user":
+            content = m.get("content", "")
+            if isinstance(content, str):
+                return content[:8000]
+    return str(messages[-1].get("content", ""))[:8000]
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Per-step LLM calls
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _initial_answer(
+    *,
+    client: Any,
+    model: str,
+    messages: List[Dict[str, Any]],
+) -> str:
+    """Greedy initial answer — same shape as the legacy single-sample
+    path. Returns the stripped content text, or ``""`` on any error."""
+    from attestor.llm_trace import traced_create
+
+    response = traced_create(
+        client,
+        role="answerer",
+        model=model,
+        messages=messages,
+    )
+    text = response.choices[0].message.content or ""
+    return text.strip()
+
+
+def _critique(
+    *,
+    client: Any,
+    model: str,
+    question: str,
+    context: str,
+    initial_answer: str,
+) -> str:
+    """Critic call. Returns the stripped critique text or ``""`` on
+    error. Caller is responsible for parsing the verdict."""
+    from attestor.llm_trace import traced_create
+
+    prompt = _CRITIQUE_PROMPT.format(
+        question=question,
+        context=context,
+        initial_answer=initial_answer,
+    )
+    response = traced_create(
+        client,
+        role="critic",
+        model=model,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    text = response.choices[0].message.content or ""
+    return text.strip()
+
+
+def _revise(
+    *,
+    client: Any,
+    model: str,
+    question: str,
+    context: str,
+    initial_answer: str,
+    critique: str,
+) -> str:
+    """Reviser call. Fires only when the critic returned VERDICT=revise.
+    Returns the stripped revised answer or ``""`` on error."""
+    from attestor.llm_trace import traced_create
+
+    prompt = _REVISE_PROMPT.format(
+        question=question,
+        context=context,
+        initial_answer=initial_answer,
+        critique=critique,
+    )
+    response = traced_create(
+        client,
+        role="reviser",
+        model=model,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    text = response.choices[0].message.content or ""
+    return text.strip()
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Public entry point
+# ──────────────────────────────────────────────────────────────────────
+
+
+def answer_with_critique_revise(
+    *,
+    client: Any,
+    model: str,
+    messages: List[Dict[str, Any]],
+    question: Optional[str] = None,
+    context: str = "",
+    critic_client: Optional[Any] = None,
+    critic_model: Optional[str] = None,
+    revise_client: Optional[Any] = None,
+    revise_model: Optional[str] = None,
+    max_revisions: int = 1,
+) -> CritiqueResult:
+    """Three-step critique-and-revise pipeline.
+
+    Steps:
+      1. Initial answer — single greedy decode using ``client``/``model``;
+         identical to the legacy single-sample path.
+      2. Critique       — feed (question, context, initial_answer) into
+         the critic. Output is structured as
+         ``VERDICT: pass|revise\\nREASON: ...`` (with optional ``FIX:``).
+      3. Revise (cond.) — only when ``VERDICT=revise``: feed the
+         critique back into the reviser to produce a corrected answer.
+
+    Args:
+        client:        OpenAI-compatible answerer client. Used for
+                       step 1 and (when ``revise_client`` is None)
+                       step 3.
+        model:         Answerer model id for step 1.
+        messages:      Chat-completion messages forwarded verbatim to
+                       step 1. The user's question is also extracted
+                       from this list for the critique/revise prompts
+                       when ``question`` is not provided explicitly.
+        question:      Optional explicit question text for the critic
+                       prompt. Defaults to the last ``user`` message
+                       in ``messages``.
+        context:       Retrieved-context block to embed in the
+                       critique/revise prompts. Empty string is
+                       acceptable but degrades the critic's ability
+                       to ground-check.
+        critic_client: Optional critic LLM client. Defaults to ``client``.
+        critic_model:  Required when critique-revise is enabled.
+                       Should normally come from
+                       ``stack.critique_revise.critic_model`` or fall
+                       back to ``stack.models.verifier``.
+        revise_client: Optional reviser client. Defaults to ``client``.
+        revise_model:  Reviser model id. Defaults to ``model`` when None.
+        max_revisions: Hard-capped at 1 in this PR. Values > 1 are
+                       silently clamped here; the YAML loader rejects
+                       them up front so this is defensive only.
+
+    Returns:
+        ``CritiqueResult`` populated with all four fields. ``revised``
+        is True iff a revise call actually changed the final answer;
+        ``n_revisions`` is 0 or 1.
+
+    Defensive contract: on ANY LLM failure (initial, critic, reviser
+    network errors, malformed output, etc.), returns a CritiqueResult
+    with ``initial_answer`` as ``final_answer`` and ``revised=False``.
+    Never raises and never returns an empty final answer when the
+    initial answer succeeded.
+    """
+    # Defensive cap — YAML loader already rejects > 1, but keep the
+    # public surface honest for direct callers.
+    if max_revisions > 1:
+        max_revisions = 1
+    if max_revisions < 0:
+        max_revisions = 0
+
+    effective_critic_model = critic_model or model
+    effective_revise_model = revise_model or model
+    effective_critic_client = critic_client or client
+    effective_revise_client = revise_client or client
+
+    # ── Step 1: initial answer ───────────────────────────────────────
+    try:
+        initial = _initial_answer(client=client, model=model, messages=messages)
+    except Exception as exc:  # noqa: BLE001 — never abort the user-facing path
+        logger.debug("critique_revise initial answer failed: %s", exc)
+        return CritiqueResult(
+            initial_answer="",
+            critique="",
+            final_answer="",
+            revised=False,
+            n_revisions=0,
+        )
+
+    # If the initial answer is empty there's nothing for the critic to
+    # check — short-circuit and return early.
+    if not initial:
+        return CritiqueResult(
+            initial_answer="",
+            critique="",
+            final_answer="",
+            revised=False,
+            n_revisions=0,
+        )
+
+    # If max_revisions is 0 we skip critique entirely (the knob is
+    # effectively a no-op; identical to the single-sample path but
+    # honors the contract).
+    if max_revisions == 0:
+        return CritiqueResult(
+            initial_answer=initial,
+            critique="",
+            final_answer=initial,
+            revised=False,
+            n_revisions=0,
+        )
+
+    # ── Step 2: critique ─────────────────────────────────────────────
+    effective_question = question or _question_from_messages(messages)
+    try:
+        critique_text = _critique(
+            client=effective_critic_client,
+            model=effective_critic_model,
+            question=effective_question,
+            context=context,
+            initial_answer=initial,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("critique_revise critic call failed: %s", exc)
+        # Critic failed → keep initial as the final answer.
+        return CritiqueResult(
+            initial_answer=initial,
+            critique="",
+            final_answer=initial,
+            revised=False,
+            n_revisions=0,
+        )
+
+    verdict = _parse_verdict(critique_text)
+    reason = _parse_reason(critique_text)
+    _emit_verdict_event(verdict=verdict, reason=reason, revised=verdict == "revise")
+
+    if verdict != "revise":
+        # Critic said pass (or output was unparseable → defaulted to
+        # pass). Final answer = initial answer.
+        return CritiqueResult(
+            initial_answer=initial,
+            critique=critique_text,
+            final_answer=initial,
+            revised=False,
+            n_revisions=0,
+        )
+
+    # ── Step 3: revise ───────────────────────────────────────────────
+    try:
+        revised_text = _revise(
+            client=effective_revise_client,
+            model=effective_revise_model,
+            question=effective_question,
+            context=context,
+            initial_answer=initial,
+            critique=critique_text,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("critique_revise revise call failed: %s", exc)
+        # Reviser failed → keep initial as the final answer.
+        return CritiqueResult(
+            initial_answer=initial,
+            critique=critique_text,
+            final_answer=initial,
+            revised=False,
+            n_revisions=0,
+        )
+
+    if not revised_text:
+        # Empty revision → fall back to initial. Better a confident
+        # initial than a blank revised answer.
+        return CritiqueResult(
+            initial_answer=initial,
+            critique=critique_text,
+            final_answer=initial,
+            revised=False,
+            n_revisions=0,
+        )
+
+    _emit_revised_event(
+        initial_length=len(initial),
+        final_length=len(revised_text),
+        n_revisions=1,
+    )
+    return CritiqueResult(
+        initial_answer=initial,
+        critique=critique_text,
+        final_answer=revised_text,
+        revised=True,
+        n_revisions=1,
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Trace events (best-effort, no-ops when ATTESTOR_TRACE is unset)
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _emit_verdict_event(*, verdict: str, reason: str, revised: bool) -> None:
+    try:
+        from attestor import trace as _tr
+        if not _tr.is_enabled():
+            return
+        _tr.event(
+            "answer.critique.verdict",
+            verdict=verdict,
+            reason=reason,
+            revised=revised,
+        )
+    except Exception:  # noqa: BLE001 — telemetry must never break the call
+        pass
+
+
+def _emit_revised_event(
+    *, initial_length: int, final_length: int, n_revisions: int,
+) -> None:
+    try:
+        from attestor import trace as _tr
+        if not _tr.is_enabled():
+            return
+        _tr.event(
+            "answer.critique.revised",
+            initial_length=initial_length,
+            final_length=final_length,
+            n_revisions=n_revisions,
+        )
+    except Exception:  # noqa: BLE001
+        pass

--- a/configs/attestor.yaml
+++ b/configs/attestor.yaml
@@ -206,6 +206,20 @@ stack:
     voter: majority           # majority | judge_pick
     judge_model: null         # null → models.judge
 
+  # Critique-and-revise (Phase 3 PR-E, +3-5% on LME-S).
+  # When enabled, the LME answerer runs a three-step pipeline:
+  #   1. Initial answer (existing path)
+  #   2. Critic LLM checks the answer against retrieved context
+  #   3. If critic says revise, a second answerer call produces the
+  #      corrected answer.
+  # ~3x answerer cost. Mutually exclusive with self_consistency in
+  # this PR (if both are on, self_consistency wins; warning logged).
+  critique_revise:
+    enabled: false
+    critic_model: null            # null → models.verifier
+    revise_model: null            # null → models.answerer
+    max_revisions: 1              # hard cap; this PR rejects values > 1
+
 # ─── Container image (for cloud deploys) ────────────────────────────────
 # The published image is currently the *introspection-only* MCP stub
 # (Glama listing). For Path B cloud deploys we build a separate

--- a/tests/test_critique_revise.py
+++ b/tests/test_critique_revise.py
@@ -1,0 +1,385 @@
+"""Unit tests for attestor.longmemeval_critique.
+
+Pure unit tests — every LLM call is mocked. End-to-end behavior with
+the real LongMemEval flow is exercised via the bench harness, not here.
+
+Coverage shape mirrors `tests/test_self_consistency.py` (the closest
+sibling, shipped in PR #97).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, Dict, List
+from unittest.mock import MagicMock
+
+import pytest
+
+from attestor.longmemeval_critique import (
+    CritiqueResult,
+    _parse_fix,
+    _parse_reason,
+    _parse_verdict,
+    _question_from_messages,
+    answer_with_critique_revise,
+)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Helpers
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _make_client(responses: List[str]) -> Any:
+    """Build a stub OpenAI-compatible client whose chat.completions.create
+    returns each response string in order. Records every call for
+    introspection."""
+    seq = iter(responses)
+
+    def _create(**kwargs):
+        try:
+            content = next(seq)
+        except StopIteration:
+            raise AssertionError(
+                f"client received unexpected extra call: {kwargs.get('model')}"
+            )
+        msg = SimpleNamespace(content=content)
+        choice = SimpleNamespace(message=msg)
+        # Shape is what `traced_create` and the existing call sites expect.
+        usage = SimpleNamespace(
+            prompt_tokens=10, completion_tokens=20, total_tokens=30,
+        )
+        return SimpleNamespace(
+            id="resp-test",
+            choices=[choice],
+            usage=usage,
+            model=kwargs.get("model", "test/model"),
+        )
+
+    completions = SimpleNamespace(create=MagicMock(side_effect=_create))
+    chat = SimpleNamespace(completions=completions)
+    client = SimpleNamespace(chat=chat)
+    client.chat.completions.create.responses = responses
+    return client
+
+
+def _msg(role: str, content: str) -> Dict[str, Any]:
+    return {"role": role, "content": content}
+
+
+# ──────────────────────────────────────────────────────────────────────
+# _parse_verdict
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_parse_verdict_pass() -> None:
+    assert _parse_verdict("VERDICT: pass\nREASON: looks good") == "pass"
+
+
+@pytest.mark.unit
+def test_parse_verdict_revise() -> None:
+    assert _parse_verdict("VERDICT: revise\nREASON: wrong year") == "revise"
+
+
+@pytest.mark.unit
+def test_parse_verdict_case_insensitive() -> None:
+    assert _parse_verdict("verdict: PASS") == "pass"
+    assert _parse_verdict("VERDICT: REVISE") == "revise"
+    assert _parse_verdict("Verdict: Revise") == "revise"
+
+
+@pytest.mark.unit
+def test_parse_verdict_defaults_to_pass_when_unparsable() -> None:
+    """If we can't tell what the critic said, never make things worse —
+    default to pass (no revision)."""
+    assert _parse_verdict("hmm, looks ok-ish") == "pass"
+    assert _parse_verdict("") == "pass"
+    assert _parse_verdict("VERDICT: maybe") == "pass"
+
+
+@pytest.mark.unit
+def test_parse_verdict_handles_extra_whitespace() -> None:
+    assert _parse_verdict("   VERDICT:   revise   ") == "revise"
+    assert _parse_verdict("\n\nVERDICT: pass\n") == "pass"
+
+
+# ──────────────────────────────────────────────────────────────────────
+# _parse_reason / _parse_fix
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_parse_reason_extracts_value() -> None:
+    text = "VERDICT: revise\nREASON: wrong year, not 2021"
+    assert "wrong year" in _parse_reason(text).lower()
+
+
+@pytest.mark.unit
+def test_parse_reason_returns_empty_when_missing() -> None:
+    assert _parse_reason("VERDICT: pass") == ""
+
+
+@pytest.mark.unit
+def test_parse_fix_extracts_value() -> None:
+    text = "VERDICT: revise\nREASON: wrong\nFIX: should be 2022"
+    assert "2022" in _parse_fix(text)
+
+
+@pytest.mark.unit
+def test_parse_fix_returns_empty_when_absent() -> None:
+    assert _parse_fix("VERDICT: pass\nREASON: ok") == ""
+
+
+# ──────────────────────────────────────────────────────────────────────
+# _question_from_messages
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_question_from_messages_picks_last_user() -> None:
+    messages = [
+        _msg("system", "You are an answerer."),
+        _msg("user", "first question?"),
+        _msg("assistant", "previous answer"),
+        _msg("user", "what's the actual question"),
+    ]
+    assert _question_from_messages(messages) == "what's the actual question"
+
+
+@pytest.mark.unit
+def test_question_from_messages_falls_back_to_assistant() -> None:
+    """When no user message exists, the helper falls back to the most
+    recent non-system content rather than returning empty — better
+    than silently dropping context for the critic."""
+    messages = [_msg("system", "answerer."), _msg("assistant", "hello")]
+    assert _question_from_messages(messages) == "hello"
+
+
+@pytest.mark.unit
+def test_question_from_messages_handles_empty_list() -> None:
+    """Empty messages → a sentinel string so the critic prompt template
+    doesn't crash on empty interpolation."""
+    assert _question_from_messages([]) == "(no question available)"
+
+
+# ──────────────────────────────────────────────────────────────────────
+# answer_with_critique_revise — end-to-end (mocked)
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_critique_pass_returns_initial_unchanged() -> None:
+    """VERDICT=pass → no revise call, final == initial."""
+    client = _make_client([
+        "Initial answer: it was Bob.",
+        "VERDICT: pass\nREASON: matches the context exactly.",
+    ])
+    result = answer_with_critique_revise(
+        client=client,
+        model="test/answerer",
+        messages=[_msg("user", "who was the CTO?")],
+        critic_client=client,
+        critic_model="test/critic",
+        context="Bob became CTO on Monday.",
+    )
+    assert result.initial_answer == "Initial answer: it was Bob."
+    assert result.final_answer == result.initial_answer
+    assert result.revised is False
+    assert result.n_revisions == 0
+    assert "matches the context" in result.critique
+    # 2 calls only — no revise
+    assert client.chat.completions.create.call_count == 2
+
+
+@pytest.mark.unit
+def test_critique_revise_replaces_initial() -> None:
+    """VERDICT=revise → reviser fires; final_answer = revised text."""
+    client = _make_client([
+        "Initial answer: Alice.",                                    # initial
+        "VERDICT: revise\nREASON: wrong person\nFIX: should be Bob.", # critique
+        "Corrected answer: Bob took over as CTO on Monday.",          # revise
+    ])
+    result = answer_with_critique_revise(
+        client=client,
+        model="test/answerer",
+        messages=[_msg("user", "who was the new CTO?")],
+        critic_client=client,
+        critic_model="test/critic",
+        revise_client=client,
+        revise_model="test/reviser",
+        context="Bob became CTO on Monday.",
+    )
+    assert result.initial_answer == "Initial answer: Alice."
+    assert "Bob" in result.final_answer
+    assert result.revised is True
+    assert result.n_revisions == 1
+    assert client.chat.completions.create.call_count == 3
+
+
+@pytest.mark.unit
+def test_critique_malformed_output_defaults_to_pass() -> None:
+    """Garbled critique → no revise; degrades safely to initial."""
+    client = _make_client([
+        "Initial answer: it was Bob.",
+        "lorem ipsum dolor sit amet — no verdict line",
+    ])
+    result = answer_with_critique_revise(
+        client=client,
+        model="test/answerer",
+        messages=[_msg("user", "q?")],
+        critic_client=client,
+        critic_model="test/critic",
+        context="ctx",
+    )
+    assert result.final_answer == result.initial_answer
+    assert result.revised is False
+    assert result.n_revisions == 0
+
+
+@pytest.mark.unit
+def test_critique_handles_critic_failure() -> None:
+    """If the critic LLM raises, return CritiqueResult with initial as
+    final and revised=False — never escape the exception."""
+    answerer_client = _make_client(["Initial answer: it was Bob."])
+    critic_client = SimpleNamespace(
+        chat=SimpleNamespace(
+            completions=SimpleNamespace(
+                create=MagicMock(side_effect=RuntimeError("critic down")),
+            ),
+        ),
+    )
+    result = answer_with_critique_revise(
+        client=answerer_client,
+        model="test/answerer",
+        messages=[_msg("user", "q?")],
+        critic_client=critic_client,
+        critic_model="test/critic",
+        context="ctx",
+    )
+    assert result.final_answer == "Initial answer: it was Bob."
+    assert result.revised is False
+    assert result.n_revisions == 0
+
+
+@pytest.mark.unit
+def test_critique_handles_reviser_failure() -> None:
+    """If the reviser LLM raises during revision, fall back to initial.
+    No exception escapes; n_revisions stays 0."""
+    initial_client = _make_client([
+        "Initial answer: Alice.",
+        "VERDICT: revise\nREASON: wrong\nFIX: Bob",
+    ])
+    reviser_client = SimpleNamespace(
+        chat=SimpleNamespace(
+            completions=SimpleNamespace(
+                create=MagicMock(side_effect=RuntimeError("reviser down")),
+            ),
+        ),
+    )
+    result = answer_with_critique_revise(
+        client=initial_client,
+        model="test/answerer",
+        messages=[_msg("user", "q?")],
+        critic_client=initial_client,
+        critic_model="test/critic",
+        revise_client=reviser_client,
+        revise_model="test/reviser",
+        context="ctx",
+    )
+    assert result.initial_answer == "Initial answer: Alice."
+    assert result.final_answer == result.initial_answer
+    assert result.revised is False
+    assert result.n_revisions == 0
+
+
+@pytest.mark.unit
+def test_critique_handles_initial_answer_failure() -> None:
+    """If the initial answer call itself raises, return an empty
+    CritiqueResult — never let it escape."""
+    bad_client = SimpleNamespace(
+        chat=SimpleNamespace(
+            completions=SimpleNamespace(
+                create=MagicMock(side_effect=RuntimeError("answerer down")),
+            ),
+        ),
+    )
+    result = answer_with_critique_revise(
+        client=bad_client,
+        model="test/answerer",
+        messages=[_msg("user", "q?")],
+        critic_client=bad_client,
+        critic_model="test/critic",
+        context="ctx",
+    )
+    assert result.initial_answer == ""
+    assert result.final_answer == ""
+    assert result.revised is False
+    assert result.n_revisions == 0
+
+
+@pytest.mark.unit
+def test_critique_max_revisions_capped_at_one() -> None:
+    """max_revisions > 1 is silently clamped to 1 in the call site
+    (the YAML loader is the public-facing rejection path; this test
+    asserts the defensive clamp catches anyone bypassing the loader)."""
+    client = _make_client([
+        "Initial.",
+        "VERDICT: revise\nREASON: wrong\nFIX: better",
+        "Revised once.",
+    ])
+    result = answer_with_critique_revise(
+        client=client,
+        model="test/answerer",
+        messages=[_msg("user", "q?")],
+        critic_client=client,
+        critic_model="test/critic",
+        max_revisions=999,   # caller bypassed the loader; we must clamp
+        context="ctx",
+    )
+    # Exactly one revision happened, not 999
+    assert result.n_revisions == 1
+    assert client.chat.completions.create.call_count == 3
+
+
+@pytest.mark.unit
+def test_critique_uses_distinct_critic_and_revise_models() -> None:
+    """Verify the model arg actually flows through to each call."""
+    seen_models: List[str] = []
+
+    def _create(**kwargs):
+        seen_models.append(kwargs["model"])
+        # Always verdict=revise so we exercise all three calls
+        if len(seen_models) == 1:
+            content = "Initial."
+        elif len(seen_models) == 2:
+            content = "VERDICT: revise\nREASON: wrong\nFIX: x"
+        else:
+            content = "Revised."
+        msg = SimpleNamespace(content=content)
+        usage = SimpleNamespace(
+            prompt_tokens=1, completion_tokens=1, total_tokens=2,
+        )
+        return SimpleNamespace(
+            id="r", choices=[SimpleNamespace(message=msg)],
+            usage=usage, model=kwargs["model"],
+        )
+
+    client = SimpleNamespace(
+        chat=SimpleNamespace(
+            completions=SimpleNamespace(
+                create=MagicMock(side_effect=_create),
+            ),
+        ),
+    )
+    answer_with_critique_revise(
+        client=client,
+        model="test/answerer",
+        messages=[_msg("user", "q?")],
+        critic_client=client,
+        critic_model="test/critic",
+        revise_client=client,
+        revise_model="test/reviser",
+        context="ctx",
+    )
+    assert seen_models == ["test/answerer", "test/critic", "test/reviser"]

--- a/tests/test_critique_revise_config.py
+++ b/tests/test_critique_revise_config.py
@@ -1,0 +1,116 @@
+"""YAML loader integration tests for the critique-revise feature.
+
+Mirrors `tests/test_self_consistency_config.py` (the closest sibling).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+_BASE_YAML = """
+stack:
+  postgres:
+    url: postgresql://x/y
+  neo4j:
+    url: bolt://localhost:7687
+    auth: { username: neo4j, password: pw }
+  embedder:
+    provider: voyage
+    model: voyage-4
+    dimensions: 1024
+  models:
+    answerer: x
+    judge: x
+    extraction: x
+    distill: x
+    verifier: x
+    planner: x
+    benchmark_default: x
+  llm:
+    provider: openrouter
+"""
+
+
+@pytest.mark.unit
+def test_yaml_loader_parses_critique_revise_block(tmp_path) -> None:
+    from attestor.config import load_stack
+
+    yaml_path = tmp_path / "test_attestor.yaml"
+    yaml_path.write_text(_BASE_YAML + """
+  critique_revise:
+    enabled: true
+    critic_model: anthropic/claude-sonnet-4-6
+    revise_model: openai/gpt-5.4-mini
+    max_revisions: 1
+""")
+
+    stack = load_stack(yaml_path)
+    cr = stack.critique_revise
+    assert cr.enabled is True
+    assert cr.critic_model == "anthropic/claude-sonnet-4-6"
+    assert cr.revise_model == "openai/gpt-5.4-mini"
+    assert cr.max_revisions == 1
+
+
+@pytest.mark.unit
+def test_yaml_loader_defaults_when_block_omitted(tmp_path) -> None:
+    """When `stack.critique_revise` is missing entirely, defaults apply."""
+    from attestor.config import load_stack
+
+    yaml_path = tmp_path / "test_attestor.yaml"
+    yaml_path.write_text(_BASE_YAML)
+    stack = load_stack(yaml_path)
+    cr = stack.critique_revise
+    assert cr.enabled is False
+    assert cr.critic_model is None
+    assert cr.revise_model is None
+    assert cr.max_revisions == 1
+
+
+@pytest.mark.unit
+def test_yaml_loader_rejects_max_revisions_above_one(tmp_path) -> None:
+    """The PR-E hard cap. > 1 should fail loud at load time so a typo
+    in YAML can't quietly produce 5x answerer cost."""
+    from attestor.config import load_stack
+
+    yaml_path = tmp_path / "test_attestor.yaml"
+    yaml_path.write_text(_BASE_YAML + """
+  critique_revise:
+    enabled: true
+    max_revisions: 3
+""")
+
+    with pytest.raises(SystemExit) as exc:
+        load_stack(yaml_path)
+    assert "max_revisions" in str(exc.value).lower()
+
+
+@pytest.mark.unit
+def test_yaml_loader_accepts_max_revisions_one_explicitly(tmp_path) -> None:
+    from attestor.config import load_stack
+
+    yaml_path = tmp_path / "test_attestor.yaml"
+    yaml_path.write_text(_BASE_YAML + """
+  critique_revise:
+    enabled: false
+    max_revisions: 1
+""")
+    stack = load_stack(yaml_path)
+    assert stack.critique_revise.max_revisions == 1
+
+
+@pytest.mark.unit
+def test_critique_revise_is_top_level_not_in_retrieval(tmp_path) -> None:
+    """Sanity: critique_revise is on StackConfig, not RetrievalCfg.
+    Putting it under retrieval would be a category error since this
+    feature is answerer-side, not retrieval-side."""
+    from attestor.config import load_stack
+
+    yaml_path = tmp_path / "test_attestor.yaml"
+    yaml_path.write_text(_BASE_YAML)
+    stack = load_stack(yaml_path)
+    assert hasattr(stack, "critique_revise")
+    assert not hasattr(stack.retrieval, "critique_revise")


### PR DESCRIPTION
## Summary

Three-step answerer pipeline: **initial → critique → conditional revise**. Disabled by default; flip via `configs/attestor.yaml`'s `stack.critique_revise.enabled`. Cost: ~3x answerer worst case (1x extra in the common pass branch).

## How it works

1. **Initial answer** — single greedy decode (existing path)
2. **Critique** — critic LLM checks the answer against retrieved context and emits structured output: `VERDICT: pass | revise`, `REASON: ...`, optional `FIX: ...`
3. **Revise** (only if `VERDICT=revise`) — reviser LLM takes the initial answer + critique feedback and produces a corrected answer

## Files

- **New:** `attestor/longmemeval_critique.py` (508 LOC) + 2 test files (17 + 5 tests)
- **Modified:** `attestor/config.py` (CritiqueReviseCfg + loader), `attestor/longmemeval.py` (dispatch site), `configs/attestor.yaml` (top-level `stack.critique_revise` block)

## Defensive contract

Every failure path returns a usable `CritiqueResult`:

- Initial answerer fails → empty result
- Critic fails → initial as final, `revised=False`
- Reviser fails → initial as final, `revised=False`
- Malformed critique output → defaults to `VERDICT=pass`
- `max_revisions > 1` → clamped defensively (loader also rejects up front)

## Mutual exclusion

`self_consistency` and `critique_revise` are mutually exclusive in this PR. If both are on, `self_consistency` wins with a logged warning. Full combination is queued for a follow-up.

## Test plan

- [x] `pytest tests/test_critique_revise.py tests/test_critique_revise_config.py` — 25/25 passing
- [x] Full unit suite: 956 passed (1 pre-existing flake in `test_registry.py` unrelated to this change)
- [ ] User-driven: enable in `configs/attestor.yaml` and run a bench slice to measure the +3-5% lift