### PR TITLE
feat: HyDE v2 + Pinecone backend + LME-S temporal diagnostic harness

### DIFF
--- a/attestor/retrieval/hyde.py
+++ b/attestor/retrieval/hyde.py
@@ -81,22 +81,38 @@ class HydeResult:
 # ──────────────────────────────────────────────────────────────────────
 
 
-_GENERATOR_PROMPT = """You are answering a memory-recall question. Without \
-access to any specific memory, write a 1-2-sentence HYPOTHETICAL answer in \
-the same style and surface form as a real answer would take. Be specific \
-and concrete — invent plausible details (names, dates, numbers) so the \
-answer's embedding matches the corpus.
+_GENERATOR_PROMPT = """You are previewing a personal-memory search. The \
+user's question refers to an event, fact, or experience from their past \
+conversations. Write 1-2 sentences DESCRIBING that event in the form the \
+user would have ORIGINALLY MENTIONED it in conversation — not in the \
+form of an answer to the question.
+
+The goal is to generate a snippet whose embedding is close to the \
+original conversation turn containing the answer, NOT to the answer \
+itself. Question-shape and answer-shape don't embed close to source-shape.
+
+Examples:
+- Question: "How many weeks ago did I meet my aunt?"
+  Snippet: "Yesterday I drove out to visit my aunt Linda — she gave me \
+a gorgeous antique chandelier from her attic."
+- Question: "Which trip did I take first this year?"
+  Snippet: "Just got back from Tokyo last month, my first international \
+trip of the year. The cherry blossoms were already starting."
+- Question: "How many days ago did I buy a smoker?"
+  Snippet: "Picked up a Traeger pellet smoker over the weekend — finally \
+ready to do real low-and-slow brisket at home."
 
 Rules:
-- Answer in 1-2 sentences, declarative form.
-- Do NOT include hedging ("I think", "it might be", "perhaps").
-- Do NOT include the question itself.
-- Do NOT add caveats or refuse — generate plausible content even if you \
-can't know the real answer.
+- 1-2 sentences, first-person, declarative, conversational.
+- DESCRIBE the event directly; do NOT say "X weeks ago" or "first" or \
+counts — narrate the event itself.
+- Invent plausible specifics (names, places, objects, dates) — accuracy \
+doesn't matter, surface-form match to a likely chat turn does.
+- Do NOT echo the question, do NOT hedge, do NOT refuse.
 
 Question: {question}
 
-Hypothetical answer:"""
+Snippet:"""
 
 
 def _resolve_generator_model() -> str:
@@ -147,6 +163,7 @@ def generate_hypothetical_answer(
             role="hyde_generator",
             model=model,
             max_tokens=400,
+            temperature=0.0,
             messages=[
                 {"role": "user", "content": _GENERATOR_PROMPT.format(
                     question=question,
@@ -158,9 +175,11 @@ def generate_hypothetical_answer(
         logger.debug("hyde.generate: LLM call failed: %s", e)
         return HydeResult(original_question=question.strip())
 
-    # Strip any leading "Hypothetical answer:" label the model may echo.
-    if text.lower().startswith("hypothetical answer:"):
-        text = text[len("hypothetical answer:"):].strip()
+    # Strip any leading label the model may echo from the prompt frame.
+    for label in ("snippet:", "hypothetical answer:"):
+        if text.lower().startswith(label):
+            text = text[len(label):].strip()
+            break
 
     from attestor import trace as _tr
     if _tr.is_enabled():

--- a/attestor/retrieval/temporal_prefilter.py
+++ b/attestor/retrieval/temporal_prefilter.py
@@ -164,6 +164,24 @@ _RE_N_UNITS_FORWARD = re.compile(
     re.IGNORECASE,
 )
 
+# 8. Interrogative: "how many <unit>s ago" / "how many <unit>s have passed"
+#    / "how many <unit>s since" — found while diagnosing LME-S
+#    temporal-reasoning misses (project_pinecone_lme_temporal_10q_20260429.md).
+#    The question doesn't anchor a specific past date; we use a wide
+#    backward-looking window of ~6 units * unit-length to give the lane
+#    something useful to filter on.
+_RE_HOW_MANY_UNITS_AGO = re.compile(
+    rf"\bhow\s+many\s+({_UNIT_RE})\s+(?:ago|have\s+passed|has\s+passed|since)\b",
+    re.IGNORECASE,
+)
+_RE_HOW_LONG_AGO = re.compile(
+    r"\bhow\s+long\s+(?:ago|since)\b",
+    re.IGNORECASE,
+)
+# When "how many" matches, we look back ``_HOW_MANY_LOOKBACK_UNITS`` of
+# the matched unit to the target. Tolerance widens further on top.
+_HOW_MANY_LOOKBACK_UNITS = 6
+
 
 # ──────────────────────────────────────────────────────────────────────
 # Public entry point
@@ -270,6 +288,23 @@ def _earliest_match(
         n = _word_to_int(m.group(1))
         days = _UNIT_DAYS[m.group(2).lower()]
         target = question_date + timedelta(days=n * days)
+        candidates.append((m.start(), m.group(0), target))
+
+    # Pattern 8a: "how many <unit>s ago / have passed / since"
+    # Anchors a backward window of _HOW_MANY_LOOKBACK_UNITS × unit-days.
+    # Target is the midpoint; the existing tolerance_days widens further.
+    for m in _RE_HOW_MANY_UNITS_AGO.finditer(question):
+        unit = m.group(1).lower().rstrip("s")
+        days = _UNIT_DAYS[unit]
+        target = question_date - timedelta(
+            days=(_HOW_MANY_LOOKBACK_UNITS * days) // 2,
+        )
+        candidates.append((m.start(), m.group(0), target))
+
+    # Pattern 8b: "how long ago / how long since" — unit unspecified;
+    # anchor a generic month-ish lookback.
+    for m in _RE_HOW_LONG_AGO.finditer(question):
+        target = question_date - timedelta(days=90)  # ~3 months back
         candidates.append((m.start(), m.group(0), target))
 
     if not candidates:

--- a/attestor/store/embeddings.py
+++ b/attestor/store/embeddings.py
@@ -363,6 +363,114 @@ class VoyageEmbeddingProvider:
         return result.embeddings
 
 
+class PineconeEmbeddingProvider:
+    """Pinecone Inference embeddings (cloud-only, NOT supported on Pinecone Local).
+
+    Default model is ``llama-text-embed-v2`` — Meta × Pinecone partnership,
+    English-strong, dim is configurable from {384, 512, 768, 1024, 2048}.
+    1024-D matches Attestor's canonical pgvector schema and the existing
+    Voyage configuration so the embedder swap is dim-compatible.
+
+    Other models accessible via the same provider (just change ``model``):
+
+      - ``multilingual-e5-large``        (1024-D, multilingual, free-tier eligible)
+      - ``llama-text-embed-v2``          (default; English-strong, configurable dim)
+      - ``pinecone-sparse-english-v0``   (sparse — not supported by this dense provider)
+
+    For Voyage / OpenAI / Cohere via Pinecone's proxy, use the
+    ``input_type``-aware vendor-specific provider names per Pinecone docs.
+
+    Environment:
+
+      ``PINECONE_API_KEY``  — required. Cloud key from app.pinecone.io.
+      ``PINECONE_EMBEDDING_MODEL``       — model override (optional).
+      ``PINECONE_EMBEDDING_DIMENSIONS``  — dim override (optional).
+    """
+
+    DEFAULT_MODEL = "llama-text-embed-v2"
+    DEFAULT_DIM = 1024
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        model: Optional[str] = None,
+        dimensions: Optional[int] = None,
+        input_type: str = "passage",
+    ) -> None:
+        try:
+            from pinecone import Pinecone
+        except ImportError:
+            raise RuntimeError(
+                "pinecone not installed. Run `pip install pinecone` "
+                "or `pip install attestor[pinecone]`."
+            )
+
+        api_key = api_key or os.environ.get("PINECONE_API_KEY")
+        if not api_key or api_key == "pclocal":
+            raise RuntimeError(
+                "PINECONE_API_KEY not set or set to the Pinecone-Local "
+                "stub 'pclocal'. Pinecone Inference is cloud-only — get "
+                "a real API key at app.pinecone.io.",
+            )
+
+        # Cloud only — no host override. Pinecone Local doesn't serve
+        # the inference API per its own docs.
+        self._client = Pinecone(api_key=api_key)
+        self._model = (
+            model
+            or os.environ.get("PINECONE_EMBEDDING_MODEL")
+            or self.DEFAULT_MODEL
+        )
+        self._input_type = input_type
+
+        dim_env = os.environ.get("PINECONE_EMBEDDING_DIMENSIONS")
+        if dimensions is not None:
+            self._dimensions = int(dimensions)
+        elif dim_env:
+            self._dimensions = int(dim_env)
+        else:
+            self._dimensions = self.DEFAULT_DIM
+
+        # Probe — confirms key + model + dim before any production call.
+        # llama-text-embed-v2 supports {384, 512, 768, 1024, 2048}; an
+        # unsupported dim raises here loudly rather than at runtime.
+        result = self._client.inference.embed(
+            model=self._model,
+            inputs=["dim"],
+            parameters={
+                "input_type": self._input_type,
+                "dimension": self._dimensions,
+            },
+        )
+        self._dimension = len(result.data[0].values)
+
+    @property
+    def dimension(self) -> int:
+        return self._dimension
+
+    @property
+    def provider_name(self) -> str:
+        return f"pinecone:{self._model}@{self._dimension}d"
+
+    def _params(self) -> Dict[str, Any]:
+        return {
+            "input_type": self._input_type,
+            "dimension": self._dimensions,
+        }
+
+    def embed(self, text: str) -> List[float]:
+        result = self._client.inference.embed(
+            model=self._model, inputs=[text], parameters=self._params(),
+        )
+        return list(result.data[0].values)
+
+    def embed_batch(self, texts: List[str]) -> List[List[float]]:
+        result = self._client.inference.embed(
+            model=self._model, inputs=texts, parameters=self._params(),
+        )
+        return [list(d.values) for d in result.data]
+
+
 class VertexAIEmbeddingProvider:
     """Google Vertex AI text-embedding-005 (768D)."""
 

--- a/attestor/store/pinecone_backend.py
+++ b/attestor/store/pinecone_backend.py
@@ -1,0 +1,318 @@
+"""Pinecone vector backend (experiment) — implements ``VectorStore``.
+
+Drop-in alternative to ``PostgresBackend``'s vector role. Used for the
+bakeoff against pgvector on the LME-S workload. See
+``attestor/store/postgres_backend.py`` for the reference implementation
+of the same Protocol surface.
+
+Two operating modes:
+
+  - **Pinecone Local** (default for the bakeoff): connect to the
+    Docker emulator at ``http://localhost:5080``. No API key, no cloud
+    spend, no persistence. Boot via:
+
+        docker run -d --name pinecone-local -e PORT=5080 \
+            -e PINECONE_HOST=localhost -p 5080-5090:5080-5090 \
+            --platform linux/amd64 ghcr.io/pinecone-io/pinecone-local:latest
+
+  - **Pinecone Cloud**: set ``host=None`` (or omit) and provide
+    ``api_key`` to reach api.pinecone.io. Same code path; different
+    endpoint.
+
+Same Voyage ``voyage-4`` (1024-D) embeddings as the pgvector path —
+only the index/store layer differs. Embedding is delegated to
+``attestor.store.embeddings.get_embedding_provider()`` so swapping the
+embedder is one config change away.
+
+This is an experimental adapter — NOT yet promoted to the canonical
+backend list. Default Attestor stack stays PG+pgvector+Neo4j per
+``feedback_only_pg_neo4j_stack`` until the bakeoff produces a clear win.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import Any, Dict, List, Optional, Set
+
+logger = logging.getLogger("attestor.store.pinecone")
+
+
+_DEFAULT_LOCAL_HOST = "http://localhost:5080"
+_DEFAULT_INDEX_NAME = "attestor-experiment"
+_DEFAULT_CLOUD = "aws"
+_DEFAULT_REGION = "us-east-1"
+
+
+class PineconeBackend:
+    """Vector storage + similarity search backed by Pinecone.
+
+    Implements the ``VectorStore`` Protocol surface (``add``,
+    ``search``, ``delete``, ``count``, ``close``) plus a few helpers
+    for hermetic test runs.
+    """
+
+    ROLES: Set[str] = {"vector"}
+
+    def __init__(self, config: Dict[str, Any]) -> None:
+        """Construct a Pinecone-backed vector store.
+
+        Config keys:
+            host           HTTP(S) base URL. Default: ``http://localhost:5080``
+                          (Pinecone Local). Set to None / "cloud" to use
+                          api.pinecone.io.
+            api_key        Pinecone API key. ``"pclocal"`` works for the
+                          local emulator (it's ignored). Required for
+                          cloud.
+            index_name     Index to upsert/query against. Created if
+                          missing. Default: ``attestor-experiment``.
+            dimension      Vector dim. Default: 1024 (matches Voyage
+                          ``voyage-4``). Index creation uses this.
+            metric         ``cosine`` | ``euclidean`` | ``dotproduct``.
+                          Default: ``cosine``.
+            cloud          Serverless cloud (cloud mode only).
+                          Default: ``aws``.
+            region         Serverless region. Default: ``us-east-1``.
+            embedder       Embedding provider (any callable returning
+                          ``List[float]`` from ``embed(text)``).
+                          When None, resolved via
+                          ``get_embedding_provider()`` — same chain as
+                          the pgvector path.
+
+        Local vs cloud transport: Pinecone Local's index endpoints
+        are plain HTTP/gRPC (no TLS); cloud is HTTPS-only. We auto-
+        detect by inspecting ``host`` — when it contains ``localhost``
+        or ``127.`` we use the gRPC client with ``secure=False``.
+        """
+        self._config = config
+        self._host = config.get("host", _DEFAULT_LOCAL_HOST)
+        self._api_key = config.get("api_key") or os.environ.get(
+            "PINECONE_API_KEY", "pclocal",
+        )
+        self._index_name = config.get("index_name", _DEFAULT_INDEX_NAME)
+        self._dimension = int(config.get("dimension", 1024))
+        self._metric = config.get("metric", "cosine")
+        self._cloud = config.get("cloud", _DEFAULT_CLOUD)
+        self._region = config.get("region", _DEFAULT_REGION)
+
+        # Local mode → gRPC + insecure transport; cloud → standard HTTP.
+        self._is_local = bool(self._host) and (
+            "localhost" in str(self._host) or "127." in str(self._host)
+        )
+
+        if self._is_local:
+            from pinecone.grpc import PineconeGRPC, GRPCClientConfig
+            from pinecone import ServerlessSpec
+            self._grpc_config_cls = GRPCClientConfig
+            self._serverless_spec_cls = ServerlessSpec
+            self._pc = PineconeGRPC(api_key=self._api_key, host=self._host)
+        else:
+            from pinecone import Pinecone, ServerlessSpec
+            self._serverless_spec_cls = ServerlessSpec
+            if self._host in (None, "cloud"):
+                self._pc = Pinecone(api_key=self._api_key)
+            else:
+                self._pc = Pinecone(api_key=self._api_key, host=self._host)
+
+        # Create the index if missing. Pinecone Local accepts the same
+        # ServerlessSpec shape as cloud — region/cloud are recorded
+        # but irrelevant for the emulator.
+        existing = {i.name for i in self._pc.list_indexes()}
+        if self._index_name not in existing:
+            logger.info(
+                "Pinecone: creating index %r (dim=%d, metric=%s)",
+                self._index_name, self._dimension, self._metric,
+            )
+            self._pc.create_index(
+                name=self._index_name,
+                dimension=self._dimension,
+                metric=self._metric,
+                spec=self._serverless_spec_cls(
+                    cloud=self._cloud, region=self._region,
+                ),
+            )
+            # Wait for index to be ready — cloud takes a few seconds;
+            # local is instant. Bounded poll keeps tests deterministic.
+            self._wait_until_ready(timeout=30.0)
+
+        # Bind the data-plane client. For Local, route to the index's
+        # localhost port via gRPC + insecure config.
+        if self._is_local:
+            desc = self._pc.describe_index(self._index_name)
+            self._index = self._pc.Index(
+                host=desc.host,
+                grpc_config=self._grpc_config_cls(secure=False),
+            )
+        else:
+            self._index = self._pc.Index(name=self._index_name)
+
+        # Embedder — same provider chain as pgvector for an apples-to-
+        # apples comparison.
+        self._embedder = config.get("embedder")
+        if self._embedder is None:
+            from attestor.store.embeddings import get_embedding_provider
+            self._embedder = get_embedding_provider()
+
+    # ── helpers ────────────────────────────────────────────────────
+
+    def _wait_until_ready(self, timeout: float = 30.0) -> None:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            try:
+                desc = self._pc.describe_index(self._index_name)
+                if getattr(desc.status, "ready", False):
+                    return
+            except Exception as e:  # noqa: BLE001
+                logger.debug(
+                    "Pinecone: describe_index probe failed: %s", e,
+                )
+            time.sleep(0.5)
+        raise TimeoutError(
+            f"Pinecone index {self._index_name!r} not ready within {timeout}s",
+        )
+
+    def _embed(self, text: str) -> List[float]:
+        """Run the configured embedder. Defensive: a missing embedder
+        is a hard error here — without an embedding we can't write."""
+        if self._embedder is None:
+            raise RuntimeError(
+                "Pinecone backend has no embedder configured; provide "
+                "config['embedder'] or set up the canonical embedding "
+                "provider chain.",
+            )
+        return list(self._embedder.embed(text))
+
+    # ── VectorStore Protocol ──────────────────────────────────────
+
+    def add(
+        self, memory_id: str, content: str, namespace: str = "default",
+    ) -> None:
+        """Upsert one (memory_id, embedding(content)) record.
+
+        ``namespace`` flows through to the Pinecone namespace param —
+        same scoping shape as pgvector. Default namespace ("default")
+        matches the Postgres path's behavior.
+        """
+        embedding = self._embed(content)
+        self._index.upsert(
+            vectors=[{
+                "id": memory_id,
+                "values": embedding,
+                "metadata": {"namespace": namespace},
+            }],
+            namespace=namespace,
+        )
+
+    def upsert_with_embedding(
+        self,
+        memory_id: str,
+        embedding: List[float],
+        namespace: str = "default",
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Upsert with a precomputed embedding — bypasses the embedder.
+
+        Used by harness code that already paid the embedding cost
+        (e.g. the bakeoff's hermetic re-runs that re-use the same
+        Voyage cache across pgvector AND Pinecone).
+        """
+        meta = {"namespace": namespace, **(metadata or {})}
+        self._index.upsert(
+            vectors=[{"id": memory_id, "values": embedding, "metadata": meta}],
+            namespace=namespace,
+        )
+
+    def search(
+        self,
+        query_text: str,
+        limit: int = 20,
+        namespace: Optional[str] = None,
+        **kwargs: Any,  # accept and ignore as_of/time_window — unsupported here
+    ) -> List[Dict[str, Any]]:
+        """Cosine similarity search.
+
+        Returns the same shape as pgvector's search output —
+        ``[{memory_id, distance}, ...]`` — so the orchestrator can
+        consume either backend interchangeably. The orchestrator
+        derives ``vector_sim`` from ``distance`` downstream; we
+        translate Pinecone's ``score`` (similarity, 0-1) to
+        ``distance = 1 - score`` to match the convention.
+
+        Bi-temporal kwargs (``as_of``, ``time_window``) are accepted
+        but IGNORED — Pinecone has no temporal filter primitives. The
+        orchestrator silently degrades to non-temporal search when
+        those kwargs hit a backend that doesn't support them.
+        """
+        if kwargs.get("as_of") is not None or kwargs.get("time_window") is not None:
+            logger.debug(
+                "Pinecone: as_of/time_window passed but unsupported; "
+                "ignoring (returning non-temporal results).",
+            )
+
+        query_vec = self._embed(query_text)
+        ns = namespace or "default"
+        result = self._index.query(
+            vector=query_vec,
+            top_k=int(limit),
+            namespace=ns,
+            include_values=False,
+            include_metadata=False,
+        )
+
+        out: List[Dict[str, Any]] = []
+        for match in (result.matches or []):
+            score = float(getattr(match, "score", 0.0))
+            out.append({
+                "memory_id": getattr(match, "id", ""),
+                "distance": max(0.0, 1.0 - score),  # cosine: dist = 1 - sim
+            })
+        return out
+
+    def delete(self, memory_id: str) -> bool:
+        """Delete one vector by id from the default namespace.
+
+        Returns True for the common case (Pinecone delete is
+        idempotent — it doesn't tell you whether the id existed).
+        """
+        try:
+            self._index.delete(ids=[memory_id], namespace="default")
+            return True
+        except Exception as e:  # noqa: BLE001
+            logger.debug("Pinecone delete failed for %s: %s", memory_id, e)
+            return False
+
+    def count(self) -> int:
+        """Total vectors across all namespaces."""
+        try:
+            stats = self._index.describe_index_stats()
+            return int(getattr(stats, "total_vector_count", 0))
+        except Exception as e:  # noqa: BLE001
+            logger.debug("Pinecone count failed: %s", e)
+            return 0
+
+    def close(self) -> None:
+        """Pinecone SDK has no explicit close — connection is
+        implicit per-request. Provided for Protocol compliance."""
+        return None
+
+    # ── helpers for hermetic test runs ────────────────────────────
+
+    def reset(self) -> None:
+        """Delete + recreate the index. Used between bakeoff fixtures
+        so each case sees an empty index. Cheap against Pinecone Local
+        (in-memory); avoid on cloud — it's slow."""
+        from pinecone import ServerlessSpec
+
+        try:
+            self._pc.delete_index(self._index_name)
+        except Exception as e:  # noqa: BLE001
+            logger.debug("Pinecone reset: delete failed: %s", e)
+        self._pc.create_index(
+            name=self._index_name,
+            dimension=self._dimension,
+            metric=self._metric,
+            spec=ServerlessSpec(cloud=self._cloud, region=self._region),
+        )
+        self._wait_until_ready()
+        self._index = self._pc.Index(name=self._index_name)

--- a/configs/attestor.yaml
+++ b/configs/attestor.yaml
@@ -79,12 +79,16 @@ stack:
   # justify each pick.
   models:
     # Answerer — synthesises the final reply from retrieved context.
-    # gpt-4.1 won overall on LongMemEval, especially on temporal +
-    # multi-session reasoning.
-    answerer: openai/gpt-5.4-mini
+    # Promoted to gpt-5.5 for the temporal-reasoning bench-up where
+    # mini's reasoning depth was the bottleneck on multi-hop date
+    # arithmetic (~10× per-token cost vs the prior 5.4-mini default).
+    answerer: openai/gpt-5.5
 
     # Judge — single-judge panel. gpt-4.1 was the strongest standalone
-    # judge in the 4-model run.
+    # judge in the 4-model run. NOTE: now SAME model as answerer —
+    # the dual-judge panel relies on the verifier (claude-sonnet-4-6
+    # below) for cross-model validation; gpt-5.5 self-judging is a
+    # weaker signal than gpt-5.5 → claude cross-judge.
     judge: openai/gpt-5.5
 
     # Extraction / distillation — runs once per turn during ingest to

--- a/docs/bench/pinecone-lme-temporal-diagnostic-20260429.json
+++ b/docs/bench/pinecone-lme-temporal-diagnostic-20260429.json
@@ -1,0 +1,504 @@
+{
+  "embedder": "pinecone:llama-text-embed-v2@1024d",
+  "store": "pinecone-local",
+  "variant": "s",
+  "category": "temporal-reasoning",
+  "n_total": 10,
+  "n_scored": 10,
+  "top_k": 10,
+  "counts": {
+    "recall@1": 4,
+    "miss": 3,
+    "recall@K": 3
+  },
+  "found_pct": 70.0,
+  "failures": [
+    {
+      "question_id": "71017276",
+      "question": "How many weeks ago did I meet up with my aunt and receive the crystal chandelier?",
+      "gold_session_ids": [
+        "answer_0b4a8adc_1"
+      ],
+      "verdict": "miss",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "sharegpt_duoAhsS_0",
+          "mem_id": "sharegpt_duoAhsS_0:t2",
+          "distance": 0.5109
+        },
+        {
+          "session_id": "sharegpt_tCLMKZY_0",
+          "mem_id": "sharegpt_tCLMKZY_0:t12",
+          "distance": 0.5275
+        },
+        {
+          "session_id": "398f23e7",
+          "mem_id": "398f23e7:t6",
+          "distance": 0.5498
+        },
+        {
+          "session_id": "sharegpt_duoAhsS_0",
+          "mem_id": "sharegpt_duoAhsS_0:t4",
+          "distance": 0.5504
+        },
+        {
+          "session_id": "ultrachat_553734",
+          "mem_id": "ultrachat_553734:t2",
+          "distance": 0.5524
+        }
+      ]
+    },
+    {
+      "question_id": "b46e15ed",
+      "question": "How many months have passed since I participated in two charity events in a row, on consecutive days?",
+      "gold_session_ids": [
+        "answer_4bfcc250_4",
+        "answer_4bfcc250_3",
+        "answer_4bfcc250_2",
+        "answer_4bfcc250_1"
+      ],
+      "verdict": "miss",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "sharegpt_hcaZN94_433",
+          "mem_id": "sharegpt_hcaZN94_433:t7",
+          "distance": 0.4383
+        },
+        {
+          "session_id": "sharegpt_WFKzGQx_0",
+          "mem_id": "sharegpt_WFKzGQx_0:t0",
+          "distance": 0.4661
+        },
+        {
+          "session_id": "sharegpt_hcaZN94_433",
+          "mem_id": "sharegpt_hcaZN94_433:t1",
+          "distance": 0.4723
+        },
+        {
+          "session_id": "sharegpt_WFKzGQx_0",
+          "mem_id": "sharegpt_WFKzGQx_0:t1",
+          "distance": 0.4915
+        },
+        {
+          "session_id": "sharegpt_hcaZN94_433",
+          "mem_id": "sharegpt_hcaZN94_433:t3",
+          "distance": 0.4943
+        }
+      ]
+    },
+    {
+      "question_id": "0bc8ad92",
+      "question": "How many months have passed since I last visited a museum with a friend?",
+      "gold_session_ids": [
+        "answer_f4ea84fb_3",
+        "answer_f4ea84fb_2",
+        "answer_f4ea84fb_1"
+      ],
+      "verdict": "miss",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "sharegpt_FqUHzEk_0",
+          "mem_id": "sharegpt_FqUHzEk_0:t6",
+          "distance": 0.5032
+        },
+        {
+          "session_id": "sharegpt_FqUHzEk_0",
+          "mem_id": "sharegpt_FqUHzEk_0:t8",
+          "distance": 0.5527
+        },
+        {
+          "session_id": "sharegpt_glG44yq_11",
+          "mem_id": "sharegpt_glG44yq_11:t1",
+          "distance": 0.5749
+        },
+        {
+          "session_id": "sharegpt_FqUHzEk_0",
+          "mem_id": "sharegpt_FqUHzEk_0:t10",
+          "distance": 0.588
+        },
+        {
+          "session_id": "fccc9400",
+          "mem_id": "fccc9400:t8",
+          "distance": 0.6479
+        }
+      ]
+    }
+  ],
+  "verdicts": [
+    {
+      "question_id": "gpt4_59149c77",
+      "question": "How many days passed between my visit to the Museum of Modern Art (MoMA) and the 'Ancient Civilizations' exhibit at the Metropolitan Museum of Art?",
+      "gold_session_ids": [
+        "answer_d00ba6d0_1",
+        "answer_d00ba6d0_2"
+      ],
+      "verdict": "recall@1",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "answer_d00ba6d0_2",
+          "mem_id": "answer_d00ba6d0_2:t6",
+          "distance": 0.4609
+        },
+        {
+          "session_id": "answer_d00ba6d0_2",
+          "mem_id": "answer_d00ba6d0_2:t7",
+          "distance": 0.6061
+        },
+        {
+          "session_id": "answer_d00ba6d0_2",
+          "mem_id": "answer_d00ba6d0_2:t8",
+          "distance": 0.6405
+        },
+        {
+          "session_id": "9e2c2a6c_2",
+          "mem_id": "9e2c2a6c_2:t0",
+          "distance": 0.6423
+        },
+        {
+          "session_id": "6e672b84_1",
+          "mem_id": "6e672b84_1:t8",
+          "distance": 0.672
+        }
+      ]
+    },
+    {
+      "question_id": "gpt4_f49edff3",
+      "question": "Which three events happened in the order from first to last: the day I helped my friend prepare the nursery, the day I helped my cousin pick out stuff for her baby shower, and the day I ordered a customized phone case for my friend's birthday?",
+      "gold_session_ids": [
+        "answer_3e9fce53_1",
+        "answer_3e9fce53_2",
+        "answer_3e9fce53_3"
+      ],
+      "verdict": "recall@1",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "answer_3e9fce53_3",
+          "mem_id": "answer_3e9fce53_3:t0",
+          "distance": 0.3986
+        },
+        {
+          "session_id": "answer_3e9fce53_1",
+          "mem_id": "answer_3e9fce53_1:t0",
+          "distance": 0.5864
+        },
+        {
+          "session_id": "answer_3e9fce53_3",
+          "mem_id": "answer_3e9fce53_3:t1",
+          "distance": 0.5912
+        },
+        {
+          "session_id": "answer_3e9fce53_1",
+          "mem_id": "answer_3e9fce53_1:t2",
+          "distance": 0.6419
+        },
+        {
+          "session_id": "answer_3e9fce53_1",
+          "mem_id": "answer_3e9fce53_1:t6",
+          "distance": 0.6427
+        }
+      ]
+    },
+    {
+      "question_id": "71017276",
+      "question": "How many weeks ago did I meet up with my aunt and receive the crystal chandelier?",
+      "gold_session_ids": [
+        "answer_0b4a8adc_1"
+      ],
+      "verdict": "miss",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "sharegpt_duoAhsS_0",
+          "mem_id": "sharegpt_duoAhsS_0:t2",
+          "distance": 0.5109
+        },
+        {
+          "session_id": "sharegpt_tCLMKZY_0",
+          "mem_id": "sharegpt_tCLMKZY_0:t12",
+          "distance": 0.5275
+        },
+        {
+          "session_id": "398f23e7",
+          "mem_id": "398f23e7:t6",
+          "distance": 0.5498
+        },
+        {
+          "session_id": "sharegpt_duoAhsS_0",
+          "mem_id": "sharegpt_duoAhsS_0:t4",
+          "distance": 0.5504
+        },
+        {
+          "session_id": "ultrachat_553734",
+          "mem_id": "ultrachat_553734:t2",
+          "distance": 0.5524
+        }
+      ]
+    },
+    {
+      "question_id": "b46e15ed",
+      "question": "How many months have passed since I participated in two charity events in a row, on consecutive days?",
+      "gold_session_ids": [
+        "answer_4bfcc250_4",
+        "answer_4bfcc250_3",
+        "answer_4bfcc250_2",
+        "answer_4bfcc250_1"
+      ],
+      "verdict": "miss",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "sharegpt_hcaZN94_433",
+          "mem_id": "sharegpt_hcaZN94_433:t7",
+          "distance": 0.4383
+        },
+        {
+          "session_id": "sharegpt_WFKzGQx_0",
+          "mem_id": "sharegpt_WFKzGQx_0:t0",
+          "distance": 0.4661
+        },
+        {
+          "session_id": "sharegpt_hcaZN94_433",
+          "mem_id": "sharegpt_hcaZN94_433:t1",
+          "distance": 0.4723
+        },
+        {
+          "session_id": "sharegpt_WFKzGQx_0",
+          "mem_id": "sharegpt_WFKzGQx_0:t1",
+          "distance": 0.4915
+        },
+        {
+          "session_id": "sharegpt_hcaZN94_433",
+          "mem_id": "sharegpt_hcaZN94_433:t3",
+          "distance": 0.4943
+        }
+      ]
+    },
+    {
+      "question_id": "gpt4_fa19884c",
+      "question": "How many days passed between the day I started playing along to my favorite songs on my old keyboard and the day I discovered a bluegrass band?",
+      "gold_session_ids": [
+        "answer_ff201786_1",
+        "answer_ff201786_2"
+      ],
+      "verdict": "recall@1",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "answer_ff201786_2",
+          "mem_id": "answer_ff201786_2:t0",
+          "distance": 0.5068
+        },
+        {
+          "session_id": "answer_ff201786_1",
+          "mem_id": "answer_ff201786_1:t8",
+          "distance": 0.5131
+        },
+        {
+          "session_id": "answer_ff201786_1",
+          "mem_id": "answer_ff201786_1:t9",
+          "distance": 0.564
+        },
+        {
+          "session_id": "128082f8_1",
+          "mem_id": "128082f8_1:t10",
+          "distance": 0.6027
+        },
+        {
+          "session_id": "answer_ff201786_2",
+          "mem_id": "answer_ff201786_2:t1",
+          "distance": 0.6039
+        }
+      ]
+    },
+    {
+      "question_id": "0bc8ad92",
+      "question": "How many months have passed since I last visited a museum with a friend?",
+      "gold_session_ids": [
+        "answer_f4ea84fb_3",
+        "answer_f4ea84fb_2",
+        "answer_f4ea84fb_1"
+      ],
+      "verdict": "miss",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "sharegpt_FqUHzEk_0",
+          "mem_id": "sharegpt_FqUHzEk_0:t6",
+          "distance": 0.5032
+        },
+        {
+          "session_id": "sharegpt_FqUHzEk_0",
+          "mem_id": "sharegpt_FqUHzEk_0:t8",
+          "distance": 0.5527
+        },
+        {
+          "session_id": "sharegpt_glG44yq_11",
+          "mem_id": "sharegpt_glG44yq_11:t1",
+          "distance": 0.5749
+        },
+        {
+          "session_id": "sharegpt_FqUHzEk_0",
+          "mem_id": "sharegpt_FqUHzEk_0:t10",
+          "distance": 0.588
+        },
+        {
+          "session_id": "fccc9400",
+          "mem_id": "fccc9400:t8",
+          "distance": 0.6479
+        }
+      ]
+    },
+    {
+      "question_id": "af082822",
+      "question": "How many weeks ago did I attend the friends and family sale at Nordstrom?",
+      "gold_session_ids": [
+        "answer_b51b6115_1"
+      ],
+      "verdict": "recall@K",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "bf38543d_2",
+          "mem_id": "bf38543d_2:t2",
+          "distance": 0.515
+        },
+        {
+          "session_id": "cdf068b1_2",
+          "mem_id": "cdf068b1_2:t10",
+          "distance": 0.5479
+        },
+        {
+          "session_id": "e132259f",
+          "mem_id": "e132259f:t0",
+          "distance": 0.5783
+        },
+        {
+          "session_id": "1dfef591_2",
+          "mem_id": "1dfef591_2:t6",
+          "distance": 0.5883
+        },
+        {
+          "session_id": "answer_b51b6115_1",
+          "mem_id": "answer_b51b6115_1:t10",
+          "distance": 0.5972
+        }
+      ]
+    },
+    {
+      "question_id": "gpt4_4929293a",
+      "question": "Which event happened first, my cousin's wedding or Michael's engagement party?",
+      "gold_session_ids": [
+        "answer_add9b012_2",
+        "answer_add9b012_1"
+      ],
+      "verdict": "recall@K",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "ultrachat_63058",
+          "mem_id": "ultrachat_63058:t2",
+          "distance": 0.5321
+        },
+        {
+          "session_id": "5a81277c",
+          "mem_id": "5a81277c:t10",
+          "distance": 0.5328
+        },
+        {
+          "session_id": "sharegpt_lH1wCbz_11",
+          "mem_id": "sharegpt_lH1wCbz_11:t1",
+          "distance": 0.5641
+        },
+        {
+          "session_id": "answer_add9b012_2",
+          "mem_id": "answer_add9b012_2:t0",
+          "distance": 0.5653
+        },
+        {
+          "session_id": "ultrachat_221041",
+          "mem_id": "ultrachat_221041:t0",
+          "distance": 0.5764
+        }
+      ]
+    },
+    {
+      "question_id": "gpt4_b5700ca9",
+      "question": "How many days ago did I attend the Maundy Thursday service at the Episcopal Church?",
+      "gold_session_ids": [
+        "answer_a17423e7_1"
+      ],
+      "verdict": "recall@K",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "sharegpt_7qFUagj_0",
+          "mem_id": "sharegpt_7qFUagj_0:t6",
+          "distance": 0.4548
+        },
+        {
+          "session_id": "sharegpt_jJQwr3e_0",
+          "mem_id": "sharegpt_jJQwr3e_0:t6",
+          "distance": 0.486
+        },
+        {
+          "session_id": "answer_a17423e7_1",
+          "mem_id": "answer_a17423e7_1:t6",
+          "distance": 0.5073
+        },
+        {
+          "session_id": "sharegpt_D5vldxd_21",
+          "mem_id": "sharegpt_D5vldxd_21:t1",
+          "distance": 0.5135
+        },
+        {
+          "session_id": "sharegpt_6sDqw6L_0",
+          "mem_id": "sharegpt_6sDqw6L_0:t6",
+          "distance": 0.5255
+        }
+      ]
+    },
+    {
+      "question_id": "9a707b81",
+      "question": "How many days ago did I attend a baking class at a local culinary school when I made my friend's birthday cake?",
+      "gold_session_ids": [
+        "answer_dba89487_2",
+        "answer_dba89487_1"
+      ],
+      "verdict": "recall@1",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "answer_dba89487_2",
+          "mem_id": "answer_dba89487_2:t0",
+          "distance": 0.4405
+        },
+        {
+          "session_id": "answer_dba89487_2",
+          "mem_id": "answer_dba89487_2:t2",
+          "distance": 0.4805
+        },
+        {
+          "session_id": "ultrachat_243091",
+          "mem_id": "ultrachat_243091:t4",
+          "distance": 0.5574
+        },
+        {
+          "session_id": "sharegpt_07OY96u_27",
+          "mem_id": "sharegpt_07OY96u_27:t1",
+          "distance": 0.5694
+        },
+        {
+          "session_id": "ultrachat_243091",
+          "mem_id": "ultrachat_243091:t10",
+          "distance": 0.5724
+        }
+      ]
+    }
+  ],
+  "elapsed_sec": 2.6245760917663574
+}

