### PR TITLE
feat(retrieval): PR-D HyDE — hypothetical-document embedding (+6-10% recall)

### DIFF
--- a/attestor/config.py
+++ b/attestor/config.py
@@ -277,6 +277,34 @@ _MAX_CRITIQUE_REVISIONS = 1
 
 
 @dataclass(frozen=True)
+class HydeCfg:
+    """HyDE retrieval knobs (Phase 3 PR-D — +6-10% recall lever).
+
+    When ``enabled`` is True, the orchestrator generates a hypothetical
+    answer to the question via a small LLM, embeds it, and runs both
+    the original question AND the hypothetical answer through the
+    vector lane — RRF-merging the two ranked lists before the rest
+    of the cascade. Sibling of multi_query (PR #94); same RRF helpers,
+    different rewrite strategy.
+
+    Mutually exclusive with multi_query in this PR — if both flags are
+    on, the orchestrator prefers multi_query (logged warning).
+
+    Configuration:
+      enabled                       — master switch
+      generator_model               — null → ``models.extraction``
+      generator_reasoning_effort    — low | medium | high (gpt-5.x knob)
+      merge                         — ``rrf`` (default, consensus-weighted)
+                                      or ``union`` (cheaper, no fusion)
+    """
+
+    enabled: bool = False
+    generator_model: Optional[str] = None
+    generator_reasoning_effort: str = "low"
+    merge: str = "rrf"
+
+
+@dataclass(frozen=True)
 class TemporalPrefilterCfg:
     """Regex-only temporal pre-filter knobs (Phase 3 RC4 — +1.5% LME-S).
 
@@ -345,6 +373,7 @@ class RetrievalCfg:
     temporal_prefilter: TemporalPrefilterCfg = field(
         default_factory=TemporalPrefilterCfg,
     )
+    hyde: HydeCfg = field(default_factory=HydeCfg)
 
 
 @dataclass(frozen=True)
@@ -507,11 +536,21 @@ def _parse_yaml(cfg_path: Path, *, strict: bool) -> StackConfig:
         enabled=bool(tp_blk.get("enabled", False)),
         tolerance_days=int(tp_blk.get("tolerance_days", 3)),
     )
+    hyde_blk = retrieval_blk.get("hyde") or {}
+    hyde_cfg = HydeCfg(
+        enabled=bool(hyde_blk.get("enabled", False)),
+        generator_model=hyde_blk.get("generator_model"),
+        generator_reasoning_effort=str(
+            hyde_blk.get("generator_reasoning_effort", "low"),
+        ),
+        merge=str(hyde_blk.get("merge", "rrf")),
+    )
     retrieval_cfg = RetrievalCfg(
         vector_top_k=int(retrieval_blk.get("vector_top_k", 50)),
         mmr_top_n=(int(mmr_top_raw) if mmr_top_raw is not None else None),
         multi_query=mq_cfg,
         temporal_prefilter=tp_cfg,
+        hyde=hyde_cfg,
     )
 
     sc_blk = stack_blk.get("self_consistency") or {}

--- a/attestor/core.py
+++ b/attestor/core.py
@@ -170,6 +170,7 @@ class AgentMemory:
             self._retrieval.temporal_prefilter_cfg = (
                 _retrieval_cfg.temporal_prefilter
             )
+            self._retrieval.hyde_cfg = _retrieval_cfg.hyde
         except Exception as _e:
             logger.debug("retrieval cfg not applied: %s", _e)
 

--- a/attestor/retrieval/hyde.py
+++ b/attestor/retrieval/hyde.py
@@ -1,0 +1,235 @@
+"""HyDE retrieval — Hypothetical Document Embedding (Phase 3 PR-D).
+
+A small LLM generates a 1-2-sentence hypothetical answer to the user's
+question; the orchestrator embeds and searches BOTH the original
+question AND the hypothetical answer in parallel, then RRF-merges the
+two ranked lists before the rest of the cascade.
+
+Per the RCA roadmap, this is the +6-10% recall lever sibling to
+multi-query (PR #94). Intuition: dense embedding similarity between
+a question and an answer is asymmetric — questions don't structurally
+resemble their answers. Running both as queries widens the search
+pattern across the latent space, raising the chance the correct
+memory is in *some* lane's top-K.
+
+This module is pure — it produces ``(queries: List[str], merged_hits:
+List[dict])`` but does not call the vector store. The orchestrator
+wires the lane in by handing in a ``vector_search`` callable, mirror
+of the multi_query integration pattern.
+
+Configuration lives in ``configs/attestor.yaml`` under
+``retrieval.hyde``:
+
+    retrieval:
+      hyde:
+        enabled: false           # default off
+        generator_model: null    # null → models.extraction
+        generator_reasoning_effort: low
+        merge: rrf               # rrf | union
+
+Trace events emitted (when ATTESTOR_TRACE=1):
+
+  - ``recall.hyde.generated`` — the original + the hypothetical preview
+  - ``recall.hyde.merged``    — pre-merge per-lane sizes + final size
+
+Mutually exclusive with multi_query in this PR. The orchestrator
+prefers multi_query when both are enabled (it's been shipped longer
+and proven; HyDE is new). The combination is left for a follow-up.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
+
+logger = logging.getLogger("attestor.retrieval.hyde")
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Result shape
+# ──────────────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class HydeResult:
+    """The generator's output. ``original_question`` is always
+    present; ``hypothetical_answer`` is empty string on degraded paths
+    so the caller can detect "generation failed → just use the
+    question alone" without checking for sentinel exceptions.
+    """
+
+    original_question: str
+    hypothetical_answer: str = ""
+
+    @property
+    def queries(self) -> List[str]:
+        """Queries to fan out, in lane-priority order. The original
+        is always rank-0; the hypothetical comes second when present.
+
+        On degraded paths (empty ``hypothetical_answer``), returns just
+        the original — the caller naturally falls back to single-query.
+        """
+        if not self.hypothetical_answer.strip():
+            return [self.original_question]
+        return [self.original_question, self.hypothetical_answer]
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Generator
+# ──────────────────────────────────────────────────────────────────────
+
+
+_GENERATOR_PROMPT = """You are answering a memory-recall question. Without \
+access to any specific memory, write a 1-2-sentence HYPOTHETICAL answer in \
+the same style and surface form as a real answer would take. Be specific \
+and concrete — invent plausible details (names, dates, numbers) so the \
+answer's embedding matches the corpus.
+
+Rules:
+- Answer in 1-2 sentences, declarative form.
+- Do NOT include hedging ("I think", "it might be", "perhaps").
+- Do NOT include the question itself.
+- Do NOT add caveats or refuse — generate plausible content even if you \
+can't know the real answer.
+
+Question: {question}
+
+Hypothetical answer:"""
+
+
+def _resolve_generator_model() -> str:
+    """Generator model: env override > YAML > extraction default."""
+    if env := os.environ.get("HYDE_GENERATOR_MODEL"):
+        return env
+    from attestor.config import get_stack
+    stack = get_stack()
+    hyde_cfg = getattr(stack.retrieval, "hyde", None)
+    if hyde_cfg is not None and getattr(hyde_cfg, "generator_model", None):
+        return hyde_cfg.generator_model
+    return stack.models.extraction
+
+
+def generate_hypothetical_answer(
+    question: str,
+    *,
+    model: Optional[str] = None,
+    api_key: Optional[str] = None,
+    timeout: float = 30.0,
+) -> HydeResult:
+    """Single LLM call returning a hypothetical answer for ``question``.
+
+    On any error (missing key, malformed response, network timeout),
+    returns ``HydeResult(original_question=question, hypothetical_answer="")``
+    — the caller naturally degrades to a single-query lane.
+    """
+    if not question.strip():
+        return HydeResult(original_question=question.strip())
+
+    api_key = api_key or os.environ.get("OPENROUTER_API_KEY")
+    if not api_key:
+        logger.debug("hyde.generate: no API key; returning degraded result")
+        return HydeResult(original_question=question.strip())
+
+    model = model or _resolve_generator_model()
+
+    try:
+        from openai import OpenAI
+        client = OpenAI(
+            base_url="https://openrouter.ai/api/v1",
+            api_key=api_key,
+            timeout=timeout,
+        )
+        from attestor.llm_trace import traced_create
+        response = traced_create(
+            client,
+            role="hyde_generator",
+            model=model,
+            max_tokens=400,
+            messages=[
+                {"role": "user", "content": _GENERATOR_PROMPT.format(
+                    question=question,
+                )},
+            ],
+        )
+        text = (response.choices[0].message.content or "").strip()
+    except Exception as e:  # noqa: BLE001
+        logger.debug("hyde.generate: LLM call failed: %s", e)
+        return HydeResult(original_question=question.strip())
+
+    # Strip any leading "Hypothetical answer:" label the model may echo.
+    if text.lower().startswith("hypothetical answer:"):
+        text = text[len("hypothetical answer:"):].strip()
+
+    from attestor import trace as _tr
+    if _tr.is_enabled():
+        _tr.event(
+            "recall.hyde.generated",
+            original=question[:200],
+            hypothetical_length=len(text),
+            hypothetical_preview=text[:200],
+        )
+
+    return HydeResult(
+        original_question=question.strip(),
+        hypothetical_answer=text,
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# End-to-end lane
+# ──────────────────────────────────────────────────────────────────────
+
+
+def hyde_search(
+    question: str,
+    *,
+    vector_search: Callable[[str], List[Dict[str, Any]]],
+    model: Optional[str] = None,
+    merge: str = "rrf",
+    api_key: Optional[str] = None,
+) -> Tuple[List[str], List[Dict[str, Any]]]:
+    """Run the generator, fan out to ``vector_search`` for each query
+    (original + hypothetical), merge the lanes, return
+    ``(queries_used, merged_hits)``.
+
+    Same pattern as ``attestor.retrieval.multi_query.multi_query_search``
+    — RRF helpers are imported from there to avoid duplication. Falls
+    back to single-query when generation fails (queries_used == [original]).
+    """
+    result = generate_hypothetical_answer(
+        question, model=model, api_key=api_key,
+    )
+    queries = result.queries
+
+    lanes: List[List[Dict[str, Any]]] = []
+    for q in queries:
+        try:
+            hits = list(vector_search(q))
+        except Exception as e:  # noqa: BLE001
+            logger.debug("hyde: lane %r failed: %s", q[:60], e)
+            hits = []
+        lanes.append(hits)
+
+    # Reuse multi_query's merge helpers — same RRF k=60, same union
+    # behavior. Single source of truth for ranked-list fusion.
+    from attestor.retrieval.multi_query import (
+        reciprocal_rank_fusion, union_merge,
+    )
+    if merge == "union":
+        merged = union_merge(lanes)
+    else:
+        merged = reciprocal_rank_fusion(lanes)
+
+    from attestor import trace as _tr
+    if _tr.is_enabled():
+        _tr.event(
+            "recall.hyde.merged",
+            n_queries=len(queries),
+            per_lane_sizes=[len(l) for l in lanes],
+            merged_size=len(merged),
+            merge_strategy=merge,
+        )
+
+    return queries, merged

--- a/attestor/retrieval/orchestrator.py
+++ b/attestor/retrieval/orchestrator.py
@@ -92,6 +92,14 @@ class RetrievalOrchestrator:
         # ``time_window`` kwarg before Step 1 runs.
         self.temporal_prefilter_cfg = None  # type: ignore[assignment]
 
+        # HyDE retrieval (Phase 3 PR-D). Sibling of multi_query.
+        # Defaults to None — no behavior change. AgentMemory wires
+        # the resolved HydeCfg post-construction. Mutually exclusive
+        # with multi_query in this PR — if both are enabled, the
+        # orchestrator prefers multi_query (it shipped first + has
+        # the longer track record) and logs a warning.
+        self.hyde_cfg = None  # type: ignore[assignment]
+
     # ── Helpers ──
 
     def _question_entities(self, query: str) -> List[str]:
@@ -316,9 +324,25 @@ class RetrievalOrchestrator:
             except Exception:
                 return []
 
+        # Path priority: multi_query > hyde > single. They are
+        # mutually exclusive in this PR — combining them is a future
+        # follow-up. If both flags are on, prefer multi_query (longer
+        # track record) and warn loudly so the operator notices.
+        path = "single"
         if self.vector_store:
             mq_cfg = getattr(self, "multi_query_cfg", None)
+            hyde_cfg = getattr(self, "hyde_cfg", None)
             mq_enabled = bool(getattr(mq_cfg, "enabled", False))
+            hyde_enabled = bool(getattr(hyde_cfg, "enabled", False))
+
+            if mq_enabled and hyde_enabled:
+                import logging as _log
+                _log.getLogger("attestor.retrieval.orchestrator").warning(
+                    "retrieval.multi_query and retrieval.hyde both enabled; "
+                    "preferring multi_query (HyDE skipped this run).",
+                )
+                hyde_enabled = False
+
             if mq_enabled:
                 from attestor.retrieval.multi_query import multi_query_search
 
@@ -329,6 +353,17 @@ class RetrievalOrchestrator:
                     merge=str(getattr(mq_cfg, "merge", "rrf")),
                     rewriter_model=getattr(mq_cfg, "rewriter_model", None),
                 )
+                path = "multi_query"
+            elif hyde_enabled:
+                from attestor.retrieval.hyde import hyde_search
+
+                mq_used, vector_hits_raw = hyde_search(
+                    query,
+                    vector_search=_single_vector_search,
+                    model=getattr(hyde_cfg, "generator_model", None),
+                    merge=str(getattr(hyde_cfg, "merge", "rrf")),
+                )
+                path = "hyde"
             else:
                 vector_hits_raw = _single_vector_search(query)
         if _tr.is_enabled():
@@ -336,6 +371,7 @@ class RetrievalOrchestrator:
                       top_k=self.vector_top_k, hit_count=len(vector_hits_raw),
                       multi_query=bool(mq_used),
                       n_queries=(len(mq_used) if mq_used else 1),
+                      path=path,
                       hits=[{"id": h.get("memory_id"),
                              "distance": round(float(h.get("distance", 1.0)), 4)}
                             for h in vector_hits_raw[:10]])

