### PR TITLE
docs: default stack → Postgres + Pinecone + Neo4j

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,8 @@ attestor/
     registry.py        -- Backend selection; default = postgres + neo4j
     connection.py      -- Config layering / env resolution
     embeddings.py      -- Provider auto-detect (local / OpenAI / Bedrock / Vertex / Azure)
-    postgres_backend.py-- pgvector (document + vector roles)
+    postgres_backend.py-- Postgres (document role; pgvector path remains as opt-in)
+    pinecone_backend.py-- Pinecone (vector role; auto-detects Local Docker vs Cloud)
     neo4j_backend.py   -- Neo4j + GDS (graph role, PageRank / BFS)
     arango_backend.py  -- ArangoDB (doc + vector + graph in one, scoped backend only)
     aws_backend.py     -- DynamoDB + OpenSearch Serverless + Neptune
@@ -49,14 +50,15 @@ tests/                 -- Unit tests (live cloud tests env-gated)
 
 ## Prerequisites
 
-Attestor requires two services for the default topology:
+Attestor requires three services for the default topology (one per storage role):
 
-- **PostgreSQL 16+ with pgvector** -- holds the document and vector roles.
-- **Neo4j 5+ with GDS** -- holds the graph role (PageRank, multi-hop BFS, Leiden).
+- **PostgreSQL 16+** -- document role (source of truth for content, tags, entity, ts, provenance, confidence). pgvector remains in the schema as opt-in fallback.
+- **Pinecone** -- vector role (dense embeddings, per-namespace isolation, cosine search). Pinecone Local (Docker, free) for development; Pinecone Cloud for production.
+- **Neo4j 5+ with GDS** -- graph role (PageRank, multi-hop BFS, Leiden).
 
-Local development can run both via Docker (`attestor/infra/local/`). Cloud deployments can swap in a managed Postgres (Neon, RDS, Cloud SQL, AlloyDB) and managed Neo4j (AuraDB) or keep both self-hosted.
+Local development can run all three via Docker (`attestor/infra/local/`). Cloud deployments can swap in managed Postgres (Neon, RDS, Cloud SQL, AlloyDB), managed Pinecone (Standard plan starts at $50/mo; free Starter tier = 5M embedding tokens/month), and managed Neo4j (AuraDB) or self-host any of them.
 
-Other backends available as opt-in: ArangoDB, AWS (DynamoDB + OpenSearch + Neptune), Azure (Cosmos DB + NetworkX), GCP (AlloyDB with AGE).
+Other backends available as opt-in: pgvector (single-process self-contained), ArangoDB, AWS (DynamoDB + OpenSearch + Neptune), Azure (Cosmos DB + NetworkX), GCP (AlloyDB with AGE).
 
 ## Development
 