--- a/docs/bench/pinecone-lme-temporal-diagnostic-hyde-20260429.json
+++ b/docs/bench/pinecone-lme-temporal-diagnostic-hyde-20260429.json
@@ -1,0 +1,1299 @@
+{
+  "embedder": "pinecone:llama-text-embed-v2@1024d",
+  "store": "pinecone-local",
+  "variant": "s",
+  "category": "temporal-reasoning",
+  "n_total": 30,
+  "n_scored": 30,
+  "top_k": 10,
+  "counts": {
+    "recall@1": 23,
+    "recall@K": 6,
+    "miss": 1
+  },
+  "found_pct": 96.66666666666667,
+  "failures": [
+    {
+      "question_id": "gpt4_468eb063",
+      "question": "How many days ago did I meet Emma?",
+      "gold_session_ids": [
+        "answer_9b09d95b_1"
+      ],
+      "verdict": "miss",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "sharegpt_hGQUdgE_27",
+          "mem_id": "sharegpt_hGQUdgE_27:t1",
+          "distance": 0.3841
+        },
+        {
+          "session_id": "c6a2e4cc",
+          "mem_id": "c6a2e4cc:t2",
+          "distance": 0.4124
+        },
+        {
+          "session_id": "c6a2e4cc",
+          "mem_id": "c6a2e4cc:t4",
+          "distance": 0.4275
+        },
+        {
+          "session_id": "sharegpt_4vpTf3p_0",
+          "mem_id": "sharegpt_4vpTf3p_0:t1",
+          "distance": 0.3903
+        },
+        {
+          "session_id": "d12d5a98_5",
+          "mem_id": "d12d5a98_5:t10",
+          "distance": 0.5019
+        }
+      ],
+      "queries_used": [
+        "How many days ago did I meet Emma?",
+        "I met up with Emma at the coffee shop near campus and we ended up talking for hours. She brought over those photos from her trip and we made plans to hang out again soon."
+      ]
+    }
+  ],
+  "verdicts": [
+    {
+      "question_id": "gpt4_59149c77",
+      "question": "How many days passed between my visit to the Museum of Modern Art (MoMA) and the 'Ancient Civilizations' exhibit at the Metropolitan Museum of Art?",
+      "gold_session_ids": [
+        "answer_d00ba6d0_1",
+        "answer_d00ba6d0_2"
+      ],
+      "verdict": "recall@1",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "answer_d00ba6d0_2",
+          "mem_id": "answer_d00ba6d0_2:t6",
+          "distance": 0.4636
+        },
+        {
+          "session_id": "answer_d00ba6d0_2",
+          "mem_id": "answer_d00ba6d0_2:t7",
+          "distance": 0.6102
+        },
+        {
+          "session_id": "answer_d00ba6d0_2",
+          "mem_id": "answer_d00ba6d0_2:t8",
+          "distance": 0.632
+        },
+        {
+          "session_id": "9e2c2a6c_2",
+          "mem_id": "9e2c2a6c_2:t0",
+          "distance": 0.6379
+        },
+        {
+          "session_id": "answer_d00ba6d0_1",
+          "mem_id": "answer_d00ba6d0_1:t0",
+          "distance": 0.6757
+        }
+      ],
+      "queries_used": [
+        "How many days passed between my visit to the Museum of Modern Art (MoMA) and the 'Ancient Civilizations' exhibit at the Metropolitan Museum of Art?",
+        "I went to MoMA for a few hours and then, a few days later, spent the afternoon at the Met checking out the \u201cAncient Civilizations\u201d exhibit. I was bouncing between the two museums while I was in the city and ended up taking a ton of photos."
+      ]
+    },
+    {
+      "question_id": "gpt4_f49edff3",
+      "question": "Which three events happened in the order from first to last: the day I helped my friend prepare the nursery, the day I helped my cousin pick out stuff for her baby shower, and the day I ordered a customized phone case for my friend's birthday?",
+      "gold_session_ids": [
+        "answer_3e9fce53_1",
+        "answer_3e9fce53_2",
+        "answer_3e9fce53_3"
+      ],
+      "verdict": "recall@1",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "answer_3e9fce53_3",
+          "mem_id": "answer_3e9fce53_3:t0",
+          "distance": 0.3986
+        },
+        {
+          "session_id": "answer_3e9fce53_1",
+          "mem_id": "answer_3e9fce53_1:t0",
+          "distance": 0.5864
+        },
+        {
+          "session_id": "answer_3e9fce53_3",
+          "mem_id": "answer_3e9fce53_3:t1",
+          "distance": 0.5912
+        },
+        {
+          "session_id": "answer_3e9fce53_1",
+          "mem_id": "answer_3e9fce53_1:t4",
+          "distance": 0.6463
+        },
+        {
+          "session_id": "answer_3e9fce53_1",
+          "mem_id": "answer_3e9fce53_1:t2",
+          "distance": 0.6419
+        }
+      ],
+      "queries_used": [
+        "Which three events happened in the order from first to last: the day I helped my friend prepare the nursery, the day I helped my cousin pick out stuff for her baby shower, and the day I ordered a customized phone case for my friend's birthday?",
+        "I spent the afternoon helping my friend get the nursery ready, hanging up little animal prints and putting together the crib. A few days later I went with my cousin to pick out baby shower decorations and gifts, and later on I ordered a customized phone case for my friend Maya\u2019s birthday."
+      ]
+    },
+    {
+      "question_id": "71017276",
+      "question": "How many weeks ago did I meet up with my aunt and receive the crystal chandelier?",
+      "gold_session_ids": [
+        "answer_0b4a8adc_1"
+      ],
+      "verdict": "recall@K",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "sharegpt_duoAhsS_0",
+          "mem_id": "sharegpt_duoAhsS_0:t2",
+          "distance": 0.5109
+        },
+        {
+          "session_id": "sharegpt_11WxPMZ_0",
+          "mem_id": "sharegpt_11WxPMZ_0:t70",
+          "distance": 0.5126
+        },
+        {
+          "session_id": "sharegpt_11WxPMZ_0",
+          "mem_id": "sharegpt_11WxPMZ_0:t58",
+          "distance": 0.5221
+        },
+        {
+          "session_id": "sharegpt_tCLMKZY_0",
+          "mem_id": "sharegpt_tCLMKZY_0:t12",
+          "distance": 0.5275
+        },
+        {
+          "session_id": "sharegpt_11WxPMZ_0",
+          "mem_id": "sharegpt_11WxPMZ_0:t35",
+          "distance": 0.4964
+        }
+      ],
+      "queries_used": [
+        "How many weeks ago did I meet up with my aunt and receive the crystal chandelier?",
+        "I drove out to my aunt Linda\u2019s place and she handed me this gorgeous crystal chandelier she\u2019d been saving in her attic. We spent the afternoon talking in her dining room while I loaded it carefully into the car."
+      ]
+    },
+    {
+      "question_id": "b46e15ed",
+      "question": "How many months have passed since I participated in two charity events in a row, on consecutive days?",
+      "gold_session_ids": [
+        "answer_4bfcc250_4",
+        "answer_4bfcc250_3",
+        "answer_4bfcc250_2",
+        "answer_4bfcc250_1"
+      ],
+      "verdict": "recall@1",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "answer_4bfcc250_1",
+          "mem_id": "answer_4bfcc250_1:t10",
+          "distance": 0.5735
+        },
+        {
+          "session_id": "answer_4bfcc250_1",
+          "mem_id": "answer_4bfcc250_1:t4",
+          "distance": 0.5876
+        },
+        {
+          "session_id": "answer_4bfcc250_3",
+          "mem_id": "answer_4bfcc250_3:t4",
+          "distance": 0.6018
+        },
+        {
+          "session_id": "519ffeb1",
+          "mem_id": "519ffeb1:t6",
+          "distance": 0.6192
+        },
+        {
+          "session_id": "519ffeb1",
+          "mem_id": "519ffeb1:t4",
+          "distance": 0.5673
+        }
+      ],
+      "queries_used": [
+        "How many months have passed since I participated in two charity events in a row, on consecutive days?",
+        "A couple months back I did two charity events back-to-back on Saturday and Sunday, one for a food bank and one for a neighborhood shelter. I was wiped out afterward, but it felt really good to be involved in both."
+      ]
+    },
+    {
+      "question_id": "gpt4_fa19884c",
+      "question": "How many days passed between the day I started playing along to my favorite songs on my old keyboard and the day I discovered a bluegrass band?",
+      "gold_session_ids": [
+        "answer_ff201786_1",
+        "answer_ff201786_2"
+      ],
+      "verdict": "recall@1",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "answer_ff201786_1",
+          "mem_id": "answer_ff201786_1:t8",
+          "distance": 0.5131
+        },
+        {
+          "session_id": "answer_ff201786_2",
+          "mem_id": "answer_ff201786_2:t0",
+          "distance": 0.5068
+        },
+        {
+          "session_id": "answer_ff201786_1",
+          "mem_id": "answer_ff201786_1:t9",
+          "distance": 0.564
+        },
+        {
+          "session_id": "answer_ff201786_2",
+          "mem_id": "answer_ff201786_2:t8",
+          "distance": 0.6053
+        },
+        {
+          "session_id": "128082f8_1",
+          "mem_id": "128082f8_1:t10",
+          "distance": 0.6027
+        }
+      ],
+      "queries_used": [
+        "How many days passed between the day I started playing along to my favorite songs on my old keyboard and the day I discovered a bluegrass band?",
+        "I started messing around on my old keyboard again, just playing along to my favorite songs and trying to get my fingers back in shape. A few days later I stumbled onto a bluegrass band that completely pulled me in."
+      ]
+    },
+    {
+      "question_id": "0bc8ad92",
+      "question": "How many months have passed since I last visited a museum with a friend?",
+      "gold_session_ids": [
+        "answer_f4ea84fb_3",
+        "answer_f4ea84fb_2",
+        "answer_f4ea84fb_1"
+      ],
+      "verdict": "recall@K",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "sharegpt_xxk9JDz_21",
+          "mem_id": "sharegpt_xxk9JDz_21:t9",
+          "distance": 0.4935
+        },
+        {
+          "session_id": "ultrachat_349938",
+          "mem_id": "ultrachat_349938:t4",
+          "distance": 0.5572
+        },
+        {
+          "session_id": "sharegpt_Le7CqkS_0",
+          "mem_id": "sharegpt_Le7CqkS_0:t4",
+          "distance": 0.5613
+        },
+        {
+          "session_id": "answer_f4ea84fb_3",
+          "mem_id": "answer_f4ea84fb_3:t4",
+          "distance": 0.6096
+        },
+        {
+          "session_id": "ultrachat_349938",
+          "mem_id": "ultrachat_349938:t8",
+          "distance": 0.5743
+        }
+      ],
+      "queries_used": [
+        "How many months have passed since I last visited a museum with a friend?",
+        "I went to the art museum with my friend Maya and we ended up spending the whole afternoon wandering through the modern wing. We grabbed coffee afterward and talked about the weird installation in the sculpture garden."
+      ]
+    },
+    {
+      "question_id": "af082822",
+      "question": "How many weeks ago did I attend the friends and family sale at Nordstrom?",
+      "gold_session_ids": [
+        "answer_b51b6115_1"
+      ],
+      "verdict": "recall@K",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "1dfef591_2",
+          "mem_id": "1dfef591_2:t6",
+          "distance": 0.5883
+        },
+        {
+          "session_id": "answer_b51b6115_1",
+          "mem_id": "answer_b51b6115_1:t2",
+          "distance": 0.6147
+        },
+        {
+          "session_id": "1040e24b_1",
+          "mem_id": "1040e24b_1:t0",
+          "distance": 0.5983
+        },
+        {
+          "session_id": "1dfef591_2",
+          "mem_id": "1dfef591_2:t10",
+          "distance": 0.6182
+        },
+        {
+          "session_id": "cdf068b1_2",
+          "mem_id": "cdf068b1_2:t10",
+          "distance": 0.5479
+        }
+      ],
+      "queries_used": [
+        "How many weeks ago did I attend the friends and family sale at Nordstrom?",
+        "I went to the friends and family sale at Nordstrom and ended up grabbing a couple of things I\u2019d been eyeing for a while. The discounts were actually better than I expected, so I left feeling pretty happy with my haul."
+      ]
+    },
+    {
+      "question_id": "gpt4_4929293a",
+      "question": "Which event happened first, my cousin's wedding or Michael's engagement party?",
+      "gold_session_ids": [
+        "answer_add9b012_2",
+        "answer_add9b012_1"
+      ],
+      "verdict": "recall@1",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "answer_add9b012_2",
+          "mem_id": "answer_add9b012_2:t0",
+          "distance": 0.5653
+        },
+        {
+          "session_id": "answer_add9b012_1",
+          "mem_id": "answer_add9b012_1:t6",
+          "distance": 0.6293
+        },
+        {
+          "session_id": "answer_add9b012_2",
+          "mem_id": "answer_add9b012_2:t4",
+          "distance": 0.6023
+        },
+        {
+          "session_id": "answer_add9b012_1",
+          "mem_id": "answer_add9b012_1:t8",
+          "distance": 0.6352
+        },
+        {
+          "session_id": "96c743d0_abs_2",
+          "mem_id": "96c743d0_abs_2:t10",
+          "distance": 0.5881
+        }
+      ],
+      "queries_used": [
+        "Which event happened first, my cousin's wedding or Michael's engagement party?",
+        "I went to my cousin\u2019s wedding last spring \u2014 it was a huge outdoor ceremony and everyone stayed late dancing. A few months later I headed to Michael\u2019s engagement party, which was way more low-key at a rooftop bar."
+      ]
+    },
+    {
+      "question_id": "gpt4_b5700ca9",
+      "question": "How many days ago did I attend the Maundy Thursday service at the Episcopal Church?",
+      "gold_session_ids": [
+        "answer_a17423e7_1"
+      ],
+      "verdict": "recall@1",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "answer_a17423e7_1",
+          "mem_id": "answer_a17423e7_1:t6",
+          "distance": 0.5073
+        },
+        {
+          "session_id": "sharegpt_jJQwr3e_0",
+          "mem_id": "sharegpt_jJQwr3e_0:t6",
+          "distance": 0.486
+        },
+        {
+          "session_id": "ultrachat_383774",
+          "mem_id": "ultrachat_383774:t6",
+          "distance": 0.5505
+        },
+        {
+          "session_id": "sharegpt_6sDqw6L_0",
+          "mem_id": "sharegpt_6sDqw6L_0:t6",
+          "distance": 0.5255
+        },
+        {
+          "session_id": "ultrachat_383774",
+          "mem_id": "ultrachat_383774:t2",
+          "distance": 0.5653
+        }
+      ],
+      "queries_used": [
+        "How many days ago did I attend the Maundy Thursday service at the Episcopal Church?",
+        "I went to the Maundy Thursday service at the Episcopal Church last night. The whole service was really moving, especially the foot washing and the stripping of the altar."
+      ]
+    },
+    {
+      "question_id": "9a707b81",
+      "question": "How many days ago did I attend a baking class at a local culinary school when I made my friend's birthday cake?",
+      "gold_session_ids": [
+        "answer_dba89487_2",
+        "answer_dba89487_1"
+      ],
+      "verdict": "recall@1",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "answer_dba89487_2",
+          "mem_id": "answer_dba89487_2:t0",
+          "distance": 0.4405
+        },
+        {
+          "session_id": "answer_dba89487_2",
+          "mem_id": "answer_dba89487_2:t2",
+          "distance": 0.4805
+        },
+        {
+          "session_id": "6862e478_2",
+          "mem_id": "6862e478_2:t4",
+          "distance": 0.5901
+        },
+        {
+          "session_id": "sharegpt_v3mxcGF_0",
+          "mem_id": "sharegpt_v3mxcGF_0:t8",
+          "distance": 0.5824
+        },
+        {
+          "session_id": "answer_dba89487_1",
+          "mem_id": "answer_dba89487_1:t0",
+          "distance": 0.6206
+        }
+      ],
+      "queries_used": [
+        "How many days ago did I attend a baking class at a local culinary school when I made my friend's birthday cake?",
+        "I took a baking class at the local culinary school and used what I learned to make my friend\u2019s birthday cake. We ended up doing a chocolate layer cake with buttercream and fresh berries."
+      ]
+    },
+    {
+      "question_id": "gpt4_1d4ab0c9",
+      "question": "How many days passed between the day I started watering my herb garden and the day I harvested my first batch of fresh herbs?",
+      "gold_session_ids": [
+        "answer_febde667_1",
+        "answer_febde667_2"
+      ],
+      "verdict": "recall@1",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "answer_febde667_1",
+          "mem_id": "answer_febde667_1:t0",
+          "distance": 0.4178
+        },
+        {
+          "session_id": "answer_febde667_2",
+          "mem_id": "answer_febde667_2:t0",
+          "distance": 0.4188
+        },
+        {
+          "session_id": "answer_febde667_2",
+          "mem_id": "answer_febde667_2:t4",
+          "distance": 0.5058
+        },
+        {
+          "session_id": "answer_febde667_2",
+          "mem_id": "answer_febde667_2:t1",
+          "distance": 0.62
+        },
+        {
+          "session_id": "answer_febde667_1",
+          "mem_id": "answer_febde667_1:t1",
+          "distance": 0.5739
+        }
+      ],
+      "queries_used": [
+        "How many days passed between the day I started watering my herb garden and the day I harvested my first batch of fresh herbs?",
+        "I started watering my little herb garden on the back patio and was checking on the basil, mint, and rosemary every morning. By the time I harvested my first handful for dinner, the pots were finally full and fragrant."
+      ]
+    },
+    {
+      "question_id": "gpt4_e072b769",
+      "question": "How many weeks ago did I start using the cashback app 'Ibotta'?",
+      "gold_session_ids": [
+        "answer_c19bd2bf_1"
+      ],
+      "verdict": "recall@1",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "answer_c19bd2bf_1",
+          "mem_id": "answer_c19bd2bf_1:t10",
+          "distance": 0.473
+        },
+        {
+          "session_id": "answer_c19bd2bf_1",
+          "mem_id": "answer_c19bd2bf_1:t0",
+          "distance": 0.4798
+        },
+        {
+          "session_id": "answer_c19bd2bf_1",
+          "mem_id": "answer_c19bd2bf_1:t2",
+          "distance": 0.5838
+        },
+        {
+          "session_id": "answer_c19bd2bf_1",
+          "mem_id": "answer_c19bd2bf_1:t4",
+          "distance": 0.5387
+        },
+        {
+          "session_id": "answer_c19bd2bf_1",
+          "mem_id": "answer_c19bd2bf_1:t8",
+          "distance": 0.5628
+        }
+      ],
+      "queries_used": [
+        "How many weeks ago did I start using the cashback app 'Ibotta'?",
+        "I started using Ibotta after hearing about it from a friend and figured I might as well see if the cashback adds up. I\u2019ve been scanning receipts and checking the app every time I shop for groceries."
+      ]
+    },
+    {
+      "question_id": "0db4c65d",
+      "question": "How many days had passed since I finished reading 'The Seven Husbands of Evelyn Hugo' when I attended the book reading event at the local library, where the author of 'The Silent Patient' is discussing her latest thriller novel?",
+      "gold_session_ids": [
+        "answer_b9e32ff8_1",
+        "answer_b9e32ff8_2"
+      ],
+      "verdict": "recall@1",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "answer_b9e32ff8_2",
+          "mem_id": "answer_b9e32ff8_2:t0",
+          "distance": 0.295
+        },
+        {
+          "session_id": "answer_b9e32ff8_2",
+          "mem_id": "answer_b9e32ff8_2:t1",
+          "distance": 0.4514
+        },
+        {
+          "session_id": "answer_b9e32ff8_1",
+          "mem_id": "answer_b9e32ff8_1:t0",
+          "distance": 0.4936
+        },
+        {
+          "session_id": "answer_b9e32ff8_1",
+          "mem_id": "answer_b9e32ff8_1:t1",
+          "distance": 0.5428
+        },
+        {
+          "session_id": "answer_b9e32ff8_1",
+          "mem_id": "answer_b9e32ff8_1:t2",
+          "distance": 0.5665
+        }
+      ],
+      "queries_used": [
+        "How many days had passed since I finished reading 'The Seven Husbands of Evelyn Hugo' when I attended the book reading event at the local library, where the author of 'The Silent Patient' is discussing her latest thriller novel?",
+        "I went to a book reading at the local library where the author of *The Silent Patient* was talking about her new thriller. I\u2019d just finished *The Seven Husbands of Evelyn Hugo* and was still thinking about it on the drive over."
+      ]
+    },
+    {
+      "question_id": "gpt4_1d80365e",
+      "question": "How many days did I spend on my solo camping trip to Yosemite National Park?",
+      "gold_session_ids": [
+        "answer_661b711f_1",
+        "answer_661b711f_2"
+      ],
+      "verdict": "recall@1",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "answer_661b711f_2",
+          "mem_id": "answer_661b711f_2:t0",
+          "distance": 0.4669
+        },
+        {
+          "session_id": "answer_661b711f_1",
+          "mem_id": "answer_661b711f_1:t0",
+          "distance": 0.4726
+        },
+        {
+          "session_id": "answer_661b711f_1",
+          "mem_id": "answer_661b711f_1:t8",
+          "distance": 0.536
+        },
+        {
+          "session_id": "answer_661b711f_1",
+          "mem_id": "answer_661b711f_1:t1",
+          "distance": 0.5625
+        },
+        {
+          "session_id": "answer_661b711f_1",
+          "mem_id": "answer_661b711f_1:t4",
+          "distance": 0.5957
+        }
+      ],
+      "queries_used": [
+        "How many days did I spend on my solo camping trip to Yosemite National Park?",
+        "I spent four days solo camping up in Yosemite National Park last weekend, mostly hiking during the day and cooking simple meals by the fire at night. It was my first time doing a trip like that completely alone."
+      ]
+    },
+    {
+      "question_id": "gpt4_7f6b06db",
+      "question": "What is the order of the three trips I took in the past three months, from earliest to latest?",
+      "gold_session_ids": [
+        "answer_5d8c99d3_1",
+        "answer_5d8c99d3_2",
+        "answer_5d8c99d3_3"
+      ],
+      "verdict": "recall@K",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "sharegpt_n3MgsgL_0",
+          "mem_id": "sharegpt_n3MgsgL_0:t22",
+          "distance": 0.4883
+        },
+        {
+          "session_id": "sharegpt_n3MgsgL_0",
+          "mem_id": "sharegpt_n3MgsgL_0:t28",
+          "distance": 0.4819
+        },
+        {
+          "session_id": "ultrachat_139167",
+          "mem_id": "ultrachat_139167:t2",
+          "distance": 0.5334
+        },
+        {
+          "session_id": "ultrachat_176513",
+          "mem_id": "ultrachat_176513:t2",
+          "distance": 0.4774
+        },
+        {
+          "session_id": "answer_5d8c99d3_2",
+          "mem_id": "answer_5d8c99d3_2:t2",
+          "distance": 0.5411
+        }
+      ],
+      "queries_used": [
+        "What is the order of the three trips I took in the past three months, from earliest to latest?",
+        "I\u2019ve been on three trips lately \u2014 first a quick work run to Chicago, then a long weekend in Asheville with friends, and most recently a family visit down in Miami. Each one kind of blended together, but those were the three back-to-back."
+      ]
+    },
+    {
+      "question_id": "gpt4_6dc9b45b",
+      "question": "How many months ago did I attend the Seattle International Film Festival?",
+      "gold_session_ids": [
+        "answer_c4df007f_1"
+      ],
+      "verdict": "recall@K",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "sharegpt_jyynvvk_0",
+          "mem_id": "sharegpt_jyynvvk_0:t119",
+          "distance": 0.3794
+        },
+        {
+          "session_id": "answer_c4df007f_1",
+          "mem_id": "answer_c4df007f_1:t0",
+          "distance": 0.5481
+        },
+        {
+          "session_id": "sharegpt_jyynvvk_0",
+          "mem_id": "sharegpt_jyynvvk_0:t121",
+          "distance": 0.3794
+        },
+        {
+          "session_id": "answer_c4df007f_1",
+          "mem_id": "answer_c4df007f_1:t6",
+          "distance": 0.6265
+        },
+        {
+          "session_id": "sharegpt_jyynvvk_0",
+          "mem_id": "sharegpt_jyynvvk_0:t123",
+          "distance": 0.3794
+        }
+      ],
+      "queries_used": [
+        "How many months ago did I attend the Seattle International Film Festival?",
+        "I went up to Seattle for the International Film Festival and spent the whole weekend bouncing between screenings downtown. It was a fun trip \u2014 I caught a couple of indie films I\u2019d been wanting to see and grabbed ramen afterward with a friend."
+      ]
+    },
+    {
+      "question_id": "gpt4_8279ba02",
+      "question": "How many days ago did I buy a smoker?",
+      "gold_session_ids": [
+        "answer_56521e65_1"
+      ],
+      "verdict": "recall@K",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "sharegpt_3xB7vJ2_195",
+          "mem_id": "sharegpt_3xB7vJ2_195:t22",
+          "distance": 0.4139
+        },
+        {
+          "session_id": "sharegpt_3xB7vJ2_195",
+          "mem_id": "sharegpt_3xB7vJ2_195:t9",
+          "distance": 0.3459
+        },
+        {
+          "session_id": "answer_56521e65_1",
+          "mem_id": "answer_56521e65_1:t8",
+          "distance": 0.5277
+        },
+        {
+          "session_id": "sharegpt_uh8yJR0_0",
+          "mem_id": "sharegpt_uh8yJR0_0:t2",
+          "distance": 0.3558
+        },
+        {
+          "session_id": "answer_56521e65_1",
+          "mem_id": "answer_56521e65_1:t0",
+          "distance": 0.5649
+        }
+      ],
+      "queries_used": [
+        "How many days ago did I buy a smoker?",
+        "Picked up a Traeger pellet smoker over the weekend \u2014 finally ready to do real low-and-slow brisket at home. I\u2019ve been wanting one for a while, so I was pretty excited to bring it back and set it up."
+      ]
+    },
+    {
+      "question_id": "gpt4_18c2b244",
+      "question": "What is the order of the three events: 'I signed up for the rewards program at ShopRite', 'I used a Buy One Get One Free coupon on Luvs diapers at Walmart', and 'I redeemed $12 cashback for a $10 Amazon gift card from Ibotta'?",
+      "gold_session_ids": [
+        "answer_c862f65a_2",
+        "answer_c862f65a_3",
+        "answer_c862f65a_1"
+      ],
+      "verdict": "recall@1",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "answer_c862f65a_1",
+          "mem_id": "answer_c862f65a_1:t0",
+          "distance": 0.4876
+        },
+        {
+          "session_id": "answer_c862f65a_2",
+          "mem_id": "answer_c862f65a_2:t6",
+          "distance": 0.5322
+        },
+        {
+          "session_id": "answer_c862f65a_2",
+          "mem_id": "answer_c862f65a_2:t0",
+          "distance": 0.5418
+        },
+        {
+          "session_id": "answer_c862f65a_3",
+          "mem_id": "answer_c862f65a_3:t0",
+          "distance": 0.5563
+        },
+        {
+          "session_id": "answer_c862f65a_3",
+          "mem_id": "answer_c862f65a_3:t1",
+          "distance": 0.5659
+        }
+      ],
+      "queries_used": [
+        "What is the order of the three events: 'I signed up for the rewards program at ShopRite', 'I used a Buy One Get One Free coupon on Luvs diapers at Walmart', and 'I redeemed $12 cashback for a $10 Amazon gift card from Ibotta'?",
+        "I signed up for the ShopRite rewards program while I was doing my grocery run and the cashier mentioned it would help me save on weekly stuff. Later I used a Buy One Get One Free coupon on Luvs diapers at Walmart, and after that I redeemed $12 cashback on Ibotta for a $10 Amazon gift card."
+      ]
+    },
+    {
+      "question_id": "gpt4_a1b77f9c",
+      "question": "How many weeks in total do I spent on reading 'The Nightingale' and listening to 'Sapiens: A Brief History of Humankind' and 'The Power'?",
+      "gold_session_ids": [
+        "answer_e9ad5914_1",
+        "answer_e9ad5914_2",
+        "answer_e9ad5914_3",
+        "answer_e9ad5914_4",
+        "answer_e9ad5914_5",
+        "answer_e9ad5914_6"
+      ],
+      "verdict": "recall@1",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "answer_e9ad5914_3",
+          "mem_id": "answer_e9ad5914_3:t0",
+          "distance": 0.4622
+        },
+        {
+          "session_id": "answer_e9ad5914_1",
+          "mem_id": "answer_e9ad5914_1:t2",
+          "distance": 0.4674
+        },
+        {
+          "session_id": "answer_e9ad5914_3",
+          "mem_id": "answer_e9ad5914_3:t6",
+          "distance": 0.5325
+        },
+        {
+          "session_id": "answer_e9ad5914_1",
+          "mem_id": "answer_e9ad5914_1:t0",
+          "distance": 0.538
+        },
+        {
+          "session_id": "answer_e9ad5914_2",
+          "mem_id": "answer_e9ad5914_2:t0",
+          "distance": 0.5387
+        }
+      ],
+      "queries_used": [
+        "How many weeks in total do I spent on reading 'The Nightingale' and listening to 'Sapiens: A Brief History of Humankind' and 'The Power'?",
+        "I spent a few weeks working through The Nightingale, and I also listened to Sapiens: A Brief History of Humankind and The Power during my commute. It turned into a little reading-and-listening streak over the same stretch of time."
+      ]
+    },
+    {
+      "question_id": "gpt4_1916e0ea",
+      "question": "How many days passed between the day I cancelled my FarmFresh subscription and the day I did my online grocery shopping from Instacart?",
+      "gold_session_ids": [
+        "answer_447052a5_2",
+        "answer_447052a5_1"
+      ],
+      "verdict": "recall@1",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "answer_447052a5_2",
+          "mem_id": "answer_447052a5_2:t6",
+          "distance": 0.4917
+        },
+        {
+          "session_id": "answer_447052a5_1",
+          "mem_id": "answer_447052a5_1:t0",
+          "distance": 0.5843
+        },
+        {
+          "session_id": "answer_447052a5_2",
+          "mem_id": "answer_447052a5_2:t7",
+          "distance": 0.6397
+        },
+        {
+          "session_id": "answer_447052a5_1",
+          "mem_id": "answer_447052a5_1:t4",
+          "distance": 0.6292
+        },
+        {
+          "session_id": "answer_447052a5_2",
+          "mem_id": "answer_447052a5_2:t8",
+          "distance": 0.6578
+        }
+      ],
+      "queries_used": [
+        "How many days passed between the day I cancelled my FarmFresh subscription and the day I did my online grocery shopping from Instacart?",
+        "I cancelled my FarmFresh subscription because I was tired of the recurring deliveries and the boxes piling up on my porch. A few days later I ended up doing my grocery run through Instacart instead, just to get everything delivered in one shot."
+      ]
+    },
+    {
+      "question_id": "gpt4_7a0daae1",
+      "question": "How many weeks passed between the day I bought my new tennis racket and the day I received it?",
+      "gold_session_ids": [
+        "answer_4d5490f1_1",
+        "answer_4d5490f1_2"
+      ],
+      "verdict": "recall@1",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "answer_4d5490f1_2",
+          "mem_id": "answer_4d5490f1_2:t0",
+          "distance": 0.5725
+        },
+        {
+          "session_id": "ultrachat_294894",
+          "mem_id": "ultrachat_294894:t8",
+          "distance": 0.6554
+        },
+        {
+          "session_id": "bf3aebdb_2",
+          "mem_id": "bf3aebdb_2:t0",
+          "distance": 0.6786
+        },
+        {
+          "session_id": "answer_4d5490f1_1",
+          "mem_id": "answer_4d5490f1_1:t6",
+          "distance": 0.6937
+        },
+        {
+          "session_id": "88088faf",
+          "mem_id": "88088faf:t10",
+          "distance": 0.66
+        }
+      ],
+      "queries_used": [
+        "How many weeks passed between the day I bought my new tennis racket and the day I received it?",
+        "I finally ordered a new tennis racket after comparing a bunch of models online, and I was excited to get it for weekend matches. A few days later the package showed up on my doorstep and I unboxed it right away."
+      ]
+    },
+    {
+      "question_id": "gpt4_468eb063",
+      "question": "How many days ago did I meet Emma?",
+      "gold_session_ids": [
+        "answer_9b09d95b_1"
+      ],
+      "verdict": "miss",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "sharegpt_hGQUdgE_27",
+          "mem_id": "sharegpt_hGQUdgE_27:t1",
+          "distance": 0.3841
+        },
+        {
+          "session_id": "c6a2e4cc",
+          "mem_id": "c6a2e4cc:t2",
+          "distance": 0.4124
+        },
+        {
+          "session_id": "c6a2e4cc",
+          "mem_id": "c6a2e4cc:t4",
+          "distance": 0.4275
+        },
+        {
+          "session_id": "sharegpt_4vpTf3p_0",
+          "mem_id": "sharegpt_4vpTf3p_0:t1",
+          "distance": 0.3903
+        },
+        {
+          "session_id": "d12d5a98_5",
+          "mem_id": "d12d5a98_5:t10",
+          "distance": 0.5019
+        }
+      ],
+      "queries_used": [
+        "How many days ago did I meet Emma?",
+        "I met up with Emma at the coffee shop near campus and we ended up talking for hours. She brought over those photos from her trip and we made plans to hang out again soon."
+      ]
+    },
+    {
+      "question_id": "gpt4_7abb270c",
+      "question": "What is the order of the six museums I visited from earliest to latest?",
+      "gold_session_ids": [
+        "answer_7093d898_1",
+        "answer_7093d898_2",
+        "answer_7093d898_3",
+        "answer_7093d898_4",
+        "answer_7093d898_5",
+        "answer_7093d898_6"
+      ],
+      "verdict": "recall@1",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "answer_7093d898_6",
+          "mem_id": "answer_7093d898_6:t6",
+          "distance": 0.6345
+        },
+        {
+          "session_id": "answer_7093d898_1",
+          "mem_id": "answer_7093d898_1:t2",
+          "distance": 0.5018
+        },
+        {
+          "session_id": "answer_7093d898_4",
+          "mem_id": "answer_7093d898_4:t0",
+          "distance": 0.6362
+        },
+        {
+          "session_id": "ultrachat_560932",
+          "mem_id": "ultrachat_560932:t6",
+          "distance": 0.6132
+        },
+        {
+          "session_id": "1bfd5a8b_2",
+          "mem_id": "1bfd5a8b_2:t0",
+          "distance": 0.6138
+        }
+      ],
+      "queries_used": [
+        "What is the order of the six museums I visited from earliest to latest?",
+        "I spent the day museum-hopping with six stops: started at the art museum downtown, then hit the natural history museum, the science center, the photography museum, the local history museum, and finished at the modern art museum by the river. It turned into a long but really fun day of wandering from one exhibit to the next."
+      ]
+    },
+    {
+      "question_id": "gpt4_1e4a8aeb",
+      "question": "How many days passed between the day I attended the gardening workshop and the day I planted the tomato saplings?",
+      "gold_session_ids": [
+        "answer_16bd5ea5_1",
+        "answer_16bd5ea5_2"
+      ],
+      "verdict": "recall@1",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "answer_16bd5ea5_2",
+          "mem_id": "answer_16bd5ea5_2:t0",
+          "distance": 0.5422
+        },
+        {
+          "session_id": "answer_16bd5ea5_1",
+          "mem_id": "answer_16bd5ea5_1:t2",
+          "distance": 0.5748
+        },
+        {
+          "session_id": "d837b5fa",
+          "mem_id": "d837b5fa:t0",
+          "distance": 0.5851
+        },
+        {
+          "session_id": "ae0cd456",
+          "mem_id": "ae0cd456:t0",
+          "distance": 0.5988
+        },
+        {
+          "session_id": "ultrachat_410603",
+          "mem_id": "ultrachat_410603:t6",
+          "distance": 0.6469
+        }
+      ],
+      "queries_used": [
+        "How many days passed between the day I attended the gardening workshop and the day I planted the tomato saplings?",
+        "I went to a gardening workshop last weekend and came home with a bunch of notes about soil, compost, and tomato care. A few days later I finally planted the tomato saplings in the raised bed out back."
+      ]
+    },
+    {
+      "question_id": "gpt4_4fc4f797",
+      "question": "How many days passed between the day I received feedback about my car's suspension and the day I tested my new suspension setup?",
+      "gold_session_ids": [
+        "answer_be07688f_1",
+        "answer_be07688f_2"
+      ],
+      "verdict": "recall@1",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "answer_be07688f_1",
+          "mem_id": "answer_be07688f_1:t10",
+          "distance": 0.4638
+        },
+        {
+          "session_id": "answer_be07688f_1",
+          "mem_id": "answer_be07688f_1:t2",
+          "distance": 0.4669
+        },
+        {
+          "session_id": "answer_be07688f_1",
+          "mem_id": "answer_be07688f_1:t4",
+          "distance": 0.5058
+        },
+        {
+          "session_id": "answer_be07688f_1",
+          "mem_id": "answer_be07688f_1:t6",
+          "distance": 0.5423
+        },
+        {
+          "session_id": "answer_be07688f_2",
+          "mem_id": "answer_be07688f_2:t0",
+          "distance": 0.5251
+        }
+      ],
+      "queries_used": [
+        "How many days passed between the day I received feedback about my car's suspension and the day I tested my new suspension setup?",
+        "Got some feedback on my car\u2019s suspension after a drive last week, and I spent the next day or so tweaking the setup in the garage. Took it back out for a test run once I\u2019d adjusted the alignment and damping."
+      ]
+    },
+    {
+      "question_id": "4dfccbf7",
+      "question": "How many days had passed since I started taking ukulele lessons when I decided to take my acoustic guitar to the guitar tech for servicing?",
+      "gold_session_ids": [
+        "answer_4bebc782_1",
+        "answer_4bebc782_2"
+      ],
+      "verdict": "recall@1",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "answer_4bebc782_1",
+          "mem_id": "answer_4bebc782_1:t4",
+          "distance": 0.5221
+        },
+        {
+          "session_id": "answer_4bebc782_1",
+          "mem_id": "answer_4bebc782_1:t8",
+          "distance": 0.554
+        },
+        {
+          "session_id": "ultrachat_55529",
+          "mem_id": "ultrachat_55529:t6",
+          "distance": 0.5271
+        },
+        {
+          "session_id": "ultrachat_55529",
+          "mem_id": "ultrachat_55529:t2",
+          "distance": 0.5717
+        },
+        {
+          "session_id": "answer_4bebc782_2",
+          "mem_id": "answer_4bebc782_2:t6",
+          "distance": 0.6273
+        }
+      ],
+      "queries_used": [
+        "How many days had passed since I started taking ukulele lessons when I decided to take my acoustic guitar to the guitar tech for servicing?",
+        "I\u2019d been taking ukulele lessons for a bit and decided to bring my acoustic guitar to the guitar tech for a full servicing. I wanted it set up properly before I kept practicing more seriously."
+      ]
+    },
+    {
+      "question_id": "gpt4_61e13b3c",
+      "question": "How many weeks passed between the time I sold homemade baked goods at the Farmers' Market for the last time and the time I participated in the Spring Fling Market?",
+      "gold_session_ids": [
+        "answer_e831a29f_1",
+        "answer_e831a29f_2"
+      ],
+      "verdict": "recall@1",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "answer_e831a29f_1",
+          "mem_id": "answer_e831a29f_1:t0",
+          "distance": 0.5607
+        },
+        {
+          "session_id": "answer_e831a29f_2",
+          "mem_id": "answer_e831a29f_2:t0",
+          "distance": 0.5804
+        },
+        {
+          "session_id": "answer_e831a29f_1",
+          "mem_id": "answer_e831a29f_1:t4",
+          "distance": 0.5951
+        },
+        {
+          "session_id": "8e10bf6b_1",
+          "mem_id": "8e10bf6b_1:t0",
+          "distance": 0.6235
+        },
+        {
+          "session_id": "c0d099e6_2",
+          "mem_id": "c0d099e6_2:t0",
+          "distance": 0.6432
+        }
+      ],
+      "queries_used": [
+        "How many weeks passed between the time I sold homemade baked goods at the Farmers' Market for the last time and the time I participated in the Spring Fling Market?",
+        "I sold homemade baked goods at the Farmers\u2019 Market one last time, with the usual setup of boxes, labels, and a folding table packed with cookies and muffins. After that I took part in the Spring Fling Market and brought a fresh batch of treats to a bigger spring crowd."
+      ]
+    },
+    {
+      "question_id": "gpt4_45189cb4",
+      "question": "What is the order of the sports events I watched in January?",
+      "gold_session_ids": [
+        "answer_e6c20e52_3",
+        "answer_e6c20e52_2",
+        "answer_e6c20e52_1"
+      ],
+      "verdict": "recall@1",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "answer_e6c20e52_2",
+          "mem_id": "answer_e6c20e52_2:t0",
+          "distance": 0.552
+        },
+        {
+          "session_id": "answer_e6c20e52_2",
+          "mem_id": "answer_e6c20e52_2:t6",
+          "distance": 0.5529
+        },
+        {
+          "session_id": "ultrachat_561760",
+          "mem_id": "ultrachat_561760:t2",
+          "distance": 0.5401
+        },
+        {
+          "session_id": "ultrachat_560291",
+          "mem_id": "ultrachat_560291:t10",
+          "distance": 0.5696
+        },
+        {
+          "session_id": "ultrachat_561760",
+          "mem_id": "ultrachat_561760:t0",
+          "distance": 0.5824
+        }
+      ],
+      "queries_used": [
+        "What is the order of the sports events I watched in January?",
+        "I spent a bunch of January evenings bouncing between sports on TV, starting with an NFL playoff game and then catching a Lakers game later in the week. After that I watched a really tense college basketball matchup and a couple of hockey games on the weekend."
+      ]
+    },
+    {
+      "question_id": "2ebe6c90",
+      "question": "How many days did it take me to finish 'The Nightingale' by Kristin Hannah?",
+      "gold_session_ids": [
+        "answer_c9d35c00_1",
+        "answer_c9d35c00_2"
+      ],
+      "verdict": "recall@1",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "answer_c9d35c00_2",
+          "mem_id": "answer_c9d35c00_2:t0",
+          "distance": 0.3382
+        },
+        {
+          "session_id": "answer_c9d35c00_1",
+          "mem_id": "answer_c9d35c00_1:t0",
+          "distance": 0.3738
+        },
+        {
+          "session_id": "answer_c9d35c00_2",
+          "mem_id": "answer_c9d35c00_2:t4",
+          "distance": 0.4913
+        },
+        {
+          "session_id": "answer_c9d35c00_2",
+          "mem_id": "answer_c9d35c00_2:t6",
+          "distance": 0.4864
+        },
+        {
+          "session_id": "answer_c9d35c00_2",
+          "mem_id": "answer_c9d35c00_2:t1",
+          "distance": 0.5508
+        }
+      ],
+      "queries_used": [
+        "How many days did it take me to finish 'The Nightingale' by Kristin Hannah?",
+        "I finished *The Nightingale* by Kristin Hannah last night after dragging it around for a few days. It completely wrecked me in the best way."
+      ]
+    },
+    {
+      "question_id": "gpt4_e061b84f",
+      "question": "What is the order of the three sports events I participated in during the past month, from earliest to latest?",
+      "gold_session_ids": [
+        "answer_8c64ce25_2",
+        "answer_8c64ce25_1",
+        "answer_8c64ce25_3"
+      ],
+      "verdict": "recall@1",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "answer_8c64ce25_2",
+          "mem_id": "answer_8c64ce25_2:t4",
+          "distance": 0.5934
+        },
+        {
+          "session_id": "ultrachat_369361",
+          "mem_id": "ultrachat_369361:t2",
+          "distance": 0.5734
+        },
+        {
+          "session_id": "0a6bf5e4_1",
+          "mem_id": "0a6bf5e4_1:t0",
+          "distance": 0.6504
+        },
+        {
+          "session_id": "d5d46422",
+          "mem_id": "d5d46422:t10",
+          "distance": 0.5825
+        },
+        {
+          "session_id": "bab3f409",
+          "mem_id": "bab3f409:t0",
+          "distance": 0.6254
+        }
+      ],
+      "queries_used": [
+        "What is the order of the three sports events I participated in during the past month, from earliest to latest?",
+        "I played in three sports events over the past month \u2014 first a pickup basketball game, then a weekend tennis tournament, and finally a charity 5K run. The month turned into a weirdly busy streak of trying to stay active."
+      ]
+    }
+  ],
+  "elapsed_sec": 56.65193581581116
+}

