### PR TITLE
test(async): RED tests for P1+P2 + audit-preserving plan

### DIFF
--- a/docs/plans/async-retrieval/PLAN.md
+++ b/docs/plans/async-retrieval/PLAN.md
@@ -1,0 +1,169 @@
+# Async Retrieval — Audit-Preserving Plan
+
+**Status:** RED phase — tests written, code not changed.
+**Branch:** `feat/async-retrieval-plan-and-tests` (this PR ships PLAN + failing tests).
+**Goal:** Reduce recall latency by parallelizing independent steps WITHOUT weakening any of Attestor's eight audit guarantees.
+
+---
+
+## 1. Goal & non-goals
+
+### Goal
+
+Cut typical recall latency from ~1.5–3.5 s (with HyDE) to ~700 ms–1 s by running independent operations concurrently. Specifically:
+
+- HyDE LLM call ‖ original-question vector embed
+- Per-lane vector searches (HyDE / multi-query) in parallel
+- Vector lane ‖ BM25 lane ‖ graph candidate fetch
+- Graph BFS ‖ document fetch
+- Self-consistency K-fanout (K parallel answerer calls)
+
+### Non-goals (this plan)
+
+- **No write-side async.** All `add()`, `update()`, supersession writes stay synchronous. Audit chain depends on serial write ordering.
+- **No DB driver migration in this plan.** Keep `psycopg2` (sync) wrapped via `run_in_executor`. asyncpg is its own multi-week project.
+- **No public API change for embedded users.** `AgentMemory.recall()` remains callable from sync code via a `recall_sync()` shim.
+
+---
+
+## 2. Audit invariants that must hold
+
+All seven phases must preserve every one of these, verified by tests in `tests/async/test_audit_invariants_under_async.py`:
+
+| # | Invariant | Test |
+|---|---|---|
+| **A1** | `recall(as_of=X)` returns the same memories regardless of concurrent writes | `test_as_of_replay_under_concurrent_writes` |
+| **A2** | `t_created` ceiling per recall — nothing visible inside a recall is newer than its `recall_started_at` | `test_recall_started_at_ceiling` |
+| **A3** | Provenance fields immutable per memory_id | `test_provenance_immutable_across_concurrent_reads` |
+| **A4** | Supersession decisions are linearizable per memory_id (no parallel `superseded_by` writes) | `test_supersession_serial_per_memory_id` |
+| **A5** | Trace events reconstructable into a per-recall tree (recall_id + seq + parent_event_id) | `test_trace_reconstructable_under_async` |
+| **A6** | RLS still enforced — `attestor.current_user_id` propagates correctly through async tasks | `test_rls_propagates_through_async_tasks` |
+| **A7** | HyDE/multi-query LLM determinism — same query → same enrichment → same RRF result (temperature=0) | `test_hyde_temperature_zero_determinism` |
+| **A8** | Deletion audit (`deletion_audit` table) gets the row even if the deletion executes async | `test_deletion_audit_under_async` |
+
+---
+
+## 3. Phases (in dependency order)
+
+| # | Phase | Files | LOC | Risk |
+|---|---|---|---|---|
+| **P1** | HyDE LLM ‖ original-question embed | `attestor/retrieval/hyde.py` | ~50 | Low |
+| **P2** | Per-lane parallel inside HyDE/multi_query | `hyde.py`, `multi_query.py` | ~60 | Low |
+| **P3** | Trace schema bump (`recall_id`, `seq`, `parent_event_id`) | `attestor/trace.py` + 3-4 callers | ~80 | Low |
+| **P4** | Self-consistency K-fanout | `attestor/longmemeval_consistency.py` | ~40 | Low |
+| **P5** | `recall_started_at` ceiling primitive | `core.py`, `orchestrator.py`, store backends | ~120 | Medium |
+| **P6** | Vector ‖ BM25 ‖ graph parallel in orchestrator | `orchestrator.py` (~1500 LOC today) | ~250-400 | High |
+| **P7** | Graph BFS ‖ doc fetch | orchestrator + backends | ~60 | Medium |
+
+P1 and P2 are independent of every other phase. They ship first as the proving ground.
+
+---
+
+## 4. Test coverage matrix
+
+### Phase 1 — HyDE LLM ‖ original embed (`tests/async/test_hyde_async.py`)
+
+| Test | What it asserts | Status |
+|---|---|---|
+| `test_hyde_search_async_runs_lanes_concurrently` | The 2 awaitables (LLM + embed) run via `asyncio.gather`, total wallclock ≤ max(LLM, embed) + ε | RED |
+| `test_hyde_search_async_returns_same_result_as_sync` | `await hyde_search_async(q, ...)` produces the same merged hits as `hyde_search(q, ...)` given identical inputs | RED |
+| `test_hyde_search_async_handles_lane_timeout` | If HyDE LLM exceeds timeout, fall back to single-lane (original-only) without raising | RED |
+| `test_hyde_search_async_handles_lane_exception` | If the HyDE LLM call raises, the original-question lane still produces hits | RED |
+| `test_hyde_async_preserves_temperature_zero` | The `traced_create` call still passes `temperature=0.0` | RED |
+
+### Phase 2 — Multi-query lane parallelism (`tests/async/test_multi_query_async.py`)
+
+| Test | What it asserts | Status |
+|---|---|---|
+| `test_multi_query_async_parallelizes_n_lanes` | N+1 vector_search calls overlap; wallclock ≤ max(per-lane) + ε, NOT sum | RED |
+| `test_multi_query_async_preserves_RRF_order` | Async fan-out produces the same RRF-ranked output as the sync version | RED |
+| `test_multi_query_async_handles_partial_lane_failure` | If one paraphrase's vector search raises, the remaining lanes still RRF-merge | RED |
+
+### Phase 3 — Trace schema (`tests/async/test_trace_async.py`)
+
+| Test | What it asserts | Status |
+|---|---|---|
+| `test_trace_event_includes_recall_id` | Every event emitted within a recall has a `recall_id` field | TODO |
+| `test_trace_event_includes_monotonic_seq` | `seq` is monotonic per `recall_id` | TODO |
+| `test_trace_event_parent_id_under_async_gather` | Events spawned inside `asyncio.gather` carry the parent's `event_id` | TODO |
+| `test_trace_backward_compat_pre_async_format` | Old logs without `recall_id` still parse | TODO |
+
+### Phase 4 — Self-consistency K-fanout (`tests/async/test_self_consistency_async.py`)
+
+| Test | What it asserts | Status |
+|---|---|---|
+| `test_self_consistency_async_runs_K_concurrently` | Wallclock ≈ slowest-call, NOT K × per-call | TODO |
+| `test_self_consistency_consensus_order_independent` | Vote result independent of completion order | TODO |
+| `test_self_consistency_handles_K_minus_one_failures` | K-1 calls fail, the surviving 1 is the consensus | TODO |
+
+### Phase 5 — `recall_started_at` ceiling (`tests/async/test_recall_started_at_ceiling.py`)
+
+| Test | What it asserts | Status |
+|---|---|---|
+| `test_recall_started_at_excludes_writes_after_ceiling` | Memory inserted at t=ceiling+ε is NOT in recall result | TODO |
+| `test_recall_started_at_propagates_to_postgres` | Postgres query uses ceiling as `t_created <= ceiling` | TODO |
+| `test_recall_started_at_propagates_to_pinecone` | Pinecone metadata filter applies ceiling | TODO |
+| `test_recall_started_at_propagates_to_neo4j` | Cypher query bounds graph reads by ceiling | TODO |
+
+### Phase 6/7 — Orchestrator parallelism (`tests/async/test_orchestrator_async.py`)
+
+| Test | What it asserts | Status |
+|---|---|---|
+| `test_orchestrator_async_parallelizes_three_lanes` | Vector ‖ BM25 ‖ graph candidate fetch overlap | TODO |
+| `test_orchestrator_async_handles_one_lane_failure` | RRF degrades to remaining lanes when one fails | TODO |
+| `test_graph_bfs_and_doc_fetch_concurrent` | Graph BFS + Postgres doc fetch run in parallel after RRF | TODO |
+
+### Audit invariants — cross-cutting (`tests/async/test_audit_invariants_under_async.py`)
+
+| Test | What it asserts | Status |
+|---|---|---|
+| `test_as_of_replay_under_concurrent_writes` | Hammer recall(as_of=X) while writer coroutine adds memories; recall result stable | RED (P1 scope) |
+| `test_supersession_serial_per_memory_id` | Two concurrent supersession attempts on same memory_id linearize | TODO |
+| `test_trace_reconstructable_under_async` | 10 concurrent recalls; per-recall trace tree is reconstructable | TODO |
+| `test_rls_propagates_through_async_tasks` | Each async task sees its parent's `attestor.current_user_id` | TODO |
+| `test_hyde_temperature_zero_determinism` | Same query → same hypothetical → same RRF order across N runs | RED (P1 scope) |
+
+### Performance regression guards (`tests/async/test_async_perf_regression.py`)
+
+| Test | What it asserts | Status |
+|---|---|---|
+| `test_async_overhead_under_50ms_no_op_recall` | Bare async event-loop tax on a recall with no real work < 50 ms | RED (P1 scope) |
+| `test_sync_recall_shim_works` | Calling the sync `recall_sync()` from non-async code returns identical result | TODO |
+
+---
+
+## 5. RED → GREEN → REFACTOR ordering
+
+This PR ships **PLAN.md + the RED tests for P1 + P2 + the P1-scope audit invariants**. All tests fail because async paths don't exist yet.
+
+Subsequent PRs (one per phase):
+1. **PR-1:** P1 implementation (`hyde_search_async`) — turn the P1 RED tests GREEN. ~50 LOC.
+2. **PR-2:** P2 implementation (per-lane gather in HyDE + multi_query) — turn P2 tests GREEN. ~60 LOC.
+3. **PR-3:** P3 trace schema bump — turn P3 RED tests GREEN. Schema-only, no perf change.
+4. **PR-4:** P4 self-consistency K-fanout. Independent of orchestrator.
+5. **PR-5:** P5 `recall_started_at` ceiling primitive. Foundation for P6/P7.
+6. **PR-6:** P6 orchestrator parallel reads. The big one.
+7. **PR-7:** P7 graph BFS ‖ doc fetch. Smallest, ships last.
+
+After every GREEN PR, run the full LME-S 30q diagnostic with HyDE+BM25 hybrid and compare wallclock to the pre-async baseline. Acceptance is < 80 % of baseline wallclock with no recall@K regression.
+
+---
+
+## 6. Acceptance criteria for the whole effort
+
+- [ ] All audit invariants A1–A8 hold (tests green)
+- [ ] `tests/async/` covers ≥ 80 % of the new async code paths
+- [ ] LME-S 30q HyDE+BM25 wallclock < 50 % of pre-async baseline (we measured ~60 s today; target < 30 s)
+- [ ] Self-consistency K=5 wallclock < 2× per-call latency (today: 5×)
+- [ ] Sync `recall_sync()` shim still works for embedded callers without an event loop
+- [ ] No regression in `test_as_of_replay.py` (the load-bearing audit test)
+- [ ] Connection pool sizes documented + sized for expected concurrency (Postgres ≥ 20, Pinecone client default, Neo4j ≥ 10)
+
+---
+
+## 7. Open questions to resolve before P5/P6 ship
+
+- **Trace storage cost.** Adding `recall_id` + `seq` + `parent_event_id` is ~30 bytes/event × 6 events/recall = ~180 bytes/recall. At 1k recalls/day × 30 days = ~5 MB/month. Acceptable; not worth a schema change.
+- **Connection pool sizing.** Need a pre-flight check in `attestor doctor` that warns if pool < 2× expected concurrency.
+- **`recall_started_at` clock source.** Use `datetime.now(timezone.utc)` (matches Postgres `NOW()` semantics) NOT `time.monotonic()` (no wall-clock anchor). The test in `test_recall_started_at_ceiling.py` pins this.
+- **Cancellation propagation.** `asyncio.gather(..., return_exceptions=True)` is the default — we never want one slow lane to cancel the others. Document this in the lane closure utility.

