### PR TITLE
feat(evals): supersession runner fixes + abstention scaffold (#16, #25)

### DIFF
--- a/docs/bench/knowledge-updates-20260429.report.json
+++ b/docs/bench/knowledge-updates-20260429.report.json
@@ -1,0 +1,574 @@
+{
+  "total": 50,
+  "new_wins": 4,
+  "stale_wins": 37,
+  "miss": 8,
+  "ambiguous": 1,
+  "score_pct": 8.0,
+  "target_score_pct": 92.0,
+  "passed_target": false,
+  "by_category": {
+    "numeric": {
+      "new_wins": 1,
+      "stale_wins": 4,
+      "miss": 0,
+      "ambiguous": 0
+    },
+    "categorical": {
+      "new_wins": 1,
+      "stale_wins": 4,
+      "miss": 0,
+      "ambiguous": 0
+    },
+    "temporal": {
+      "new_wins": 0,
+      "stale_wins": 4,
+      "miss": 1,
+      "ambiguous": 0
+    },
+    "preference": {
+      "new_wins": 0,
+      "stale_wins": 4,
+      "miss": 1,
+      "ambiguous": 0
+    },
+    "entity": {
+      "new_wins": 0,
+      "stale_wins": 5,
+      "miss": 0,
+      "ambiguous": 0
+    },
+    "locational": {
+      "new_wins": 0,
+      "stale_wins": 5,
+      "miss": 0,
+      "ambiguous": 0
+    },
+    "intent": {
+      "new_wins": 0,
+      "stale_wins": 4,
+      "miss": 1,
+      "ambiguous": 0
+    },
+    "relational": {
+      "new_wins": 1,
+      "stale_wins": 2,
+      "miss": 1,
+      "ambiguous": 1
+    },
+    "count": {
+      "new_wins": 0,
+      "stale_wins": 5,
+      "miss": 0,
+      "ambiguous": 0
+    },
+    "status_binary": {
+      "new_wins": 1,
+      "stale_wins": 0,
+      "miss": 4,
+      "ambiguous": 0
+    }
+  },
+  "cases": [
+    {
+      "case_id": "ku_numeric_001",
+      "category": "numeric",
+      "question": "How much did I sell my Tesla for?",
+      "gold_answer": "$38,500",
+      "stale_answer": "$42,000",
+      "top1_content": "Sold the Tesla last weekend for $38,500 \u2014 depreciation hit harder than I thought.",
+      "top1_score": 0.8723388475254887,
+      "verdict": "new_wins"
+    },
+    {
+      "case_id": "ku_numeric_002",
+      "category": "numeric",
+      "question": "What's my current monthly rent?",
+      "gold_answer": "$2,650",
+      "stale_answer": "$2,400",
+      "top1_content": "My monthly rent is $2,400.",
+      "top1_score": 0.6703222841503136,
+      "verdict": "stale_wins"
+    },
+    {
+      "case_id": "ku_numeric_003",
+      "category": "numeric",
+      "question": "What's my current weight?",
+      "gold_answer": "172 pounds",
+      "stale_answer": "185 pounds",
+      "top1_content": "I weigh 185 pounds.",
+      "top1_score": 0.6481231238880835,
+      "verdict": "stale_wins"
+    },
+    {
+      "case_id": "ku_numeric_004",
+      "category": "numeric",
+      "question": "What's my current base salary?",
+      "gold_answer": "$168,000",
+      "stale_answer": "$145,000",
+      "top1_content": "My salary is $145,000 base.",
+      "top1_score": 0.6639715927371228,
+      "verdict": "stale_wins"
+    },
+    {
+      "case_id": "ku_numeric_005",
+      "category": "numeric",
+      "question": "How many engineers are on the platform team currently?",
+      "gold_answer": "5",
+      "stale_answer": "3",
+      "top1_content": "We have 3 engineers on the platform team.",
+      "top1_score": 0.7338896412708616,
+      "verdict": "stale_wins"
+    },
+    {
+      "case_id": "ku_categorical_001",
+      "category": "categorical",
+      "question": "What's the current status of Project Atlas?",
+      "gold_answer": "Suspended",
+      "stale_answer": "Active",
+      "top1_content": "Project Atlas is in 'Active' status.",
+      "top1_score": 0.8495005759360404,
+      "verdict": "stale_wins"
+    },
+    {
+      "case_id": "ku_categorical_002",
+      "category": "categorical",
+      "question": "What's my current dietary classification?",
+      "gold_answer": "Pescatarian",
+      "stale_answer": "Vegetarian",
+      "top1_content": "I'm a vegetarian.",
+      "top1_score": 0.6216362296824364,
+      "verdict": "stale_wins"
+    },
+    {
+      "case_id": "ku_categorical_003",
+      "category": "categorical",
+      "question": "What plan tier am I on?",
+      "gold_answer": "Enterprise",
+      "stale_answer": "Pro",
+      "top1_content": "Just upgraded to the Enterprise plan.",
+      "top1_score": 0.6232712376979609,
+      "verdict": "new_wins"
+    },
+    {
+      "case_id": "ku_categorical_004",
+      "category": "categorical",
+      "question": "What's my current primary laptop?",
+      "gold_answer": "Framework 16",
+      "stale_answer": "MacBook Pro",
+      "top1_content": "My laptop is a MacBook Pro.",
+      "top1_score": 0.6644857311847624,
+      "verdict": "stale_wins"
+    },
+    {
+      "case_id": "ku_categorical_005",
+      "category": "categorical",
+      "question": "What's the status of issue #443?",
+      "gold_answer": "Closed",
+      "stale_answer": "In Progress",
+      "top1_content": "Issue #443 is currently 'In Progress'.",
+      "top1_score": 0.746918113146906,
+      "verdict": "stale_wins"
+    },
+    {
+      "case_id": "ku_temporal_001",
+      "category": "temporal",
+      "question": "When is the launch scheduled?",
+      "gold_answer": "April 22nd",
+      "stale_answer": "March 15th",
+      "top1_content": "The launch is scheduled for March 15th.",
+      "top1_score": 0.849999987063472,
+      "verdict": "stale_wins"
+    },
+    {
+      "case_id": "ku_temporal_002",
+      "category": "temporal",
+      "question": "Which day does my Tokyo flight leave?",
+      "gold_answer": "Friday",
+      "stale_answer": "Tuesday",
+      "top1_content": "My flight to Tokyo leaves Tuesday.",
+      "top1_score": 0.8618534134533391,
+      "verdict": "stale_wins"
+    },
+    {
+      "case_id": "ku_temporal_003",
+      "category": "temporal",
+      "question": "When is my annual review?",
+      "gold_answer": "March 28th",
+      "stale_answer": "March 1st",
+      "top1_content": "Annual review is on March 1st this year.",
+      "top1_score": 0.8499999891580138,
+      "verdict": "stale_wins"
+    },
+    {
+      "case_id": "ku_temporal_004",
+      "category": "temporal",
+      "question": "Which day did we end up holding my daughter's birthday party?",
+      "gold_answer": "Sunday",
+      "stale_answer": "Saturday",
+      "top1_content": "My daughter's birthday party is on Saturday.",
+      "top1_score": 0.6670310174626749,
+      "verdict": "stale_wins"
+    },
+    {
+      "case_id": "ku_temporal_005",
+      "category": "temporal",
+      "question": "When does my current lease end?",
+      "gold_answer": "September 30th, 2026",
+      "stale_answer": "June 30th, 2025",
+      "top1_content": "Lease ends June 30th.",
+      "top1_score": 0.6992114750325883,
+      "verdict": "miss"
+    },
+    {
+      "case_id": "ku_preference_001",
+      "category": "preference",
+      "question": "What do I drink in the mornings these days?",
+      "gold_answer": "Matcha",
+      "stale_answer": "Coffee",
+      "top1_content": "Coffee in the morning is non-negotiable for me.",
+      "top1_score": 0.631141736132423,
+      "verdict": "stale_wins"
+    },
+    {
+      "case_id": "ku_preference_002",
+      "category": "preference",
+      "question": "Which editor do I currently use?",
+      "gold_answer": "VSCode",
+      "stale_answer": "Vim",
+      "top1_content": "I prefer Vim for editing.",
+      "top1_score": 0.621222810888505,
+      "verdict": "stale_wins"
+    },
+    {
+      "case_id": "ku_preference_003",
+      "category": "preference",
+      "question": "Which type of seat do I prefer on flights?",
+      "gold_answer": "Window",
+      "stale_answer": "Aisle",
+      "top1_content": "I always book aisle seats on flights.",
+      "top1_score": 0.6830949635878985,
+      "verdict": "stale_wins"
+    },
+    {
+      "case_id": "ku_preference_004",
+      "category": "preference",
+      "question": "What's my current default database?",
+      "gold_answer": "SQLite",
+      "stale_answer": "Postgres",
+      "top1_content": "Postgres is my default for any new project.",
+      "top1_score": 0.6191556998407526,
+      "verdict": "stale_wins"
+    },
+    {
+      "case_id": "ku_preference_005",
+      "category": "preference",
+      "question": "What's my current morning exercise?",
+      "gold_answer": "Swimming",
+      "stale_answer": "Running",
+      "top1_content": "I run 5K every morning before work.",
+      "top1_score": 0.6230929163230355,
+      "verdict": "miss"
+    },
+    {
+      "case_id": "ku_entity_001",
+      "category": "entity",
+      "question": "Who is the company's current CTO?",
+      "gold_answer": "Bob Patel",
+      "stale_answer": "Alice Chen",
+      "top1_content": "Alice Chen is our CTO.",
+      "top1_score": 0.8402820322908477,
+      "verdict": "stale_wins"
+    },
+    {
+      "case_id": "ku_entity_002",
+      "category": "entity",
+      "question": "Who's my primary care doctor right now?",
+      "gold_answer": "Dr. Khoury",
+      "stale_answer": "Dr. Mendez",
+      "top1_content": "My primary care doctor is Dr. Mendez.",
+      "top1_score": 0.70768493495236,
+      "verdict": "stale_wins"
+    },
+    {
+      "case_id": "ku_entity_003",
+      "category": "entity",
+      "question": "Who is our current AWS account manager?",
+      "gold_answer": "Marcus Lee",
+      "stale_answer": "Jen Wu",
+      "top1_content": "Our AWS account manager is Jen Wu.",
+      "top1_score": 0.8866259947603977,
+      "verdict": "stale_wins"
+    },
+    {
+      "case_id": "ku_entity_004",
+      "category": "entity",
+      "question": "What's the name of my current dog?",
+      "gold_answer": "Loki",
+      "stale_answer": "Maya",
+      "top1_content": "Maya is my dog.",
+      "top1_score": 0.6519536751459837,
+      "verdict": "stale_wins"
+    },
+    {
+      "case_id": "ku_entity_005",
+      "category": "entity",
+      "question": "Who's our current agency of record?",
+      "gold_answer": "Mother Design",
+      "stale_answer": "Wieden+Kennedy",
+      "top1_content": "Our agency of record is Wieden+Kennedy.",
+      "top1_score": 0.660261220957684,
+      "verdict": "stale_wins"
+    },
+    {
+      "case_id": "ku_locational_001",
+      "category": "locational",
+      "question": "What's my current address?",
+      "gold_answer": "456 Oak Avenue, Austin",
+      "stale_answer": "123 Main Street, Austin",
+      "top1_content": "I live at 123 Main Street, Austin.",
+      "top1_score": 0.6044129867803054,
+      "verdict": "stale_wins"
+    },
+    {
+      "case_id": "ku_locational_002",
+      "category": "locational",
+      "question": "Where is our company HQ now?",
+      "gold_answer": "Austin",
+      "stale_answer": "San Francisco",
+      "top1_content": "Our HQ is in San Francisco.",
+      "top1_score": 0.6947051008860681,
+      "verdict": "stale_wins"
+    },
+    {
+      "case_id": "ku_locational_003",
+      "category": "locational",
+      "question": "Which AWS region is our database in?",
+      "gold_answer": "us-west-2",
+      "stale_answer": "us-east-1",
+      "top1_content": "Database is hosted in us-east-1.",
+      "top1_score": 0.7094091063698013,
+      "verdict": "stale_wins"
+    },
+    {
+      "case_id": "ku_locational_004",
+      "category": "locational",
+      "question": "Where is my standing desk currently?",
+      "gold_answer": "Living room",
+      "stale_answer": "Home office",
+      "top1_content": "My standing desk is in the home office.",
+      "top1_score": 0.7175441842194886,
+      "verdict": "stale_wins"
+    },
+    {
+      "case_id": "ku_locational_005",
+      "category": "locational",
+      "question": "Which city am I based in right now?",
+      "gold_answer": "Denver",
+      "stale_answer": "Seattle",
+      "top1_content": "I'm based in Seattle for the next year.",
+      "top1_score": 0.633469448143819,
+      "verdict": "stale_wins"
+    },
+    {
+      "case_id": "ku_intent_001",
+      "category": "intent",
+      "question": "What's the current plan for the Acme project?",
+      "gold_answer": "On the roadmap (continuing)",
+      "stale_answer": "Cancel",
+      "top1_content": "I'm planning to cancel the Acme project.",
+      "top1_score": 0.7919197131656096,
+      "verdict": "stale_wins"
+    },
+    {
+      "case_id": "ku_intent_002",
+      "category": "intent",
+      "question": "What was my Q1 goal in the end?",
+      "gold_answer": "Platform stability",
+      "stale_answer": "Ship feature X",
+      "top1_content": "Goal this quarter: ship feature X by end of Q1.",
+      "top1_score": 0.8499999898887777,
+      "verdict": "stale_wins"
+    },
+    {
+      "case_id": "ku_intent_003",
+      "category": "intent",
+      "question": "Which language am I currently focused on learning?",
+      "gold_answer": "Zig",
+      "stale_answer": "Rust",
+      "top1_content": "[2023-05-28] The user wants to focus more on learning new skills and expanding their knowledge in different areas.",
+      "top1_score": 0.5956742971277268,
+      "verdict": "miss"
+    },
+    {
+      "case_id": "ku_intent_004",
+      "category": "intent",
+      "question": "What's my current career plan?",
+      "gold_answer": "Build the startup full-time",
+      "stale_answer": "Apply for Stanford MBA",
+      "top1_content": "Going to apply for Stanford MBA this fall.",
+      "top1_score": 0.5635161736733663,
+      "verdict": "stale_wins"
+    },
+    {
+      "case_id": "ku_intent_005",
+      "category": "intent",
+      "question": "Which car am I planning to buy next?",
+      "gold_answer": "Rivian R1S",
+      "stale_answer": "Tesla",
+      "top1_content": "Thinking about getting a Tesla as my next car.",
+      "top1_score": 0.7265509689884416,
+      "verdict": "stale_wins"
+    },
+    {
+      "case_id": "ku_relational_001",
+      "category": "relational",
+      "question": "What's my current relationship status with Sara?",
+      "gold_answer": "Broken up",
+      "stale_answer": "Dating",
+      "top1_content": "Sara and I have been dating for two years.",
+      "top1_score": 0.7647764757806603,
+      "verdict": "stale_wins"
+    },
+    {
+      "case_id": "ku_relational_002",
+      "category": "relational",
+      "question": "Who is James's manager right now?",
+      "gold_answer": "Priya",
+      "stale_answer": "Me",
+      "top1_content": "James moved over to the platform team after the reorg \u2014 Priya is now his manager.",
+      "top1_score": 0.600226128747186,
+      "verdict": "ambiguous"
+    },
+    {
+      "case_id": "ku_relational_003",
+      "category": "relational",
+      "question": "Is Acme Corp currently a customer?",
+      "gold_answer": "No (churned)",
+      "stale_answer": "Yes (paying customer)",
+      "top1_content": "Acme Corp is a paying customer of ours.",
+      "top1_score": 0.8300321336390073,
+      "verdict": "miss"
+    },
+    {
+      "case_id": "ku_relational_004",
+      "category": "relational",
+      "question": "Am I currently on the NonProfit X board?",
+      "gold_answer": "No",
+      "stale_answer": "Yes",
+      "top1_content": "I'm on the board of NonProfit X.",
+      "top1_score": 0.8625028527665637,
+      "verdict": "new_wins"
+    },
+    {
+      "case_id": "ku_relational_005",
+      "category": "relational",
+      "question": "Who is our top integration partner right now?",
+      "gold_answer": "Globex",
+      "stale_answer": "Acme",
+      "top1_content": "Working closely with Acme as our top integration partner.",
+      "top1_score": 0.6988661006072254,
+      "verdict": "stale_wins"
+    },
+    {
+      "case_id": "ku_count_001",
+      "category": "count",
+      "question": "How many kids do I have?",
+      "gold_answer": "3",
+      "stale_answer": "2",
+      "top1_content": "We have 2 kids.",
+      "top1_score": 0.6880727206393956,
+      "verdict": "stale_wins"
+    },
+    {
+      "case_id": "ku_count_002",
+      "category": "count",
+      "question": "How many open positions are on my team?",
+      "gold_answer": "1",
+      "stale_answer": "4",
+      "top1_content": "Open positions on my team: 4.",
+      "top1_score": 0.7270974437081501,
+      "verdict": "stale_wins"
+    },
+    {
+      "case_id": "ku_count_003",
+      "category": "count",
+      "question": "How many properties do I currently own?",
+      "gold_answer": "4",
+      "stale_answer": "5",
+      "top1_content": "I own 5 properties total.",
+      "top1_score": 0.7091161433558569,
+      "verdict": "stale_wins"
+    },
+    {
+      "case_id": "ku_count_004",
+      "category": "count",
+      "question": "How many active GitHub repos do I have?",
+      "gold_answer": "7",
+      "stale_answer": "12",
+      "top1_content": "I have 12 active GitHub repos.",
+      "top1_score": 0.8803646702904265,
+      "verdict": "stale_wins"
+    },
+    {
+      "case_id": "ku_count_005",
+      "category": "count",
+      "question": "How many deals are in my pipeline right now?",
+      "gold_answer": "10",
+      "stale_answer": "8",
+      "top1_content": "I'm tracking 8 deals in my pipeline.",
+      "top1_score": 0.7252648431657277,
+      "verdict": "stale_wins"
+    },
+    {
+      "case_id": "ku_status_binary_001",
+      "category": "status_binary",
+      "question": "Am I currently subscribed to The Information?",
+      "gold_answer": "No",
+      "stale_answer": "Yes",
+      "top1_content": "I'm subscribed to The Information.",
+      "top1_score": 0.8663130647937696,
+      "verdict": "miss"
+    },
+    {
+      "case_id": "ku_status_binary_002",
+      "category": "status_binary",
+      "question": "Is 2FA enabled on my main account?",
+      "gold_answer": "Yes",
+      "stale_answer": "No",
+      "top1_content": "Finally enabled 2FA on the main account after the phishing scare.",
+      "top1_score": 0.8499999926944859,
+      "verdict": "miss"
+    },
+    {
+      "case_id": "ku_status_binary_003",
+      "category": "status_binary",
+      "question": "Has my flu vaccination status changed this season?",
+      "gold_answer": "Yes (now skipped/no longer planned)",
+      "stale_answer": "No (still vaccinated)",
+      "top1_content": "I'm vaccinated for the flu this season.",
+      "top1_score": 0.6812433484634434,
+      "verdict": "miss"
+    },
+    {
+      "case_id": "ku_status_binary_004",
+      "category": "status_binary",
+      "question": "Am I fully remote right now?",
+      "gold_answer": "No (hybrid, 3 days in office)",
+      "stale_answer": "Yes (full-time remote)",
+      "top1_content": "Working from home full-time these days.",
+      "top1_score": 0.6599814639265122,
+      "verdict": "miss"
+    },
+    {
+      "case_id": "ku_status_binary_005",
+      "category": "status_binary",
+      "question": "Am I currently abstaining from alcohol?",
+      "gold_answer": "No",
+      "stale_answer": "Yes",
+      "top1_content": "On a strict no-alcohol regimen for 90 days.",
+      "top1_score": 0.6345641779767369,
+      "verdict": "new_wins"
+    }
+  ]
+}

--- a/docs/bench/knowledge-updates-20260429.summary.json
+++ b/docs/bench/knowledge-updates-20260429.summary.json
@@ -1,0 +1,22 @@
+{
+  "benchmark": "knowledge_updates",
+  "primary_metric": 8.0,
+  "primary_metric_name": "supersession_top1_pct",
+  "total": 50,
+  "per_category": {
+    "numeric": 20.0,
+    "categorical": 20.0,
+    "temporal": 0.0,
+    "preference": 0.0,
+    "entity": 0.0,
+    "locational": 0.0,
+    "intent": 0.0,
+    "relational": 20.0,
+    "count": 0.0,
+    "status_binary": 20.0
+  },
+  "metadata": {
+    "target_score_pct": 92.0,
+    "passed_target": false
+  }
+}

--- a/evals/abstention/fixtures.json
+++ b/evals/abstention/fixtures.json
@@ -1,0 +1,262 @@
+{
+  "version": 1,
+  "description": "30 hand-curated abstention fixtures (15 answerable + 15 unanswerable). Plugs into the existing AbstentionBench harness via synthetic_loader.py — each fixture maps to one AbstentionSample with a category for per-slice F1.",
+  "samples": [
+    {
+      "sample_id": "abs_ans_001",
+      "category": "personal_attribute",
+      "answerable": true,
+      "context": "I told my doctor my A1C reading was 5.6 last quarter.",
+      "query": "What was my last A1C reading?",
+      "expected_answer": "5.6"
+    },
+    {
+      "sample_id": "abs_ans_002",
+      "category": "personal_attribute",
+      "answerable": true,
+      "context": "I bought my Tesla Model 3 in March 2024 for $42,000.",
+      "query": "How much did I pay for my Tesla?",
+      "expected_answer": "$42,000"
+    },
+    {
+      "sample_id": "abs_ans_003",
+      "category": "personal_attribute",
+      "answerable": true,
+      "context": "My current address is 123 Main Street, Austin TX.",
+      "query": "What's my home address?",
+      "expected_answer": "123 Main Street"
+    },
+    {
+      "sample_id": "abs_ans_004",
+      "category": "decision_record",
+      "answerable": true,
+      "context": "We decided to migrate the API to Postgres 16 next sprint after the latency review.",
+      "query": "What did we decide about Postgres?",
+      "expected_answer": "migrate"
+    },
+    {
+      "sample_id": "abs_ans_005",
+      "category": "decision_record",
+      "answerable": true,
+      "context": "Bob is taking over as CTO starting Monday after Alice stepped down.",
+      "query": "Who is the new CTO?",
+      "expected_answer": "Bob"
+    },
+    {
+      "sample_id": "abs_ans_006",
+      "category": "decision_record",
+      "answerable": true,
+      "context": "We agreed the launch is set for April 22nd, pushed back from March 15th.",
+      "query": "When is the launch scheduled?",
+      "expected_answer": "April 22"
+    },
+    {
+      "sample_id": "abs_ans_007",
+      "category": "preference",
+      "answerable": true,
+      "context": "I switched my morning drink from coffee to matcha after the anxiety started.",
+      "query": "What do I drink in the mornings now?",
+      "expected_answer": "matcha"
+    },
+    {
+      "sample_id": "abs_ans_008",
+      "category": "preference",
+      "answerable": true,
+      "context": "I prefer the aisle seat on flights — easier to get up.",
+      "query": "What seat do I prefer on planes?",
+      "expected_answer": "aisle"
+    },
+    {
+      "sample_id": "abs_ans_009",
+      "category": "relationship",
+      "answerable": true,
+      "context": "Sara and I have been dating for two years; we live together in Austin.",
+      "query": "What's my relationship with Sara?",
+      "expected_answer": "dating"
+    },
+    {
+      "sample_id": "abs_ans_010",
+      "category": "relationship",
+      "answerable": true,
+      "context": "Maya is my golden retriever; she's 7 years old.",
+      "query": "What kind of pet do I have?",
+      "expected_answer": "golden retriever"
+    },
+    {
+      "sample_id": "abs_ans_011",
+      "category": "count",
+      "answerable": true,
+      "context": "We have 5 engineers on the platform team after the two new hires last month.",
+      "query": "How many engineers are on the platform team?",
+      "expected_answer": "5"
+    },
+    {
+      "sample_id": "abs_ans_012",
+      "category": "count",
+      "answerable": true,
+      "context": "I have three kids: two boys and a girl.",
+      "query": "How many kids do I have?",
+      "expected_answer": "three"
+    },
+    {
+      "sample_id": "abs_ans_013",
+      "category": "professional",
+      "answerable": true,
+      "context": "I work at Acme Corp as a senior backend engineer; my manager is Priya.",
+      "query": "Who is my manager?",
+      "expected_answer": "Priya"
+    },
+    {
+      "sample_id": "abs_ans_014",
+      "category": "professional",
+      "answerable": true,
+      "context": "My team's standup is at 9am Pacific every weekday.",
+      "query": "When is my team standup?",
+      "expected_answer": "9am"
+    },
+    {
+      "sample_id": "abs_ans_015",
+      "category": "professional",
+      "answerable": true,
+      "context": "I just got promoted to staff engineer; my new salary is $185,000.",
+      "query": "What's my current title?",
+      "expected_answer": "staff engineer"
+    },
+
+    {
+      "sample_id": "abs_unans_001",
+      "category": "unknown_topic",
+      "answerable": false,
+      "context": "I told my doctor my A1C reading was 5.6 last quarter. The weather has been mild recently.",
+      "query": "What was my LDL cholesterol level?",
+      "expected_answer": null,
+      "metadata": {"why": "A1C is in context, but LDL was never mentioned"}
+    },
+    {
+      "sample_id": "abs_unans_002",
+      "category": "unknown_topic",
+      "answerable": false,
+      "context": "I bought my Tesla Model 3 in March 2024 for $42,000.",
+      "query": "What's my home address?",
+      "expected_answer": null,
+      "metadata": {"why": "context is about a car, not housing"}
+    },
+    {
+      "sample_id": "abs_unans_003",
+      "category": "unknown_topic",
+      "answerable": false,
+      "context": "We use Postgres 16 for the primary database.",
+      "query": "What's our marketing budget for Q3?",
+      "expected_answer": null,
+      "metadata": {"why": "engineering context, not financial"}
+    },
+    {
+      "sample_id": "abs_unans_004",
+      "category": "false_premise",
+      "answerable": false,
+      "context": "I'm an only child; we lived in Boston growing up.",
+      "query": "How many siblings do I have?",
+      "expected_answer": null,
+      "metadata": {"why": "user explicitly stated only-child; Q presumes siblings"}
+    },
+    {
+      "sample_id": "abs_unans_005",
+      "category": "false_premise",
+      "answerable": false,
+      "context": "We canceled the Acme project last quarter after the budget review.",
+      "query": "When is the Acme project shipping?",
+      "expected_answer": null,
+      "metadata": {"why": "Q presumes ongoing project; context says canceled"}
+    },
+    {
+      "sample_id": "abs_unans_006",
+      "category": "false_premise",
+      "answerable": false,
+      "context": "I don't drink coffee — never have.",
+      "query": "How many cups of coffee do I have per day?",
+      "expected_answer": null,
+      "metadata": {"why": "Q presumes regular consumption; context says zero"}
+    },
+    {
+      "sample_id": "abs_unans_007",
+      "category": "future_event",
+      "answerable": false,
+      "context": "Annual review process kicks off in March each year. I haven't had this year's yet.",
+      "query": "What was my performance rating in this year's review?",
+      "expected_answer": null,
+      "metadata": {"why": "future event; no review has happened yet"}
+    },
+    {
+      "sample_id": "abs_unans_008",
+      "category": "future_event",
+      "answerable": false,
+      "context": "I'm planning to start a Rust learning project at some point.",
+      "query": "What did I learn in my Rust project last week?",
+      "expected_answer": null,
+      "metadata": {"why": "project hasn't started yet"}
+    },
+    {
+      "sample_id": "abs_unans_009",
+      "category": "future_event",
+      "answerable": false,
+      "context": "We have a board meeting scheduled for next month.",
+      "query": "What did we decide at last month's board meeting?",
+      "expected_answer": null,
+      "metadata": {"why": "Q references past meeting; only future one in context"}
+    },
+    {
+      "sample_id": "abs_unans_010",
+      "category": "underspecified",
+      "answerable": false,
+      "context": "The quarterly review went well overall.",
+      "query": "What were the three biggest concerns raised?",
+      "expected_answer": null,
+      "metadata": {"why": "context is high-level; no specifics in haystack"}
+    },
+    {
+      "sample_id": "abs_unans_011",
+      "category": "underspecified",
+      "answerable": false,
+      "context": "I have a meeting tomorrow.",
+      "query": "What time and with whom is my meeting tomorrow?",
+      "expected_answer": null,
+      "metadata": {"why": "meeting mentioned, but no time/attendee specifics"}
+    },
+    {
+      "sample_id": "abs_unans_012",
+      "category": "underspecified",
+      "answerable": false,
+      "context": "I went to the doctor last week.",
+      "query": "What did the doctor diagnose?",
+      "expected_answer": null,
+      "metadata": {"why": "visit mentioned, no diagnosis recorded"}
+    },
+    {
+      "sample_id": "abs_unans_013",
+      "category": "subjective_opinion",
+      "answerable": false,
+      "context": "I work at Acme Corp as a senior backend engineer.",
+      "query": "Is Acme Corp a great company to work for?",
+      "expected_answer": null,
+      "metadata": {"why": "asks for subjective judgement not in context"}
+    },
+    {
+      "sample_id": "abs_unans_014",
+      "category": "subjective_opinion",
+      "answerable": false,
+      "context": "I bought a Tesla Model 3 last year.",
+      "query": "Are Teslas worth the price?",
+      "expected_answer": null,
+      "metadata": {"why": "subjective question; only fact-of-purchase in context"}
+    },
+    {
+      "sample_id": "abs_unans_015",
+      "category": "absent_relationship",
+      "answerable": false,
+      "context": "Bob is the new CTO; Maya is my dog.",
+      "query": "Has Bob ever met Maya?",
+      "expected_answer": null,
+      "metadata": {"why": "two unrelated entities in context; no connecting fact"}
+    }
+  ]
+}

--- a/evals/abstention/synthetic_loader.py
+++ b/evals/abstention/synthetic_loader.py
@@ -1,0 +1,113 @@
+"""Synthetic abstention dataset loader.
+
+Plugs into the existing AbstentionBench harness
+(``evals.abstention.runner.run``) by providing a 30-sample dataset of
+hand-curated answerable + unanswerable cases. The fixtures live in
+``evals/abstention/fixtures.json`` — 15 answerable samples mixed with
+15 unanswerable across 6 categories.
+
+This is a USER-RUN scaffold (per ``project_default_config_file``). The
+loader is shipped; the user is expected to wire `mem_factory`,
+`ingest`, and `answer` callables and invoke `evals.abstention.run()`.
+
+Usage::
+
+    from evals.abstention.runner import run as abstention_run
+    from evals.abstention.synthetic_loader import SyntheticLoader
+
+    summary = abstention_run(
+        mem_factory=my_mem_factory,
+        ingest=my_ingest,
+        answer=my_answer_with_chain_of_note,
+        loader=SyntheticLoader(),
+        output_dir="docs/bench",
+    )
+
+Categories surfaced via ``AbstentionSample.category`` for per-slice F1:
+
+  Answerable (gold = should answer):
+    - personal_attribute  user states an attribute, Q asks for it
+    - decision_record     a decision was made, Q asks what
+    - preference          a preference change, Q asks current
+    - relationship        a relationship fact, Q asks about it
+    - count               a count, Q asks for it
+    - professional        a job-related fact, Q asks for it
+
+  Unanswerable (gold = should abstain):
+    - unknown_topic       Q is on a topic the haystack doesn't cover
+    - false_premise       Q presumes a fact the haystack contradicts
+    - future_event        Q asks about a not-yet-happened event
+    - underspecified      Q asks for specifics not in context
+    - subjective_opinion  Q asks for a value judgment
+    - absent_relationship Q asks about a relationship neither mentioned
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import List, Optional
+
+from evals.abstention.types import AbstentionSample
+
+
+_DEFAULT_FIXTURES = (
+    Path(__file__).resolve().parent / "fixtures.json"
+)
+
+
+class SyntheticLoader:
+    """DatasetLoader for the existing AbstentionBench harness.
+
+    Reads ``evals/abstention/fixtures.json`` and returns one
+    ``AbstentionSample`` per case. Stable order so reports are
+    diffable across runs.
+    """
+
+    def __init__(self, fixtures_path: Optional[Path | str] = None):
+        self.fixtures_path = Path(fixtures_path or _DEFAULT_FIXTURES)
+
+    def __call__(self) -> List[AbstentionSample]:
+        return load_synthetic_samples(self.fixtures_path)
+
+
+def load_synthetic_samples(
+    fixtures_path: Path | str = _DEFAULT_FIXTURES,
+) -> List[AbstentionSample]:
+    """Read fixtures.json and produce AbstentionSamples.
+
+    Strict on shape — missing required fields raise ValueError so a
+    typo can't silently produce an empty bench.
+    """
+    p = Path(fixtures_path)
+    raw = json.loads(p.read_text())
+    if not isinstance(raw, dict) or not isinstance(raw.get("samples"), list):
+        raise ValueError(
+            f"abstention fixtures: expected {{ 'samples': [...] }} in {p}; "
+            f"got top-level keys {list(raw)!r}"
+        )
+
+    out: List[AbstentionSample] = []
+    for case in raw["samples"]:
+        for required in ("sample_id", "category", "answerable", "context", "query"):
+            if required not in case:
+                raise ValueError(
+                    f"abstention fixture {case.get('sample_id', '?')!r} "
+                    f"missing required field {required!r}"
+                )
+        out.append(AbstentionSample(
+            sample_id=str(case["sample_id"]),
+            context=str(case["context"]),
+            query=str(case["query"]),
+            answerable=bool(case["answerable"]),
+            expected_answer=case.get("expected_answer"),
+            category=str(case["category"]),
+            metadata=dict(case.get("metadata") or {}),
+        ))
+
+    if not out:
+        raise ValueError(
+            f"abstention fixtures: {p} contains no samples — "
+            f"expected ≥ 1 case",
+        )
+    return out

--- a/evals/knowledge_updates/runner.py
+++ b/evals/knowledge_updates/runner.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
 import sys
 import uuid
 from dataclasses import asdict, dataclass, field
@@ -185,13 +186,38 @@ def _ingest_session(mem: Any, user_id: str, session: dict) -> int:
     return n
 
 
-def run_one_case(mem_factory: Any, case: dict) -> CaseResult:
+def run_one_case(
+    mem_factory: Any, case: dict, *, pg_url: Optional[str] = None,
+) -> CaseResult:
     """Hermetic single-case run.
 
-    Each call gets a fresh AgentMemory (and therefore a fresh user_id)
-    so prior cases can't leak into the recall surface.
+    Each call gets a fresh AgentMemory and a freshly-provisioned user
+    so prior cases can't leak into the recall surface. The v4 schema
+    requires the user row to exist before any memory write — we
+    bootstrap via ``UserRepo.create_or_get(external_id=...)`` and use
+    the returned UUID for ``mem.add`` / ``mem.recall``.
     """
-    user_id = f"ku-{uuid.uuid4().hex[:12]}"
+    import psycopg2
+
+    from attestor.identity.users import UserRepo
+
+    pg_url = pg_url or os.environ.get(
+        "POSTGRES_URL",
+        "postgresql://postgres:attestor@localhost:5432/attestor_v4_test",
+    )
+    external_id = f"ku-{uuid.uuid4().hex[:12]}"
+    boot = psycopg2.connect(pg_url)
+    boot.autocommit = True
+    try:
+        user = UserRepo(boot).create_or_get(
+            external_id=external_id,
+            display_name="knowledge_updates_eval",
+            metadata={"source": "knowledge_updates_suite"},
+        )
+        user_id = user.id
+    finally:
+        boot.close()
+
     mem = mem_factory()
     sessions = sorted(case["sessions"], key=lambda s: s.get("date", ""))
     for sess in sessions:

--- a/tests/test_abstention_synthetic_loader.py
+++ b/tests/test_abstention_synthetic_loader.py
@@ -1,0 +1,193 @@
+"""Unit tests for evals/abstention/synthetic_loader.py.
+
+Pure tests on the fixture loader — no DB, no LLM. The end-to-end
+AbstentionBench wiring is exercised by the user via the harness.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from evals.abstention.synthetic_loader import (
+    SyntheticLoader, load_synthetic_samples,
+)
+from evals.abstention.types import AbstentionSample
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FIXTURES = REPO_ROOT / "evals" / "abstention" / "fixtures.json"
+
+
+# ── load_synthetic_samples — happy path ───────────────────────────────
+
+
+@pytest.mark.unit
+def test_load_returns_30_samples() -> None:
+    samples = load_synthetic_samples(FIXTURES)
+    assert len(samples) == 30
+
+
+@pytest.mark.unit
+def test_samples_split_15_answerable_15_not() -> None:
+    samples = load_synthetic_samples(FIXTURES)
+    answerable = [s for s in samples if s.answerable]
+    unanswerable = [s for s in samples if not s.answerable]
+    assert len(answerable) == 15
+    assert len(unanswerable) == 15
+
+
+@pytest.mark.unit
+def test_all_sample_ids_unique() -> None:
+    samples = load_synthetic_samples(FIXTURES)
+    ids = [s.sample_id for s in samples]
+    assert len(set(ids)) == len(ids)
+
+
+@pytest.mark.unit
+def test_all_samples_are_frozen_dataclasses() -> None:
+    """AbstentionSample is frozen — confirms our loader produces the
+    right type (not e.g. a dict that quacks)."""
+    samples = load_synthetic_samples(FIXTURES)
+    s = samples[0]
+    assert isinstance(s, AbstentionSample)
+    with pytest.raises(Exception):
+        s.query = "mutated"   # type: ignore[misc]
+
+
+@pytest.mark.unit
+def test_categories_cover_six_types() -> None:
+    """6 answerable categories + 6 unanswerable categories. Specific
+    enumeration prevents typos in the JSON from going unnoticed."""
+    samples = load_synthetic_samples(FIXTURES)
+    cats = {s.category for s in samples}
+    expected = {
+        # Answerable
+        "personal_attribute", "decision_record", "preference",
+        "relationship", "count", "professional",
+        # Unanswerable
+        "unknown_topic", "false_premise", "future_event",
+        "underspecified", "subjective_opinion", "absent_relationship",
+    }
+    assert cats == expected
+
+
+@pytest.mark.unit
+def test_unanswerable_samples_have_null_expected_answer() -> None:
+    samples = load_synthetic_samples(FIXTURES)
+    for s in samples:
+        if not s.answerable:
+            assert s.expected_answer is None, (
+                f"{s.sample_id}: unanswerable but has expected_answer="
+                f"{s.expected_answer!r}"
+            )
+
+
+@pytest.mark.unit
+def test_answerable_samples_have_substring_expected() -> None:
+    samples = load_synthetic_samples(FIXTURES)
+    for s in samples:
+        if s.answerable:
+            assert s.expected_answer, (
+                f"{s.sample_id}: answerable=True but expected_answer is empty"
+            )
+            # Sanity: the expected answer should appear in the context too,
+            # otherwise the "answerable" label is wrong.
+            assert s.expected_answer.lower() in s.context.lower(), (
+                f"{s.sample_id}: expected_answer={s.expected_answer!r} not "
+                f"found in context — would mark a real correct answer wrong"
+            )
+
+
+@pytest.mark.unit
+def test_unanswerable_metadata_records_why() -> None:
+    """Every unanswerable case should document WHY in metadata.why
+    so future maintainers understand the test intent."""
+    samples = load_synthetic_samples(FIXTURES)
+    for s in samples:
+        if not s.answerable:
+            assert "why" in s.metadata, (
+                f"{s.sample_id}: unanswerable case missing metadata.why"
+            )
+
+
+# ── SyntheticLoader class wrapper ─────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_synthetic_loader_is_callable() -> None:
+    """The class must be a zero-arg callable per the DatasetLoader
+    Protocol in evals/abstention/runner.py."""
+    loader = SyntheticLoader()
+    samples = loader()
+    assert len(samples) == 30
+
+
+@pytest.mark.unit
+def test_synthetic_loader_uses_default_path() -> None:
+    """Default constructor → bundled fixtures.json."""
+    loader = SyntheticLoader()
+    assert loader.fixtures_path == FIXTURES
+    assert loader.fixtures_path.exists()
+
+
+@pytest.mark.unit
+def test_synthetic_loader_accepts_custom_path(tmp_path) -> None:
+    custom = tmp_path / "custom.json"
+    custom.write_text(json.dumps({
+        "version": 1,
+        "samples": [
+            {
+                "sample_id": "x",
+                "category": "test",
+                "answerable": True,
+                "context": "ctx",
+                "query": "q",
+                "expected_answer": "ctx",
+            },
+        ],
+    }))
+    loader = SyntheticLoader(custom)
+    samples = loader()
+    assert len(samples) == 1
+    assert samples[0].sample_id == "x"
+
+
+# ── Error paths ───────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_load_rejects_missing_top_level_samples_key(tmp_path) -> None:
+    p = tmp_path / "bad.json"
+    p.write_text(json.dumps({"version": 1, "wrong_key": []}))
+    with pytest.raises(ValueError, match="samples"):
+        load_synthetic_samples(p)
+
+
+@pytest.mark.unit
+def test_load_rejects_empty_samples_list(tmp_path) -> None:
+    p = tmp_path / "empty.json"
+    p.write_text(json.dumps({"version": 1, "samples": []}))
+    with pytest.raises(ValueError, match="no samples"):
+        load_synthetic_samples(p)
+
+
+@pytest.mark.unit
+def test_load_rejects_sample_missing_required_field(tmp_path) -> None:
+    p = tmp_path / "bad.json"
+    p.write_text(json.dumps({
+        "version": 1,
+        "samples": [
+            {
+                "sample_id": "x",
+                "category": "test",
+                # answerable is missing
+                "context": "ctx",
+                "query": "q",
+            },
+        ],
+    }))
+    with pytest.raises(ValueError, match="answerable"):
+        load_synthetic_samples(p)


### PR DESCRIPTION
## Summary

Two evals deliverables:

### #16 — Supersession runner: real fix + first baseline

The shipped runner had two pre-existing bugs preventing it from completing **any** case:
- Generated user_ids as `f\"ku-{uuid4().hex[:12]}\"` — Postgres rejects (users.id is uuid)
- Never bootstrapped the user row — v4 RLS requires it to exist before any memory write

Fixed both. First end-to-end 50-case baseline now possible:

| Metric | Result |
|---|---|
| Score | 4/50 new_wins (**8.0%**) |
| Target | 92% |
| Gap | -84 pp |

Per-category breakdown (5 cases each):

| Category | new_wins |
|---|---|
| numeric | 1 |
| categorical | 1 |
| temporal | 0 |
| preference | 0 |
| entity | 0 |
| locational | 0 |
| intent | 0 |
| relational | 1 |
| count | 0 |
| status_binary | 1 |

**Read:** the default cosine retrieval gives near-equal weight to old + new facts. The supersession-confidence-decay in `attestor/retrieval/scorer.py` needs tuning. Saved as `project_supersession_baseline_20260429.md`.

The persisted artifacts (`docs/bench/knowledge-updates-20260429.{report,summary}.json`) commit alongside this PR as evidence-of-life.

### #25 — Abstention synthetic dataset scaffold

Plugs into the existing AbstentionBench harness (Phase 9.4) that was waiting for a dataset loader.

- 30 hand-curated cases, balanced 15 answerable + 15 unanswerable across 12 categories (6 each side)
- `SyntheticLoader` class matching the DatasetLoader Protocol
- 14 unit tests with strict schema validation; flags any typo that would mislabel a case

This is a **USER-RUN scaffold** — the user wires `mem_factory + ingest + answer` and invokes `evals.abstention.runner.run()` with `SyntheticLoader()`.

## Files

- **Modified:** `evals/knowledge_updates/runner.py` (UUID + user bootstrap)
- **New:** `docs/bench/knowledge-updates-20260429.{report,summary}.json` (baseline artifacts), `evals/abstention/fixtures.json` (30 cases), `evals/abstention/synthetic_loader.py`, `tests/test_abstention_synthetic_loader.py` (14 tests)

## Test plan

- [x] `pytest tests/test_abstention_synthetic_loader.py` — 14/14
- [x] Full suite: 1004 passed, no regressions
- [x] Live: ran 50-case supersession suite end-to-end (this is what produced the baseline above)
- [ ] User-driven: wire AbstentionBench `answer` and run the 30-case suite