### PR TITLE
feat(bench): trend.csv tracking + README retrieval-features section

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,19 +336,50 @@ If one slice fails, the script logs it and moves on to the next.
 Aggregates every `docs/bench/lme-*.summary.json` into one markdown table; picks the most-recent file per `(variant, category)`:
 
 ```bash
-.venv/bin/python scripts/bench/lme_report.py                       # stdout
-.venv/bin/python scripts/bench/lme_report.py --variant s           # filter
+.venv/bin/python scripts/bench/lme_report.py                       # latest-per-slice
+.venv/bin/python scripts/bench/lme_report.py --variant s           # filter to LME-S
 .venv/bin/python scripts/bench/lme_report.py \
     --markdown-out docs/bench/LME-S.md                             # also write file
+.venv/bin/python scripts/bench/lme_report.py --trend               # progression over time
 ```
 
-Output shape:
+Default mode (latest-per-slice):
 
 ```
 | Variant | Category | Score | N | Date | Answer | Judges |
 | ------- | -------- | -----:| -:| ---- | ------ | ------ |
 | s | knowledge-update | 87.5% | 78 | 20260429 | openai/gpt-5.4-mini | openai/gpt-5.5, anthropic/claude-sonnet-4-6 |
 ```
+
+Trend mode (`--trend`) reads `docs/bench/trend.csv` — one row appended per bench run (auto-populated by `lme_run.sh`) — and shows progression with a `Δ` column:
+
+```
+| Variant | Category | Date | N | Score | Δ | SHA | Features | Run |
+| ------- | -------- | ---- | -:| -----:| -:| --- | -------- | --- |
+| s | knowledge-update | 20260429 | 78 | 80.0% |       | a126e7a |               | bench |
+| s | knowledge-update | 20260430 | 78 | 88.0% | +8.0  | badcf1b | multi_query   | bench |
+| s | knowledge-update | 20260501 | 78 | 91.5% | +3.5  | xxxxxxx | multi_query,hyde | bench |
+```
+
+The `Features` column records exactly which retrieval/answerer flags were enabled per run, so you can see at a glance which knob produced which lift.
+
+### Retrieval + answerer feature flags
+
+Five orthogonal features land via `configs/attestor.yaml` boolean flips. All disabled by default — pick one per bench run, measure the lift, decide which to ship enabled.
+
+| Flag | Section | Estimated lift (literature) | Cost overhead |
+|---|---|---|---|
+| `retrieval.multi_query` | rewrite question into N paraphrases, RRF-merge N+1 vector lanes | +6-10% | 1 small LLM call + N extra vector searches per recall |
+| `retrieval.hyde` | generate hypothetical answer, embed it as a parallel vector lane | +6-10% | 1 small LLM call + 1 extra vector search per recall |
+| `retrieval.temporal_prefilter` | regex-detect "two weeks ago" etc; narrow event-time window before vector | +1.5% | Free (regex-only, no LLM) |
+| `self_consistency` | answerer draws K=5 samples at temperature, elects consensus | +3-6% | 5× answerer cost |
+| `critique_revise` | answer → critique → conditional revise | +3-5% | ~3× answerer worst case |
+
+`multi_query` and `hyde` are mutually exclusive in this release (multi_query wins if both flags are on with a logged warning). `self_consistency` and `critique_revise` are similarly mutually exclusive on the answerer side. Combinations across the two sides (e.g. `multi_query + self_consistency`) are fine.
+
+**To benchmark a single feature:** flip its `enabled: true` in `configs/attestor.yaml`, run the bench slice, compare against a same-day baseline run with everything off. The trend table will show the delta in the `Δ` column.
+
+**Estimated lifts above are from the published literature** — the numbers Attestor actually delivers on LME-S are produced by user-driven bench runs and surfaced via `lme_report.py --trend` once enough data points have accumulated.
 
 ### Synthetic supersession suite — `python -m evals.knowledge_updates`
 

--- a/scripts/bench/lme_report.py
+++ b/scripts/bench/lme_report.py
@@ -42,6 +42,15 @@ def _parse_args() -> argparse.Namespace:
         "--markdown-out", default=None,
         help="Write the markdown table to this path in addition to stdout.",
     )
+    p.add_argument(
+        "--trend", action="store_true",
+        help=(
+            "Read docs/bench/trend.csv (path from bench.yaml's "
+            "report.trend_csv) and emit a chronological per-(variant, "
+            "category) progression table with deltas. Replaces the "
+            "default summary view."
+        ),
+    )
     return p.parse_args()
 
 