--- a/configs/attestor.yaml
+++ b/configs/attestor.yaml
@@ -188,6 +188,19 @@ stack:
       enabled: false
       tolerance_days: 3
 
+    # HyDE — Hypothetical Document Embedding (Phase 3 PR-D, +6-10% recall).
+    # When enabled, generates a hypothetical 1-2-sentence answer to
+    # the question via a small LLM and runs THAT through the vector
+    # lane in parallel with the original question. RRF-merges the two
+    # ranked lists. Disabled by default and mutually exclusive with
+    # multi_query — if both are on, multi_query wins (logged warning).
+    # Flip per bench run to measure the recall lift.
+    hyde:
+      enabled: false
+      generator_model: null              # null → models.extraction
+      generator_reasoning_effort: low
+      merge: rrf                         # rrf | union
+
   budget: 4000   # tokens for the pack sent to the answerer
 
   # Concurrency across samples in benchmark runs (LME / LoCoMo / BEAM).

--- a/tests/test_hyde.py
+++ b/tests/test_hyde.py
@@ -1,0 +1,264 @@
+"""Unit tests for the HyDE retrieval module.
+
+Mirror of `tests/test_multi_query.py` — same shape (mocked LLM,
+deterministic merge tests, lane-failure tolerance).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from attestor.retrieval.hyde import (
+    HydeResult,
+    generate_hypothetical_answer,
+    hyde_search,
+)
+
+
+# ── HydeResult.queries ────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_hyde_result_queries_includes_original_first() -> None:
+    r = HydeResult(
+        original_question="who is the cto",
+        hypothetical_answer="The CTO is Bob Patel.",
+    )
+    assert r.queries == ["who is the cto", "The CTO is Bob Patel."]
+
+
+@pytest.mark.unit
+def test_hyde_result_empty_hypothetical_returns_just_original() -> None:
+    """Degraded path: when generation failed, queries is just [original]
+    so the caller naturally falls back to single-query."""
+    r = HydeResult(original_question="x", hypothetical_answer="")
+    assert r.queries == ["x"]
+
+
+@pytest.mark.unit
+def test_hyde_result_whitespace_only_hypothetical_treated_as_empty() -> None:
+    r = HydeResult(original_question="x", hypothetical_answer="   \n  ")
+    assert r.queries == ["x"]
+
+
+# ── generate_hypothetical_answer ──────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_generate_no_api_key_returns_degraded(monkeypatch) -> None:
+    """No API key → return original-only result, never raise."""
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    r = generate_hypothetical_answer("who is alice")
+    assert r.original_question == "who is alice"
+    assert r.hypothetical_answer == ""
+
+
+@pytest.mark.unit
+def test_generate_empty_question_returns_degraded() -> None:
+    r = generate_hypothetical_answer("")
+    assert r.hypothetical_answer == ""
+
+
+@pytest.mark.unit
+def test_generate_with_mocked_llm_returns_hypothetical(monkeypatch) -> None:
+    """OpenAI is imported locally inside generate_hypothetical_answer
+    so we patch the source module (`openai.OpenAI`), not the alias."""
+    monkeypatch.setenv("OPENROUTER_API_KEY", "fake-test-key")
+
+    fake_response = MagicMock()
+    fake_response.choices = [
+        MagicMock(message=MagicMock(content="Bob Patel is the CTO.")),
+    ]
+    fake_response.id = "test-id"
+    fake_response.model = "test/model"
+    fake_response.usage = {
+        "prompt_tokens": 5, "completion_tokens": 8, "total_tokens": 13,
+    }
+
+    fake_client = MagicMock()
+    fake_client.chat.completions.create.return_value = fake_response
+
+    with patch("openai.OpenAI", return_value=fake_client):
+        r = generate_hypothetical_answer(
+            "who is the cto", model="test/m", api_key="fake",
+        )
+
+    assert "Bob Patel" in r.hypothetical_answer
+    assert r.original_question == "who is the cto"
+
+
+@pytest.mark.unit
+def test_generate_strips_label_prefix(monkeypatch) -> None:
+    """Some models echo the 'Hypothetical answer:' label — strip it."""
+    monkeypatch.setenv("OPENROUTER_API_KEY", "fake-test-key")
+
+    fake_response = MagicMock()
+    fake_response.choices = [MagicMock(message=MagicMock(
+        content="Hypothetical answer: Bob is CTO.",
+    ))]
+    fake_response.id = "x"
+    fake_response.model = "test/m"
+    fake_response.usage = {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+
+    fake_client = MagicMock()
+    fake_client.chat.completions.create.return_value = fake_response
+
+    with patch("openai.OpenAI", return_value=fake_client):
+        r = generate_hypothetical_answer("q?", model="test/m", api_key="fake")
+
+    assert not r.hypothetical_answer.lower().startswith("hypothetical answer:")
+    assert "Bob is CTO" in r.hypothetical_answer
+
+
+@pytest.mark.unit
+def test_generate_handles_llm_failure(monkeypatch) -> None:
+    """LLM call raises → return degraded result, never escape."""
+    monkeypatch.setenv("OPENROUTER_API_KEY", "fake-test-key")
+
+    fake_client = MagicMock()
+    fake_client.chat.completions.create.side_effect = RuntimeError("network down")
+
+    with patch("openai.OpenAI", return_value=fake_client):
+        r = generate_hypothetical_answer("q?", model="test/m", api_key="fake")
+
+    assert r.hypothetical_answer == ""
+    assert r.original_question == "q?"
+
+
+# ── hyde_search end-to-end (mocked) ───────────────────────────────────
+
+
+@pytest.mark.unit
+def test_hyde_search_runs_two_lanes_when_generation_succeeds(monkeypatch) -> None:
+    """generate succeeds → vector_search called once per (original, hypothetical)."""
+    from attestor.retrieval import hyde as _h
+
+    monkeypatch.setattr(
+        _h, "generate_hypothetical_answer",
+        lambda q, model=None, api_key=None, timeout=30.0: HydeResult(
+            original_question=q,
+            hypothetical_answer="Bob Patel is the new CTO.",
+        ),
+    )
+
+    calls: List[str] = []
+
+    def fake_search(q: str):
+        calls.append(q)
+        return [{"memory_id": f"{q[:5]}-hit", "distance": 0.1}]
+
+    queries, merged = hyde_search(
+        "who is the cto",
+        vector_search=fake_search,
+    )
+
+    assert queries == ["who is the cto", "Bob Patel is the new CTO."]
+    assert calls == queries
+    # Two distinct memories merged, each annotated with rrf_score
+    assert all("rrf_score" in h for h in merged)
+
+
+@pytest.mark.unit
+def test_hyde_search_falls_back_to_single_lane_on_degraded_gen(
+    monkeypatch,
+) -> None:
+    """When generator returns empty hypothetical, only the original
+    runs through vector_search."""
+    from attestor.retrieval import hyde as _h
+
+    monkeypatch.setattr(
+        _h, "generate_hypothetical_answer",
+        lambda q, model=None, api_key=None, timeout=30.0: HydeResult(
+            original_question=q, hypothetical_answer="",
+        ),
+    )
+
+    calls: List[str] = []
+
+    def fake_search(q: str):
+        calls.append(q)
+        return [{"memory_id": "a"}]
+
+    queries, merged = hyde_search("x", vector_search=fake_search)
+    assert queries == ["x"]
+    assert calls == ["x"]
+    assert len(merged) == 1
+
+
+@pytest.mark.unit
+def test_hyde_search_handles_lane_failure(monkeypatch) -> None:
+    """If one lane raises, the other lane's results still merge."""
+    from attestor.retrieval import hyde as _h
+
+    monkeypatch.setattr(
+        _h, "generate_hypothetical_answer",
+        lambda q, model=None, api_key=None, timeout=30.0: HydeResult(
+            original_question=q,
+            hypothetical_answer="hypo answer",
+        ),
+    )
+
+    def flaky_search(q: str):
+        if q == "x":
+            return [{"memory_id": "ok"}]
+        raise RuntimeError("hypothetical lane down")
+
+    queries, merged = hyde_search("x", vector_search=flaky_search)
+    assert {h["memory_id"] for h in merged} == {"ok"}
+
+
+@pytest.mark.unit
+def test_hyde_search_union_merge_strategy(monkeypatch) -> None:
+    """When merge='union', no rrf_score annotation; first-seen order."""
+    from attestor.retrieval import hyde as _h
+
+    monkeypatch.setattr(
+        _h, "generate_hypothetical_answer",
+        lambda q, model=None, api_key=None, timeout=30.0: HydeResult(
+            original_question=q, hypothetical_answer="hypo",
+        ),
+    )
+
+    def fake_search(q: str):
+        return [{"memory_id": q}]
+
+    queries, merged = hyde_search(
+        "x", vector_search=fake_search, merge="union",
+    )
+    assert "rrf_score" not in merged[0]
+    assert [h["memory_id"] for h in merged] == ["x", "hypo"]
+
+
+@pytest.mark.unit
+def test_hyde_search_consensus_outranks_lone_top(monkeypatch) -> None:
+    """A memory found in BOTH lanes should outrank one found in only
+    one lane — proves RRF actually drives the merge ordering, same
+    invariant as test_rrf_consensus_beats_one_off_top_rank in
+    test_multi_query.py."""
+    from attestor.retrieval import hyde as _h
+
+    monkeypatch.setattr(
+        _h, "generate_hypothetical_answer",
+        lambda q, model=None, api_key=None, timeout=30.0: HydeResult(
+            original_question=q, hypothetical_answer="hypo",
+        ),
+    )
+
+    def fake_search(q: str):
+        if q == "x":
+            return [
+                {"memory_id": "lone_top"},
+                {"memory_id": "consensus"},
+            ]
+        else:
+            # hypo lane: consensus at rank 1, no lone_top
+            return [{"memory_id": "consensus"}, {"memory_id": "y"}]
+
+    queries, merged = hyde_search("x", vector_search=fake_search)
+    ids = [h["memory_id"] for h in merged]
+    assert ids.index("consensus") < ids.index("lone_top"), (
+        f"RRF should lift consensus above lone_top; got {ids}"
+    )