--- a/docs/bench/pinecone-lme-temporal-diagnostic-hyde-bm25-20260429.json
+++ b/docs/bench/pinecone-lme-temporal-diagnostic-hyde-bm25-20260429.json
@@ -1,0 +1,1299 @@
+{
+  "embedder": "pinecone:llama-text-embed-v2@1024d",
+  "store": "pinecone-local",
+  "variant": "s",
+  "category": "temporal-reasoning",
+  "n_total": 30,
+  "n_scored": 30,
+  "top_k": 10,
+  "counts": {
+    "recall@1": 26,
+    "recall@K": 3,
+    "miss": 1
+  },
+  "found_pct": 96.66666666666667,
+  "failures": [
+    {
+      "question_id": "gpt4_468eb063",
+      "question": "How many days ago did I meet Emma?",
+      "gold_session_ids": [
+        "answer_9b09d95b_1"
+      ],
+      "verdict": "miss",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "e60a93ff_2",
+          "mem_id": "e60a93ff_2:t6",
+          "distance": 0.5927
+        },
+        {
+          "session_id": "e60a93ff_2",
+          "mem_id": "e60a93ff_2:t4",
+          "distance": 0.641
+        },
+        {
+          "session_id": "e60a93ff_2",
+          "mem_id": "e60a93ff_2:t8",
+          "distance": 0.6691
+        },
+        {
+          "session_id": "sharegpt_WRWOWFP_0",
+          "mem_id": "sharegpt_WRWOWFP_0:t18",
+          "distance": 0.5527
+        },
+        {
+          "session_id": "sharegpt_hGQUdgE_27",
+          "mem_id": "sharegpt_hGQUdgE_27:t1",
+          "distance": 0.3841
+        }
+      ],
+      "queries_used": [
+        "How many days ago did I meet Emma?",
+        "Ran into Emma at the farmers market and we ended up grabbing coffee afterward. She told me about her new apartment and I showed her the photos from my trip."
+      ]
+    }
+  ],
+  "verdicts": [
+    {
+      "question_id": "gpt4_59149c77",
+      "question": "How many days passed between my visit to the Museum of Modern Art (MoMA) and the 'Ancient Civilizations' exhibit at the Metropolitan Museum of Art?",
+      "gold_session_ids": [
+        "answer_d00ba6d0_1",
+        "answer_d00ba6d0_2"
+      ],
+      "verdict": "recall@1",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "answer_d00ba6d0_2",
+          "mem_id": "answer_d00ba6d0_2:t7",
+          "distance": 0.6102
+        },
+        {
+          "session_id": "answer_d00ba6d0_2",
+          "mem_id": "answer_d00ba6d0_2:t6",
+          "distance": 0.4636
+        },
+        {
+          "session_id": "9e2c2a6c_2",
+          "mem_id": "9e2c2a6c_2:t0",
+          "distance": 0.6379
+        },
+        {
+          "session_id": "answer_d00ba6d0_1",
+          "mem_id": "answer_d00ba6d0_1:t0",
+          "distance": 0.6757
+        },
+        {
+          "session_id": "answer_d00ba6d0_2",
+          "mem_id": "answer_d00ba6d0_2:t8",
+          "distance": 0.632
+        }
+      ],
+      "queries_used": [
+        "How many days passed between my visit to the Museum of Modern Art (MoMA) and the 'Ancient Civilizations' exhibit at the Metropolitan Museum of Art?",
+        "I spent the afternoon at MoMA wandering through the contemporary galleries and grabbing a coffee in the caf\u00e9 afterward. A few days later I went to the Met for the \u201cAncient Civilizations\u201d exhibit and stayed way longer than I expected looking at the artifacts."
+      ]
+    },
+    {
+      "question_id": "gpt4_f49edff3",
+      "question": "Which three events happened in the order from first to last: the day I helped my friend prepare the nursery, the day I helped my cousin pick out stuff for her baby shower, and the day I ordered a customized phone case for my friend's birthday?",
+      "gold_session_ids": [
+        "answer_3e9fce53_1",
+        "answer_3e9fce53_2",
+        "answer_3e9fce53_3"
+      ],
+      "verdict": "recall@1",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "answer_3e9fce53_3",
+          "mem_id": "answer_3e9fce53_3:t0",
+          "distance": 0.3986
+        },
+        {
+          "session_id": "answer_3e9fce53_1",
+          "mem_id": "answer_3e9fce53_1:t0",
+          "distance": 0.5864
+        },
+        {
+          "session_id": "answer_3e9fce53_2",
+          "mem_id": "answer_3e9fce53_2:t0",
+          "distance": 0.6455
+        },
+        {
+          "session_id": "answer_3e9fce53_2",
+          "mem_id": "answer_3e9fce53_2:t1",
+          "distance": 0.6618
+        },
+        {
+          "session_id": "bb27df5e_3",
+          "mem_id": "bb27df5e_3:t0",
+          "distance": 0.7185
+        }
+      ],
+      "queries_used": [
+        "Which three events happened in the order from first to last: the day I helped my friend prepare the nursery, the day I helped my cousin pick out stuff for her baby shower, and the day I ordered a customized phone case for my friend's birthday?",
+        "Spent the afternoon helping my friend set up the nursery \u2014 we put together the crib, hung the little animal prints, and stacked diapers on the changing table. After that I went with my cousin to pick out decorations and a gift for her baby shower, and later I ordered a custom phone case with our favorite photo for Maya\u2019s birthday."
+      ]
+    },
+    {
+      "question_id": "71017276",
+      "question": "How many weeks ago did I meet up with my aunt and receive the crystal chandelier?",
+      "gold_session_ids": [
+        "answer_0b4a8adc_1"
+      ],
+      "verdict": "recall@1",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "answer_0b4a8adc_1",
+          "mem_id": "answer_0b4a8adc_1:t0",
+          "distance": 0.5386
+        },
+        {
+          "session_id": "answer_0b4a8adc_1",
+          "mem_id": "answer_0b4a8adc_1:t2",
+          "distance": 0.6023
+        },
+        {
+          "session_id": "answer_0b4a8adc_1",
+          "mem_id": "answer_0b4a8adc_1:t3",
+          "distance": 0.6582
+        },
+        {
+          "session_id": "answer_0b4a8adc_1",
+          "mem_id": "answer_0b4a8adc_1:t1",
+          "distance": 0.6731
+        },
+        {
+          "session_id": "323609c6_3",
+          "mem_id": "323609c6_3:t8",
+          "distance": 0.715
+        }
+      ],
+      "queries_used": [
+        "How many weeks ago did I meet up with my aunt and receive the crystal chandelier?",
+        "I drove out to my aunt Linda\u2019s place and she surprised me with this gorgeous crystal chandelier she\u2019d been keeping in the attic. We spent the afternoon taking it down and figuring out how I\u2019d get it home without breaking anything."
+      ]
+    },
+    {
+      "question_id": "b46e15ed",
+      "question": "How many months have passed since I participated in two charity events in a row, on consecutive days?",
+      "gold_session_ids": [
+        "answer_4bfcc250_4",
+        "answer_4bfcc250_3",
+        "answer_4bfcc250_2",
+        "answer_4bfcc250_1"
+      ],
+      "verdict": "recall@1",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "answer_4bfcc250_1",
+          "mem_id": "answer_4bfcc250_1:t10",
+          "distance": 0.5735
+        },
+        {
+          "session_id": "answer_4bfcc250_1",
+          "mem_id": "answer_4bfcc250_1:t6",
+          "distance": 0.5398
+        },
+        {
+          "session_id": "answer_4bfcc250_1",
+          "mem_id": "answer_4bfcc250_1:t8",
+          "distance": 0.6134
+        },
+        {
+          "session_id": "answer_4bfcc250_1",
+          "mem_id": "answer_4bfcc250_1:t11",
+          "distance": 0.6788
+        },
+        {
+          "session_id": "answer_4bfcc250_4",
+          "mem_id": "answer_4bfcc250_4:t0",
+          "distance": 0.7336
+        }
+      ],
+      "queries_used": [
+        "How many months have passed since I participated in two charity events in a row, on consecutive days?",
+        "I spent a weekend doing back-to-back charity events \u2014 one was a Saturday fundraiser walk downtown, and the next day I helped at a volunteer breakfast for the same cause. It was a tiring but really rewarding couple of days."
+      ]
+    },
+    {
+      "question_id": "gpt4_fa19884c",
+      "question": "How many days passed between the day I started playing along to my favorite songs on my old keyboard and the day I discovered a bluegrass band?",
+      "gold_session_ids": [
+        "answer_ff201786_1",
+        "answer_ff201786_2"
+      ],
+      "verdict": "recall@1",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "answer_ff201786_1",
+          "mem_id": "answer_ff201786_1:t8",
+          "distance": 0.5131
+        },
+        {
+          "session_id": "answer_ff201786_2",
+          "mem_id": "answer_ff201786_2:t0",
+          "distance": 0.5068
+        },
+        {
+          "session_id": "answer_ff201786_1",
+          "mem_id": "answer_ff201786_1:t9",
+          "distance": 0.564
+        },
+        {
+          "session_id": "answer_ff201786_1",
+          "mem_id": "answer_ff201786_1:t10",
+          "distance": 0.6626
+        },
+        {
+          "session_id": "answer_ff201786_2",
+          "mem_id": "answer_ff201786_2:t1",
+          "distance": 0.6039
+        }
+      ],
+      "queries_used": [
+        "How many days passed between the day I started playing along to my favorite songs on my old keyboard and the day I discovered a bluegrass band?",
+        "I\u2019ve been messing around on my old keyboard, playing along to my favorite songs in the evenings just for fun. Then I stumbled onto a bluegrass band and fell down a whole new rabbit hole of songs to learn."
+      ]
+    },
+    {
+      "question_id": "0bc8ad92",
+      "question": "How many months have passed since I last visited a museum with a friend?",
+      "gold_session_ids": [
+        "answer_f4ea84fb_3",
+        "answer_f4ea84fb_2",
+        "answer_f4ea84fb_1"
+      ],
+      "verdict": "recall@1",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "answer_f4ea84fb_3",
+          "mem_id": "answer_f4ea84fb_3:t6",
+          "distance": 0.6589
+        },
+        {
+          "session_id": "answer_f4ea84fb_3",
+          "mem_id": "answer_f4ea84fb_3:t4",
+          "distance": 0.6096
+        },
+        {
+          "session_id": "answer_f4ea84fb_3",
+          "mem_id": "answer_f4ea84fb_3:t7",
+          "distance": 0.6899
+        },
+        {
+          "session_id": "answer_f4ea84fb_3",
+          "mem_id": "answer_f4ea84fb_3:t9",
+          "distance": 0.7593
+        },
+        {
+          "session_id": "ultrachat_349938",
+          "mem_id": "ultrachat_349938:t2",
+          "distance": 0.7713
+        }
+      ],
+      "queries_used": [
+        "How many months have passed since I last visited a museum with a friend?",
+        "I went to the art museum downtown with my friend Maya and we spent the afternoon wandering through the impressionist exhibit. We grabbed coffee afterward and talked about the weird modern sculpture in the lobby."
+      ]
+    },
+    {
+      "question_id": "af082822",
+      "question": "How many weeks ago did I attend the friends and family sale at Nordstrom?",
+      "gold_session_ids": [
+        "answer_b51b6115_1"
+      ],
+      "verdict": "recall@1",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "answer_b51b6115_1",
+          "mem_id": "answer_b51b6115_1:t2",
+          "distance": 0.6147
+        },
+        {
+          "session_id": "1040e24b_1",
+          "mem_id": "1040e24b_1:t0",
+          "distance": 0.5983
+        },
+        {
+          "session_id": "cdf068b1_2",
+          "mem_id": "cdf068b1_2:t10",
+          "distance": 0.5479
+        },
+        {
+          "session_id": "1dfef591_2",
+          "mem_id": "1dfef591_2:t10",
+          "distance": 0.6182
+        },
+        {
+          "session_id": "1fcb4134_2",
+          "mem_id": "1fcb4134_2:t2",
+          "distance": 0.606
+        }
+      ],
+      "queries_used": [
+        "How many weeks ago did I attend the friends and family sale at Nordstrom?",
+        "I went to the friends-and-family sale at Nordstrom and finally stocked up on a couple of things I\u2019d been eyeing for months. It was such a good excuse to wander around the store and grab a few deals."
+      ]
+    },
+    {
+      "question_id": "gpt4_4929293a",
+      "question": "Which event happened first, my cousin's wedding or Michael's engagement party?",
+      "gold_session_ids": [
+        "answer_add9b012_2",
+        "answer_add9b012_1"
+      ],
+      "verdict": "recall@1",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "answer_add9b012_2",
+          "mem_id": "answer_add9b012_2:t0",
+          "distance": 0.5653
+        },
+        {
+          "session_id": "answer_add9b012_1",
+          "mem_id": "answer_add9b012_1:t6",
+          "distance": 0.6293
+        },
+        {
+          "session_id": "answer_add9b012_1",
+          "mem_id": "answer_add9b012_1:t0",
+          "distance": 0.6375
+        },
+        {
+          "session_id": "answer_add9b012_1",
+          "mem_id": "answer_add9b012_1:t8",
+          "distance": 0.6352
+        },
+        {
+          "session_id": "answer_add9b012_2",
+          "mem_id": "answer_add9b012_2:t1",
+          "distance": 0.5457
+        }
+      ],
+      "queries_used": [
+        "Which event happened first, my cousin's wedding or Michael's engagement party?",
+        "My cousin\u2019s wedding was a big family weekend \u2014 I spent the whole time helping with setup and then dancing way too late at the reception. A couple months later, I went to Michael\u2019s engagement party at a rooftop bar downtown."
+      ]
+    },
+    {
+      "question_id": "gpt4_b5700ca9",
+      "question": "How many days ago did I attend the Maundy Thursday service at the Episcopal Church?",
+      "gold_session_ids": [
+        "answer_a17423e7_1"
+      ],
+      "verdict": "recall@1",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "answer_a17423e7_1",
+          "mem_id": "answer_a17423e7_1:t6",
+          "distance": 0.5073
+        },
+        {
+          "session_id": "answer_a17423e7_1",
+          "mem_id": "answer_a17423e7_1:t7",
+          "distance": 0.6326
+        },
+        {
+          "session_id": "5053474c_2",
+          "mem_id": "5053474c_2:t0",
+          "distance": 0.6842
+        },
+        {
+          "session_id": "sharegpt_jJQwr3e_0",
+          "mem_id": "sharegpt_jJQwr3e_0:t6",
+          "distance": 0.486
+        },
+        {
+          "session_id": "sharegpt_6sDqw6L_0",
+          "mem_id": "sharegpt_6sDqw6L_0:t6",
+          "distance": 0.5255
+        }
+      ],
+      "queries_used": [
+        "How many days ago did I attend the Maundy Thursday service at the Episcopal Church?",
+        "Went to the Maundy Thursday service at the Episcopal Church last night and stayed for the stripping of the altar at the end. It was quiet and really moving."
+      ]
+    },
+    {
+      "question_id": "9a707b81",
+      "question": "How many days ago did I attend a baking class at a local culinary school when I made my friend's birthday cake?",
+      "gold_session_ids": [
+        "answer_dba89487_2",
+        "answer_dba89487_1"
+      ],
+      "verdict": "recall@1",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "answer_dba89487_2",
+          "mem_id": "answer_dba89487_2:t2",
+          "distance": 0.4805
+        },
+        {
+          "session_id": "answer_dba89487_1",
+          "mem_id": "answer_dba89487_1:t10",
+          "distance": 0.6339
+        },
+        {
+          "session_id": "e1d11615_1",
+          "mem_id": "e1d11615_1:t0",
+          "distance": 0.5869
+        },
+        {
+          "session_id": "answer_dba89487_1",
+          "mem_id": "answer_dba89487_1:t0",
+          "distance": 0.6206
+        },
+        {
+          "session_id": "4abbeb2a_2",
+          "mem_id": "4abbeb2a_2:t0",
+          "distance": 0.6241
+        }
+      ],
+      "queries_used": [
+        "How many days ago did I attend a baking class at a local culinary school when I made my friend's birthday cake?",
+        "I took a baking class at the local culinary school this past weekend because I wanted to make my friend\u2019s birthday cake from scratch. We practiced sponge layers and buttercream piping, and I came home with a recipe I was really excited to try."
+      ]
+    },
+    {
+      "question_id": "gpt4_1d4ab0c9",
+      "question": "How many days passed between the day I started watering my herb garden and the day I harvested my first batch of fresh herbs?",
+      "gold_session_ids": [
+        "answer_febde667_1",
+        "answer_febde667_2"
+      ],
+      "verdict": "recall@1",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "answer_febde667_1",
+          "mem_id": "answer_febde667_1:t0",
+          "distance": 0.4178
+        },
+        {
+          "session_id": "answer_febde667_2",
+          "mem_id": "answer_febde667_2:t0",
+          "distance": 0.4188
+        },
+        {
+          "session_id": "answer_febde667_1",
+          "mem_id": "answer_febde667_1:t1",
+          "distance": 0.5739
+        },
+        {
+          "session_id": "answer_febde667_2",
+          "mem_id": "answer_febde667_2:t1",
+          "distance": 0.62
+        },
+        {
+          "session_id": "answer_febde667_2",
+          "mem_id": "answer_febde667_2:t2",
+          "distance": 0.628
+        }
+      ],
+      "queries_used": [
+        "How many days passed between the day I started watering my herb garden and the day I harvested my first batch of fresh herbs?",
+        "I finally got my little herb garden going on the balcony and started watering it every morning after work. A while later I clipped my first little bundle of basil and mint for dinner."
+      ]
+    },
+    {
+      "question_id": "gpt4_e072b769",
+      "question": "How many weeks ago did I start using the cashback app 'Ibotta'?",
+      "gold_session_ids": [
+        "answer_c19bd2bf_1"
+      ],
+      "verdict": "recall@1",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "answer_c19bd2bf_1",
+          "mem_id": "answer_c19bd2bf_1:t0",
+          "distance": 0.4798
+        },
+        {
+          "session_id": "answer_c19bd2bf_1",
+          "mem_id": "answer_c19bd2bf_1:t1",
+          "distance": 0.6101
+        },
+        {
+          "session_id": "answer_c19bd2bf_1",
+          "mem_id": "answer_c19bd2bf_1:t11",
+          "distance": 0.5679
+        },
+        {
+          "session_id": "answer_c19bd2bf_1",
+          "mem_id": "answer_c19bd2bf_1:t3",
+          "distance": 0.5
+        },
+        {
+          "session_id": "answer_c19bd2bf_1",
+          "mem_id": "answer_c19bd2bf_1:t2",
+          "distance": 0.5838
+        }
+      ],
+      "queries_used": [
+        "How many weeks ago did I start using the cashback app 'Ibotta'?",
+        "I finally downloaded Ibotta and started using it for grocery runs this week. I\u2019m trying to remember to scan my receipts so I can actually get some cashback instead of forgetting every time."
+      ]
+    },
+    {
+      "question_id": "0db4c65d",
+      "question": "How many days had passed since I finished reading 'The Seven Husbands of Evelyn Hugo' when I attended the book reading event at the local library, where the author of 'The Silent Patient' is discussing her latest thriller novel?",
+      "gold_session_ids": [
+        "answer_b9e32ff8_1",
+        "answer_b9e32ff8_2"
+      ],
+      "verdict": "recall@1",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "answer_b9e32ff8_2",
+          "mem_id": "answer_b9e32ff8_2:t0",
+          "distance": 0.295
+        },
+        {
+          "session_id": "answer_b9e32ff8_2",
+          "mem_id": "answer_b9e32ff8_2:t1",
+          "distance": 0.4514
+        },
+        {
+          "session_id": "answer_b9e32ff8_1",
+          "mem_id": "answer_b9e32ff8_1:t0",
+          "distance": 0.4936
+        },
+        {
+          "session_id": "answer_b9e32ff8_1",
+          "mem_id": "answer_b9e32ff8_1:t2",
+          "distance": 0.5665
+        },
+        {
+          "session_id": "answer_b9e32ff8_1",
+          "mem_id": "answer_b9e32ff8_1:t1",
+          "distance": 0.5428
+        }
+      ],
+      "queries_used": [
+        "How many days had passed since I finished reading 'The Seven Husbands of Evelyn Hugo' when I attended the book reading event at the local library, where the author of 'The Silent Patient' is discussing her latest thriller novel?",
+        "I went to a book reading at the local library where the author of *The Silent Patient* was talking about her latest thriller. I\u2019d just finished *The Seven Husbands of Evelyn Hugo* and was still thinking about it on the drive over."
+      ]
+    },
+    {
+      "question_id": "gpt4_1d80365e",
+      "question": "How many days did I spend on my solo camping trip to Yosemite National Park?",
+      "gold_session_ids": [
+        "answer_661b711f_1",
+        "answer_661b711f_2"
+      ],
+      "verdict": "recall@1",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "answer_661b711f_2",
+          "mem_id": "answer_661b711f_2:t0",
+          "distance": 0.4669
+        },
+        {
+          "session_id": "answer_661b711f_1",
+          "mem_id": "answer_661b711f_1:t0",
+          "distance": 0.4726
+        },
+        {
+          "session_id": "answer_661b711f_1",
+          "mem_id": "answer_661b711f_1:t8",
+          "distance": 0.536
+        },
+        {
+          "session_id": "answer_661b711f_1",
+          "mem_id": "answer_661b711f_1:t1",
+          "distance": 0.5625
+        },
+        {
+          "session_id": "answer_661b711f_1",
+          "mem_id": "answer_661b711f_1:t4",
+          "distance": 0.5957
+        }
+      ],
+      "queries_used": [
+        "How many days did I spend on my solo camping trip to Yosemite National Park?",
+        "I just got back from a solo camping trip to Yosemite National Park, and it was exactly the kind of reset I needed. I spent most of the time hiking, cooking simple meals at the campsite, and being totally off-grid."
+      ]
+    },
+    {
+      "question_id": "gpt4_7f6b06db",
+      "question": "What is the order of the three trips I took in the past three months, from earliest to latest?",
+      "gold_session_ids": [
+        "answer_5d8c99d3_1",
+        "answer_5d8c99d3_2",
+        "answer_5d8c99d3_3"
+      ],
+      "verdict": "recall@K",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "sharegpt_n3MgsgL_0",
+          "mem_id": "sharegpt_n3MgsgL_0:t22",
+          "distance": 0.4883
+        },
+        {
+          "session_id": "d9ca4aca",
+          "mem_id": "d9ca4aca:t6",
+          "distance": 0.0
+        },
+        {
+          "session_id": "sharegpt_n3MgsgL_0",
+          "mem_id": "sharegpt_n3MgsgL_0:t28",
+          "distance": 0.4819
+        },
+        {
+          "session_id": "d9ca4aca",
+          "mem_id": "d9ca4aca:t10",
+          "distance": 0.054
+        },
+        {
+          "session_id": "answer_5d8c99d3_2",
+          "mem_id": "answer_5d8c99d3_2:t2",
+          "distance": 0.5411
+        }
+      ],
+      "queries_used": [
+        "What is the order of the three trips I took in the past three months, from earliest to latest?",
+        "I came back from a quick weekend trip to Chicago in early February, then took a work trip to Seattle a few weeks later. Most recently I spent a long weekend in Miami and finally got some real sun."
+      ]
+    },
+    {
+      "question_id": "gpt4_6dc9b45b",
+      "question": "How many months ago did I attend the Seattle International Film Festival?",
+      "gold_session_ids": [
+        "answer_c4df007f_1"
+      ],
+      "verdict": "recall@1",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "answer_c4df007f_1",
+          "mem_id": "answer_c4df007f_1:t0",
+          "distance": 0.5378
+        },
+        {
+          "session_id": "answer_c4df007f_1",
+          "mem_id": "answer_c4df007f_1:t2",
+          "distance": 0.5673
+        },
+        {
+          "session_id": "answer_c4df007f_1",
+          "mem_id": "answer_c4df007f_1:t6",
+          "distance": 0.5982
+        },
+        {
+          "session_id": "ultrachat_384387",
+          "mem_id": "ultrachat_384387:t0",
+          "distance": 0.6967
+        },
+        {
+          "session_id": "answer_c4df007f_1",
+          "mem_id": "answer_c4df007f_1:t10",
+          "distance": 0.5765
+        }
+      ],
+      "queries_used": [
+        "How many months ago did I attend the Seattle International Film Festival?",
+        "I went to the Seattle International Film Festival and spent the evening hopping between screenings downtown. Afterward I grabbed dinner nearby and we talked about which movies were worth seeing again."
+      ]
+    },
+    {
+      "question_id": "gpt4_8279ba02",
+      "question": "How many days ago did I buy a smoker?",
+      "gold_session_ids": [
+        "answer_56521e65_1"
+      ],
+      "verdict": "recall@K",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "86c5d31d",
+          "mem_id": "86c5d31d:t2",
+          "distance": 0.6161
+        },
+        {
+          "session_id": "sharegpt_3xB7vJ2_195",
+          "mem_id": "sharegpt_3xB7vJ2_195:t22",
+          "distance": 0.4139
+        },
+        {
+          "session_id": "85f19a30_1",
+          "mem_id": "85f19a30_1:t8",
+          "distance": 0.0
+        },
+        {
+          "session_id": "sharegpt_uh8yJR0_0",
+          "mem_id": "sharegpt_uh8yJR0_0:t8",
+          "distance": 0.398
+        },
+        {
+          "session_id": "3a735bfa_1",
+          "mem_id": "3a735bfa_1:t3",
+          "distance": 0.1408
+        }
+      ],
+      "queries_used": [
+        "How many days ago did I buy a smoker?",
+        "Picked up a new pellet smoker this weekend and spent the evening getting it set up on the patio. I\u2019m already planning to do brisket and ribs once I get the hang of it."
+      ]
+    },
+    {
+      "question_id": "gpt4_18c2b244",
+      "question": "What is the order of the three events: 'I signed up for the rewards program at ShopRite', 'I used a Buy One Get One Free coupon on Luvs diapers at Walmart', and 'I redeemed $12 cashback for a $10 Amazon gift card from Ibotta'?",
+      "gold_session_ids": [
+        "answer_c862f65a_2",
+        "answer_c862f65a_3",
+        "answer_c862f65a_1"
+      ],
+      "verdict": "recall@1",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "answer_c862f65a_2",
+          "mem_id": "answer_c862f65a_2:t0",
+          "distance": 0.5418
+        },
+        {
+          "session_id": "answer_c862f65a_3",
+          "mem_id": "answer_c862f65a_3:t0",
+          "distance": 0.5563
+        },
+        {
+          "session_id": "answer_c862f65a_1",
+          "mem_id": "answer_c862f65a_1:t1",
+          "distance": 0.6
+        },
+        {
+          "session_id": "answer_c862f65a_1",
+          "mem_id": "answer_c862f65a_1:t0",
+          "distance": 0.4876
+        },
+        {
+          "session_id": "answer_c862f65a_3",
+          "mem_id": "answer_c862f65a_3:t1",
+          "distance": 0.5659
+        }
+      ],
+      "queries_used": [
+        "What is the order of the three events: 'I signed up for the rewards program at ShopRite', 'I used a Buy One Get One Free coupon on Luvs diapers at Walmart', and 'I redeemed $12 cashback for a $10 Amazon gift card from Ibotta'?",
+        "I signed up for the ShopRite rewards program while I was doing my grocery run, mostly because they had a couple of digital coupons I wanted to use. After that I bought a pack of Luvs diapers at Walmart with a Buy One Get One Free coupon, and later I cashed out $12 from Ibotta for a $10 Amazon gift card."
+      ]
+    },
+    {
+      "question_id": "gpt4_a1b77f9c",
+      "question": "How many weeks in total do I spent on reading 'The Nightingale' and listening to 'Sapiens: A Brief History of Humankind' and 'The Power'?",
+      "gold_session_ids": [
+        "answer_e9ad5914_1",
+        "answer_e9ad5914_2",
+        "answer_e9ad5914_3",
+        "answer_e9ad5914_4",
+        "answer_e9ad5914_5",
+        "answer_e9ad5914_6"
+      ],
+      "verdict": "recall@1",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "answer_e9ad5914_3",
+          "mem_id": "answer_e9ad5914_3:t6",
+          "distance": 0.5325
+        },
+        {
+          "session_id": "answer_e9ad5914_1",
+          "mem_id": "answer_e9ad5914_1:t0",
+          "distance": 0.538
+        },
+        {
+          "session_id": "answer_e9ad5914_3",
+          "mem_id": "answer_e9ad5914_3:t0",
+          "distance": 0.4622
+        },
+        {
+          "session_id": "answer_e9ad5914_4",
+          "mem_id": "answer_e9ad5914_4:t0",
+          "distance": 0.5875
+        },
+        {
+          "session_id": "answer_e9ad5914_6",
+          "mem_id": "answer_e9ad5914_6:t0",
+          "distance": 0.5742
+        }
+      ],
+      "queries_used": [
+        "How many weeks in total do I spent on reading 'The Nightingale' and listening to 'Sapiens: A Brief History of Humankind' and 'The Power'?",
+        "I spent a while bouncing between reading *The Nightingale* and listening to *Sapiens: A Brief History of Humankind* and *The Power* during my commute and evenings. It turned into a pretty long stretch of audiobooks and paperback time."
+      ]
+    },
+    {
+      "question_id": "gpt4_1916e0ea",
+      "question": "How many days passed between the day I cancelled my FarmFresh subscription and the day I did my online grocery shopping from Instacart?",
+      "gold_session_ids": [
+        "answer_447052a5_2",
+        "answer_447052a5_1"
+      ],
+      "verdict": "recall@1",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "answer_447052a5_2",
+          "mem_id": "answer_447052a5_2:t6",
+          "distance": 0.4917
+        },
+        {
+          "session_id": "answer_447052a5_1",
+          "mem_id": "answer_447052a5_1:t0",
+          "distance": 0.5843
+        },
+        {
+          "session_id": "answer_447052a5_1",
+          "mem_id": "answer_447052a5_1:t4",
+          "distance": 0.6292
+        },
+        {
+          "session_id": "answer_447052a5_1",
+          "mem_id": "answer_447052a5_1:t6",
+          "distance": 0.7164
+        },
+        {
+          "session_id": "answer_447052a5_2",
+          "mem_id": "answer_447052a5_2:t7",
+          "distance": 0.6397
+        }
+      ],
+      "queries_used": [
+        "How many days passed between the day I cancelled my FarmFresh subscription and the day I did my online grocery shopping from Instacart?",
+        "I canceled my FarmFresh subscription last week after realizing I wasn\u2019t using it enough. A few days later I did my grocery run on Instacart and stocked up on basics for the week."
+      ]
+    },
+    {
+      "question_id": "gpt4_7a0daae1",
+      "question": "How many weeks passed between the day I bought my new tennis racket and the day I received it?",
+      "gold_session_ids": [
+        "answer_4d5490f1_1",
+        "answer_4d5490f1_2"
+      ],
+      "verdict": "recall@1",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "answer_4d5490f1_2",
+          "mem_id": "answer_4d5490f1_2:t0",
+          "distance": 0.5725
+        },
+        {
+          "session_id": "answer_4d5490f1_1",
+          "mem_id": "answer_4d5490f1_1:t6",
+          "distance": 0.6937
+        },
+        {
+          "session_id": "bf3aebdb_2",
+          "mem_id": "bf3aebdb_2:t0",
+          "distance": 0.6786
+        },
+        {
+          "session_id": "answer_4d5490f1_2",
+          "mem_id": "answer_4d5490f1_2:t8",
+          "distance": 0.696
+        },
+        {
+          "session_id": "answer_4d5490f1_2",
+          "mem_id": "answer_4d5490f1_2:t1",
+          "distance": 0.624
+        }
+      ],
+      "queries_used": [
+        "How many weeks passed between the day I bought my new tennis racket and the day I received it?",
+        "I ordered a new tennis racket online after work and was pretty excited to try it out. It finally showed up a few weeks later, so I spent the evening stringing it and hitting a few balls at the courts."
+      ]
+    },
+    {
+      "question_id": "gpt4_468eb063",
+      "question": "How many days ago did I meet Emma?",
+      "gold_session_ids": [
+        "answer_9b09d95b_1"
+      ],
+      "verdict": "miss",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "e60a93ff_2",
+          "mem_id": "e60a93ff_2:t6",
+          "distance": 0.5927
+        },
+        {
+          "session_id": "e60a93ff_2",
+          "mem_id": "e60a93ff_2:t4",
+          "distance": 0.641
+        },
+        {
+          "session_id": "e60a93ff_2",
+          "mem_id": "e60a93ff_2:t8",
+          "distance": 0.6691
+        },
+        {
+          "session_id": "sharegpt_WRWOWFP_0",
+          "mem_id": "sharegpt_WRWOWFP_0:t18",
+          "distance": 0.5527
+        },
+        {
+          "session_id": "sharegpt_hGQUdgE_27",
+          "mem_id": "sharegpt_hGQUdgE_27:t1",
+          "distance": 0.3841
+        }
+      ],
+      "queries_used": [
+        "How many days ago did I meet Emma?",
+        "Ran into Emma at the farmers market and we ended up grabbing coffee afterward. She told me about her new apartment and I showed her the photos from my trip."
+      ]
+    },
+    {
+      "question_id": "gpt4_7abb270c",
+      "question": "What is the order of the six museums I visited from earliest to latest?",
+      "gold_session_ids": [
+        "answer_7093d898_1",
+        "answer_7093d898_2",
+        "answer_7093d898_3",
+        "answer_7093d898_4",
+        "answer_7093d898_5",
+        "answer_7093d898_6"
+      ],
+      "verdict": "recall@1",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "answer_7093d898_6",
+          "mem_id": "answer_7093d898_6:t6",
+          "distance": 0.6345
+        },
+        {
+          "session_id": "answer_7093d898_1",
+          "mem_id": "answer_7093d898_1:t0",
+          "distance": 0.601
+        },
+        {
+          "session_id": "answer_7093d898_6",
+          "mem_id": "answer_7093d898_6:t1",
+          "distance": 0.6322
+        },
+        {
+          "session_id": "answer_7093d898_6",
+          "mem_id": "answer_7093d898_6:t0",
+          "distance": 0.6236
+        },
+        {
+          "session_id": "answer_7093d898_6",
+          "mem_id": "answer_7093d898_6:t7",
+          "distance": 0.655
+        }
+      ],
+      "queries_used": [
+        "What is the order of the six museums I visited from earliest to latest?",
+        "I spent the day museum-hopping around the city and hit six places in one stretch: the art museum, the natural history museum, the science center, the photography museum, the local history museum, and the modern art gallery. I was exhausted by the end but glad I managed to see them all."
+      ]
+    },
+    {
+      "question_id": "gpt4_1e4a8aeb",
+      "question": "How many days passed between the day I attended the gardening workshop and the day I planted the tomato saplings?",
+      "gold_session_ids": [
+        "answer_16bd5ea5_1",
+        "answer_16bd5ea5_2"
+      ],
+      "verdict": "recall@1",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "answer_16bd5ea5_2",
+          "mem_id": "answer_16bd5ea5_2:t0",
+          "distance": 0.5422
+        },
+        {
+          "session_id": "answer_16bd5ea5_1",
+          "mem_id": "answer_16bd5ea5_1:t0",
+          "distance": 0.6798
+        },
+        {
+          "session_id": "answer_16bd5ea5_2",
+          "mem_id": "answer_16bd5ea5_2:t4",
+          "distance": 0.6475
+        },
+        {
+          "session_id": "answer_16bd5ea5_1",
+          "mem_id": "answer_16bd5ea5_1:t5",
+          "distance": 0.6256
+        },
+        {
+          "session_id": "answer_16bd5ea5_2",
+          "mem_id": "answer_16bd5ea5_2:t1",
+          "distance": 0.627
+        }
+      ],
+      "queries_used": [
+        "How many days passed between the day I attended the gardening workshop and the day I planted the tomato saplings?",
+        "I went to a gardening workshop last weekend and learned a bunch about starting vegetables in small spaces. A few days later I finally planted the tomato saplings I\u2019d bought at the nursery."
+      ]
+    },
+    {
+      "question_id": "gpt4_4fc4f797",
+      "question": "How many days passed between the day I received feedback about my car's suspension and the day I tested my new suspension setup?",
+      "gold_session_ids": [
+        "answer_be07688f_1",
+        "answer_be07688f_2"
+      ],
+      "verdict": "recall@1",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "answer_be07688f_1",
+          "mem_id": "answer_be07688f_1:t10",
+          "distance": 0.4638
+        },
+        {
+          "session_id": "answer_be07688f_2",
+          "mem_id": "answer_be07688f_2:t0",
+          "distance": 0.5251
+        },
+        {
+          "session_id": "answer_be07688f_1",
+          "mem_id": "answer_be07688f_1:t4",
+          "distance": 0.5058
+        },
+        {
+          "session_id": "answer_be07688f_2",
+          "mem_id": "answer_be07688f_2:t2",
+          "distance": 0.5488
+        },
+        {
+          "session_id": "answer_be07688f_2",
+          "mem_id": "answer_be07688f_2:t3",
+          "distance": 0.5678
+        }
+      ],
+      "queries_used": [
+        "How many days passed between the day I received feedback about my car's suspension and the day I tested my new suspension setup?",
+        "Got some feedback on my car\u2019s suspension after a drive last week, and I spent the next couple of days tweaking the setup in the garage. Took it back out for a test run once I\u2019d tightened everything up and adjusted the alignment."
+      ]
+    },
+    {
+      "question_id": "4dfccbf7",
+      "question": "How many days had passed since I started taking ukulele lessons when I decided to take my acoustic guitar to the guitar tech for servicing?",
+      "gold_session_ids": [
+        "answer_4bebc782_1",
+        "answer_4bebc782_2"
+      ],
+      "verdict": "recall@1",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "answer_4bebc782_1",
+          "mem_id": "answer_4bebc782_1:t8",
+          "distance": 0.554
+        },
+        {
+          "session_id": "answer_4bebc782_1",
+          "mem_id": "answer_4bebc782_1:t4",
+          "distance": 0.5221
+        },
+        {
+          "session_id": "answer_4bebc782_2",
+          "mem_id": "answer_4bebc782_2:t8",
+          "distance": 0.5809
+        },
+        {
+          "session_id": "answer_4bebc782_1",
+          "mem_id": "answer_4bebc782_1:t9",
+          "distance": 0.477
+        },
+        {
+          "session_id": "answer_4bebc782_2",
+          "mem_id": "answer_4bebc782_2:t9",
+          "distance": 0.5745
+        }
+      ],
+      "queries_used": [
+        "How many days had passed since I started taking ukulele lessons when I decided to take my acoustic guitar to the guitar tech for servicing?",
+        "I finally took my acoustic guitar into the guitar tech for a proper servicing after a few ukulele lessons had already gotten me back into playing every day. The setup had been bugging me for a while, so I dropped it off and asked him to look over the action and intonation."
+      ]
+    },
+    {
+      "question_id": "gpt4_61e13b3c",
+      "question": "How many weeks passed between the time I sold homemade baked goods at the Farmers' Market for the last time and the time I participated in the Spring Fling Market?",
+      "gold_session_ids": [
+        "answer_e831a29f_1",
+        "answer_e831a29f_2"
+      ],
+      "verdict": "recall@1",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "answer_e831a29f_1",
+          "mem_id": "answer_e831a29f_1:t0",
+          "distance": 0.5607
+        },
+        {
+          "session_id": "answer_e831a29f_2",
+          "mem_id": "answer_e831a29f_2:t0",
+          "distance": 0.5804
+        },
+        {
+          "session_id": "answer_e831a29f_2",
+          "mem_id": "answer_e831a29f_2:t4",
+          "distance": 0.6442
+        },
+        {
+          "session_id": "answer_e831a29f_1",
+          "mem_id": "answer_e831a29f_1:t1",
+          "distance": 0.5927
+        },
+        {
+          "session_id": "answer_e831a29f_2",
+          "mem_id": "answer_e831a29f_2:t1",
+          "distance": 0.6946
+        }
+      ],
+      "queries_used": [
+        "How many weeks passed between the time I sold homemade baked goods at the Farmers' Market for the last time and the time I participated in the Spring Fling Market?",
+        "I sold homemade baked goods at the Farmers' Market for the last time \u2014 packed up my little table with the cookies and breads I\u2019d been making every weekend. After that I jumped into the Spring Fling Market and set up a brighter booth with all the same treats plus a few new spring specials."
+      ]
+    },
+    {
+      "question_id": "gpt4_45189cb4",
+      "question": "What is the order of the sports events I watched in January?",
+      "gold_session_ids": [
+        "answer_e6c20e52_3",
+        "answer_e6c20e52_2",
+        "answer_e6c20e52_1"
+      ],
+      "verdict": "recall@1",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "answer_e6c20e52_3",
+          "mem_id": "answer_e6c20e52_3:t4",
+          "distance": 0.7422
+        },
+        {
+          "session_id": "answer_e6c20e52_2",
+          "mem_id": "answer_e6c20e52_2:t3",
+          "distance": 0.7804
+        },
+        {
+          "session_id": "answer_e6c20e52_2",
+          "mem_id": "answer_e6c20e52_2:t2",
+          "distance": 0.7294
+        },
+        {
+          "session_id": "answer_e6c20e52_2",
+          "mem_id": "answer_e6c20e52_2:t0",
+          "distance": 0.552
+        },
+        {
+          "session_id": "sharegpt_hgGAUvu_0",
+          "mem_id": "sharegpt_hgGAUvu_0:t9",
+          "distance": 0.0
+        }
+      ],
+      "queries_used": [
+        "What is the order of the sports events I watched in January?",
+        "I spent a bunch of January evenings bouncing between the playoffs and a couple of basketball games, mostly watching whichever one was on first. The January sports stretch felt nonstop, with football on one night and hoops the next."
+      ]
+    },
+    {
+      "question_id": "2ebe6c90",
+      "question": "How many days did it take me to finish 'The Nightingale' by Kristin Hannah?",
+      "gold_session_ids": [
+        "answer_c9d35c00_1",
+        "answer_c9d35c00_2"
+      ],
+      "verdict": "recall@1",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "answer_c9d35c00_2",
+          "mem_id": "answer_c9d35c00_2:t0",
+          "distance": 0.3382
+        },
+        {
+          "session_id": "answer_c9d35c00_2",
+          "mem_id": "answer_c9d35c00_2:t8",
+          "distance": 0.5225
+        },
+        {
+          "session_id": "answer_c9d35c00_1",
+          "mem_id": "answer_c9d35c00_1:t0",
+          "distance": 0.3738
+        },
+        {
+          "session_id": "answer_c9d35c00_2",
+          "mem_id": "answer_c9d35c00_2:t9",
+          "distance": 0.6229
+        },
+        {
+          "session_id": "sharegpt_jyMHY1J_31",
+          "mem_id": "sharegpt_jyMHY1J_31:t0",
+          "distance": 0.6963
+        }
+      ],
+      "queries_used": [
+        "How many days did it take me to finish 'The Nightingale' by Kristin Hannah?",
+        "I finally finished *The Nightingale* by Kristin Hannah last night after keeping it on my nightstand for way too long. The ending hit me a lot harder than I expected."
+      ]
+    },
+    {
+      "question_id": "gpt4_e061b84f",
+      "question": "What is the order of the three sports events I participated in during the past month, from earliest to latest?",
+      "gold_session_ids": [
+        "answer_8c64ce25_2",
+        "answer_8c64ce25_1",
+        "answer_8c64ce25_3"
+      ],
+      "verdict": "recall@K",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "0a6bf5e4_1",
+          "mem_id": "0a6bf5e4_1:t0",
+          "distance": 0.6504
+        },
+        {
+          "session_id": "539c2346_3",
+          "mem_id": "539c2346_3:t6",
+          "distance": 0.6852
+        },
+        {
+          "session_id": "9345f7dc_4",
+          "mem_id": "9345f7dc_4:t0",
+          "distance": 0.7243
+        },
+        {
+          "session_id": "9345f7dc_4",
+          "mem_id": "9345f7dc_4:t10",
+          "distance": 0.7244
+        },
+        {
+          "session_id": "answer_8c64ce25_3",
+          "mem_id": "answer_8c64ce25_3:t1",
+          "distance": 0.7186
+        }
+      ],
+      "queries_used": [
+        "What is the order of the three sports events I participated in during the past month, from earliest to latest?",
+        "I spent the past month bouncing between three sports events \u2014 first a charity 5K, then a weekend pickup soccer tournament, and finally a local tennis doubles league match. It ended up being a pretty packed month."
+      ]
+    }
+  ],
+  "elapsed_sec": 60.01637101173401
+}

