### PR TITLE
fix(v4): namespace filter for search + list_memories on v4 schema

### DIFF
--- a/attestor/store/postgres_backend.py
+++ b/attestor/store/postgres_backend.py
@@ -465,7 +465,12 @@ class PostgresBackend(DocumentStore, VectorStore, GraphStore):
     ) -> List[Memory]:
         # v4 schema replaces the v3 ``created_at`` text column with the
         # bi-temporal ``t_created`` (TIMESTAMPTZ). Use the right one per
-        # active schema; namespace is ignored on v4 (replaced by RLS).
+        # active schema. v4 has no ``namespace`` column — namespace is
+        # stored as ``metadata->>'_namespace'`` (PR #77 write-side fix);
+        # the RLS policy at memories filters by ``user_id`` only, NOT
+        # by namespace, so namespace must still be filtered here when
+        # the caller passes one (e.g. LME bench writes one user with
+        # many per-sample namespaces).
         time_col = "t_created" if self._v4 else "created_at"
 
         filters = []
@@ -480,8 +485,11 @@ class PostgresBackend(DocumentStore, VectorStore, GraphStore):
         if entity:
             filters.append("entity = %(entity)s")
             params["entity"] = entity
-        if namespace and not self._v4:
-            filters.append("namespace = %(namespace)s")
+        if namespace:
+            if self._v4:
+                filters.append("metadata->>'_namespace' = %(namespace)s")
+            else:
+                filters.append("namespace = %(namespace)s")
             params["namespace"] = namespace
         if after:
             filters.append(f"{time_col} >= %(after)s")
@@ -701,8 +709,11 @@ class PostgresBackend(DocumentStore, VectorStore, GraphStore):
         params: List[Any] = [str(query_vec)]
         where: List[str] = ["embedding IS NOT NULL"]
 
-        if namespace is not None and not self._v4:
-            where.append("namespace = %s")
+        if namespace is not None:
+            if self._v4:
+                where.append("metadata->>'_namespace' = %s")
+            else:
+                where.append("namespace = %s")
             params.append(namespace)
 
         if self._v4:

--- a/tests/test_v4_namespace_roundtrip.py
+++ b/tests/test_v4_namespace_roundtrip.py
@@ -120,3 +120,142 @@ def test_v4_row_with_explicit_default_namespace_in_metadata():
     }
     mem = Memory.from_row(row)
     assert mem.namespace == "default"
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Search-side filter: pin that v4 search filters on metadata->>'_namespace'
+#
+# Background — the missing companion to the read-side fix:
+#     PR #77 made namespace round-trip through metadata["_namespace"] on
+#     the WRITE path. But ``PostgresBackend.search()`` and
+#     ``list_memories()`` skipped the namespace filter entirely on v4
+#     ("replaced by RLS" — the comment was misleading; RLS at memories
+#     filters by user_id, NOT namespace). LME-S benchmarks (one bench
+#     user + many per-sample namespaces) returned cross-sample
+#     contaminated candidates, blowing up retrieval verdicts.
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _build_v4_backend_stub(captured_sql: list, captured_params: list):
+    """Construct a PostgresBackend in v4 mode without going through
+    schema init. _execute is stubbed to capture (sql, params) so the
+    test can assert on the WHERE clause.
+    """
+    from attestor.store.postgres_backend import PostgresBackend
+
+    backend = PostgresBackend.__new__(PostgresBackend)
+    backend._v4 = True
+
+    def _capture(sql, params=None):
+        captured_sql.append(sql)
+        captured_params.append(params)
+        return []
+
+    backend._execute = _capture
+    backend._embed = lambda text: [0.0] * 1024  # deterministic stub
+    return backend
+
+
+def _build_v3_backend_stub(captured_sql: list, captured_params: list):
+    from attestor.store.postgres_backend import PostgresBackend
+
+    backend = PostgresBackend.__new__(PostgresBackend)
+    backend._v4 = False
+    backend._execute = lambda sql, params=None: (
+        captured_sql.append(sql) or captured_params.append(params) or []
+    )
+    backend._embed = lambda text: [0.0] * 1024
+    return backend
+
+
+@pytest.mark.unit
+def test_v4_search_filters_on_metadata_namespace():
+    """Vector search MUST add ``metadata->>'_namespace' = %s`` when v4
+    + namespace passed. Pre-fix, this filter was skipped → bench saw
+    cross-namespace contamination across 80+ samples."""
+    sqls: list = []
+    params_log: list = []
+    backend = _build_v4_backend_stub(sqls, params_log)
+
+    backend.search("any query", namespace="lme_sample_42")
+
+    assert sqls, "search did not call _execute"
+    sql = sqls[0]
+    assert "metadata->>'_namespace' = %s" in sql, (
+        f"v4 search must filter on metadata->>'_namespace', got SQL: {sql}"
+    )
+    # The namespace value is the second positional param (after the
+    # query vector embedded as %s::vector).
+    assert "lme_sample_42" in params_log[0], (
+        f"namespace must be passed as a param, got: {params_log[0]}"
+    )
+
+
+@pytest.mark.unit
+def test_v3_search_filters_on_namespace_column():
+    """v3 keeps the original ``namespace = %s`` filter (top-level
+    column). Regression guard for legacy v3 deployments."""
+    sqls: list = []
+    params_log: list = []
+    backend = _build_v3_backend_stub(sqls, params_log)
+
+    backend.search("any query", namespace="legacy-tenant")
+
+    sql = sqls[0]
+    assert "namespace = %s" in sql, (
+        f"v3 search must filter on top-level namespace, got SQL: {sql}"
+    )
+    assert "metadata->>" not in sql, (
+        f"v3 search must NOT use metadata jsonb path, got SQL: {sql}"
+    )
+
+
+@pytest.mark.unit
+def test_v4_search_no_namespace_filter_when_namespace_omitted():
+    """Calling search() without a namespace should produce NO namespace
+    filter on either schema — preserves the SOLO single-tenant happy
+    path where every namespace is "default" and an explicit filter
+    would be needless overhead."""
+    sqls: list = []
+    params_log: list = []
+    backend = _build_v4_backend_stub(sqls, params_log)
+
+    backend.search("any query", namespace=None)
+
+    sql = sqls[0]
+    assert "metadata->>'_namespace'" not in sql
+    assert "namespace = " not in sql
+
+
+@pytest.mark.unit
+def test_v4_list_memories_filters_on_metadata_namespace():
+    """Same fix applied to the list_memories() (temporal/category
+    filter path). Pre-fix, list_memories with namespace silently
+    returned ALL of the user's memories on v4."""
+    sqls: list = []
+    params_log: list = []
+    backend = _build_v4_backend_stub(sqls, params_log)
+
+    backend.list_memories(namespace="tenant-acme")
+
+    assert sqls
+    sql = sqls[0]
+    assert "metadata->>'_namespace' = %(namespace)s" in sql, (
+        f"v4 list_memories must filter on metadata->>'_namespace', "
+        f"got SQL: {sql}"
+    )
+    assert params_log[0].get("namespace") == "tenant-acme"
+
+
+@pytest.mark.unit
+def test_v3_list_memories_filters_on_namespace_column():
+    """v3 list_memories keeps namespace = %(namespace)s."""
+    sqls: list = []
+    params_log: list = []
+    backend = _build_v3_backend_stub(sqls, params_log)
+
+    backend.list_memories(namespace="legacy-tenant")
+
+    sql = sqls[0]
+    assert "namespace = %(namespace)s" in sql
+    assert "metadata->>" not in sql