--- a/tests/test_hyde_orchestrator.py
+++ b/tests/test_hyde_orchestrator.py
@@ -1,0 +1,274 @@
+"""Integration tests for the HyDE lane wired into the orchestrator.
+
+Mirror of `tests/test_multi_query_orchestrator.py` — same FakeStore /
+FakeVectorStore stubs, same wire-up assertions. Adds the
+HyDE-vs-multi_query mutual-exclusion check.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from attestor.config import HydeCfg, MultiQueryCfg
+from attestor.retrieval.hyde import HydeResult
+
+
+class FakeVectorStore:
+    """Records calls so tests can assert fan-out behavior."""
+
+    def __init__(self, hits_per_query: Dict[str, List[Dict]]):
+        self.hits_per_query = hits_per_query
+        self.calls: List[str] = []
+
+    def search(
+        self,
+        query: str,
+        *,
+        limit: int = 50,
+        namespace: Optional[str] = None,
+        **kwargs: Any,
+    ) -> List[Dict]:
+        self.calls.append(query)
+        return list(self.hits_per_query.get(query, []))
+
+
+class FakeStore:
+    """Real Memory dataclass instances keyed by id."""
+
+    def __init__(self):
+        self._mems: Dict[str, Any] = {}
+
+    def add_memory(self, memory_id: str, content: str = "x") -> None:
+        from attestor.models import Memory
+        self._mems[memory_id] = Memory(id=memory_id, content=content)
+
+    def get(self, memory_id: str):
+        return self._mems.get(memory_id)
+
+
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_hyde_disabled_runs_single_vector_call() -> None:
+    """hyde_cfg.enabled=False (default) → exactly one vector_store.search."""
+    from attestor.retrieval.orchestrator import RetrievalOrchestrator
+
+    store = FakeStore()
+    store.add_memory("a")
+    vec = FakeVectorStore({"x": [{"memory_id": "a", "distance": 0.1}]})
+
+    orch = RetrievalOrchestrator(store=store, vector_store=vec)
+    assert orch.hyde_cfg is None  # default
+
+    orch.recall("x")
+    assert vec.calls == ["x"]
+
+
+@pytest.mark.unit
+def test_hyde_enabled_fans_out_to_two_lanes(monkeypatch) -> None:
+    """hyde_cfg.enabled=True + mocked generator → 2 vector_search calls."""
+    from attestor.retrieval.orchestrator import RetrievalOrchestrator
+    from attestor.retrieval import hyde as _h
+
+    store = FakeStore()
+    store.add_memory("a")
+    store.add_memory("b")
+    vec = FakeVectorStore({
+        "x":          [{"memory_id": "a", "distance": 0.1}],
+        "hypo answer": [{"memory_id": "b", "distance": 0.2}],
+    })
+
+    monkeypatch.setattr(
+        _h, "generate_hypothetical_answer",
+        lambda q, model=None, api_key=None, timeout=30.0: HydeResult(
+            original_question=q, hypothetical_answer="hypo answer",
+        ),
+    )
+
+    orch = RetrievalOrchestrator(store=store, vector_store=vec)
+    orch.hyde_cfg = HydeCfg(enabled=True)
+
+    orch.recall("x")
+    assert vec.calls == ["x", "hypo answer"]
+
+
+@pytest.mark.unit
+def test_hyde_and_multi_query_both_enabled_prefers_multi_query(
+    monkeypatch, caplog,
+) -> None:
+    """Mutual exclusion: when both flags are True, multi_query wins
+    and a warning is logged. HyDE's generator MUST NOT run."""
+    from attestor.retrieval.orchestrator import RetrievalOrchestrator
+    from attestor.retrieval import multi_query as _mq
+    from attestor.retrieval import hyde as _h
+    from attestor.retrieval.multi_query import RewriteResult
+
+    store = FakeStore()
+    store.add_memory("a")
+    vec = FakeVectorStore({
+        "x":     [{"memory_id": "a", "distance": 0.1}],
+        "x v1":  [{"memory_id": "a", "distance": 0.1}],
+    })
+
+    # Stub both rewriters; we'll assert which one fires.
+    mq_called = []
+    hyde_called = []
+
+    def stub_mq_rewrite(q, n=3, model=None, api_key=None, timeout=30.0):
+        mq_called.append(q)
+        return RewriteResult(original=q, paraphrases=["x v1"])
+
+    def stub_hyde_gen(q, model=None, api_key=None, timeout=30.0):
+        hyde_called.append(q)
+        return HydeResult(original_question=q, hypothetical_answer="hypo")
+
+    monkeypatch.setattr(_mq, "rewrite_query", stub_mq_rewrite)
+    monkeypatch.setattr(_h, "generate_hypothetical_answer", stub_hyde_gen)
+
+    orch = RetrievalOrchestrator(store=store, vector_store=vec)
+    orch.multi_query_cfg = MultiQueryCfg(enabled=True, n=1)
+    orch.hyde_cfg = HydeCfg(enabled=True)
+
+    with caplog.at_level("WARNING"):
+        orch.recall("x")
+
+    assert mq_called, "multi_query rewriter should have fired"
+    assert not hyde_called, "HyDE generator must NOT fire when multi_query wins"
+    assert any(
+        "multi_query and retrieval.hyde both enabled" in rec.message
+        for rec in caplog.records
+    ), "expected mutual-exclusion warning in log"
+
+
+@pytest.mark.unit
+def test_hyde_consensus_hit_outranks_lone_top(monkeypatch) -> None:
+    """A memory in both lanes should outrank a lane-1 hit thanks to
+    RRF fusion (mirror of multi_query's analogous test)."""
+    from attestor.retrieval.orchestrator import RetrievalOrchestrator
+    from attestor.retrieval import hyde as _h
+
+    store = FakeStore()
+    store.add_memory("consensus")
+    store.add_memory("lone_top")
+    for i in range(3):
+        store.add_memory(f"x{i}")
+
+    vec = FakeVectorStore({
+        "q": [
+            {"memory_id": "lone_top", "distance": 0.05},
+            {"memory_id": "x0", "distance": 0.1},
+            {"memory_id": "x1", "distance": 0.15},
+            {"memory_id": "x2", "distance": 0.2},
+            {"memory_id": "consensus", "distance": 0.25},
+        ],
+        "hypo": [
+            {"memory_id": "consensus", "distance": 0.05},
+        ],
+    })
+
+    monkeypatch.setattr(
+        _h, "generate_hypothetical_answer",
+        lambda q, model=None, api_key=None, timeout=30.0: HydeResult(
+            original_question=q, hypothetical_answer="hypo",
+        ),
+    )
+
+    orch = RetrievalOrchestrator(store=store, vector_store=vec)
+    orch.hyde_cfg = HydeCfg(enabled=True)
+    orch.enable_mmr = False  # isolate the HyDE/RRF effect
+
+    results = orch.recall("q")
+    ids = [r.memory.id for r in results]
+    assert "consensus" in ids
+    assert "lone_top" in ids
+    assert ids.index("consensus") < ids.index("lone_top"), (
+        f"RRF should lift consensus above lone_top; got {ids}"
+    )
+
+
+@pytest.mark.unit
+def test_yaml_loader_parses_hyde_block(tmp_path) -> None:
+    """retrieval.hyde block flows through to RetrievalCfg.hyde."""
+    from attestor.config import load_stack
+
+    yaml_path = tmp_path / "test_attestor.yaml"
+    yaml_path.write_text(
+        """
+stack:
+  postgres:
+    url: postgresql://x/y
+  neo4j:
+    url: bolt://localhost:7687
+    auth: { username: neo4j, password: pw }
+  embedder:
+    provider: voyage
+    model: voyage-4
+    dimensions: 1024
+  models:
+    answerer: x
+    judge: x
+    extraction: x
+    distill: x
+    verifier: x
+    planner: x
+    benchmark_default: x
+  llm:
+    provider: openrouter
+  retrieval:
+    vector_top_k: 50
+    hyde:
+      enabled: true
+      generator_model: openai/custom
+      generator_reasoning_effort: medium
+      merge: union
+""",
+    )
+    stack = load_stack(yaml_path)
+    h = stack.retrieval.hyde
+    assert h.enabled is True
+    assert h.generator_model == "openai/custom"
+    assert h.generator_reasoning_effort == "medium"
+    assert h.merge == "union"
+
+
+@pytest.mark.unit
+def test_yaml_loader_defaults_hyde_to_disabled(tmp_path) -> None:
+    """When retrieval.hyde is omitted, defaults apply (enabled=False,
+    merge=rrf, generator_model=None)."""
+    from attestor.config import load_stack
+
+    yaml_path = tmp_path / "test_attestor.yaml"
+    yaml_path.write_text(
+        """
+stack:
+  postgres:
+    url: postgresql://x/y
+  neo4j:
+    url: bolt://localhost:7687
+    auth: { username: neo4j, password: pw }
+  embedder:
+    provider: voyage
+    model: voyage-4
+    dimensions: 1024
+  models:
+    answerer: x
+    judge: x
+    extraction: x
+    distill: x
+    verifier: x
+    planner: x
+    benchmark_default: x
+  llm:
+    provider: openrouter
+  retrieval:
+    vector_top_k: 50
+""",
+    )
+    stack = load_stack(yaml_path)
+    h = stack.retrieval.hyde
+    assert h.enabled is False
+    assert h.generator_model is None
+    assert h.merge == "rrf"