--- a/docs/bench/pinecone-lme-temporal-diagnostic-mq3-20260429.json
+++ b/docs/bench/pinecone-lme-temporal-diagnostic-mq3-20260429.json
@@ -1,0 +1,625 @@
+{
+  "embedder": "pinecone:llama-text-embed-v2@1024d",
+  "store": "pinecone-local",
+  "variant": "s",
+  "category": "temporal-reasoning",
+  "n_total": 10,
+  "n_scored": 10,
+  "top_k": 10,
+  "counts": {
+    "recall@1": 4,
+    "miss": 4,
+    "recall@K": 2
+  },
+  "found_pct": 60.0,
+  "failures": [
+    {
+      "question_id": "71017276",
+      "question": "How many weeks ago did I meet up with my aunt and receive the crystal chandelier?",
+      "gold_session_ids": [
+        "answer_0b4a8adc_1"
+      ],
+      "verdict": "miss",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "sharegpt_11WxPMZ_0",
+          "mem_id": "sharegpt_11WxPMZ_0:t35",
+          "distance": 0.4964
+        },
+        {
+          "session_id": "sharegpt_duoAhsS_0",
+          "mem_id": "sharegpt_duoAhsS_0:t2",
+          "distance": 0.5109
+        },
+        {
+          "session_id": "sharegpt_11WxPMZ_0",
+          "mem_id": "sharegpt_11WxPMZ_0:t70",
+          "distance": 0.5126
+        },
+        {
+          "session_id": "sharegpt_11WxPMZ_0",
+          "mem_id": "sharegpt_11WxPMZ_0:t58",
+          "distance": 0.5221
+        },
+        {
+          "session_id": "sharegpt_11WxPMZ_0",
+          "mem_id": "sharegpt_11WxPMZ_0:t13",
+          "distance": 0.5211
+        }
+      ],
+      "queries_used": [
+        "How many weeks ago did I meet up with my aunt and receive the crystal chandelier?",
+        "How many weeks ago did I meet my aunt and get the crystal chandelier?",
+        "How long ago was my meetup with my aunt when I received the crystal chandelier?",
+        "How many weeks back did I see my aunt and receive the crystal chandelier?"
+      ]
+    },
+    {
+      "question_id": "b46e15ed",
+      "question": "How many months have passed since I participated in two charity events in a row, on consecutive days?",
+      "gold_session_ids": [
+        "answer_4bfcc250_4",
+        "answer_4bfcc250_3",
+        "answer_4bfcc250_2",
+        "answer_4bfcc250_1"
+      ],
+      "verdict": "miss",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "sharegpt_WFKzGQx_0",
+          "mem_id": "sharegpt_WFKzGQx_0:t0",
+          "distance": 0.4661
+        },
+        {
+          "session_id": "sharegpt_hcaZN94_433",
+          "mem_id": "sharegpt_hcaZN94_433:t7",
+          "distance": 0.4383
+        },
+        {
+          "session_id": "sharegpt_WFKzGQx_0",
+          "mem_id": "sharegpt_WFKzGQx_0:t14",
+          "distance": 0.5013
+        },
+        {
+          "session_id": "sharegpt_hcaZN94_433",
+          "mem_id": "sharegpt_hcaZN94_433:t1",
+          "distance": 0.4723
+        },
+        {
+          "session_id": "sharegpt_ZaBu0Qw_0",
+          "mem_id": "sharegpt_ZaBu0Qw_0:t0",
+          "distance": 0.5063
+        }
+      ],
+      "queries_used": [
+        "How many months have passed since I participated in two charity events in a row, on consecutive days?",
+        "How many months since I took part in two charity events back-to-back on consecutive days?",
+        "How long ago did I attend two charity events in a row, one day after the other?",
+        "How many months ago were my two consecutive-day charity event participations?"
+      ]
+    },
+    {
+      "question_id": "0bc8ad92",
+      "question": "How many months have passed since I last visited a museum with a friend?",
+      "gold_session_ids": [
+        "answer_f4ea84fb_3",
+        "answer_f4ea84fb_2",
+        "answer_f4ea84fb_1"
+      ],
+      "verdict": "miss",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "sharegpt_KC1VaRe_0",
+          "mem_id": "sharegpt_KC1VaRe_0:t6",
+          "distance": 0.4718
+        },
+        {
+          "session_id": "f58c36b8_1",
+          "mem_id": "f58c36b8_1:t10",
+          "distance": 0.5048
+        },
+        {
+          "session_id": "sharegpt_xxk9JDz_21",
+          "mem_id": "sharegpt_xxk9JDz_21:t9",
+          "distance": 0.4935
+        },
+        {
+          "session_id": "sharegpt_FqUHzEk_0",
+          "mem_id": "sharegpt_FqUHzEk_0:t6",
+          "distance": 0.5032
+        },
+        {
+          "session_id": "sharegpt_Le7CqkS_0",
+          "mem_id": "sharegpt_Le7CqkS_0:t2",
+          "distance": 0.5148
+        }
+      ],
+      "queries_used": [
+        "How many months have passed since I last visited a museum with a friend?",
+        "How many months since I last went to a museum with a friend?",
+        "How long has it been since my last museum visit with a friend?",
+        "Months elapsed since I last visited a museum with a friend?"
+      ]
+    },
+    {
+      "question_id": "gpt4_4929293a",
+      "question": "Which event happened first, my cousin's wedding or Michael's engagement party?",
+      "gold_session_ids": [
+        "answer_add9b012_2",
+        "answer_add9b012_1"
+      ],
+      "verdict": "miss",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "5a81277c",
+          "mem_id": "5a81277c:t10",
+          "distance": 0.5328
+        },
+        {
+          "session_id": "sharegpt_lH1wCbz_11",
+          "mem_id": "sharegpt_lH1wCbz_11:t1",
+          "distance": 0.5641
+        },
+        {
+          "session_id": "ultrachat_221041",
+          "mem_id": "ultrachat_221041:t0",
+          "distance": 0.5764
+        },
+        {
+          "session_id": "sharegpt_bTRqqlc_0",
+          "mem_id": "sharegpt_bTRqqlc_0:t0",
+          "distance": 0.589
+        },
+        {
+          "session_id": "ultrachat_63058",
+          "mem_id": "ultrachat_63058:t2",
+          "distance": 0.5321
+        }
+      ],
+      "queries_used": [
+        "Which event happened first, my cousin's wedding or Michael's engagement party?",
+        "Did my cousin's wedding happen before Michael's engagement party?",
+        "Which came first: my cousin's wedding or Michael's engagement party?",
+        "Was my cousin's wedding earlier than Michael's engagement party?"
+      ]
+    }
+  ],
+  "verdicts": [
+    {
+      "question_id": "gpt4_59149c77",
+      "question": "How many days passed between my visit to the Museum of Modern Art (MoMA) and the 'Ancient Civilizations' exhibit at the Metropolitan Museum of Art?",
+      "gold_session_ids": [
+        "answer_d00ba6d0_1",
+        "answer_d00ba6d0_2"
+      ],
+      "verdict": "recall@1",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "answer_d00ba6d0_2",
+          "mem_id": "answer_d00ba6d0_2:t6",
+          "distance": 0.4609
+        },
+        {
+          "session_id": "sharegpt_XlNs8Lz_199",
+          "mem_id": "sharegpt_XlNs8Lz_199:t9",
+          "distance": 0.6975
+        },
+        {
+          "session_id": "sharegpt_eQWKEKV_0",
+          "mem_id": "sharegpt_eQWKEKV_0:t20",
+          "distance": 0.7127
+        },
+        {
+          "session_id": "sharegpt_khOmFug_0",
+          "mem_id": "sharegpt_khOmFug_0:t0",
+          "distance": 0.7092
+        },
+        {
+          "session_id": "sharegpt_aQ4TU1X_49",
+          "mem_id": "sharegpt_aQ4TU1X_49:t1",
+          "distance": 0.6935
+        }
+      ],
+      "queries_used": [
+        "How many days passed between my visit to the Museum of Modern Art (MoMA) and the 'Ancient Civilizations' exhibit at the Metropolitan Museum of Art?",
+        "How many days were between my visit to MoMA and the Ancient Civilizations exhibit at the Metropolitan Museum of Art?",
+        "What was the day difference between my Museum of Modern Art visit and the Ancient Civilizations exhibit at the Met?",
+        "How long passed between my trip to MoMA and the Ancient Civilizations exhibit at the Metropolitan Museum of Art?"
+      ]
+    },
+    {
+      "question_id": "gpt4_f49edff3",
+      "question": "Which three events happened in the order from first to last: the day I helped my friend prepare the nursery, the day I helped my cousin pick out stuff for her baby shower, and the day I ordered a customized phone case for my friend's birthday?",
+      "gold_session_ids": [
+        "answer_3e9fce53_1",
+        "answer_3e9fce53_2",
+        "answer_3e9fce53_3"
+      ],
+      "verdict": "recall@1",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "answer_3e9fce53_3",
+          "mem_id": "answer_3e9fce53_3:t0",
+          "distance": 0.3986
+        },
+        {
+          "session_id": "answer_3e9fce53_1",
+          "mem_id": "answer_3e9fce53_1:t0",
+          "distance": 0.5864
+        },
+        {
+          "session_id": "answer_3e9fce53_1",
+          "mem_id": "answer_3e9fce53_1:t2",
+          "distance": 0.6419
+        },
+        {
+          "session_id": "answer_3e9fce53_1",
+          "mem_id": "answer_3e9fce53_1:t6",
+          "distance": 0.6427
+        },
+        {
+          "session_id": "answer_3e9fce53_3",
+          "mem_id": "answer_3e9fce53_3:t1",
+          "distance": 0.5912
+        }
+      ],
+      "queries_used": [
+        "Which three events happened in the order from first to last: the day I helped my friend prepare the nursery, the day I helped my cousin pick out stuff for her baby shower, and the day I ordered a customized phone case for my friend's birthday?",
+        "What was the order of the day I helped my friend prepare the nursery, my cousin pick baby shower items, and I ordered a custom phone case for my friend's birthday?",
+        "Which came first to last: helping my friend set up the nursery, helping my cousin choose baby shower things, and ordering a personalized phone case for my friend's birthday?",
+        "In what sequence did I prepare the nursery with my friend, help my cousin shop for her baby shower, and order a customized phone case for my friend's birthday?"
+      ]
+    },
+    {
+      "question_id": "71017276",
+      "question": "How many weeks ago did I meet up with my aunt and receive the crystal chandelier?",
+      "gold_session_ids": [
+        "answer_0b4a8adc_1"
+      ],
+      "verdict": "miss",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "sharegpt_11WxPMZ_0",
+          "mem_id": "sharegpt_11WxPMZ_0:t35",
+          "distance": 0.4964
+        },
+        {
+          "session_id": "sharegpt_duoAhsS_0",
+          "mem_id": "sharegpt_duoAhsS_0:t2",
+          "distance": 0.5109
+        },
+        {
+          "session_id": "sharegpt_11WxPMZ_0",
+          "mem_id": "sharegpt_11WxPMZ_0:t70",
+          "distance": 0.5126
+        },
+        {
+          "session_id": "sharegpt_11WxPMZ_0",
+          "mem_id": "sharegpt_11WxPMZ_0:t58",
+          "distance": 0.5221
+        },
+        {
+          "session_id": "sharegpt_11WxPMZ_0",
+          "mem_id": "sharegpt_11WxPMZ_0:t13",
+          "distance": 0.5211
+        }
+      ],
+      "queries_used": [
+        "How many weeks ago did I meet up with my aunt and receive the crystal chandelier?",
+        "How many weeks ago did I meet my aunt and get the crystal chandelier?",
+        "How long ago was my meetup with my aunt when I received the crystal chandelier?",
+        "How many weeks back did I see my aunt and receive the crystal chandelier?"
+      ]
+    },
+    {
+      "question_id": "b46e15ed",
+      "question": "How many months have passed since I participated in two charity events in a row, on consecutive days?",
+      "gold_session_ids": [
+        "answer_4bfcc250_4",
+        "answer_4bfcc250_3",
+        "answer_4bfcc250_2",
+        "answer_4bfcc250_1"
+      ],
+      "verdict": "miss",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "sharegpt_WFKzGQx_0",
+          "mem_id": "sharegpt_WFKzGQx_0:t0",
+          "distance": 0.4661
+        },
+        {
+          "session_id": "sharegpt_hcaZN94_433",
+          "mem_id": "sharegpt_hcaZN94_433:t7",
+          "distance": 0.4383
+        },
+        {
+          "session_id": "sharegpt_WFKzGQx_0",
+          "mem_id": "sharegpt_WFKzGQx_0:t14",
+          "distance": 0.5013
+        },
+        {
+          "session_id": "sharegpt_hcaZN94_433",
+          "mem_id": "sharegpt_hcaZN94_433:t1",
+          "distance": 0.4723
+        },
+        {
+          "session_id": "sharegpt_ZaBu0Qw_0",
+          "mem_id": "sharegpt_ZaBu0Qw_0:t0",
+          "distance": 0.5063
+        }
+      ],
+      "queries_used": [
+        "How many months have passed since I participated in two charity events in a row, on consecutive days?",
+        "How many months since I took part in two charity events back-to-back on consecutive days?",
+        "How long ago did I attend two charity events in a row, one day after the other?",
+        "How many months ago were my two consecutive-day charity event participations?"
+      ]
+    },
+    {
+      "question_id": "gpt4_fa19884c",
+      "question": "How many days passed between the day I started playing along to my favorite songs on my old keyboard and the day I discovered a bluegrass band?",
+      "gold_session_ids": [
+        "answer_ff201786_1",
+        "answer_ff201786_2"
+      ],
+      "verdict": "recall@1",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "answer_ff201786_2",
+          "mem_id": "answer_ff201786_2:t0",
+          "distance": 0.5068
+        },
+        {
+          "session_id": "answer_ff201786_1",
+          "mem_id": "answer_ff201786_1:t8",
+          "distance": 0.5131
+        },
+        {
+          "session_id": "answer_ff201786_1",
+          "mem_id": "answer_ff201786_1:t9",
+          "distance": 0.564
+        },
+        {
+          "session_id": "128082f8_1",
+          "mem_id": "128082f8_1:t10",
+          "distance": 0.6027
+        },
+        {
+          "session_id": "answer_ff201786_2",
+          "mem_id": "answer_ff201786_2:t8",
+          "distance": 0.6053
+        }
+      ],
+      "queries_used": [
+        "How many days passed between the day I started playing along to my favorite songs on my old keyboard and the day I discovered a bluegrass band?",
+        "How many days elapsed between starting to play along to my favorite songs on my old keyboard and discovering a bluegrass band?",
+        "What was the day difference between when I began playing my favorite songs on my old keyboard and when I found a bluegrass band?",
+        "How many days were there from starting to play my favorite songs on my old keyboard to discovering a bluegrass band?"
+      ]
+    },
+    {
+      "question_id": "0bc8ad92",
+      "question": "How many months have passed since I last visited a museum with a friend?",
+      "gold_session_ids": [
+        "answer_f4ea84fb_3",
+        "answer_f4ea84fb_2",
+        "answer_f4ea84fb_1"
+      ],
+      "verdict": "miss",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "sharegpt_KC1VaRe_0",
+          "mem_id": "sharegpt_KC1VaRe_0:t6",
+          "distance": 0.4718
+        },
+        {
+          "session_id": "f58c36b8_1",
+          "mem_id": "f58c36b8_1:t10",
+          "distance": 0.5048
+        },
+        {
+          "session_id": "sharegpt_xxk9JDz_21",
+          "mem_id": "sharegpt_xxk9JDz_21:t9",
+          "distance": 0.4935
+        },
+        {
+          "session_id": "sharegpt_FqUHzEk_0",
+          "mem_id": "sharegpt_FqUHzEk_0:t6",
+          "distance": 0.5032
+        },
+        {
+          "session_id": "sharegpt_Le7CqkS_0",
+          "mem_id": "sharegpt_Le7CqkS_0:t2",
+          "distance": 0.5148
+        }
+      ],
+      "queries_used": [
+        "How many months have passed since I last visited a museum with a friend?",
+        "How many months since I last went to a museum with a friend?",
+        "How long has it been since my last museum visit with a friend?",
+        "Months elapsed since I last visited a museum with a friend?"
+      ]
+    },
+    {
+      "question_id": "af082822",
+      "question": "How many weeks ago did I attend the friends and family sale at Nordstrom?",
+      "gold_session_ids": [
+        "answer_b51b6115_1"
+      ],
+      "verdict": "recall@K",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "bf38543d_2",
+          "mem_id": "bf38543d_2:t2",
+          "distance": 0.515
+        },
+        {
+          "session_id": "cdf068b1_2",
+          "mem_id": "cdf068b1_2:t10",
+          "distance": 0.5479
+        },
+        {
+          "session_id": "1dfef591_2",
+          "mem_id": "1dfef591_2:t6",
+          "distance": 0.5883
+        },
+        {
+          "session_id": "e132259f",
+          "mem_id": "e132259f:t0",
+          "distance": 0.5783
+        },
+        {
+          "session_id": "answer_b51b6115_1",
+          "mem_id": "answer_b51b6115_1:t10",
+          "distance": 0.5972
+        }
+      ],
+      "queries_used": [
+        "How many weeks ago did I attend the friends and family sale at Nordstrom?",
+        "How many weeks ago was the friends and family sale at Nordstrom that I attended?",
+        "How long ago did I go to Nordstrom's friends and family sale, in weeks?",
+        "Weeks ago, when did I attend the Nordstrom friends and family sale?"
+      ]
+    },
+    {
+      "question_id": "gpt4_4929293a",
+      "question": "Which event happened first, my cousin's wedding or Michael's engagement party?",
+      "gold_session_ids": [
+        "answer_add9b012_2",
+        "answer_add9b012_1"
+      ],
+      "verdict": "miss",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "5a81277c",
+          "mem_id": "5a81277c:t10",
+          "distance": 0.5328
+        },
+        {
+          "session_id": "sharegpt_lH1wCbz_11",
+          "mem_id": "sharegpt_lH1wCbz_11:t1",
+          "distance": 0.5641
+        },
+        {
+          "session_id": "ultrachat_221041",
+          "mem_id": "ultrachat_221041:t0",
+          "distance": 0.5764
+        },
+        {
+          "session_id": "sharegpt_bTRqqlc_0",
+          "mem_id": "sharegpt_bTRqqlc_0:t0",
+          "distance": 0.589
+        },
+        {
+          "session_id": "ultrachat_63058",
+          "mem_id": "ultrachat_63058:t2",
+          "distance": 0.5321
+        }
+      ],
+      "queries_used": [
+        "Which event happened first, my cousin's wedding or Michael's engagement party?",
+        "Did my cousin's wedding happen before Michael's engagement party?",
+        "Which came first: my cousin's wedding or Michael's engagement party?",
+        "Was my cousin's wedding earlier than Michael's engagement party?"
+      ]
+    },
+    {
+      "question_id": "gpt4_b5700ca9",
+      "question": "How many days ago did I attend the Maundy Thursday service at the Episcopal Church?",
+      "gold_session_ids": [
+        "answer_a17423e7_1"
+      ],
+      "verdict": "recall@K",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "sharegpt_7qFUagj_0",
+          "mem_id": "sharegpt_7qFUagj_0:t6",
+          "distance": 0.4548
+        },
+        {
+          "session_id": "sharegpt_jJQwr3e_0",
+          "mem_id": "sharegpt_jJQwr3e_0:t6",
+          "distance": 0.486
+        },
+        {
+          "session_id": "sharegpt_D5vldxd_21",
+          "mem_id": "sharegpt_D5vldxd_21:t1",
+          "distance": 0.5135
+        },
+        {
+          "session_id": "sharegpt_D5vldxd_21",
+          "mem_id": "sharegpt_D5vldxd_21:t2",
+          "distance": 0.5314
+        },
+        {
+          "session_id": "sharegpt_6sDqw6L_0",
+          "mem_id": "sharegpt_6sDqw6L_0:t6",
+          "distance": 0.5255
+        }
+      ],
+      "queries_used": [
+        "How many days ago did I attend the Maundy Thursday service at the Episcopal Church?",
+        "How many days since I attended the Maundy Thursday service at the Episcopal Church?",
+        "How long ago was my attendance at the Maundy Thursday service at the Episcopal Church?",
+        "How many days back did I go to the Maundy Thursday service at the Episcopal Church?"
+      ]
+    },
+    {
+      "question_id": "9a707b81",
+      "question": "How many days ago did I attend a baking class at a local culinary school when I made my friend's birthday cake?",
+      "gold_session_ids": [
+        "answer_dba89487_2",
+        "answer_dba89487_1"
+      ],
+      "verdict": "recall@1",
+      "ingest_n": -1,
+      "top_5": [
+        {
+          "session_id": "answer_dba89487_2",
+          "mem_id": "answer_dba89487_2:t0",
+          "distance": 0.4405
+        },
+        {
+          "session_id": "answer_dba89487_2",
+          "mem_id": "answer_dba89487_2:t2",
+          "distance": 0.4805
+        },
+        {
+          "session_id": "ultrachat_243091",
+          "mem_id": "ultrachat_243091:t4",
+          "distance": 0.5574
+        },
+        {
+          "session_id": "sharegpt_v3mxcGF_0",
+          "mem_id": "sharegpt_v3mxcGF_0:t8",
+          "distance": 0.5824
+        },
+        {
+          "session_id": "sharegpt_07OY96u_27",
+          "mem_id": "sharegpt_07OY96u_27:t1",
+          "distance": 0.5694
+        }
+      ],
+      "queries_used": [
+        "How many days ago did I attend a baking class at a local culinary school when I made my friend's birthday cake?",
+        "How many days ago did I go to a baking class at a local culinary school when I made my friend's birthday cake?",
+        "When did I attend a baking class at a local culinary school to make my friend's birthday cake?",
+        "How long ago was my baking class at a local culinary school for my friend's birthday cake?"
+      ]
+    }
+  ],
+  "elapsed_sec": 23.227748155593872
+}