### PR DESCRIPTION
## Summary

PR #77 fixed the **WRITE side** — namespace round-trips through `metadata["_namespace"]` on v4 (which has no top-level `namespace` column). The **READ side was missed**: `PostgresBackend.search()` and `list_memories()` both had `and not self._v4` guards that silently skipped the namespace filter on v4.

The misleading comment claimed namespace was *"replaced by RLS"* — but the RLS policy at `memories` filters by `user_id`, **not by namespace**.

## Impact

LongMemEval-style benches write **one bench user with N per-sample namespaces**. Pre-fix, recall returned all of the user's memories across all samples instead of just the current sample's. A separate diagnostic session caught a ~72% wrong-fact rate on an 86-sample run that was fully attributable to this — vector search found the right embedding but in the wrong sample.

## Changes

`attestor/store/postgres_backend.py`:
- **line 483** (`list_memories` filter): adds a v4 branch that filters `metadata->>'_namespace' = %(namespace)s`
- **line 704** (vector search filter): same v4 branch with positional `%s` placeholder for the `search()` WHERE clause builder
- updates the misleading "replaced by RLS" comment to call out the user_id-only RLS scope and reaffirm the namespace filter is still needed at the application layer

`tests/test_v4_namespace_roundtrip.py` — 5 new regression tests:
- `test_v4_search_filters_on_metadata_namespace`
- `test_v3_search_filters_on_namespace_column`
- `test_v4_search_no_namespace_filter_when_namespace_omitted`
- `test_v4_list_memories_filters_on_metadata_namespace`
- `test_v3_list_memories_filters_on_namespace_column`

The new tests use `__new__` + monkey-patched `_execute()` to capture generated SQL and assert the WHERE clause — no live DB needed. All 11 namespace-related tests green (6 existing + 5 new).

## Scope

- **Search-side only.** Bi-temporal / scope / status / category filters in the same methods are unaffected.
- **No schema migration.** `metadata->>'_namespace'` is a JSONB path expression on the existing `metadata` jsonb column.
- **No GIN/index work in this PR.** A future expression index on `(metadata->>'_namespace')` would make the new filter cheap on large tables, but the correctness fix is the priority.

## Test plan

- [x] Unit tests for v4 search filter (asserts SQL contains `metadata->>'_namespace' = %s`)
- [x] Unit tests for v3 search filter (regression guard — still uses top-level `namespace = %s`)
- [x] Unit tests for `list_memories()` on both schemas
- [x] Unit test for null-namespace path (no filter added)
- [ ] Live LME-S re-run on a Postgres+pgvector default stack to confirm the wrong-fact rate drops (user-bench territory)