### PR DESCRIPTION
## Summary

Sibling of multi-query (PR #94), shipping the +6-10% recall lever. Generates a 1-2-sentence hypothetical answer to the question via a small LLM, embeds it, runs as a parallel vector lane, and RRF-merges with the original-question lane.

## How it works

1. **Generate** — LLM (defaults to `models.extraction`) writes a hypothetical answer in declarative form
2. **Fan out** — vector_store.search runs once per (original, hypothetical)
3. **RRF merge** — reuses `attestor/retrieval/multi_query.py`'s tested `reciprocal_rank_fusion` so consensus hits across the two lanes outrank lone hits
4. **Pipeline continues** — BM25, graph, MMR, budget fit all unchanged. Step 2's rank-derived sim logic (shipped in PR #94) handles HyDE-merged candidates automatically.

## Mutual exclusion

`multi_query` and `hyde` cannot both run in this PR. If both flags are on, `multi_query` wins with a logged warning. Combination left for a follow-up.

## Files

- **New:** `attestor/retrieval/hyde.py` (245 LOC), `tests/test_hyde.py` (13 tests), `tests/test_hyde_orchestrator.py` (6 tests)
- **Modified:** `attestor/config.py` (HydeCfg + loader), `attestor/core.py` (AgentMemory wire), `attestor/retrieval/orchestrator.py` (Step 1 dispatch), `configs/attestor.yaml` (retrieval.hyde block)

## Test plan

- [x] `pytest tests/test_hyde.py tests/test_hyde_orchestrator.py` — 19/19
- [x] Full unit suite: 976 passed (no regressions)
- [x] Mutual-exclusion warning fires when both `multi_query.enabled` and `hyde.enabled` are True; HyDE generator does NOT fire
- [x] RRF consensus lift verified — a memory in both lanes outranks a memory found in only one
- [ ] User-driven: enable in `configs/attestor.yaml` and run a bench slice to measure the +6-10% lift