@@ -114,8 +123,16 @@ def main(argv: Optional[List[str]] = None) -> int:
     cfg = get_bench()
     output_dir = ROOT / cfg.lme.output_dir
 
-    rows = _scan_summaries(output_dir)
-    md = _format_markdown(rows, variant_filter=args.variant)
+    if args.trend:
+        from scripts.bench.trend import format_trend_markdown, read_trend
+        trend_path = ROOT / cfg.report.trend_csv
+        rows = read_trend(trend_path)
+        if args.variant:
+            rows = [r for r in rows if r.get("variant") == args.variant]
+        md = format_trend_markdown(rows)
+    else:
+        rows = _scan_summaries(output_dir)
+        md = _format_markdown(rows, variant_filter=args.variant)
 
     print(md)
 

--- a/scripts/bench/trend.py
+++ b/scripts/bench/trend.py
@@ -1,0 +1,238 @@
+"""Trend.csv accumulator + reader for LME bench runs.
+
+One row appended per bench summary persisted by ``scripts/lme_smoke_local.py``.
+The CSV lives at the path configured in ``configs/bench.yaml``'s
+``report.trend_csv`` (default ``docs/bench/trend.csv``) and grows monotonically
+across runs so the team can see the score curve over time.
+
+Schema (CSV columns):
+    timestamp        ISO 8601 UTC, sub-second resolution
+    date             YYYYMMDD, for fast date filtering
+    git_sha          short hash of HEAD at run time (or ``unknown``)
+    variant          s | m | oracle
+    category         single slice name or ``all``
+    n                number of samples scored
+    score_pct        primary metric (0-100 float)
+    answer_model     models.answerer at run time
+    judges           semicolon-separated judge models
+    features         comma-separated feature flags that were enabled
+                     (multi_query, hyde, temporal_prefilter,
+                     self_consistency, critique_revise) — empty when
+                     all flags were default (off)
+    run_label        free-text marker for ad-hoc runs
+
+The schema is intentionally append-only and forward-compatible: new
+columns can be added at the right edge without breaking existing
+readers (the report uses ``DictReader`` so missing columns just yield
+None).
+"""
+
+from __future__ import annotations
+
+import csv
+import os
+import subprocess
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+TREND_HEADERS = (
+    "timestamp",
+    "date",
+    "git_sha",
+    "variant",
+    "category",
+    "n",
+    "score_pct",
+    "answer_model",
+    "judges",
+    "features",
+    "run_label",
+)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Helpers
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _git_sha_short(repo_root: Optional[Path] = None) -> str:
+    """Return the short HEAD hash, or ``unknown`` when git is unavailable
+    or the repo isn't initialized. Defensive — bench tracking must not
+    crash because of git.
+    """
+    try:
+        out = subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"],
+            cwd=str(repo_root) if repo_root else None,
+            stderr=subprocess.DEVNULL,
+        )
+        return out.decode("utf-8", errors="replace").strip() or "unknown"
+    except Exception:  # noqa: BLE001
+        return "unknown"
+
+
+def _features_from_stack(stack: Any) -> List[str]:
+    """Inspect a StackConfig and list the retrieval/answerer features
+    that are currently enabled. Used to record what was on for a given
+    bench run.
+    """
+    enabled: List[str] = []
+    retr = getattr(stack, "retrieval", None)
+    if retr is not None:
+        for name in ("multi_query", "hyde", "temporal_prefilter"):
+            cfg = getattr(retr, name, None)
+            if cfg is not None and getattr(cfg, "enabled", False):
+                enabled.append(name)
+    for name in ("self_consistency", "critique_revise"):
+        cfg = getattr(stack, name, None)
+        if cfg is not None and getattr(cfg, "enabled", False):
+            enabled.append(name)
+    return enabled
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Append a row
+# ──────────────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class TrendRow:
+    """One bench run, one row. All fields are stringly-typed at write
+    time because CSV is stringly-typed at read time anyway — keeps the
+    appender simple and the schema robust to extension."""
+
+    timestamp: str
+    date: str
+    git_sha: str
+    variant: str
+    category: str
+    n: int
+    score_pct: float
+    answer_model: str
+    judges: str
+    features: str
+    run_label: str
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {h: getattr(self, h) for h in TREND_HEADERS}
+
+
+def append_trend_row(
+    csv_path: Path | str,
+    *,
+    summary: Dict[str, Any],
+    variant: str,
+    category: Optional[str],
+    features: List[str],
+    git_sha: Optional[str] = None,
+    run_label: str = "",
+) -> TrendRow:
+    """Append one row to ``csv_path``. Creates the file with headers
+    if missing, writes only the data row otherwise. Returns the row
+    that was appended for logging.
+
+    ``summary`` is the BenchmarkSummary dict (``primary_metric``,
+    ``total``, ``metadata.{answer_model, judges}``).
+    """
+    p = Path(csv_path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+
+    now = datetime.now(timezone.utc)
+    metadata = summary.get("metadata") or {}
+    judges = metadata.get("judges") or []
+    if isinstance(judges, list):
+        judges_str = ";".join(str(j) for j in judges)
+    else:
+        judges_str = str(judges)
+
+    row = TrendRow(
+        timestamp=now.isoformat(),
+        date=now.strftime("%Y%m%d"),
+        git_sha=(git_sha if git_sha is not None else _git_sha_short()),
+        variant=str(variant),
+        category=str(category or "all"),
+        n=int(summary.get("total", 0)),
+        score_pct=float(summary.get("primary_metric", 0.0)),
+        answer_model=str(metadata.get("answer_model", "")),
+        judges=judges_str,
+        features=",".join(features),
+        run_label=str(run_label),
+    )
+
+    write_headers = not p.exists()
+    with p.open("a", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=list(TREND_HEADERS))
+        if write_headers:
+            writer.writeheader()
+        writer.writerow(row.as_dict())
+
+    return row
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Reader + markdown formatter
+# ──────────────────────────────────────────────────────────────────────
+
+
+def read_trend(csv_path: Path | str) -> List[Dict[str, Any]]:
+    """Read every row from ``csv_path``. Empty / missing → empty list."""
+    p = Path(csv_path)
+    if not p.exists():
+        return []
+    with p.open("r", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+    return rows
+
+
+def _coerce(row: Dict[str, Any]) -> Dict[str, Any]:
+    """Convert numeric fields to numeric types; leave others as strings."""
+    out = dict(row)
+    try:
+        out["score_pct"] = float(row.get("score_pct", 0.0))
+    except (TypeError, ValueError):
+        out["score_pct"] = 0.0
+    try:
+        out["n"] = int(row.get("n", 0))
+    except (TypeError, ValueError):
+        out["n"] = 0
+    return out
+
+
+def format_trend_markdown(rows: List[Dict[str, Any]]) -> str:
+    """Render the trend as a markdown table grouped by (variant, category).
+    Within each group, rows are sorted by timestamp ascending and a
+    ``Δ`` column shows the score delta from the previous run in the
+    same group.
+    """
+    if not rows:
+        return (
+            "_No trend rows yet. Bench runs append to "
+            "`docs/bench/trend.csv`; come back after the first run._\n"
+        )
+
+    rows = [_coerce(r) for r in rows]
+    rows.sort(key=lambda r: (
+        r.get("variant", ""), r.get("category", ""), r.get("timestamp", ""),
+    ))
+
+    lines = [
+        "| Variant | Category | Date | N | Score | Δ | SHA | Features | Run |",
+        "| ------- | -------- | ---- | -:| -----:| -:| --- | -------- | --- |",
+    ]
+    prev_score: Dict[tuple, float] = {}
+    for r in rows:
+        key = (r.get("variant", ""), r.get("category", ""))
+        prev = prev_score.get(key)
+        delta = "" if prev is None else f"{r['score_pct'] - prev:+.1f}"
+        lines.append(
+            f"| {r.get('variant','')} | {r.get('category','')} | "
+            f"{r.get('date','')} | {r['n']} | {r['score_pct']:.1f}% | "
+            f"{delta} | {r.get('git_sha','')} | {r.get('features','')} | "
+            f"{r.get('run_label','')} |"
+        )
+        prev_score[key] = r["score_pct"]
+    return "\n".join(lines) + "\n"

--- a/scripts/lme_smoke_local.py
+++ b/scripts/lme_smoke_local.py
@@ -273,6 +273,36 @@ async def _run(args: argparse.Namespace, stack: StackConfig) -> None:
         )
         print(f"[{RUN_LABEL}] persisted → {base}.{{report,summary}}.json")
 
+        # Append one row to docs/bench/trend.csv so the report tooling
+        # can show progression over time. Defensive: trend tracking is
+        # optional — never break the bench because of a CSV write.
+        try:
+            from scripts.bench.trend import (
+                append_trend_row, _features_from_stack,
+            )
+            from attestor.bench_config import get_bench
+
+            bench_cfg = get_bench()
+            trend_path = ROOT / bench_cfg.report.trend_csv
+            features = _features_from_stack(stack)
+            row = append_trend_row(
+                trend_path,
+                summary=summary.to_dict(),
+                variant=args.variant,
+                category=args.category,
+                features=features,
+                run_label=RUN_LABEL,
+            )
+            print(
+                f"[{RUN_LABEL}] trend row appended → "
+                f"{trend_path.relative_to(ROOT)} "
+                f"(score={row.score_pct:.1f}%, features={row.features or 'none'})",
+            )
+        except Exception as e:  # noqa: BLE001
+            sys.stderr.write(
+                f"[{RUN_LABEL}] warning: trend.csv append failed — {e}\n"
+            )
+
 
 def main() -> int:
     args = _parse_args()

--- a/tests/test_bench_trend.py
+++ b/tests/test_bench_trend.py
@@ -1,0 +1,298 @@
+"""Unit tests for the bench trend.csv accumulator + reader."""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from scripts.bench.trend import (
+    TREND_HEADERS,
+    _features_from_stack,
+    append_trend_row,
+    format_trend_markdown,
+    read_trend,
+)
+
+
+# ── append_trend_row ──────────────────────────────────────────────────
+
+
+@pytest.fixture
+def summary_dict() -> dict:
+    return {
+        "primary_metric": 87.5,
+        "primary_metric_name": "accuracy_pct",
+        "total": 78,
+        "metadata": {
+            "answer_model": "openai/gpt-5.4-mini",
+            "judges": ["openai/gpt-5.5", "anthropic/claude-sonnet-4-6"],
+        },
+    }
+
+
+@pytest.mark.unit
+def test_append_creates_file_with_headers(tmp_path, summary_dict) -> None:
+    p = tmp_path / "trend.csv"
+    append_trend_row(
+        p,
+        summary=summary_dict,
+        variant="s",
+        category="knowledge-update",
+        features=["multi_query"],
+        git_sha="abc1234",
+    )
+    text = p.read_text().splitlines()
+    assert text[0].startswith("timestamp,")  # header line
+    # All schema columns present in the header
+    for h in TREND_HEADERS:
+        assert h in text[0]
+    # One data row
+    assert len(text) == 2
+
+
+@pytest.mark.unit
+def test_append_subsequent_rows_skip_headers(tmp_path, summary_dict) -> None:
+    p = tmp_path / "trend.csv"
+    for _ in range(3):
+        append_trend_row(
+            p,
+            summary=summary_dict,
+            variant="s",
+            category="knowledge-update",
+            features=["hyde"],
+            git_sha="abc1234",
+        )
+    rows = list(csv.DictReader(p.open()))
+    assert len(rows) == 3, f"expected 3 data rows, got {len(rows)}"
+    # All same input → all rows have same fingerprint
+    assert all(r["score_pct"] == "87.5" for r in rows)
+
+
+@pytest.mark.unit
+def test_append_records_features_and_metadata(tmp_path, summary_dict) -> None:
+    p = tmp_path / "trend.csv"
+    row = append_trend_row(
+        p,
+        summary=summary_dict,
+        variant="s",
+        category="multi-session",
+        features=["multi_query", "hyde", "self_consistency"],
+        git_sha="deadbee",
+        run_label="ablation_a",
+    )
+    assert row.features == "multi_query,hyde,self_consistency"
+    assert row.git_sha == "deadbee"
+    assert row.run_label == "ablation_a"
+    assert row.judges == "openai/gpt-5.5;anthropic/claude-sonnet-4-6"
+    assert row.score_pct == 87.5
+    assert row.n == 78
+
+
+@pytest.mark.unit
+def test_append_handles_empty_features_list(tmp_path, summary_dict) -> None:
+    p = tmp_path / "trend.csv"
+    row = append_trend_row(
+        p, summary=summary_dict, variant="s", category=None,
+        features=[], git_sha="x",
+    )
+    assert row.features == ""
+    assert row.category == "all"  # None → "all" canonicalization
+
+
+@pytest.mark.unit
+def test_append_creates_parent_dir(tmp_path, summary_dict) -> None:
+    p = tmp_path / "nested" / "deeper" / "trend.csv"
+    append_trend_row(
+        p, summary=summary_dict, variant="s", category="x",
+        features=[], git_sha="x",
+    )
+    assert p.exists()
+
+
+# ── read_trend ────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_read_trend_empty_file_returns_empty(tmp_path) -> None:
+    assert read_trend(tmp_path / "missing.csv") == []
+
+
+@pytest.mark.unit
+def test_read_trend_round_trip(tmp_path, summary_dict) -> None:
+    p = tmp_path / "trend.csv"
+    append_trend_row(
+        p, summary=summary_dict, variant="s", category="x",
+        features=["multi_query"], git_sha="abc",
+    )
+    rows = read_trend(p)
+    assert len(rows) == 1
+    assert rows[0]["variant"] == "s"
+    assert rows[0]["category"] == "x"
+    assert rows[0]["features"] == "multi_query"
+
+
+# ── format_trend_markdown ─────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_format_trend_empty_returns_placeholder() -> None:
+    md = format_trend_markdown([])
+    assert "No trend rows yet" in md
+
+
+@pytest.mark.unit
+def test_format_trend_renders_table_headers() -> None:
+    rows = [{
+        "timestamp": "2026-04-29T14:00:00+00:00",
+        "date": "20260429",
+        "git_sha": "abc",
+        "variant": "s",
+        "category": "knowledge-update",
+        "n": "78",
+        "score_pct": "87.5",
+        "answer_model": "x",
+        "judges": "j1;j2",
+        "features": "multi_query",
+        "run_label": "smoke",
+    }]
+    md = format_trend_markdown(rows)
+    assert "| Variant | Category | Date" in md
+    assert "knowledge-update" in md
+    assert "87.5%" in md
+
+
+@pytest.mark.unit
+def test_format_trend_computes_deltas_within_group() -> None:
+    """Two rows in the same (variant, category) → second shows delta
+    against the first."""
+    rows = [
+        {
+            "timestamp": "2026-04-29T10:00:00+00:00",
+            "date": "20260429",
+            "git_sha": "a",
+            "variant": "s",
+            "category": "knowledge-update",
+            "n": "78",
+            "score_pct": "80.0",
+            "answer_model": "x",
+            "judges": "j",
+            "features": "",
+            "run_label": "",
+        },
+        {
+            "timestamp": "2026-04-29T11:00:00+00:00",
+            "date": "20260429",
+            "git_sha": "b",
+            "variant": "s",
+            "category": "knowledge-update",
+            "n": "78",
+            "score_pct": "88.0",
+            "answer_model": "x",
+            "judges": "j",
+            "features": "multi_query",
+            "run_label": "",
+        },
+    ]
+    md = format_trend_markdown(rows)
+    # First row has no delta (no previous in group)
+    # Second row shows +8.0
+    assert "+8.0" in md
+
+
+@pytest.mark.unit
+def test_format_trend_groups_by_variant_and_category() -> None:
+    """Different (variant, category) groups don't share the delta lineage."""
+    rows = [
+        {
+            "timestamp": "2026-04-29T10:00:00+00:00",
+            "date": "20260429", "git_sha": "a",
+            "variant": "s", "category": "X",
+            "n": "10", "score_pct": "80.0",
+            "answer_model": "x", "judges": "j",
+            "features": "", "run_label": "",
+        },
+        {
+            "timestamp": "2026-04-29T11:00:00+00:00",
+            "date": "20260429", "git_sha": "b",
+            "variant": "s", "category": "Y",
+            "n": "10", "score_pct": "90.0",
+            "answer_model": "x", "judges": "j",
+            "features": "", "run_label": "",
+        },
+    ]
+    md = format_trend_markdown(rows)
+    # Y row should NOT have a delta because it's in a different group
+    # from X. Verify by counting "+" or "-" delta markers — there should
+    # be 0 (each is the first in its group).
+    assert "+10.0" not in md
+    assert "-10.0" not in md
+
+
+# ── _features_from_stack ──────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_features_from_stack_default_off() -> None:
+    """A default StackConfig has all feature flags off → empty list."""
+    from attestor.config import (
+        HydeCfg, MultiQueryCfg, RetrievalCfg,
+        SelfConsistencyCfg, CritiqueReviseCfg, TemporalPrefilterCfg,
+    )
+
+    stack = SimpleNamespace(
+        retrieval=RetrievalCfg(
+            multi_query=MultiQueryCfg(enabled=False),
+            temporal_prefilter=TemporalPrefilterCfg(enabled=False),
+            hyde=HydeCfg(enabled=False),
+        ),
+        self_consistency=SelfConsistencyCfg(enabled=False),
+        critique_revise=CritiqueReviseCfg(enabled=False),
+    )
+    assert _features_from_stack(stack) == []
+
+
+@pytest.mark.unit
+def test_features_from_stack_all_on() -> None:
+    """Every flag flipped on → all 5 names appear in feature list."""
+    from attestor.config import (
+        HydeCfg, MultiQueryCfg, RetrievalCfg,
+        SelfConsistencyCfg, CritiqueReviseCfg, TemporalPrefilterCfg,
+    )
+
+    stack = SimpleNamespace(
+        retrieval=RetrievalCfg(
+            multi_query=MultiQueryCfg(enabled=True),
+            temporal_prefilter=TemporalPrefilterCfg(enabled=True),
+            hyde=HydeCfg(enabled=True),
+        ),
+        self_consistency=SelfConsistencyCfg(enabled=True),
+        critique_revise=CritiqueReviseCfg(enabled=True),
+    )
+    features = _features_from_stack(stack)
+    assert set(features) == {
+        "multi_query", "hyde", "temporal_prefilter",
+        "self_consistency", "critique_revise",
+    }
+
+
+@pytest.mark.unit
+def test_features_from_stack_mixed() -> None:
+    from attestor.config import (
+        HydeCfg, MultiQueryCfg, RetrievalCfg,
+        SelfConsistencyCfg, CritiqueReviseCfg, TemporalPrefilterCfg,
+    )
+
+    stack = SimpleNamespace(
+        retrieval=RetrievalCfg(
+            multi_query=MultiQueryCfg(enabled=True),
+            temporal_prefilter=TemporalPrefilterCfg(enabled=False),
+            hyde=HydeCfg(enabled=False),
+        ),
+        self_consistency=SelfConsistencyCfg(enabled=True),
+        critique_revise=CritiqueReviseCfg(enabled=False),
+    )
+    features = _features_from_stack(stack)
+    assert features == ["multi_query", "self_consistency"]


### PR DESCRIPTION
## Summary

Phase 4a (README) + Phase 4b (trend tracking) shipped together since the README documents what 4b adds.

## Phase 4b — trend.csv tracking

- **New module**: `scripts/bench/trend.py` — append-only CSV accumulator + markdown formatter
- **Auto-append**: every `lme_smoke_local.py` run that sets `--output-dir` now appends one row to `docs/bench/trend.csv`. Defensive — failures warn, never break the bench
- **`lme_report.py --trend`**: reads trend.csv and renders a chronological per-(variant, category) progression table with a `Δ` column showing score-deltas vs the previous run in the same group
- **Auto-detected features**: each row records which retrieval/answerer flags were enabled (`multi_query`, `hyde`, `temporal_prefilter`, `self_consistency`, `critique_revise`) so the operator sees at-a-glance which knob produced which lift

## Phase 4a — README headline section

- New section: **\"Retrieval + answerer feature flags\"** — lists the five PRs that just landed (#94, #97, #98, #99, #100) with literature-estimated lifts + cost overheads
- Explicit caveat: numbers shown are **from literature**, not yet bench-validated. Headline numbers will land in a follow-up PR after the user runs benches and `lme_report.py --trend` populates real data
- \"Reporting\" section grew a `--trend` example showing the progression-table shape so users can preview what they'll see

## Files

- **New:** `scripts/bench/trend.py` (215 LOC), `tests/test_bench_trend.py` (14 tests)
- **Modified:** `scripts/lme_smoke_local.py` (auto-append on persist), `scripts/bench/lme_report.py` (--trend flag), `README.md` (features section + trend example)

## Test plan

- [x] `pytest tests/test_bench_trend.py` — 14/14 passing
- [x] CLI: `lme_report.py --trend` works on empty + populated CSV
- [x] Full unit suite (touched modules): 100/100
- [x] Defensive contract: trend.csv append failure logs warning, doesn't break bench
- [ ] User-driven: run a smoke and verify trend.csv gets a row with the right features captured