--- a/poetry.lock
+++ b/poetry.lock
@@ -378,6 +378,19 @@ isodate = ">=0.6.0"
 typing-extensions = ">=4.6.0"
 
 [[package]]
+name = "backports-asyncio-runner"
+version = "1.2.0"
+description = "Backport of asyncio.Runner, a context manager that controls event loop life cycle."
+optional = false
+python-versions = "<3.11,>=3.8"
+groups = ["dev"]
+markers = "python_version == \"3.10\""
+files = [
+    {file = "backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5"},
+    {file = "backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162"},
+]
+
+[[package]]
 name = "backports-tarfile"
 version = "1.2.0"
 description = "Backport of CPython tarfile module"
@@ -3786,6 +3799,27 @@ tomli = {version = ">=1", markers = "python_version < \"3.11\""}
 dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "requests", "setuptools", "xmlschema"]
 
 [[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+description = "Pytest support for asyncio"
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5"},
+    {file = "pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5"},
+]
+
+[package.dependencies]
+backports-asyncio-runner = {version = ">=1.1,<2", markers = "python_version < \"3.11\""}
+pytest = ">=8.2,<10"
+typing-extensions = {version = ">=4.12", markers = "python_version < \"3.13\""}
+
+[package.extras]
+docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1)"]
+testing = ["coverage (>=6.2)", "hypothesis (>=5.7.1)"]
+
+[[package]]
 name = "pytest-cov"
 version = "7.1.0"
 description = "Pytest plugin for measuring coverage."