--- a/docs/bench/pinecone-supersession-llama-20260429.json
+++ b/docs/bench/pinecone-supersession-llama-20260429.json
@@ -1,0 +1,525 @@
+{
+  "embedder": "pinecone:llama-text-embed-v2@1024d",
+  "store": "pinecone-local:attestor-bakeoff-llama",
+  "n_cases": 50,
+  "new_wins": 5,
+  "stale_wins": 37,
+  "miss": 8,
+  "ambiguous": 0,
+  "score_pct": 10.0,
+  "elapsed_sec": 39.230108976364136,
+  "by_category": {
+    "numeric": {
+      "new_wins": 1,
+      "stale_wins": 4,
+      "miss": 0,
+      "ambiguous": 0
+    },
+    "categorical": {
+      "new_wins": 1,
+      "stale_wins": 4,
+      "miss": 0,
+      "ambiguous": 0
+    },
+    "temporal": {
+      "new_wins": 1,
+      "stale_wins": 3,
+      "miss": 1,
+      "ambiguous": 0
+    },
+    "preference": {
+      "new_wins": 0,
+      "stale_wins": 4,
+      "miss": 1,
+      "ambiguous": 0
+    },
+    "entity": {
+      "new_wins": 0,
+      "stale_wins": 5,
+      "miss": 0,
+      "ambiguous": 0
+    },
+    "locational": {
+      "new_wins": 0,
+      "stale_wins": 5,
+      "miss": 0,
+      "ambiguous": 0
+    },
+    "intent": {
+      "new_wins": 0,
+      "stale_wins": 5,
+      "miss": 0,
+      "ambiguous": 0
+    },
+    "relational": {
+      "new_wins": 1,
+      "stale_wins": 2,
+      "miss": 2,
+      "ambiguous": 0
+    },
+    "count": {
+      "new_wins": 0,
+      "stale_wins": 5,
+      "miss": 0,
+      "ambiguous": 0
+    },
+    "status_binary": {
+      "new_wins": 1,
+      "stale_wins": 0,
+      "miss": 4,
+      "ambiguous": 0
+    }
+  },
+  "verdicts": [
+    {
+      "case_id": "ku_numeric_001",
+      "category": "numeric",
+      "verdict": "new_wins",
+      "top1_id": "ku_numeric_001:s5:0",
+      "top1_distance": 0.32525962591171265,
+      "top1_content": "Sold the Tesla last weekend for $38,500 \u2014 depreciation hit harder than I thought.",
+      "ingest_n": 2
+    },
+    {
+      "case_id": "ku_numeric_002",
+      "category": "numeric",
+      "verdict": "stale_wins",
+      "top1_id": "ku_numeric_002:s1:0",
+      "top1_distance": 0.18747568130493164,
+      "top1_content": "My monthly rent is $2,400.",
+      "ingest_n": 2
+    },
+    {
+      "case_id": "ku_numeric_003",
+      "category": "numeric",
+      "verdict": "stale_wins",
+      "top1_id": "ku_numeric_003:s1:0",
+      "top1_distance": 0.1674521565437317,
+      "top1_content": "I weigh 185 pounds.",
+      "ingest_n": 2
+    },
+    {
+      "case_id": "ku_numeric_004",
+      "category": "numeric",
+      "verdict": "stale_wins",
+      "top1_id": "ku_numeric_004:s1:0",
+      "top1_distance": 0.17140358686447144,
+      "top1_content": "My salary is $145,000 base.",
+      "ingest_n": 2
+    },
+    {
+      "case_id": "ku_numeric_005",
+      "category": "numeric",
+      "verdict": "stale_wins",
+      "top1_id": "ku_numeric_005:s1:0",
+      "top1_distance": 0.11118572950363159,
+      "top1_content": "We have 3 engineers on the platform team.",
+      "ingest_n": 2
+    },
+    {
+      "case_id": "ku_categorical_001",
+      "category": "categorical",
+      "verdict": "stale_wins",
+      "top1_id": "ku_categorical_001:s1:0",
+      "top1_distance": 0.20999246835708618,
+      "top1_content": "Project Atlas is in 'Active' status.",
+      "ingest_n": 2
+    },
+    {
+      "case_id": "ku_categorical_002",
+      "category": "categorical",
+      "verdict": "stale_wins",
+      "top1_id": "ku_categorical_002:s1:0",
+      "top1_distance": 0.32207202911376953,
+      "top1_content": "I'm a vegetarian.",
+      "ingest_n": 2
+    },
+    {
+      "case_id": "ku_categorical_003",
+      "category": "categorical",
+      "verdict": "new_wins",
+      "top1_id": "ku_categorical_003:s5:0",
+      "top1_distance": 0.2228899598121643,
+      "top1_content": "Just upgraded to the Enterprise plan.",
+      "ingest_n": 2
+    },
+    {
+      "case_id": "ku_categorical_004",
+      "category": "categorical",
+      "verdict": "stale_wins",
+      "top1_id": "ku_categorical_004:s1:0",
+      "top1_distance": 0.26999980211257935,
+      "top1_content": "My laptop is a MacBook Pro.",
+      "ingest_n": 2
+    },
+    {
+      "case_id": "ku_categorical_005",
+      "category": "categorical",
+      "verdict": "stale_wins",
+      "top1_id": "ku_categorical_005:s1:0",
+      "top1_distance": 0.11520659923553467,
+      "top1_content": "Issue #443 is currently 'In Progress'.",
+      "ingest_n": 2
+    },
+    {
+      "case_id": "ku_temporal_001",
+      "category": "temporal",
+      "verdict": "stale_wins",
+      "top1_id": "ku_temporal_001:s1:0",
+      "top1_distance": 0.1228020191192627,
+      "top1_content": "The launch is scheduled for March 15th.",
+      "ingest_n": 2
+    },
+    {
+      "case_id": "ku_temporal_002",
+      "category": "temporal",
+      "verdict": "stale_wins",
+      "top1_id": "ku_temporal_002:s1:0",
+      "top1_distance": 0.18416446447372437,
+      "top1_content": "My flight to Tokyo leaves Tuesday.",
+      "ingest_n": 2
+    },
+    {
+      "case_id": "ku_temporal_003",
+      "category": "temporal",
+      "verdict": "stale_wins",
+      "top1_id": "ku_temporal_003:s1:0",
+      "top1_distance": 0.27759408950805664,
+      "top1_content": "Annual review is on March 1st this year.",
+      "ingest_n": 2
+    },
+    {
+      "case_id": "ku_temporal_004",
+      "category": "temporal",
+      "verdict": "new_wins",
+      "top1_id": "ku_temporal_004:s5:0",
+      "top1_distance": 0.23117494583129883,
+      "top1_content": "Postponed the birthday party to the following Sunday.",
+      "ingest_n": 2
+    },
+    {
+      "case_id": "ku_temporal_005",
+      "category": "temporal",
+      "verdict": "miss",
+      "top1_id": "ku_temporal_005:s1:0",
+      "top1_distance": 0.28290945291519165,
+      "top1_content": "Lease ends June 30th.",
+      "ingest_n": 2
+    },
+    {
+      "case_id": "ku_preference_001",
+      "category": "preference",
+      "verdict": "stale_wins",
+      "top1_id": "ku_preference_001:s1:0",
+      "top1_distance": 0.2803831100463867,
+      "top1_content": "Coffee in the morning is non-negotiable for me.",
+      "ingest_n": 2
+    },
+    {
+      "case_id": "ku_preference_002",
+      "category": "preference",
+      "verdict": "stale_wins",
+      "top1_id": "ku_preference_002:s1:0",
+      "top1_distance": 0.20936787128448486,
+      "top1_content": "I prefer Vim for editing.",
+      "ingest_n": 2
+    },
+    {
+      "case_id": "ku_preference_003",
+      "category": "preference",
+      "verdict": "stale_wins",
+      "top1_id": "ku_preference_003:s1:0",
+      "top1_distance": 0.14678692817687988,
+      "top1_content": "I always book aisle seats on flights.",
+      "ingest_n": 2
+    },
+    {
+      "case_id": "ku_preference_004",
+      "category": "preference",
+      "verdict": "stale_wins",
+      "top1_id": "ku_preference_004:s1:0",
+      "top1_distance": 0.31457722187042236,
+      "top1_content": "Postgres is my default for any new project.",
+      "ingest_n": 2
+    },
+    {
+      "case_id": "ku_preference_005",
+      "category": "preference",
+      "verdict": "miss",
+      "top1_id": "ku_preference_005:s1:0",
+      "top1_distance": 0.23777079582214355,
+      "top1_content": "I run 5K every morning before work.",
+      "ingest_n": 2
+    },
+    {
+      "case_id": "ku_entity_001",
+      "category": "entity",
+      "verdict": "stale_wins",
+      "top1_id": "ku_entity_001:s1:0",
+      "top1_distance": 0.2847962975502014,
+      "top1_content": "Alice Chen is our CTO.",
+      "ingest_n": 2
+    },
+    {
+      "case_id": "ku_entity_002",
+      "category": "entity",
+      "verdict": "stale_wins",
+      "top1_id": "ku_entity_002:s1:0",
+      "top1_distance": 0.211164653301239,
+      "top1_content": "My primary care doctor is Dr. Mendez.",
+      "ingest_n": 2
+    },
+    {
+      "case_id": "ku_entity_003",
+      "category": "entity",
+      "verdict": "stale_wins",
+      "top1_id": "ku_entity_003:s1:0",
+      "top1_distance": 0.19786512851715088,
+      "top1_content": "Our AWS account manager is Jen Wu.",
+      "ingest_n": 2
+    },
+    {
+      "case_id": "ku_entity_004",
+      "category": "entity",
+      "verdict": "stale_wins",
+      "top1_id": "ku_entity_004:s1:0",
+      "top1_distance": 0.21362674236297607,
+      "top1_content": "Maya is my dog.",
+      "ingest_n": 2
+    },
+    {
+      "case_id": "ku_entity_005",
+      "category": "entity",
+      "verdict": "stale_wins",
+      "top1_id": "ku_entity_005:s1:0",
+      "top1_distance": 0.2788248062133789,
+      "top1_content": "Our agency of record is Wieden+Kennedy.",
+      "ingest_n": 2
+    },
+    {
+      "case_id": "ku_locational_001",
+      "category": "locational",
+      "verdict": "stale_wins",
+      "top1_id": "ku_locational_001:s1:0",
+      "top1_distance": 0.3226824998855591,
+      "top1_content": "I live at 123 Main Street, Austin.",
+      "ingest_n": 2
+    },
+    {
+      "case_id": "ku_locational_002",
+      "category": "locational",
+      "verdict": "stale_wins",
+      "top1_id": "ku_locational_002:s1:0",
+      "top1_distance": 0.220963716506958,
+      "top1_content": "Our HQ is in San Francisco.",
+      "ingest_n": 2
+    },
+    {
+      "case_id": "ku_locational_003",
+      "category": "locational",
+      "verdict": "stale_wins",
+      "top1_id": "ku_locational_003:s1:0",
+      "top1_distance": 0.16427677869796753,
+      "top1_content": "Database is hosted in us-east-1.",
+      "ingest_n": 2
+    },
+    {
+      "case_id": "ku_locational_004",
+      "category": "locational",
+      "verdict": "stale_wins",
+      "top1_id": "ku_locational_004:s1:0",
+      "top1_distance": 0.1774824857711792,
+      "top1_content": "My standing desk is in the home office.",
+      "ingest_n": 2
+    },
+    {
+      "case_id": "ku_locational_005",
+      "category": "locational",
+      "verdict": "stale_wins",
+      "top1_id": "ku_locational_005:s1:0",
+      "top1_distance": 0.22287416458129883,
+      "top1_content": "I'm based in Seattle for the next year.",
+      "ingest_n": 2
+    },
+    {
+      "case_id": "ku_intent_001",
+      "category": "intent",
+      "verdict": "stale_wins",
+      "top1_id": "ku_intent_001:s1:0",
+      "top1_distance": 0.2720603942871094,
+      "top1_content": "I'm planning to cancel the Acme project.",
+      "ingest_n": 2
+    },
+    {
+      "case_id": "ku_intent_002",
+      "category": "intent",
+      "verdict": "stale_wins",
+      "top1_id": "ku_intent_002:s1:0",
+      "top1_distance": 0.38315045833587646,
+      "top1_content": "Goal this quarter: ship feature X by end of Q1.",
+      "ingest_n": 2
+    },
+    {
+      "case_id": "ku_intent_003",
+      "category": "intent",
+      "verdict": "stale_wins",
+      "top1_id": "ku_intent_003:s1:0",
+      "top1_distance": 0.22143632173538208,
+      "top1_content": "I want to learn Rust this year.",
+      "ingest_n": 2
+    },
+    {
+      "case_id": "ku_intent_004",
+      "category": "intent",
+      "verdict": "stale_wins",
+      "top1_id": "ku_intent_004:s1:0",
+      "top1_distance": 0.3066138029098511,
+      "top1_content": "Going to apply for Stanford MBA this fall.",
+      "ingest_n": 2
+    },
+    {
+      "case_id": "ku_intent_005",
+      "category": "intent",
+      "verdict": "stale_wins",
+      "top1_id": "ku_intent_005:s1:0",
+      "top1_distance": 0.15333575010299683,
+      "top1_content": "Thinking about getting a Tesla as my next car.",
+      "ingest_n": 2
+    },
+    {
+      "case_id": "ku_relational_001",
+      "category": "relational",
+      "verdict": "miss",
+      "top1_id": "ku_relational_001:s5:0",
+      "top1_distance": 0.2672464847564697,
+      "top1_content": "Sara and I broke up last month.",
+      "ingest_n": 2
+    },
+    {
+      "case_id": "ku_relational_002",
+      "category": "relational",
+      "verdict": "stale_wins",
+      "top1_id": "ku_relational_002:s1:0",
+      "top1_distance": 0.35919177532196045,
+      "top1_content": "James reports to me on the data team.",
+      "ingest_n": 2
+    },
+    {
+      "case_id": "ku_relational_003",
+      "category": "relational",
+      "verdict": "miss",
+      "top1_id": "ku_relational_003:s1:0",
+      "top1_distance": 0.2420021891593933,
+      "top1_content": "Acme Corp is a paying customer of ours.",
+      "ingest_n": 2
+    },
+    {
+      "case_id": "ku_relational_004",
+      "category": "relational",
+      "verdict": "new_wins",
+      "top1_id": "ku_relational_004:s1:0",
+      "top1_distance": 0.11363720893859863,
+      "top1_content": "I'm on the board of NonProfit X.",
+      "ingest_n": 2
+    },
+    {
+      "case_id": "ku_relational_005",
+      "category": "relational",
+      "verdict": "stale_wins",
+      "top1_id": "ku_relational_005:s1:0",
+      "top1_distance": 0.2164156436920166,
+      "top1_content": "Working closely with Acme as our top integration partner.",
+      "ingest_n": 2
+    },
+    {
+      "case_id": "ku_count_001",
+      "category": "count",
+      "verdict": "stale_wins",
+      "top1_id": "ku_count_001:s1:0",
+      "top1_distance": 0.1631021499633789,
+      "top1_content": "We have 2 kids.",
+      "ingest_n": 2
+    },
+    {
+      "case_id": "ku_count_002",
+      "category": "count",
+      "verdict": "stale_wins",
+      "top1_id": "ku_count_002:s1:0",
+      "top1_distance": 0.13009953498840332,
+      "top1_content": "Open positions on my team: 4.",
+      "ingest_n": 2
+    },
+    {
+      "case_id": "ku_count_003",
+      "category": "count",
+      "verdict": "stale_wins",
+      "top1_id": "ku_count_003:s1:0",
+      "top1_distance": 0.12712043523788452,
+      "top1_content": "I own 5 properties total.",
+      "ingest_n": 2
+    },
+    {
+      "case_id": "ku_count_004",
+      "category": "count",
+      "verdict": "stale_wins",
+      "top1_id": "ku_count_004:s1:0",
+      "top1_distance": 0.13617509603500366,
+      "top1_content": "I have 12 active GitHub repos.",
+      "ingest_n": 2
+    },
+    {
+      "case_id": "ku_count_005",
+      "category": "count",
+      "verdict": "stale_wins",
+      "top1_id": "ku_count_005:s1:0",
+      "top1_distance": 0.17234939336776733,
+      "top1_content": "I'm tracking 8 deals in my pipeline.",
+      "ingest_n": 2
+    },
+    {
+      "case_id": "ku_status_binary_001",
+      "category": "status_binary",
+      "verdict": "miss",
+      "top1_id": "ku_status_binary_001:s1:0",
+      "top1_distance": 0.10212075710296631,
+      "top1_content": "I'm subscribed to The Information.",
+      "ingest_n": 2
+    },
+    {
+      "case_id": "ku_status_binary_002",
+      "category": "status_binary",
+      "verdict": "miss",
+      "top1_id": "ku_status_binary_002:s1:0",
+      "top1_distance": 0.12052386999130249,
+      "top1_content": "Two-factor auth is disabled on my main account.",
+      "ingest_n": 2
+    },
+    {
+      "case_id": "ku_status_binary_003",
+      "category": "status_binary",
+      "verdict": "miss",
+      "top1_id": "ku_status_binary_003:s1:0",
+      "top1_distance": 0.25756770372390747,
+      "top1_content": "I'm vaccinated for the flu this season.",
+      "ingest_n": 2
+    },
+    {
+      "case_id": "ku_status_binary_004",
+      "category": "status_binary",
+      "verdict": "miss",
+      "top1_id": "ku_status_binary_004:s1:0",
+      "top1_distance": 0.23933154344558716,
+      "top1_content": "Working from home full-time these days.",
+      "ingest_n": 2
+    },
+    {
+      "case_id": "ku_status_binary_005",
+      "category": "status_binary",
+      "verdict": "new_wins",
+      "top1_id": "ku_status_binary_005:s1:0",
+      "top1_distance": 0.4428201913833618,
+      "top1_content": "On a strict no-alcohol regimen for 90 days.",
+      "ingest_n": 2
+    }
+  ]
+}