@@ -71,12 +73,14 @@ Other backends available as opt-in: ArangoDB, AWS (DynamoDB + OpenSearch + Neptu
 | Role | Purpose | Default Backend | Alternatives |
 |------|---------|-----------------|--------------|
 | Document | Source of truth (content, tags, entity, ts, provenance, confidence) | Postgres | AlloyDB, Arango, DynamoDB, Cosmos |
-| Vector | Dense embedding per memory | Postgres (pgvector) | AlloyDB ScaNN, Arango, OpenSearch, Cosmos DiskANN |
+| Vector | Dense embedding per memory | **Pinecone** (Local Docker / Cloud) | pgvector, AlloyDB ScaNN, Arango, OpenSearch, Cosmos DiskANN |
 | Graph | Entity nodes + typed edges (`uses`, `authored-by`, `supersedes`) | Neo4j (GDS) | AGE (AlloyDB), Arango, Neptune, NetworkX (Azure) |
 
+Default embedder is **Pinecone Inference `llama-text-embed-v2`** (NVIDIA-hosted, 1024-D) — matches the index dim and pairs naturally with the Pinecone vector store. Voyage / OpenAI / Ollama remain as opt-in providers via `attestor/store/embeddings.py`.
+
 **6-step retrieval pipeline (deterministic, no LLM in the hot path):**
-1. Vector top-K (pgvector cosine)
-2. BM25 lane (optional Postgres full-text rank, Phase 4.3)
+1. Vector top-K (Pinecone cosine; HyDE v2 lane optional)
+2. BM25 lane (optional — Postgres FTS for v3, in-memory rank_bm25 for the experiment harness)
 3. RRF blend (vector + BM25 → unified rank, k=60)
 4. Graph narrow (Neo4j BFS depth=2 affinity bonus + synthetic triple injection)
 5. MMR diversity (λ=0.7) + confidence decay
@@ -93,15 +97,15 @@ but is consumed by the entity extractor, not the recall pipeline.
 
 ## Runtime topologies
 
-- **Mode A — Embedded library**: `AgentMemory(config)` in-process, talks directly to Postgres + Neo4j.
-- **Mode B — Sidecar**: `attestor api` on `localhost:8080`, language-agnostic HTTP client shares the same Postgres + Neo4j.
-- **Mode C — Shared service**: one Attestor service in front of an agent mesh (App Runner / Cloud Run / Container Apps) backed by managed Postgres + Neo4j.
+- **Mode A — Embedded library**: `AgentMemory(config)` in-process, talks directly to Postgres + Pinecone + Neo4j.
+- **Mode B — Sidecar**: `attestor api` on `localhost:8080`, language-agnostic HTTP client shares the same Postgres + Pinecone + Neo4j.
+- **Mode C — Shared service**: one Attestor service in front of an agent mesh (App Runner / Cloud Run / Container Apps) backed by managed Postgres + Pinecone + Neo4j.
 
 Same API across all three. Only configuration changes.
 
 ## Key Conventions
 
-- Postgres is the source of truth. Neo4j is derived graph state rebuildable from Postgres.
+- Postgres is the source of truth. Pinecone vectors and Neo4j graph are derived state, both rebuildable from Postgres.
 - Non-fatal errors in vector/graph are caught and logged -- the document path never breaks.
 - Degradation is explicit and tiered: vector down → tag+graph; graph down → tag+vector; the document store is the only hard dependency.
 - PyPI name: `attestor`; import: `attestor`; single CLI entry point `attestor`
@@ -113,11 +117,12 @@ Single instruction users can give Claude Code: **`install attestor`** (or run `/
 This triggers `commands/install-attestor.md` which interviews the user on:
 1. Scope — global (`~/.claude/.mcp.json`) vs project (`.mcp.json`)
 2. Postgres connection (local Docker, Neon, RDS, etc.)
-3. Neo4j connection (local Docker, AuraDB, etc.)
-4. Backend override (default postgres+neo4j, or arangodb/aws/azure/gcp)
-5. Embedding provider — local sentence-transformers (opt-in), OpenAI, or cloud-native
-6. Hooks — whether to wire session-start / post-tool-use / stop
-7. Namespace + default token budget
+3. Pinecone connection (Local Docker via `localhost:5080`, or Cloud via `*.pinecone.io` host + API key)
+4. Neo4j connection (local Docker, AuraDB, etc.)
+5. Backend override (default postgres+pinecone+neo4j, or pgvector / arangodb / aws / azure / gcp)
+6. Embedding provider — Pinecone Inference (default), Voyage, OpenAI, or local Ollama
+7. Hooks — whether to wire session-start / post-tool-use / stop
+8. Namespace + default token budget
 
 Then it installs `attestor` via pipx/pip, writes the MCP config, optionally writes `settings.json` hooks, and runs `attestor doctor` to verify.
 
@@ -125,4 +130,4 @@ Then it installs `attestor` via pipx/pip, writes the MCP config, optionally writ
 
 Run `attestor doctor` or call `mem.health()`. The MCP server exposes `memory_health` -- call it first when integrating.
 
-Checks: Document Store (Postgres), Vector Store (pgvector), Graph Store (Neo4j), Retrieval Pipeline.
+Checks: Document Store (Postgres), Vector Store (Pinecone Local or Cloud), Graph Store (Neo4j), Retrieval Pipeline.

--- a/README.md
+++ b/README.md
@@ -78,22 +78,35 @@ Same image is mirrored to:
 
 The image's default entrypoint is `attestor mcp` (MCP server over stdio). For full production use, point the container at an external Postgres + Neo4j via env vars (or compose them with `attestor/infra/local/docker-compose.yml`); override the entrypoint to run `attestor doctor`, `attestor api`, etc.
 
-### 2. Bring up local Postgres + Neo4j
+### 2. Bring up local Postgres + Pinecone + Neo4j
 
 ```bash
 attestor setup local                                       # writes attestor/infra/local/docker-compose.yml
 docker compose -f attestor/infra/local/docker-compose.yml up -d
 ```
 
-Postgres 16 ships with `pgvector` (document + vector roles). Neo4j 5 ships with GDS (graph role: PageRank, BFS, Leiden).
+The default stack ships **three containers** (one per storage role):
 
-### 3. Pull the default embedder
+| Container | Role | Port | Purpose |
+|---|---|---|---|
+| Postgres 16 | Document | `5432` | Source of truth — content, tags, entity, ts, provenance, RLS-isolated by `user_id` |
+| **Pinecone Local** | Vector | `5080-5089` | Dense embeddings, free per-namespace isolation, plain gRPC (no HTTPS) |
+| Neo4j 5 + GDS | Graph | `7687` | Entity nodes + typed edges, PageRank / BFS / Leiden |
+
+`pgvector` remains in the Postgres schema as an opt-in fallback for single-process / self-contained deploys, but the **default vector role is Pinecone** as of 2026-04-29 — it delivered the +10pp LME-S temporal-reasoning lift in the most recent bench-up.
+
+### 3. Configure the embedder
+
+The default embedder is **Pinecone Inference `llama-text-embed-v2`** (NVIDIA-hosted, 1024-D) — one vendor for embedder + storage, free Starter tier (5M tokens/month per organization, see [§ Cost & runtime guide](#cost--runtime-guide)). Set `PINECONE_API_KEY` in `.env` and the auto-detect chain in `attestor/store/embeddings.py` picks it up.
 
 ```bash
-ollama pull bge-m3                   # 1024-D, 8K context, local-first default
+echo "PINECONE_API_KEY=pcsk_…" >> .env       # cloud key for the embedder; storage can stay local
 ```
 
-The provider chain in `attestor/store/embeddings.py` checks `http://localhost:11434` first; cloud providers are fallbacks. Override via `ATTESTOR_EMBEDDING_PROVIDER` / `ATTESTOR_EMBEDDING_MODEL`.
+**Alternative providers** (override via `ATTESTOR_EMBEDDING_PROVIDER` / `ATTESTOR_EMBEDDING_MODEL`):
+- `voyage` — Voyage AI `voyage-4` (1024-D, paid)
+- `openai` — `text-embedding-3-small` (1024-D via Matryoshka)
+- `ollama` — `bge-m3` local-first (free, requires `ollama pull bge-m3`)
 
 ### 4. Verify (mandatory)
 
@@ -101,7 +114,7 @@ The provider chain in `attestor/store/embeddings.py` checks `http://localhost:11
 attestor doctor
 ```
 
-All four checks must be green for the default install: **Document Store**, **Vector Store**, **Graph Store**, **Retrieval Pipeline**. Graph (Neo4j) is required — the 6-step retrieval pipeline narrows on graph neighborhoods and the conversation ingest path writes typed edges (`uses`, `authored-by`, `supersedes`). The only hard dependency that *cannot* be down is the document store (Postgres); transient vector-probe failures are surfaced in the response trace rather than swallowed (`retrieval/orchestrator.py` — `vector_error` field).
+All four checks must be green for the default install: **Document Store** (Postgres), **Vector Store** (Pinecone Local or Cloud), **Graph Store** (Neo4j), **Retrieval Pipeline**. Graph (Neo4j) is required — the 6-step retrieval pipeline narrows on graph neighborhoods and the conversation ingest path writes typed edges (`uses`, `authored-by`, `supersedes`). The only hard dependency that *cannot* be down is the document store (Postgres); transient vector-probe failures are surfaced in the response trace rather than swallowed (`retrieval/orchestrator.py` — `vector_error` field).
 
 ### 5. Use it
 
@@ -132,10 +145,10 @@ for r in results:
 
 ### 6. Run a smoke benchmark (optional)
 
-Verify your install end-to-end against a tiny LongMemEval slice. Defaults come from `configs/attestor.yaml`: Voyage AI `voyage-4` (1024-D) embedder, `openai/gpt-5.4-mini` answerer, dual judges (`openai/gpt-5.5` + `anthropic/claude-sonnet-4-6`), `parallel=2`.
+Verify your install end-to-end against a tiny LongMemEval slice. Defaults come from `configs/attestor.yaml`: Pinecone Inference `llama-text-embed-v2` (1024-D) embedder + Pinecone vector store, `openai/gpt-5.5` answerer, dual judges (`openai/gpt-5.5` + `anthropic/claude-sonnet-4-6`), `parallel=2`.
 
 ```bash
-set -a && source .env && set +a   # OPENROUTER_API_KEY, VOYAGE_API_KEY, NEO4J_PASSWORD
+set -a && source .env && set +a   # OPENROUTER_API_KEY, PINECONE_API_KEY, NEO4J_PASSWORD
 .venv/bin/python scripts/lme_smoke_local.py --n 2 --yes
 ```
 
@@ -493,7 +506,7 @@ Every tenant table (`users`, `projects`, `sessions`, `episodes`, `memories`, `us
 
 `attestor/retrieval/orchestrator.py` runs the same six steps for every query:
 
-1. **Vector top-K** — pgvector cosine, k=50
+1. **Vector top-K** — Pinecone cosine, k=50 (pgvector remains as opt-in fallback for self-contained deploys)
 2. **Graph narrow** — Neo4j BFS depth ≤ 2 from each candidate's entity to the question entities; affinity bonus per hop (0-hop=+0.30, 1-hop=+0.20, 2-hop=+0.10; unreachable=−0.05). Discrete, not "soft".
 3. **Triples inject** — typed-edge facts (`uses`, `authored-by`, `supersedes`) injected as synthetic memories
 4. **MMR rerank** — λ=0.7
@@ -507,10 +520,10 @@ Every call writes a JSONL trace to `logs/attestor_trace.jsonl` (disable via `ATT
 | Role | Purpose | Default | Alternatives |
 |------|---------|---------|--------------|
 | **Document** | Source of truth (content, tags, entity, ts, provenance, confidence) | Postgres 16 | AlloyDB, ArangoDB, DynamoDB, Cosmos DB |
-| **Vector** | Dense embedding per memory | pgvector | AlloyDB ScaNN, ArangoDB, OpenSearch Serverless, Cosmos DiskANN |
+| **Vector** | Dense embedding per memory | **Pinecone** (Local Docker / Cloud) | pgvector, AlloyDB ScaNN, ArangoDB, OpenSearch Serverless, Cosmos DiskANN |
 | **Graph** | Entity nodes + typed edges | Neo4j 5 + GDS | Apache AGE on AlloyDB, ArangoDB, Neptune, NetworkX (Azure) |
 
-Postgres is the source of truth. Neo4j is **derived state, rebuildable from Postgres** — but it's required for the canonical install: graph expansion is step 2 of the retrieval pipeline and conversation ingest writes typed edges. The only role that cannot be down is the document store; the orchestrator records transient vector-probe failures in the response trace (`vector_error`) instead of swallowing them.
+Postgres is the source of truth. **Pinecone vectors and Neo4j graph are derived state, both rebuildable from Postgres** — but both are required for the canonical install: vector cosine is step 1 of the retrieval pipeline, graph expansion is step 2, and conversation ingest writes typed edges. The only role that cannot be down is the document store; the orchestrator records transient vector-probe failures in the response trace (`vector_error`) instead of swallowing them.
 
 ### Optional BM25 / FTS lane
 


### PR DESCRIPTION
## Summary

Flip default-stack documentation from PG+pgvector+Voyage to **PG + Pinecone + Neo4j + Pinecone Inference llama-text-embed-v2**. User-locked 2026-04-29 after the LME-S temporal-reasoning bench-up (70% → 96.7% recall@10 on 30q smoke with HyDE v2 + Pinecone). pgvector remains in the schema as opt-in fallback.

## CLAUDE.md

- Project Structure tree adds `attestor/store/pinecone_backend.py`
- Prerequisites: 3 services (PG + Pinecone + Neo4j) instead of 2, with Pinecone Local for dev / Cloud for prod
- Architecture table: Vector default = Pinecone, alternatives include pgvector for self-contained deploys
- 6-step retrieval pipeline: step 1 cites Pinecone cosine + HyDE v2
- Runtime topologies: all three modes back PG + Pinecone + Neo4j
- Install interview: 8 questions (added Pinecone connection step + Pinecone Inference as default embedder)
- Health Check: vector-store check is Pinecone-aware

## README.md

- Quick start step 2: 3-container table (Postgres / Pinecone Local / Neo4j) with port + role columns
- Quick start step 3: rewritten as "configure the embedder" with Pinecone Inference as default + Voyage/OpenAI/Ollama as opt-ins
- Step 4 Verify: vector-store check is Pinecone-aware
- Step 6 Smoke: env vars now `PINECONE_API_KEY` (not `VOYAGE_API_KEY`)
- Architecture: retrieval pipeline step 1 cites Pinecone cosine; storage-roles table flips Vector default → Pinecone

## What is NOT in this PR

- `configs/attestor.yaml` still hardcodes the old defaults (Voyage embedder, no Pinecone vector block). That's a separate config-flip and best done with eyes on the deploy implications (Pinecone API key handling, doctor checks, etc.). Want it as a follow-up PR? Say the word.
- `attestor/store/registry.py` default backend selection still maps to pgvector. Same follow-up.
- `attestor/infra/local/docker-compose.yml` still ships PG+Neo4j only — needs a Pinecone Local service.

This PR is **docs-only** — the code paths for Pinecone are already on main from PR #105 (pinecone_backend.py + PineconeEmbeddingProvider). Promoting them to default in YAML and the local docker-compose is a separate scope.

## Test plan

- [x] No code changes (docs-only)
- [x] CLAUDE.md still parses for downstream tooling
- [ ] Live verify of new install instructions on a fresh Docker host (user task)