@@ -4621,7 +4655,7 @@ files = [
     {file = "typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"},
     {file = "typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"},
 ]
-markers = {dev = "python_version == \"3.10\""}
+markers = {dev = "python_version < \"3.13\""}
 
 [[package]]
 name = "typing-inspection"
@@ -5407,4 +5441,4 @@ voyage = ["voyageai"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "8eb0ffede3a454903ab1275227113a54d5d0057fe4d3a724ee98eb810b05bd85"
+content-hash = "4aca70bd4bde4d1223c6f1cfec4c3c148794af9dcd9ceaa5a12213b3c60b55da"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ packages = [{ include = "attestor" }]
 [tool.poetry.group.dev.dependencies]
 pytest = ">=7.0"
 pytest-cov = ">=4.0"
+pytest-asyncio = ">=0.23"
 requests = ">=2.28.0"
 twine = "^6.2.0"
 
@@ -92,6 +93,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+asyncio_mode = "auto"
 markers = [
     "docker: tests requiring Docker (deselect with '-m not docker')",
     "unit: fast, dependency-free unit tests",

--- a/tests/async_retrieval/conftest.py
+++ b/tests/async_retrieval/conftest.py
@@ -1,0 +1,75 @@
+"""Shared fixtures for async retrieval tests.
+
+These tests are RED today — they target async API surfaces that don't
+exist yet (``hyde_search_async``, ``multi_query_search_async``, etc.).
+The matching code lands in subsequent PRs per ``docs/plans/async-retrieval/PLAN.md``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any, Awaitable, Callable, Dict, List
+
+import pytest
+
+
+@pytest.fixture
+def event_loop():
+    """One event loop per test — keeps tests isolated."""
+    loop = asyncio.new_event_loop()
+    yield loop
+    loop.close()
+
+
+def make_slow_search(per_call_ms: int) -> Callable[[str], Awaitable[List[Dict]]]:
+    """Build an async vector_search closure that sleeps per_call_ms then
+    returns a single hit keyed on the query string. Used to assert lanes
+    actually overlap in time — if they ran sequentially, total wallclock
+    would be N × per_call_ms; if parallel, it's ~per_call_ms + ε.
+    """
+    async def search(q: str) -> List[Dict]:
+        await asyncio.sleep(per_call_ms / 1000.0)
+        return [
+            {
+                "memory_id": f"mem-{abs(hash(q)) % 10**8}",
+                "session_id": f"sess-{abs(hash(q)) % 10**6}",
+                "distance": 0.1,
+            }
+        ]
+    return search
+
+
+def make_failing_search(when: str = "always") -> Callable[[str], Awaitable[List[Dict]]]:
+    """Build a vector_search that raises. ``when`` selects:
+        - 'always'        — every call raises
+        - 'second_lane'   — second call onwards raises
+    """
+    counter = {"n": 0}
+
+    async def search(q: str) -> List[Dict]:
+        counter["n"] += 1
+        if when == "always" or (when == "second_lane" and counter["n"] >= 2):
+            raise RuntimeError(f"intentional failure at call {counter['n']} for q={q!r}")
+        return [
+            {
+                "memory_id": f"mem-{abs(hash(q)) % 10**8}",
+                "session_id": "ok",
+                "distance": 0.2,
+            }
+        ]
+    return search
+
+
+class StopwatchAsync:
+    """Async context manager that records elapsed wallclock in ms."""
+    def __init__(self) -> None:
+        self.elapsed_ms: float = 0.0
+        self._t0: float = 0.0
+
+    async def __aenter__(self) -> "StopwatchAsync":
+        self._t0 = time.perf_counter()
+        return self
+
+    async def __aexit__(self, *exc: Any) -> None:
+        self.elapsed_ms = (time.perf_counter() - self._t0) * 1000.0

--- a/tests/async_retrieval/test_async_perf_regression.py
+++ b/tests/async_retrieval/test_async_perf_regression.py
@@ -31,6 +31,7 @@ pytestmark = [pytest.mark.unit]  # asyncio_mode=auto handles async tests; sync t
 
 
 @pytest.mark.asyncio
+@pytest.mark.xfail(reason="RED — async impl lands in next PR; remove when GREEN", strict=False)
 async def test_async_overhead_under_50ms_no_op_recall():
     """``hyde_search_async`` with both lanes returning instantly must
     complete in < 50ms wallclock. Any regression here means the async

--- a/tests/async_retrieval/test_async_perf_regression.py
+++ b/tests/async_retrieval/test_async_perf_regression.py
@@ -1,0 +1,88 @@
+"""Performance regression guards for the async retrieval refactor.
+
+Two concrete guards:
+
+1. ``test_async_overhead_under_50ms_no_op_recall`` — bare async tax on
+   a recall doing no real work must stay under 50ms. Catches event-loop
+   bootstrap or context-switch regressions early.
+
+2. ``test_sync_recall_shim_works`` — embedded users without an event
+   loop must still be able to call the sync shim. The shim wraps
+   ``asyncio.run`` and must produce identical results.
+
+P1-scope tests RED today — target async API doesn't exist.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from unittest.mock import patch
+
+import pytest
+
+
+pytestmark = [pytest.mark.unit]  # asyncio_mode=auto handles async tests; sync test below is skipped
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Async overhead budget
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_async_overhead_under_50ms_no_op_recall():
+    """``hyde_search_async`` with both lanes returning instantly must
+    complete in < 50ms wallclock. Any regression here means the async
+    layer itself (event loop bootstrap, gather overhead, context
+    switches) has gotten heavy — investigate before shipping.
+    """
+    from attestor.retrieval.hyde import hyde_search_async  # RED
+
+    async def instant_search(q: str):
+        return [{"memory_id": "m", "session_id": "s", "distance": 0.1}]
+
+    async def instant_generator(question, **kwargs):
+        from attestor.retrieval.hyde import HydeResult
+        return HydeResult(original_question=question, hypothetical_answer="x")
+
+    with patch(
+        "attestor.retrieval.hyde.generate_hypothetical_answer_async",
+        side_effect=instant_generator,
+    ):
+        t0 = time.perf_counter()
+        await hyde_search_async("q", vector_search=instant_search)
+        elapsed_ms = (time.perf_counter() - t0) * 1000.0
+
+    assert elapsed_ms < 50, (
+        f"async overhead regression: no-op hyde_search_async took "
+        f"{elapsed_ms:.1f}ms; budget is 50ms"
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Sync shim contract
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_sync_recall_shim_works():
+    """``hyde_search`` (sync) must remain a viable entrypoint for
+    callers without an event loop — e.g. pytest sync tests, the CLI,
+    one-off scripts. After the async refactor, sync may internally
+    delegate to ``asyncio.run(hyde_search_async(...))`` — but the
+    public sync API must not require the caller to know that.
+    """
+    from attestor.retrieval.hyde import hyde_search
+
+    def sync_search(q: str):
+        return [{"memory_id": "x", "session_id": "y", "distance": 0.0}]
+
+    # Sync API exists today and must keep working post-async.
+    queries, merged = hyde_search(
+        "q", vector_search=sync_search,
+    )
+    # No assertion on content here — that's covered by the existing
+    # tests/test_hyde.py suite. We're only pinning the SHAPE: sync
+    # callable, returns (List[str], List[Dict]).
+    assert isinstance(queries, list)
+    assert isinstance(merged, list)

--- a/tests/async_retrieval/test_audit_invariants_under_async.py
+++ b/tests/async_retrieval/test_audit_invariants_under_async.py
@@ -1,0 +1,155 @@
+"""Cross-cutting audit invariants — must hold across every async phase.
+
+These tests pin the audit guarantees described in
+``docs/plans/async-retrieval/PLAN.md`` § 2. P1-scope tests are RED today
+(target async API doesn't exist); P3+ scope tests are TODO and will be
+added when those phases ship.
+
+The eight audit invariants:
+  A1: recall(as_of=X) reproducible under concurrent writes
+  A2: recall_started_at ceiling — no post-recall writes leak in
+  A3: provenance fields immutable per memory_id
+  A4: supersession serial per memory_id
+  A5: trace events form per-recall reconstructable tree
+  A6: RLS propagates through async tasks (current_user_id)
+  A7: HyDE/multi-query LLM determinism (temperature=0)
+  A8: deletion_audit row written even under async
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+
+# ──────────────────────────────────────────────────────────────────────
+# A7 — HyDE determinism (P1-scope, RED)
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_hyde_temperature_zero_determinism_across_runs():
+    """Same question → same hypothetical (temp=0) → same RRF order.
+    Async amplifies non-determinism risk because gathered lanes can
+    observe different hypotheticals across runs if T > 0. This test
+    pins the contract: the async generator must call the LLM with
+    temperature=0.0 every time."""
+    from attestor.retrieval.hyde import generate_hypothetical_answer_async  # RED
+
+    captured_temps = []
+
+    class _StubResp:
+        choices = [type("C", (), {"message": type("M", (), {"content": "snippet"})()})()]
+
+    async def fake_create(**kwargs):
+        captured_temps.append(kwargs.get("temperature"))
+        return _StubResp()
+
+    with patch.dict(os.environ, {"OPENROUTER_API_KEY": "stub"}):
+        with patch("openai.AsyncOpenAI") as mock_client_cls:
+            mock_client_cls.return_value.chat.completions.create = fake_create
+            for _ in range(3):
+                await generate_hypothetical_answer_async("same question")
+
+    assert captured_temps == [0.0, 0.0, 0.0], (
+        f"async generator must call with temperature=0.0 on every invocation; "
+        f"observed {captured_temps}"
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# A1 — as_of replay under concurrent writes (P5-scope; placeholder asserts
+# the contract shape so the test file stays compileable + runnable)
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_as_of_replay_under_concurrent_writes_contract():
+    """Contract assertion (full implementation lands in P5):
+
+       Hammering recall(as_of=X) while another coroutine writes new
+       memories must produce a stable result — no half-visible writes.
+
+    This test is currently a placeholder pinning the signature of the
+    expected async API. It will be expanded in PR-5 with a real
+    Postgres+Pinecone+Neo4j fixture and a writer-coroutine that runs
+    in parallel with K=20 reader recalls.
+    """
+    pytest.skip(
+        "P5 scope — implementation lands with recall_started_at ceiling. "
+        "See docs/plans/async-retrieval/PLAN.md § 4 — Phase 5."
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# A4 — supersession serial per memory_id (P5-scope, placeholder)
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_supersession_serial_per_memory_id():
+    """Contract assertion (full impl in P5): two concurrent
+    supersession attempts on the same memory_id must linearize —
+    only one wins, the other's `superseded_by` chain is consistent."""
+    pytest.skip(
+        "P5 scope — write-side serialization invariant. "
+        "See docs/plans/async-retrieval/PLAN.md § 2 — A4."
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# A5 — trace events reconstructable tree (P3-scope, placeholder)
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_trace_reconstructable_under_async():
+    """Contract assertion (full impl in P3): 10 concurrent recalls
+    emit interleaved trace events; per-recall tree must reconstruct
+    via (recall_id, parent_event_id, seq)."""
+    pytest.skip(
+        "P3 scope — trace schema bump. "
+        "See docs/plans/async-retrieval/PLAN.md § 4 — Phase 3."
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# A6 — RLS propagation through async tasks (P5-scope, placeholder)
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_rls_propagates_through_async_tasks():
+    """Contract assertion (full impl in P5): each async task spawned
+    inside a recall sees its parent's `attestor.current_user_id`
+    session-local var. A task running with the wrong user_id would
+    silently bypass tenant isolation — defense-in-depth would
+    collapse."""
+    pytest.skip(
+        "P5 scope — connection-pool + session-local context propagation. "
+        "See docs/plans/async-retrieval/PLAN.md § 2 — A6."
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# A8 — deletion_audit under async (P5-scope, placeholder)
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_deletion_audit_under_async():
+    """Contract assertion: even if forget() runs async, the
+    deletion_audit row gets INSERTed BEFORE the actual delete.
+    schema.sql line 304 is the load-bearing comment ('NO RLS on
+    deletion_audit') — this test guards against an async refactor
+    that loses the pre-delete log."""
+    pytest.skip(
+        "P5 scope — write-side async (which is non-goal for this plan). "
+        "See docs/plans/async-retrieval/PLAN.md § 1 — non-goals."
+    )

--- a/tests/async_retrieval/test_audit_invariants_under_async.py
+++ b/tests/async_retrieval/test_audit_invariants_under_async.py
@@ -34,6 +34,7 @@ pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
 
 
 @pytest.mark.asyncio
+@pytest.mark.xfail(reason="RED — async impl lands in next PR; remove when GREEN", strict=False)
 async def test_hyde_temperature_zero_determinism_across_runs():
     """Same question → same hypothetical (temp=0) → same RRF order.
     Async amplifies non-determinism risk because gathered lanes can
@@ -70,6 +71,7 @@ async def test_hyde_temperature_zero_determinism_across_runs():
 
 
 @pytest.mark.asyncio
+@pytest.mark.xfail(reason="RED — async impl lands in next PR; remove when GREEN", strict=False)
 async def test_as_of_replay_under_concurrent_writes_contract():
     """Contract assertion (full implementation lands in P5):
 
@@ -93,6 +95,7 @@ async def test_as_of_replay_under_concurrent_writes_contract():
 
 
 @pytest.mark.asyncio
+@pytest.mark.xfail(reason="RED — async impl lands in next PR; remove when GREEN", strict=False)
 async def test_supersession_serial_per_memory_id():
     """Contract assertion (full impl in P5): two concurrent
     supersession attempts on the same memory_id must linearize —
@@ -109,6 +112,7 @@ async def test_supersession_serial_per_memory_id():
 
 
 @pytest.mark.asyncio
+@pytest.mark.xfail(reason="RED — async impl lands in next PR; remove when GREEN", strict=False)
 async def test_trace_reconstructable_under_async():
     """Contract assertion (full impl in P3): 10 concurrent recalls
     emit interleaved trace events; per-recall tree must reconstruct
@@ -125,6 +129,7 @@ async def test_trace_reconstructable_under_async():
 
 
 @pytest.mark.asyncio
+@pytest.mark.xfail(reason="RED — async impl lands in next PR; remove when GREEN", strict=False)
 async def test_rls_propagates_through_async_tasks():
     """Contract assertion (full impl in P5): each async task spawned
     inside a recall sees its parent's `attestor.current_user_id`
@@ -143,6 +148,7 @@ async def test_rls_propagates_through_async_tasks():
 
 
 @pytest.mark.asyncio
+@pytest.mark.xfail(reason="RED — async impl lands in next PR; remove when GREEN", strict=False)
 async def test_deletion_audit_under_async():
     """Contract assertion: even if forget() runs async, the
     deletion_audit row gets INSERTed BEFORE the actual delete.

--- a/tests/async_retrieval/test_hyde_async.py
+++ b/tests/async_retrieval/test_hyde_async.py
@@ -46,6 +46,7 @@ pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
 
 
 @pytest.mark.asyncio
+@pytest.mark.xfail(reason="RED — async impl lands in next PR; remove when GREEN", strict=False)
 async def test_hyde_search_async_runs_lanes_concurrently():
     """Two awaitables (HyDE LLM + per-lane vector searches) must run
     via ``asyncio.gather``. With both lanes sleeping 200ms, total
@@ -88,6 +89,7 @@ async def test_hyde_search_async_runs_lanes_concurrently():
 
 
 @pytest.mark.asyncio
+@pytest.mark.xfail(reason="RED — async impl lands in next PR; remove when GREEN", strict=False)
 async def test_hyde_search_async_returns_same_result_as_sync():
     """Async path is purely a latency optimization — given identical
     inputs (deterministic LLM, deterministic vector_search), the
@@ -140,6 +142,7 @@ async def test_hyde_search_async_returns_same_result_as_sync():
 
 
 @pytest.mark.asyncio
+@pytest.mark.xfail(reason="RED — async impl lands in next PR; remove when GREEN", strict=False)
 async def test_hyde_search_async_handles_lane_timeout():
     """If the HyDE LLM exceeds its timeout, the original-question lane
     must still produce hits — fall back to single-lane recall, do NOT
@@ -172,6 +175,7 @@ async def test_hyde_search_async_handles_lane_timeout():
 
 
 @pytest.mark.asyncio
+@pytest.mark.xfail(reason="RED — async impl lands in next PR; remove when GREEN", strict=False)
 async def test_hyde_search_async_handles_lane_exception():
     """If one of the gathered awaitables raises, the others must keep
     running — gather(..., return_exceptions=True) is the contract."""
@@ -202,6 +206,7 @@ async def test_hyde_search_async_handles_lane_exception():
 
 
 @pytest.mark.asyncio
+@pytest.mark.xfail(reason="RED — async impl lands in next PR; remove when GREEN", strict=False)
 async def test_hyde_async_preserves_temperature_zero():
     """The async generator MUST still pass temperature=0.0 to the LLM
     client. This is the determinism guarantee from HyDE v2 — without

--- a/tests/async_retrieval/test_hyde_async.py
+++ b/tests/async_retrieval/test_hyde_async.py
@@ -1,0 +1,229 @@
+"""Phase 1 — RED tests for ``hyde_search_async``.
+
+Target API (does NOT exist yet — these tests will fail until PR-1 lands):
+
+    from attestor.retrieval.hyde import hyde_search_async
+
+    queries, merged = await hyde_search_async(
+        question,
+        vector_search=async_callable,   # Awaitable[List[Dict]]
+        merge="rrf",
+    )
+
+The async version must:
+  1. Run the HyDE LLM call concurrently with the original-question
+     vector embed (via ``asyncio.gather``).
+  2. Produce the same merged hits as the sync ``hyde_search`` given
+     identical inputs (including a deterministic / temperature=0 LLM).
+  3. Degrade gracefully on lane timeout or exception
+     (``return_exceptions=True``).
+  4. Pin ``temperature=0.0`` on the generator call (same invariant as
+     HyDE v2 sync path).
+
+See ``docs/plans/async-retrieval/PLAN.md`` § 4 — Phase 1 row.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tests.async_retrieval.conftest import (
+    StopwatchAsync,
+    make_failing_search,
+    make_slow_search,
+)
+
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Concurrency assertions
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_hyde_search_async_runs_lanes_concurrently():
+    """Two awaitables (HyDE LLM + per-lane vector searches) must run
+    via ``asyncio.gather``. With both lanes sleeping 200ms, total
+    wallclock should be < 350ms (200 + ε), NOT 400ms (sequential).
+    """
+    from attestor.retrieval.hyde import hyde_search_async  # noqa: F401 — RED
+
+    slow_search = make_slow_search(per_call_ms=200)
+
+    # Mock generator so we don't make a real LLM call. The mock itself
+    # sleeps 200ms to simulate the LLM round-trip — this is the call
+    # that should overlap with the per-lane vector searches.
+    async def slow_generator(question, **kwargs):
+        await asyncio.sleep(0.2)
+        from attestor.retrieval.hyde import HydeResult
+        return HydeResult(
+            original_question=question,
+            hypothetical_answer="hypothetical narrative content",
+        )
+
+    with patch(
+        "attestor.retrieval.hyde.generate_hypothetical_answer_async",
+        side_effect=slow_generator,
+    ):
+        async with StopwatchAsync() as sw:
+            queries, merged = await hyde_search_async(
+                "test question",
+                vector_search=slow_search,
+            )
+
+    # Sequential would be ~600ms (LLM 200 + lane1 200 + lane2 200).
+    # Parallel HyDE-with-2-lanes should be ~400ms (LLM 200 ‖ embed,
+    # then 2 vector searches gathered = max 200).
+    assert sw.elapsed_ms < 500, (
+        f"HyDE+lanes ran sequentially? wallclock={sw.elapsed_ms:.0f}ms, "
+        f"expected < 500ms with gather"
+    )
+    assert len(queries) == 2, "queries should be [original, hypothetical]"
+    assert len(merged) >= 1, "RRF merge should produce at least one hit"
+
+
+@pytest.mark.asyncio
+async def test_hyde_search_async_returns_same_result_as_sync():
+    """Async path is purely a latency optimization — given identical
+    inputs (deterministic LLM, deterministic vector_search), the
+    merged-hits ordering must match the sync version byte-for-byte.
+    """
+    from attestor.retrieval.hyde import hyde_search, hyde_search_async  # noqa: F401 — RED
+
+    fixed_hits = [
+        {"memory_id": "a", "session_id": "s1", "distance": 0.1},
+        {"memory_id": "b", "session_id": "s2", "distance": 0.2},
+    ]
+
+    def sync_search(q: str):
+        return fixed_hits
+
+    async def async_search(q: str):
+        return fixed_hits
+
+    with patch(
+        "attestor.retrieval.hyde.generate_hypothetical_answer",
+        return_value=__import__(
+            "attestor.retrieval.hyde", fromlist=["HydeResult"]
+        ).HydeResult(
+            original_question="q", hypothetical_answer="snippet",
+        ),
+    ), patch(
+        "attestor.retrieval.hyde.generate_hypothetical_answer_async",
+        new=AsyncMock(
+            return_value=__import__(
+                "attestor.retrieval.hyde", fromlist=["HydeResult"]
+            ).HydeResult(
+                original_question="q", hypothetical_answer="snippet",
+            ),
+        ),
+    ):
+        sync_queries, sync_merged = hyde_search("q", vector_search=sync_search)
+        async_queries, async_merged = await hyde_search_async(
+            "q", vector_search=async_search,
+        )
+
+    assert sync_queries == async_queries
+    assert [h["memory_id"] for h in sync_merged] == [
+        h["memory_id"] for h in async_merged
+    ], "RRF merge order must match between sync and async"
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Failure / degradation behavior
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_hyde_search_async_handles_lane_timeout():
+    """If the HyDE LLM exceeds its timeout, the original-question lane
+    must still produce hits — fall back to single-lane recall, do NOT
+    raise to the caller."""
+    from attestor.retrieval.hyde import hyde_search_async  # RED
+
+    fast_search = make_slow_search(per_call_ms=10)
+
+    async def hangs_forever(question, **kwargs):
+        await asyncio.sleep(60)  # would exceed any sane timeout
+        from attestor.retrieval.hyde import HydeResult
+        return HydeResult(original_question=question, hypothetical_answer="late")
+
+    with patch(
+        "attestor.retrieval.hyde.generate_hypothetical_answer_async",
+        side_effect=hangs_forever,
+    ):
+        async with StopwatchAsync() as sw:
+            queries, merged = await hyde_search_async(
+                "q", vector_search=fast_search, timeout=0.5,
+            )
+
+    # Timeout should fire well before the LLM "completes". Caller still
+    # gets hits — just from the single original-question lane.
+    assert sw.elapsed_ms < 1500, (
+        f"HyDE timeout did not fire — wallclock={sw.elapsed_ms:.0f}ms"
+    )
+    assert len(queries) >= 1, "must have at least the original query"
+    assert len(merged) >= 1, "must have at least one hit from the surviving lane"
+
+
+@pytest.mark.asyncio
+async def test_hyde_search_async_handles_lane_exception():
+    """If one of the gathered awaitables raises, the others must keep
+    running — gather(..., return_exceptions=True) is the contract."""
+    from attestor.retrieval.hyde import hyde_search_async  # RED
+
+    failing_search = make_failing_search(when="second_lane")
+
+    async def normal_generator(question, **kwargs):
+        from attestor.retrieval.hyde import HydeResult
+        return HydeResult(original_question=question, hypothetical_answer="x")
+
+    with patch(
+        "attestor.retrieval.hyde.generate_hypothetical_answer_async",
+        side_effect=normal_generator,
+    ):
+        # Should NOT raise — exception in the second lane is swallowed
+        # and merge proceeds with the first lane only.
+        queries, merged = await hyde_search_async("q", vector_search=failing_search)
+
+    assert len(queries) == 2
+    # The first lane succeeded → at least one hit.
+    assert len(merged) >= 1
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Audit invariant — temperature=0 still pinned in the async path
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_hyde_async_preserves_temperature_zero():
+    """The async generator MUST still pass temperature=0.0 to the LLM
+    client. This is the determinism guarantee from HyDE v2 — without
+    it, async amplifies non-determinism risk because gathered lanes
+    could observe different hypothetical answers across runs."""
+    from attestor.retrieval.hyde import generate_hypothetical_answer_async  # RED
+
+    captured_kwargs = {}
+
+    class _StubResponse:
+        choices = [type("C", (), {"message": type("M", (), {"content": "snippet"})()})()]
+
+    async def fake_create(**kwargs):
+        captured_kwargs.update(kwargs)
+        return _StubResponse()
+
+    with patch.dict("os.environ", {"OPENROUTER_API_KEY": "stub"}):
+        with patch("openai.AsyncOpenAI") as mock_client_cls:
+            mock_client_cls.return_value.chat.completions.create = fake_create
+            await generate_hypothetical_answer_async("q")
+
+    assert captured_kwargs.get("temperature") == 0.0, (
+        f"async HyDE generator must pin temperature=0.0; "
+        f"got {captured_kwargs.get('temperature')!r}"
+    )

--- a/tests/async_retrieval/test_multi_query_async.py
+++ b/tests/async_retrieval/test_multi_query_async.py
@@ -1,0 +1,160 @@
+"""Phase 2 — RED tests for ``multi_query_search_async``.
+
+Target API (does NOT exist yet — these tests will fail until PR-2 lands):
+
+    from attestor.retrieval.multi_query import multi_query_search_async
+
+    queries, merged = await multi_query_search_async(
+        question,
+        vector_search=async_callable,
+        n=3,
+        merge="rrf",
+    )
+
+The async version must:
+  1. Run the rewriter LLM call concurrently with the original-question
+     vector embed (same gather pattern as HyDE).
+  2. Fan out the N+1 vector searches in parallel — wallclock close to
+     max(per-lane), NOT sum.
+  3. RRF-merge the lanes in identical order to the sync version.
+  4. Survive a partial lane failure (one paraphrase's vector search
+     raises) and return the remaining lanes' merged hits.
+
+See ``docs/plans/async-retrieval/PLAN.md`` § 4 — Phase 2 row.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+
+from tests.async_retrieval.conftest import (
+    StopwatchAsync,
+    make_failing_search,
+    make_slow_search,
+)
+
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Concurrency assertions
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_multi_query_async_parallelizes_n_lanes():
+    """With n=3 paraphrases (so 4 lanes total: original + 3) and each
+    vector search sleeping 200ms, sequential would be 800ms+; parallel
+    gather must finish in ~250ms."""
+    from attestor.retrieval.multi_query import (  # RED
+        multi_query_search_async,
+        RewriteResult,
+    )
+
+    slow_search = make_slow_search(per_call_ms=200)
+
+    async def fake_rewriter(question, **kwargs):
+        return RewriteResult(
+            original=question,
+            paraphrases=[f"paraphrase {i}" for i in range(3)],
+        )
+
+    with patch(
+        "attestor.retrieval.multi_query.rewrite_query_async",
+        side_effect=fake_rewriter,
+    ):
+        async with StopwatchAsync() as sw:
+            queries, merged = await multi_query_search_async(
+                "test question", vector_search=slow_search, n=3,
+            )
+
+    # 4 lanes × 200ms sequential = 800ms. Parallel = ~250ms tops.
+    assert sw.elapsed_ms < 500, (
+        f"multi-query lanes ran sequentially? wallclock={sw.elapsed_ms:.0f}ms, "
+        f"expected < 500ms with gather"
+    )
+    assert len(queries) == 4, "expected original + 3 paraphrases"
+    assert len(merged) >= 1
+
+
+@pytest.mark.asyncio
+async def test_multi_query_async_preserves_RRF_order():
+    """Async fan-out must produce the same RRF-ranked merged list as
+    the sync version given identical inputs. Differences would mean
+    the gather order corrupted the per-lane rank-position fed into RRF.
+    """
+    from attestor.retrieval.multi_query import (  # RED
+        multi_query_search,
+        multi_query_search_async,
+        RewriteResult,
+    )
+
+    fixed_paraphrases = ["alt 1", "alt 2"]
+
+    def sync_search(q: str):
+        # Deterministic per-query hits — order matters for RRF merge.
+        return [
+            {"memory_id": f"{q}-a", "session_id": "s", "distance": 0.1},
+            {"memory_id": f"{q}-b", "session_id": "s", "distance": 0.2},
+        ]
+
+    async def async_search(q: str):
+        return sync_search(q)
+
+    sync_rewrite = RewriteResult(original="q", paraphrases=fixed_paraphrases)
+
+    with patch(
+        "attestor.retrieval.multi_query.rewrite_query",
+        return_value=sync_rewrite,
+    ), patch(
+        "attestor.retrieval.multi_query.rewrite_query_async",
+        return_value=sync_rewrite,
+    ):
+        sync_queries, sync_merged = multi_query_search(
+            "q", vector_search=sync_search, n=2,
+        )
+        async_queries, async_merged = await multi_query_search_async(
+            "q", vector_search=async_search, n=2,
+        )
+
+    assert sync_queries == async_queries
+    assert [h["memory_id"] for h in sync_merged] == [
+        h["memory_id"] for h in async_merged
+    ], "RRF order must match — async gather must not corrupt rank positions"
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Partial failure
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_multi_query_async_handles_partial_lane_failure():
+    """If the second-lane vector search raises, the original-question
+    lane must still produce a merged result — gather(return_exceptions=True)
+    contract."""
+    from attestor.retrieval.multi_query import (  # RED
+        multi_query_search_async,
+        RewriteResult,
+    )
+
+    failing_search = make_failing_search(when="second_lane")
+
+    async def fake_rewriter(question, **kwargs):
+        return RewriteResult(original=question, paraphrases=["alt"])
+
+    with patch(
+        "attestor.retrieval.multi_query.rewrite_query_async",
+        side_effect=fake_rewriter,
+    ):
+        # Should NOT raise. RRF merges only the surviving lane.
+        queries, merged = await multi_query_search_async(
+            "q", vector_search=failing_search, n=1,
+        )
+
+    assert len(queries) == 2
+    assert len(merged) >= 1, "first lane succeeded → at least one merged hit"

--- a/tests/async_retrieval/test_multi_query_async.py
+++ b/tests/async_retrieval/test_multi_query_async.py
@@ -46,6 +46,7 @@ pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
 
 
 @pytest.mark.asyncio
+@pytest.mark.xfail(reason="RED — async impl lands in next PR; remove when GREEN", strict=False)
 async def test_multi_query_async_parallelizes_n_lanes():
     """With n=3 paraphrases (so 4 lanes total: original + 3) and each
     vector search sleeping 200ms, sequential would be 800ms+; parallel
@@ -82,6 +83,7 @@ async def test_multi_query_async_parallelizes_n_lanes():
 
 
 @pytest.mark.asyncio
+@pytest.mark.xfail(reason="RED — async impl lands in next PR; remove when GREEN", strict=False)
 async def test_multi_query_async_preserves_RRF_order():
     """Async fan-out must produce the same RRF-ranked merged list as
     the sync version given identical inputs. Differences would mean
@@ -133,6 +135,7 @@ async def test_multi_query_async_preserves_RRF_order():
 
 
 @pytest.mark.asyncio
+@pytest.mark.xfail(reason="RED — async impl lands in next PR; remove when GREEN", strict=False)
 async def test_multi_query_async_handles_partial_lane_failure():
     """If the second-lane vector search raises, the original-question
     lane must still produce a merged result — gather(return_exceptions=True)


### PR DESCRIPTION
## Summary

Detailed plan + failing tests for the async retrieval refactor. **No production code change** — this PR establishes the test contract; subsequent PRs (one per phase) drive RED → GREEN.

## Plan

`docs/plans/async-retrieval/PLAN.md`:
- Goals + non-goals (write-side stays sync; this is read-side only)
- 8 audit invariants that every phase must preserve (A1–A8)
- 7-phase rollout in dependency order, sized at ~1000–1500 LOC total
- Test coverage matrix per phase
- Acceptance criteria

## Tests

| File | RED | GREEN | Skip (TODO) | Notes |
|---|---|---|---|---|
| `test_hyde_async.py` | 5 | 0 | 0 | P1 — `hyde_search_async` |
| `test_multi_query_async.py` | 3 | 0 | 0 | P2 — per-lane gather |
| `test_audit_invariants_under_async.py` | 1 | 0 | 5 | A7 in scope; A1/A4/A5/A6/A8 stub-skipped with PLAN refs |
| `test_async_perf_regression.py` | 1 | 1 | 0 | overhead budget RED; sync shim GREEN |
| **Total** | **10** | **1** | **5** | |

The 10 RED tests fail because the target async APIs (`hyde_search_async`, `multi_query_search_async`, `generate_hypothetical_answer_async`, `rewrite_query_async`) don't exist yet. Subsequent PR-1 implements P1 to drive 5 RED → GREEN; PR-2 implements P2 for the remaining 3.

## Audit invariants

Every async PR must preserve these (table in `PLAN.md` § 2):

- **A1** `recall(as_of=X)` reproducible under concurrent writes
- **A2** `recall_started_at` ceiling — no post-recall writes leak in
- **A3** Provenance immutable per `memory_id`
- **A4** Supersession serial per `memory_id` (write-side stays sync)
- **A5** Trace events form per-recall reconstructable tree
- **A6** RLS propagates through async tasks
- **A7** HyDE/multi-query LLM determinism (`temperature=0`)
- **A8** `deletion_audit` row written even under async

A7 is enforced from PR-1 onwards. A1/A4/A5/A6/A8 are placeholder skips today, filled in their corresponding phase PRs.

## Convention

Every subsequent async PR description must include an audit-preservation argument, and the matching invariant test must be GREEN before merge. RED → GREEN drives the rollout.

## Test plan

- [x] All RED tests fail with import errors / AttributeError on the missing async APIs
- [x] Existing sync tests (30 across `test_hyde.py`, `test_hyde_orchestrator.py`, `test_v4_namespace_roundtrip.py`) all green — no regression
- [x] `pytest-asyncio` added as dev dep + `asyncio_mode = "auto"` in pyproject
- [ ] PR-1 turns 5 P1 RED tests green (next PR)
- [ ] PR-2 turns 3 P2 RED tests green