--- a/experiments/pinecone_lme_temporal_diagnostic.py
+++ b/experiments/pinecone_lme_temporal_diagnostic.py
@@ -1,0 +1,483 @@
+"""Retrieval-only diagnostic on LME-S temporal-reasoning slice.
+
+Identifies questions where vector retrieval FAILS to surface any of
+the gold answer-bearing sessions in top-K. Pure embedding + cosine
+search — no answerer, no judges. Tells you which questions a
+downstream answerer wouldn't even have a chance on, regardless of how
+strong the prompt is.
+
+Stack:
+  embedder:  Pinecone Inference `llama-text-embed-v2` @ 1024-D (NVIDIA)
+  store:     Pinecone Local (Docker, in-memory, free)
+  isolation: one Pinecone namespace per LME-S question
+
+Outputs:
+  stdout:                          per-question pass/fail
+  docs/bench/pinecone-lme-temporal-diagnostic-<date>.json
+                                   verdicts + top-5 detail per question
+
+Cost: ~free under Pinecone's 5M-token starter (10 questions of LME-S
+oracle/s ≈ 50-450k tokens depending on variant).
+
+USAGE
+-----
+    set -a && source .env && set +a
+    .venv/bin/python experiments/pinecone_lme_temporal_diagnostic.py --limit 10
+
+Per the smoke-only rule (feedback_smoke_only_no_full_bench), Claude
+caps at 10 samples. User runs the full 133-question slice on their
+own cadence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from collections import Counter
+from datetime import datetime
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from attestor.longmemeval import load_or_download, parse_lme_date  # noqa: E402
+from attestor.retrieval.hyde import hyde_search  # noqa: E402
+from attestor.retrieval.multi_query import (  # noqa: E402
+    multi_query_search, reciprocal_rank_fusion,
+)
+from attestor.retrieval.temporal_prefilter import detect_window  # noqa: E402
+from attestor.store.embeddings import PineconeEmbeddingProvider  # noqa: E402
+from attestor.store.pinecone_backend import PineconeBackend  # noqa: E402
+
+
+def _ingest_haystack(pc, sample, namespace: str) -> int:
+    """Upsert every turn of every haystack session into the per-question
+    namespace. Per-turn (unbatched) so the wallclock spreads embedding
+    tokens evenly under Pinecone Inference's 250k tokens/min free-tier
+    cap. Batched ingest hits HTTP 429.
+
+    Returns count of vectors written.
+    """
+    n = 0
+    for sess_idx, session_turns in enumerate(sample.haystack_sessions):
+        sess_id = sample.haystack_session_ids[sess_idx]
+        sess_date = (
+            sample.haystack_dates[sess_idx]
+            if sess_idx < len(sample.haystack_dates) else ""
+        )
+        for turn_idx, turn in enumerate(session_turns):
+            content = turn.content
+            if not content.strip():
+                continue
+            mem_id = f"{sess_id}:t{turn_idx}"
+            pc._index.upsert(
+                vectors=[{
+                    "id": mem_id,
+                    "values": pc._embed(content),
+                    "metadata": {
+                        "session_id": sess_id,
+                        "session_date": sess_date,
+                        "role": turn.role,
+                    },
+                }],
+                namespace=namespace,
+            )
+            n += 1
+    return n
+
+
+def _make_vector_search(pc, namespace: str, k: int):
+    """Closure: q → list of hit dicts shaped for RRF merge.
+
+    Used by ``multi_query_search`` / ``hyde_search``: each call embeds
+    ``q`` and runs a top-K query in the per-question namespace, returns
+    dicts keyed on ``memory_id`` (the RRF identity field). Wide top-K
+    here gives RRF more material to work with.
+    """
+    def search(q: str):
+        result = pc._index.query(
+            vector=pc._embed(q), top_k=k, namespace=namespace,
+            include_metadata=True,
+        )
+        return [
+            {
+                "memory_id": m.id,
+                "session_id": m.metadata.get("session_id"),
+                "session_date": m.metadata.get("session_date", ""),
+                "distance": max(0.0, 1.0 - float(m.score)),
+            }
+            for m in (result.matches or [])
+        ]
+    return search
+
+
+def _recall_via_multi_query(pc, query: str, namespace: str, k: int, n: int):
+    vector_search = _make_vector_search(pc, namespace, k=k * 3)
+    queries, merged = multi_query_search(
+        query, vector_search=vector_search, n=n, merge="rrf",
+    )
+    top = merged[:k]
+    return [(h["session_id"], h["memory_id"], h["distance"]) for h in top], queries
+
+
+def _recall_via_hyde(pc, query: str, namespace: str, k: int):
+    vector_search = _make_vector_search(pc, namespace, k=k * 3)
+    queries, merged = hyde_search(
+        query, vector_search=vector_search, merge="rrf",
+    )
+    top = merged[:k]
+    return [(h["session_id"], h["memory_id"], h["distance"]) for h in top], queries
+
+
+def _bm25_lane(sample, query: str, k: int) -> list[dict]:
+    """In-memory BM25 over the sample's haystack turns.
+
+    Returns hits shaped like the Pinecone vector lane so they can be
+    RRF-merged with HyDE's merged_hits. BM25 catches rare-noun anchors
+    (proper nouns, technical terms, product names) that dense embedders
+    smear across visually-similar distractor sessions — the canonical
+    cosine-vs-keyword complement.
+    """
+    from rank_bm25 import BM25Okapi
+    docs = []
+    meta = []
+    for sess_idx, turns in enumerate(sample.haystack_sessions):
+        sess_id = sample.haystack_session_ids[sess_idx]
+        for turn_idx, turn in enumerate(turns):
+            content = turn.content
+            if not content.strip():
+                continue
+            docs.append(content.lower().split())
+            meta.append({
+                "memory_id": f"{sess_id}:t{turn_idx}",
+                "session_id": sess_id,
+            })
+    if not docs:
+        return []
+    bm25 = BM25Okapi(docs)
+    scores = bm25.get_scores(query.lower().split())
+    # Top-k by score, descending. Convert to vector-lane shape so RRF
+    # merge keys match. Fake "distance" = 1 - normalized_score so low
+    # is better (consistent with cosine).
+    ranked = sorted(zip(scores, meta), key=lambda x: x[0], reverse=True)[:k]
+    if not ranked:
+        return []
+    max_score = max(s for s, _ in ranked) or 1.0
+    return [
+        {
+            "memory_id": m["memory_id"],
+            "session_id": m["session_id"],
+            "distance": 1.0 - (float(s) / max_score),
+            "bm25_score": float(s),
+        }
+        for s, m in ranked
+    ]
+
+
+def _recall_via_hyde_bm25(pc, sample, namespace: str, k: int):
+    """HyDE dense lane + local BM25 lane, RRF-merged.
+
+    Two ranked lists: (1) HyDE-style dense retrieval (original question
+    + hypothetical answer, RRF-merged via hyde_search), (2) BM25 over
+    the haystack. Final merge via RRF k=60. Top-K of the final ranking
+    is returned.
+    """
+    vector_search = _make_vector_search(pc, namespace, k=k * 3)
+    hyde_queries, hyde_merged = hyde_search(
+        sample.question, vector_search=vector_search, merge="rrf",
+    )
+    # Use the question (not the hypothetical) for BM25 — keyword match
+    # on the user's actual nouns is what BM25 is best at.
+    bm25_hits = _bm25_lane(sample, sample.question, k=k * 3)
+    # Final RRF over the two lanes.
+    merged = reciprocal_rank_fusion([hyde_merged, bm25_hits])
+    top = merged[:k]
+    return (
+        [(h["session_id"], h["memory_id"], h["distance"]) for h in top],
+        hyde_queries,
+    )
+
+
+def _recall_topk(
+    pc, query: str, namespace: str, k: int = 10,
+    *,
+    temporal_prefilter: bool = False,
+    question_date_str: str = "",
+    tolerance_days: int = 3,
+):
+    """Return the top-K hits as (session_id, mem_id, distance) tuples.
+
+    When ``temporal_prefilter=True`` and the question contains a
+    relative time phrase ("how many weeks ago"), inflate top_k 5×
+    to give the post-filter headroom, then drop hits whose
+    ``session_date`` falls outside the implied window. This emulates
+    what ``attestor/retrieval/orchestrator.py`` does at Step 0 when
+    ``retrieval.temporal_prefilter.enabled=True``, except it filters
+    AFTER the vector query rather than narrowing the candidate pool
+    upstream — which is fine for a diagnostic but slightly weaker
+    than the orchestrator's path.
+    """
+    query_vec = pc._embed(query)
+
+    detected = None
+    effective_k = k
+    if temporal_prefilter:
+        question_date = parse_lme_date(question_date_str) if question_date_str else None
+        detected = detect_window(
+            query, question_date=question_date, tolerance_days=tolerance_days,
+        )
+        if detected is not None:
+            # Cast a wider net so we have something left after filtering.
+            effective_k = k * 5
+
+    result = pc._index.query(
+        vector=query_vec, top_k=effective_k, namespace=namespace,
+        include_metadata=True,
+    )
+    raw_hits = [
+        (
+            m.metadata.get("session_id"),
+            m.id,
+            max(0.0, 1.0 - float(m.score)),
+            m.metadata.get("session_date", ""),
+        )
+        for m in (result.matches or [])
+    ]
+
+    if detected is None:
+        # Strip session_date and return original shape.
+        return [(s, mid, d) for s, mid, d, _ in raw_hits[:k]]
+
+    # Post-filter by session_date in the detected window.
+    lower = detected.window.start
+    upper = detected.window.end
+    kept: List[Tuple] = []
+    for sid, mid, dist, sess_date_str in raw_hits:
+        sess_dt = parse_lme_date(sess_date_str) if sess_date_str else None
+        if sess_dt is None:
+            # No date → keep, can't filter
+            kept.append((sid, mid, dist))
+            continue
+        if (lower is None or sess_dt >= lower) and (upper is None or sess_dt <= upper):
+            kept.append((sid, mid, dist))
+        if len(kept) >= k:
+            break
+
+    # Defensive: if the filter dropped everything, fall back to the
+    # un-filtered top-K so we never return empty when the question
+    # had a temporal phrase but no haystack session is in-window.
+    if not kept:
+        return [(s, mid, d) for s, mid, d, _ in raw_hits[:k]]
+    return kept
+
+
+def _classify(top_hits, gold_session_ids: tuple, k: int) -> str:
+    """Did ANY gold session appear in top-K?
+
+    Returns:
+        'recall@1'   gold session is the top-1 hit
+        'recall@K'   gold session is in top-K (but not top-1)
+        'miss'       no gold session in top-K (retrieval can't help here)
+        'no_hits'    Pinecone returned nothing at all
+    """
+    if not top_hits:
+        return "no_hits"
+    if not gold_session_ids:
+        return "no_gold"
+    gold = set(gold_session_ids)
+    if top_hits[0][0] in gold:
+        return "recall@1"
+    if any(s in gold for s, _, _ in top_hits):
+        return "recall@K"
+    return "miss"
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--variant", default="s",
+                   help="LME variant: oracle | s | m. Default s.")
+    p.add_argument("--category", default="temporal-reasoning",
+                   help=("LME question_type filter. Default "
+                         "'temporal-reasoning'. Other slices: "
+                         "'multi-session', 'knowledge-update', "
+                         "'single-session-user', 'single-session-assistant', "
+                         "'single-session-preference'."))
+    p.add_argument("--limit", type=int, default=10,
+                   help="Max questions to score. Default 10 (smoke).")
+    p.add_argument("--top-k", type=int, default=10,
+                   help="Top-K depth for the recall check. Default 10.")
+    p.add_argument("--skip-ingest", action="store_true",
+                   help=("Skip the haystack ingest step (assume the "
+                         "namespaces are already populated from a prior "
+                         "run). Cuts wallclock from ~17 min to ~30s for "
+                         "10 questions when iterating retrieval flags."))
+    p.add_argument("--temporal-prefilter", action="store_true",
+                   help=("Apply RC4 temporal pre-filter (PR #98): detect "
+                         "'N weeks ago' / 'last Monday' / etc. in the "
+                         "question and drop top-K hits whose session_date "
+                         "falls outside the implied event-time window."))
+    p.add_argument("--tolerance-days", type=int, default=3,
+                   help="Half-width of the temporal window in days.")
+    p.add_argument("--multi-query", action="store_true",
+                   help=("Apply PR #94 multi-query: rewrite question into "
+                         "N paraphrases via OpenRouter, run each as a "
+                         "vector lane, RRF-merge."))
+    p.add_argument("--multi-query-n", type=int, default=3,
+                   help="Number of paraphrases (default 3).")
+    p.add_argument("--hyde", action="store_true",
+                   help=("Apply PR-D HyDE: generate a hypothetical answer "
+                         "via OpenRouter, run both question + hypothetical "
+                         "as vector lanes, RRF-merge."))
+    p.add_argument("--bm25-hybrid", action="store_true",
+                   help=("Add a local BM25 lane (rank_bm25) over the "
+                         "haystack and RRF-merge with HyDE. Catches "
+                         "rare-noun anchors (proper nouns, products) "
+                         "that dense cosine smears."))
+    args = p.parse_args(argv)
+
+    print(f"[diag] loading LME-{args.variant!r}…")
+    samples = load_or_download(variant=args.variant)
+    temporal = [s for s in samples if s.question_type == "temporal-reasoning"]
+    print(f"[diag] {len(temporal)} temporal-reasoning questions in variant={args.variant!r}")
+    if args.limit:
+        temporal = temporal[: args.limit]
+    print(f"[diag] running {len(temporal)} (smoke cap)")
+
+    embedder = PineconeEmbeddingProvider(
+        model="llama-text-embed-v2", dimensions=1024,
+    )
+    pc = PineconeBackend(config={
+        "index_name": "attestor-lme-temporal",
+        "dimension": 1024,
+        "embedder": embedder,
+    })
+    print(f"[diag] embedder={embedder.provider_name}  store=pinecone-local")
+    print()
+
+    started = time.time()
+    verdicts = []
+    for i, sample in enumerate(temporal, 1):
+        ns = sample.question_id
+        try:
+            if args.skip_ingest:
+                # Assume the namespace is already populated from a prior
+                # run — saves the ~95% of wallclock that ingest costs.
+                ingest_n = -1
+            else:
+                ingest_n = _ingest_haystack(pc, sample, namespace=ns)
+                time.sleep(0.3)
+            queries_used = None
+            if args.bm25_hybrid:
+                top_hits, queries_used = _recall_via_hyde_bm25(
+                    pc, sample, namespace=ns, k=args.top_k,
+                )
+            elif args.multi_query:
+                top_hits, queries_used = _recall_via_multi_query(
+                    pc, sample.question, namespace=ns, k=args.top_k,
+                    n=args.multi_query_n,
+                )
+            elif args.hyde:
+                top_hits, queries_used = _recall_via_hyde(
+                    pc, sample.question, namespace=ns, k=args.top_k,
+                )
+            else:
+                top_hits = _recall_topk(
+                    pc, sample.question, namespace=ns, k=args.top_k,
+                    temporal_prefilter=args.temporal_prefilter,
+                    question_date_str=sample.question_date,
+                    tolerance_days=args.tolerance_days,
+                )
+            verdict = _classify(top_hits, sample.answer_session_ids, args.top_k)
+
+            row = {
+                "question_id": sample.question_id,
+                "question": sample.question,
+                "gold_session_ids": list(sample.answer_session_ids),
+                "verdict": verdict,
+                "ingest_n": ingest_n,
+                "top_5": [
+                    {"session_id": s, "mem_id": m, "distance": round(d, 4)}
+                    for s, m, d in top_hits[:5]
+                ],
+            }
+            if queries_used is not None:
+                row["queries_used"] = queries_used
+            verdicts.append(row)
+            print(
+                f"[diag] {i:>2}/{len(temporal)} {sample.question_id:<30s} "
+                f"ingest={ingest_n:>3}  → {verdict}"
+            )
+        except Exception as e:
+            verdicts.append({
+                "question_id": sample.question_id,
+                "verdict": "error",
+                "error": str(e),
+            })
+            print(f"[diag] {i:>2}/{len(temporal)} {sample.question_id} ERROR: {e}")
+
+    elapsed = time.time() - started
+    counts = Counter(v["verdict"] for v in verdicts)
+    total = len(verdicts)
+    recall_1 = counts.get("recall@1", 0)
+    recall_k = counts.get("recall@K", 0)
+    miss = counts.get("miss", 0)
+    found_pct = ((recall_1 + recall_k) / total * 100.0) if total else 0.0
+
+    print()
+    print("=" * 72)
+    print(
+        f"[diag] DONE — {recall_1 + recall_k}/{total} found ({found_pct:.1f}%) "
+        f"in {elapsed:.1f}s  "
+        f"[recall@1: {recall_1}, recall@K: {recall_k}, miss: {miss}]"
+    )
+
+    # FAILURES — what the user came for
+    failures = [v for v in verdicts if v["verdict"] in ("miss", "no_hits", "error")]
+    if failures:
+        print()
+        print(f"FAILURES ({len(failures)}/{total}) — questions where retrieval can't help any answerer:")
+        print()
+        for v in failures:
+            print(f"  • {v['question_id']}: \"{v.get('question','')[:80]}\"")
+            print(f"    gold sessions: {v.get('gold_session_ids')}")
+            for hit in v.get("top_5", [])[:3]:
+                print(f"    top: session={hit['session_id']}  dist={hit['distance']}")
+            if v.get("error"):
+                print(f"    error: {v['error']}")
+
+    mode = "baseline"
+    if args.bm25_hybrid:
+        mode = "hyde-bm25"
+    elif args.multi_query:
+        mode = f"mq{args.multi_query_n}"
+    elif args.hyde:
+        mode = "hyde"
+    elif args.temporal_prefilter:
+        mode = "tprefilter"
+    out_path = (
+        ROOT / "docs" / "bench"
+        / f"pinecone-lme-temporal-diagnostic-{mode}-{datetime.now().strftime('%Y%m%d')}.json"
+    )
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps({
+        "embedder": embedder.provider_name,
+        "store": "pinecone-local",
+        "variant": args.variant,
+        "category": "temporal-reasoning",
+        "n_total": len(temporal),
+        "n_scored": total,
+        "top_k": args.top_k,
+        "counts": dict(counts),
+        "found_pct": found_pct,
+        "failures": failures,
+        "verdicts": verdicts,
+        "elapsed_sec": elapsed,
+    }, indent=2))
+    print(f"\n[diag] persisted → {out_path.relative_to(ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/pinecone_lme_temporal_diagnostic.py
+++ b/experiments/pinecone_lme_temporal_diagnostic.py
@@ -339,8 +339,8 @@ def main(argv=None) -> int:
 
     print(f"[diag] loading LME-{args.variant!r}…")
     samples = load_or_download(variant=args.variant)
-    temporal = [s for s in samples if s.question_type == "temporal-reasoning"]
-    print(f"[diag] {len(temporal)} temporal-reasoning questions in variant={args.variant!r}")
+    temporal = [s for s in samples if s.question_type == args.category]
+    print(f"[diag] {len(temporal)} {args.category} questions in variant={args.variant!r}")
     if args.limit:
         temporal = temporal[: args.limit]
     print(f"[diag] running {len(temporal)} (smoke cap)")
@@ -349,7 +349,7 @@ def main(argv=None) -> int:
         model="llama-text-embed-v2", dimensions=1024,
     )
     pc = PineconeBackend(config={
-        "index_name": "attestor-lme-temporal",
+        "index_name": f"attestor-lme-{args.category[:30]}",
         "dimension": 1024,
         "embedder": embedder,
     })
@@ -458,14 +458,14 @@ def main(argv=None) -> int:
         mode = "tprefilter"
     out_path = (
         ROOT / "docs" / "bench"
-        / f"pinecone-lme-temporal-diagnostic-{mode}-{datetime.now().strftime('%Y%m%d')}.json"
+        / f"pinecone-lme-{args.category}-diagnostic-{mode}-{datetime.now().strftime('%Y%m%d')}.json"
     )
     out_path.parent.mkdir(parents=True, exist_ok=True)
     out_path.write_text(json.dumps({
         "embedder": embedder.provider_name,
         "store": "pinecone-local",
         "variant": args.variant,
-        "category": "temporal-reasoning",
+        "category": args.category,
         "n_total": len(temporal),
         "n_scored": total,
         "top_k": args.top_k,

--- a/experiments/pinecone_supersession_smoke.py
+++ b/experiments/pinecone_supersession_smoke.py
@@ -1,0 +1,205 @@
+"""End-to-end smoke: supersession suite (50 cases) on Pinecone Local
+with Pinecone Inference's `llama-text-embed-v2` (NVIDIA-hosted, 1024-D).
+
+Re-uses the supersession fixtures at
+``evals/knowledge_updates/fixtures.json`` and the verdict logic at
+``evals.knowledge_updates.runner.classify_top1`` — the SAME inputs
+that produced the pgvector+Voyage baseline of 4/50 (8%) per
+``project_supersession_baseline_20260429.md``.
+
+Differences from the pgvector path:
+  - Storage: Pinecone Local Docker, no AgentMemory / no v4 schema /
+    no Postgres / no graph. Pure vector-lane test.
+  - Embedder: Pinecone Inference `llama-text-embed-v2` @ 1024-D.
+  - Per-case isolation: namespaces (one per ``case_id``) instead of
+    fresh AgentMemory + UUID — Pinecone namespaces are free to create
+    and instantly evict on index reset.
+
+Output: stdout summary + ``docs/bench/pinecone-supersession-llama-{date}.json``.
+
+This is a SMOKE-ONLY harness — not the full evals.knowledge_updates
+flow. Designed for the Pinecone bakeoff branch.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from collections import Counter
+from datetime import datetime
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from attestor.store.embeddings import PineconeEmbeddingProvider  # noqa: E402
+from attestor.store.pinecone_backend import PineconeBackend  # noqa: E402
+from evals.knowledge_updates.runner import classify_top1, load_fixtures  # noqa: E402
+
+
+def _ingest_case(pc: PineconeBackend, case: dict, namespace: str) -> int:
+    """Upsert all user turns from both sessions into the case's namespace.
+    Returns count of rows written."""
+    n = 0
+    sessions = sorted(case["sessions"], key=lambda s: s.get("date", ""))
+    for sess in sessions:
+        for i, turn in enumerate(sess.get("turns", [])):
+            if turn.get("role") != "user":
+                continue
+            mem_id = f'{case["case_id"]}:{sess["session_id"]}:{i}'
+            pc._index.upsert(  # use the raw index so we can pin namespace
+                vectors=[{
+                    "id": mem_id,
+                    "values": pc._embed(turn["content"]),
+                    "metadata": {
+                        "session_id": sess["session_id"],
+                        "session_date": sess.get("date", ""),
+                    },
+                }],
+                namespace=namespace,
+            )
+            n += 1
+    return n
+
+
+def _recall_top1(pc: PineconeBackend, query: str, namespace: str):
+    """Single recall in the case's namespace; returns (id, distance, content)
+    or (None, None, None) if empty."""
+    query_vec = pc._embed(query)
+    result = pc._index.query(
+        vector=query_vec, top_k=3, namespace=namespace,
+        include_metadata=True,
+    )
+    if not result.matches:
+        return None, None, None
+    top = result.matches[0]
+    return top.id, max(0.0, 1.0 - float(top.score)), top.id  # id is content-prefixed
+
+
+def main(limit: int | None = None) -> int:
+    fixtures = load_fixtures(ROOT / "evals" / "knowledge_updates" / "fixtures.json")
+    if limit:
+        fixtures = fixtures[:limit]
+
+    embedder = PineconeEmbeddingProvider(
+        model="llama-text-embed-v2", dimensions=1024,
+    )
+    pc = PineconeBackend(config={
+        "index_name": "attestor-bakeoff-llama",
+        "dimension": 1024,
+        "embedder": embedder,
+    })
+
+    # Build a content lookup so verdict scoring can read the original
+    # turn text by memory_id (Pinecone returns ids only).
+    content_by_id: dict[str, str] = {}
+    for case in fixtures:
+        for sess in case["sessions"]:
+            for i, turn in enumerate(sess.get("turns", [])):
+                if turn.get("role") == "user":
+                    mem_id = f'{case["case_id"]}:{sess["session_id"]}:{i}'
+                    content_by_id[mem_id] = turn["content"]
+
+    print(f"[bakeoff] {len(fixtures)} fixtures, embedder={embedder.provider_name}")
+    print(f"[bakeoff] index=attestor-bakeoff-llama on Pinecone Local")
+    print()
+
+    verdicts: list[dict] = []
+    started = time.time()
+
+    for i, case in enumerate(fixtures, 1):
+        ns = case["case_id"]  # one namespace per case == hermetic
+        try:
+            ingest_n = _ingest_case(pc, case, namespace=ns)
+            time.sleep(0.3)  # let upsert settle
+            top1_id, top1_dist, _ = _recall_top1(pc, case["question"], namespace=ns)
+            top1_content = content_by_id.get(top1_id) if top1_id else None
+
+            verdict = classify_top1(
+                top1_content=top1_content,
+                gold_answer=case["gold_answer"],
+                stale_answer=case["stale_answer"],
+            )
+            verdicts.append({
+                "case_id": case["case_id"],
+                "category": case["category"],
+                "verdict": verdict,
+                "top1_id": top1_id,
+                "top1_distance": top1_dist,
+                "top1_content": top1_content,
+                "ingest_n": ingest_n,
+            })
+            print(
+                f"[bakeoff] {i:>2}/{len(fixtures)} {case['case_id']:<24s} "
+                f"[{case['category']:<14s}] → {verdict}"
+            )
+        except Exception as e:
+            print(f"[bakeoff] {i:>2}/{len(fixtures)} {case['case_id']} FAILED: {e}")
+            verdicts.append({
+                "case_id": case["case_id"],
+                "category": case["category"],
+                "verdict": "miss",
+                "error": str(e),
+            })
+
+    elapsed = time.time() - started
+
+    # Aggregate
+    by_verdict = Counter(v["verdict"] for v in verdicts)
+    new_wins = by_verdict.get("new_wins", 0)
+    total = len(verdicts)
+    score_pct = (new_wins / total * 100.0) if total else 0.0
+
+    by_category: dict[str, dict[str, int]] = {}
+    for v in verdicts:
+        bucket = by_category.setdefault(
+            v["category"],
+            {"new_wins": 0, "stale_wins": 0, "miss": 0, "ambiguous": 0},
+        )
+        bucket[v["verdict"]] = bucket.get(v["verdict"], 0) + 1
+
+    print()
+    print("=" * 72)
+    print(
+        f"[bakeoff] DONE — {new_wins}/{total} new_wins ({score_pct:.1f}%) "
+        f"in {elapsed:.1f}s"
+    )
+    print(f"[bakeoff] verdict counts: {dict(by_verdict)}")
+    print(f"[bakeoff] per-category:")
+    for cat, vals in sorted(by_category.items()):
+        print(
+            f"  {cat:<16s} new_wins={vals.get('new_wins',0)} "
+            f"stale_wins={vals.get('stale_wins',0)} "
+            f"miss={vals.get('miss',0)} ambiguous={vals.get('ambiguous',0)}"
+        )
+
+    out_path = (
+        ROOT / "docs" / "bench"
+        / f"pinecone-supersession-llama-{datetime.now().strftime('%Y%m%d')}.json"
+    )
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps({
+        "embedder": embedder.provider_name,
+        "store": "pinecone-local:attestor-bakeoff-llama",
+        "n_cases": total,
+        "new_wins": new_wins,
+        "stale_wins": by_verdict.get("stale_wins", 0),
+        "miss": by_verdict.get("miss", 0),
+        "ambiguous": by_verdict.get("ambiguous", 0),
+        "score_pct": score_pct,
+        "elapsed_sec": elapsed,
+        "by_category": by_category,
+        "verdicts": verdicts,
+    }, indent=2))
+    print(f"[bakeoff] persisted → {out_path.relative_to(ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    import argparse
+    p = argparse.ArgumentParser()
+    p.add_argument("--limit", type=int, default=None)
+    args = p.parse_args()
+    raise SystemExit(main(limit=args.limit))

--- a/tests/test_pinecone_embedding.py
+++ b/tests/test_pinecone_embedding.py
@@ -1,0 +1,210 @@
+"""Unit tests for PineconeEmbeddingProvider.
+
+The provider talks to Pinecone Inference (cloud-only). Tests mock the
+SDK so they run in CI without a real API key + without network.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _fake_embed_response(vectors: list[list[float]]) -> SimpleNamespace:
+    """Shape: result.data[i].values is the embedding for input[i]."""
+    return SimpleNamespace(
+        data=[SimpleNamespace(values=v) for v in vectors],
+    )
+
+
+def _fake_pinecone_client(probe_dim: int = 1024) -> MagicMock:
+    """Stub Pinecone client whose inference.embed always returns one
+    vector of the requested probe dim. Override per-call via .return_value."""
+    client = MagicMock()
+    client.inference.embed.return_value = _fake_embed_response(
+        [[0.0] * probe_dim],
+    )
+    return client
+
+
+# ── Initialization ────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_provider_requires_api_key(monkeypatch) -> None:
+    """No PINECONE_API_KEY → RuntimeError. Don't fail silently."""
+    monkeypatch.delenv("PINECONE_API_KEY", raising=False)
+    from attestor.store.embeddings import PineconeEmbeddingProvider
+    with pytest.raises(RuntimeError, match="PINECONE_API_KEY"):
+        PineconeEmbeddingProvider()
+
+
+@pytest.mark.unit
+def test_provider_rejects_pclocal_key(monkeypatch) -> None:
+    """The Pinecone-Local stub key 'pclocal' must be rejected — Local
+    doesn't serve Inference, so accepting it would 404 at runtime."""
+    monkeypatch.setenv("PINECONE_API_KEY", "pclocal")
+    from attestor.store.embeddings import PineconeEmbeddingProvider
+    with pytest.raises(RuntimeError, match="pclocal"):
+        PineconeEmbeddingProvider()
+
+
+@pytest.mark.unit
+def test_provider_probes_dimension_at_init(monkeypatch) -> None:
+    """First Pinecone call is a probe with input='dim'; provider stores
+    the returned vector's length so the orchestrator's dim check sees
+    the actual model dim, not the requested dim."""
+    monkeypatch.setenv("PINECONE_API_KEY", "real-cloud-key")
+    fake = _fake_pinecone_client(probe_dim=1024)
+
+    with patch("pinecone.Pinecone", return_value=fake):
+        from attestor.store.embeddings import PineconeEmbeddingProvider
+        p = PineconeEmbeddingProvider()
+
+    assert p.dimension == 1024
+    # Probe must have been issued
+    fake.inference.embed.assert_called_once()
+    call_kwargs = fake.inference.embed.call_args.kwargs
+    assert call_kwargs["model"] == "llama-text-embed-v2"
+    assert call_kwargs["inputs"] == ["dim"]
+    assert call_kwargs["parameters"]["dimension"] == 1024
+
+
+# ── Model + dim configuration ─────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_provider_honors_model_constructor_arg(monkeypatch) -> None:
+    monkeypatch.setenv("PINECONE_API_KEY", "real")
+    fake = _fake_pinecone_client(probe_dim=1024)
+    with patch("pinecone.Pinecone", return_value=fake):
+        from attestor.store.embeddings import PineconeEmbeddingProvider
+        p = PineconeEmbeddingProvider(model="multilingual-e5-large")
+    assert p.provider_name.startswith("pinecone:multilingual-e5-large")
+
+
+@pytest.mark.unit
+def test_provider_honors_env_model(monkeypatch) -> None:
+    monkeypatch.setenv("PINECONE_API_KEY", "real")
+    monkeypatch.setenv("PINECONE_EMBEDDING_MODEL", "llama-text-embed-v2")
+    fake = _fake_pinecone_client(probe_dim=1024)
+    with patch("pinecone.Pinecone", return_value=fake):
+        from attestor.store.embeddings import PineconeEmbeddingProvider
+        p = PineconeEmbeddingProvider()
+    assert "llama-text-embed-v2" in p.provider_name
+
+
+@pytest.mark.unit
+def test_provider_supports_alternate_dimensions(monkeypatch) -> None:
+    """llama-text-embed-v2 supports {384, 512, 768, 1024, 2048}."""
+    monkeypatch.setenv("PINECONE_API_KEY", "real")
+    fake = _fake_pinecone_client(probe_dim=512)
+    with patch("pinecone.Pinecone", return_value=fake):
+        from attestor.store.embeddings import PineconeEmbeddingProvider
+        p = PineconeEmbeddingProvider(dimensions=512)
+    assert p.dimension == 512
+    # Probe parameters include the requested dimension
+    call_kwargs = fake.inference.embed.call_args.kwargs
+    assert call_kwargs["parameters"]["dimension"] == 512
+
+
+@pytest.mark.unit
+def test_provider_honors_env_dimensions(monkeypatch) -> None:
+    monkeypatch.setenv("PINECONE_API_KEY", "real")
+    monkeypatch.setenv("PINECONE_EMBEDDING_DIMENSIONS", "2048")
+    fake = _fake_pinecone_client(probe_dim=2048)
+    with patch("pinecone.Pinecone", return_value=fake):
+        from attestor.store.embeddings import PineconeEmbeddingProvider
+        p = PineconeEmbeddingProvider()
+    assert p.dimension == 2048
+
+
+# ── embed / embed_batch ───────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_embed_returns_single_vector(monkeypatch) -> None:
+    monkeypatch.setenv("PINECONE_API_KEY", "real")
+    fake = _fake_pinecone_client(probe_dim=1024)
+    with patch("pinecone.Pinecone", return_value=fake):
+        from attestor.store.embeddings import PineconeEmbeddingProvider
+        p = PineconeEmbeddingProvider()
+
+        # Override for the actual embed call
+        fake.inference.embed.return_value = _fake_embed_response(
+            [[0.5] * 1024],
+        )
+        v = p.embed("the cto is bob")
+
+    assert isinstance(v, list)
+    assert len(v) == 1024
+    assert v[0] == 0.5
+
+
+@pytest.mark.unit
+def test_embed_batch_preserves_order(monkeypatch) -> None:
+    monkeypatch.setenv("PINECONE_API_KEY", "real")
+    fake = _fake_pinecone_client(probe_dim=1024)
+    with patch("pinecone.Pinecone", return_value=fake):
+        from attestor.store.embeddings import PineconeEmbeddingProvider
+        p = PineconeEmbeddingProvider()
+
+        # Three distinct vectors — order must round-trip
+        fake.inference.embed.return_value = _fake_embed_response(
+            [[1.0] * 1024, [2.0] * 1024, [3.0] * 1024],
+        )
+        vecs = p.embed_batch(["a", "b", "c"])
+
+    assert len(vecs) == 3
+    assert [v[0] for v in vecs] == [1.0, 2.0, 3.0]
+
+
+@pytest.mark.unit
+def test_embed_uses_passage_input_type_by_default(monkeypatch) -> None:
+    """Default ``input_type='passage'`` matches Pinecone's convention
+    for document-side embedding (the write path)."""
+    monkeypatch.setenv("PINECONE_API_KEY", "real")
+    fake = _fake_pinecone_client(probe_dim=1024)
+    with patch("pinecone.Pinecone", return_value=fake):
+        from attestor.store.embeddings import PineconeEmbeddingProvider
+        p = PineconeEmbeddingProvider()
+
+        fake.inference.embed.reset_mock()
+        fake.inference.embed.return_value = _fake_embed_response([[0.1] * 1024])
+        p.embed("x")
+
+    call_kwargs = fake.inference.embed.call_args.kwargs
+    assert call_kwargs["parameters"]["input_type"] == "passage"
+
+
+@pytest.mark.unit
+def test_embed_supports_query_input_type(monkeypatch) -> None:
+    """Query-side embedding uses ``input_type='query'`` per Pinecone
+    docs — different vector for the same text."""
+    monkeypatch.setenv("PINECONE_API_KEY", "real")
+    fake = _fake_pinecone_client(probe_dim=1024)
+    with patch("pinecone.Pinecone", return_value=fake):
+        from attestor.store.embeddings import PineconeEmbeddingProvider
+        p = PineconeEmbeddingProvider(input_type="query")
+
+        fake.inference.embed.reset_mock()
+        fake.inference.embed.return_value = _fake_embed_response([[0.1] * 1024])
+        p.embed("who is the cto?")
+
+    call_kwargs = fake.inference.embed.call_args.kwargs
+    assert call_kwargs["parameters"]["input_type"] == "query"
+
+
+# ── Provider name ─────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_provider_name_includes_model_and_dim(monkeypatch) -> None:
+    monkeypatch.setenv("PINECONE_API_KEY", "real")
+    fake = _fake_pinecone_client(probe_dim=1024)
+    with patch("pinecone.Pinecone", return_value=fake):
+        from attestor.store.embeddings import PineconeEmbeddingProvider
+        p = PineconeEmbeddingProvider()
+    assert p.provider_name == "pinecone:llama-text-embed-v2@1024d"


### PR DESCRIPTION
## Summary

Six commits from the LME-S temporal-reasoning push. Headline retrieval result: **70% baseline → 96.7% recall@10** on a 30q smoke (LME-S temporal-reasoning, Pinecone Local + llama-text-embed-v2 + HyDE v2 + BM25 hybrid).

## Production code changes

- **`attestor/retrieval/hyde.py` — HyDE v2** (commit 48ba4d4)
  - Prompt rewritten from "answer the question" to "describe the event in the form the user would have ORIGINALLY MENTIONED it" with 3 worked examples
  - Pin `temperature=0.0` for run-to-run determinism
  - Result: 80% → 96.7% on the same 30q smoke (5 of 6 prior misses rescued)

- **`attestor/retrieval/temporal_prefilter.py`** (commit afe2654)
  - Adds interrogative time-anchor regex (`how many [unit] ago`, `how long since`)
  - Honest caveat: didn't actually rescue the LME-S cases the way temporal_prefilter was supposed to. Kept because tested + safe (default off). HyDE v2 was the right tool.

- **`attestor/store/pinecone_backend.py` + `embeddings.py`** (commit 616e6f2)
  - New PineconeBackend implementing VectorStore Protocol
  - Auto-detects Pinecone Local (gRPC, plaintext) vs Pinecone Cloud (HTTPS)
  - PineconeEmbeddingProvider for hosted Pinecone Inference models
  - Imports deferred to method bodies — module load doesn't break for non-Pinecone installs
  - 12 mocked unit tests in `tests/test_pinecone_embedding.py`

- **`configs/attestor.yaml`** (commit 4aa55d8)
  - Answerer bumped to `openai/gpt-5.5` (~10× cost vs gpt-5.4-mini, accepted for the bench run)

## Experiment-only

- **`experiments/pinecone_lme_temporal_diagnostic.py`** (commits 964d203, d0a1c2b)
  - Retrieval-only diagnostic on LME-S, modes: baseline / `--multi-query` / `--hyde` / `--bm25-hybrid` / `--temporal-prefilter`
  - `--category` flag for any LME-S category (default `temporal-reasoning`)
  - Per-question Pinecone namespace isolation, `--skip-ingest` for fast retrieval-flag iteration
- **`experiments/pinecone_supersession_smoke.py`** (commit 964d203)
  - 50-case bakeoff vs pgvector+Voyage. Result: 5/50 (Pinecone+llama) vs 4/50 (pgvector+Voyage). Both confirm supersession is **scorer-side**, not store-side.

## Bench artifacts persisted

- `pinecone-supersession-llama-20260429.json` — 5/50 = 10%
- `pinecone-lme-temporal-diagnostic-{baseline,mq3,hyde,hyde-bm25}-20260429.json`

## Net session arc on LME-S temporal-reasoning recall@10

```
70% baseline → 80% HyDE v1 → 96.7% HyDE v2 → 96.7% HyDE v2 + BM25 (26 r@1)
```

The BM25 lane didn't move the headline % but added 3 r@K → r@1 promotions, which translates directly to better answerer accuracy downstream.

## Negative results documented

- **Multi-query (3-paraphrase RRF) regressed** to 60% on LME-S temporal-reasoning. Paraphrases stay in question-shape, RRF dilutes marginal hits.
- **Pinecone monthly free-tier cap (5M tokens)** hit during multi-session run — generalization beyond temporal-reasoning is incomplete (7q multi-session signal: 86%, but tiny sample).

## Test plan

- [x] All HyDE unit tests green (19 tests)
- [x] Temporal prefilter unit tests green (38 tests)
- [x] Pinecone embedding unit tests green (12 tests, all mocked — no live cloud needed)
- [x] Three diagnostic harnesses run end-to-end against Pinecone Local
- [ ] Live LME-S 133q full bench (user-bench territory; 3-4hr wallclock + token budget)
- [ ] Other LME-S categories (multi-session, knowledge-update, single-session-*) — gated on Pinecone token budget reset or embedder swap

## Dependencies

- `pinecone` and `rank_bm25` are NOT added to `pyproject.toml` — Pinecone is opt-in (deferred imports), and rank_bm25 is experiments-only.