### PR TITLE
feat(retrieval): P2 — async multi-query (latency −60% with audit unchanged)

### DIFF
--- a/attestor/retrieval/multi_query.py
+++ b/attestor/retrieval/multi_query.py
@@ -36,11 +36,12 @@ Trace events emitted (when ATTESTOR_TRACE=1):
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import os
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Sequence, Tuple
 
 logger = logging.getLogger("attestor.retrieval.multi_query")
 
@@ -148,6 +149,76 @@ def rewrite_query(
     if _tr.is_enabled():
         _tr.event(
             "recall.multi_query.rewrites",
+            original=question[:200],
+            n_requested=n,
+            n_produced=len(paraphrases),
+            paraphrases=paraphrases[:5],
+        )
+
+    return RewriteResult(
+        original=question.strip(),
+        paraphrases=paraphrases,
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Async rewriter (Phase 2 — docs/plans/async-retrieval/PLAN.md).
+# Pins temperature=0.0 — same audit invariant A7 as HyDE: same prompt
+# + same model = same paraphrases = same RRF order. Async amplifies
+# non-determinism risk if T > 0.
+# ──────────────────────────────────────────────────────────────────────
+
+
+async def rewrite_query_async(
+    question: str,
+    *,
+    n: int = 3,
+    model: Optional[str] = None,
+    api_key: Optional[str] = None,
+    timeout: float = 30.0,
+) -> RewriteResult:
+    """Async sibling of ``rewrite_query``. Same prompt, same parser,
+    same fallback semantics. Uses ``openai.AsyncOpenAI`` so the
+    rewriter call can run concurrently with vector lanes.
+    """
+    if n <= 0 or not question.strip():
+        return RewriteResult(original=question.strip())
+
+    api_key = api_key or os.environ.get("OPENROUTER_API_KEY")
+    if not api_key:
+        logger.debug("multi_query.rewrite_query_async: no API key; returning original only")
+        return RewriteResult(original=question.strip())
+
+    model = model or _resolve_rewriter_model()
+
+    try:
+        from openai import AsyncOpenAI
+        client = AsyncOpenAI(
+            base_url="https://openrouter.ai/api/v1",
+            api_key=api_key,
+            timeout=timeout,
+        )
+        response = await client.chat.completions.create(
+            model=model,
+            max_tokens=400,
+            temperature=0.0,
+            messages=[
+                {"role": "user", "content": _REWRITE_PROMPT.format(
+                    n=n, question=question,
+                )},
+            ],
+        )
+        text = (response.choices[0].message.content or "").strip()
+    except Exception as e:  # noqa: BLE001
+        logger.debug("multi_query.rewrite_query_async: LLM call failed: %s", e)
+        return RewriteResult(original=question.strip())
+
+    paraphrases = _parse_rewrites(text, n=n)
+
+    from attestor import trace as _tr
+    if _tr.is_enabled():
+        _tr.event(
+            "recall.multi_query.rewrites.async",
             original=question[:200],
             n_requested=n,
             n_produced=len(paraphrases),
@@ -334,3 +405,115 @@ def multi_query_search(
         )
 
     return queries, merged
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Async end-to-end lane (Phase 2 — docs/plans/async-retrieval/PLAN.md)
+#
+# Two concurrency levers:
+#   1. Rewriter LLM call runs concurrently with the original-question
+#      vector search (orig lane embeds while rewriter writes paraphrases).
+#   2. Once paraphrases are known, the N paraphrase lanes fan out
+#      simultaneously via asyncio.gather. Wallclock collapses from
+#      (N+1) × per-lane to ~max(per-lane).
+#
+# Audit invariants preserved:
+#   A7 — rewriter pins temperature=0.0 (same as HyDE generator).
+#   RRF merge is deterministic given identical lane inputs — gather
+#   order does NOT affect rank positions because ranks are assigned
+#   per-lane independently before merge (see test_multi_query_async
+#   _preserves_RRF_order).
+# ──────────────────────────────────────────────────────────────────────
+
+
+async def multi_query_search_async(
+    question: str,
+    *,
+    vector_search: Callable[[str], Awaitable[List[Dict[str, Any]]]],
+    n: int = 3,
+    merge: str = "rrf",
+    rewriter_model: Optional[str] = None,
+    api_key: Optional[str] = None,
+    timeout: float = 30.0,
+) -> Tuple[List[str], List[Dict[str, Any]]]:
+    """Async sibling of ``multi_query_search``. ``vector_search`` MUST
+    be an async callable.
+
+    Latency story (with both LLM and vector ~200ms each, n=3 → 4 lanes):
+        sync:  ~1000ms (rewriter 200 + 4 lanes × 200 sequential)
+        async: ~400ms  (rewriter 200 ‖ orig lane 200, then 3 paraphrase
+                        lanes gathered ≈ 200) — ~60% reduction
+
+    Per-lane failures are isolated via gather(return_exceptions=True);
+    RRF degrades to surviving lanes. On rewriter failure, falls back
+    to single-lane (original-question) without raising.
+    """
+    # Phase A: rewriter + orig-lane in parallel. Orig lane is "free"
+    # on the wallclock — it runs while the LLM writes paraphrases.
+    rewriter_task = asyncio.create_task(
+        rewrite_query_async(
+            question, n=n, model=rewriter_model, api_key=api_key,
+            timeout=timeout,
+        )
+    )
+    orig_task = asyncio.create_task(_safe_async_call(vector_search, question))
+
+    try:
+        rewrite = await asyncio.wait_for(rewriter_task, timeout=timeout)
+    except asyncio.TimeoutError:
+        logger.debug("multi_query_async: rewriter exceeded timeout=%.2fs", timeout)
+        rewrite = RewriteResult(original=question.strip())
+    except Exception as e:  # noqa: BLE001
+        logger.debug("multi_query_async: rewriter failed: %s", e)
+        rewrite = RewriteResult(original=question.strip())
+
+    queries = rewrite.queries
+
+    # Phase B: fan out paraphrase lanes (all known after rewriter
+    # returns) gathered with the already-running orig task.
+    paraphrase_tasks = [
+        asyncio.create_task(_safe_async_call(vector_search, p))
+        for p in rewrite.paraphrases
+    ]
+    all_tasks = [orig_task] + paraphrase_tasks
+    lanes_results = await asyncio.gather(*all_tasks, return_exceptions=True)
+
+    # Coerce to lanes; exceptions become empty lanes (RRF handles).
+    lanes: List[List[Dict[str, Any]]] = []
+    for lr in lanes_results:
+        if isinstance(lr, Exception):
+            lanes.append([])
+        else:
+            lanes.append(lr or [])
+
+    if merge == "union":
+        merged = union_merge(lanes)
+    else:
+        merged = reciprocal_rank_fusion(lanes)
+
+    from attestor import trace as _tr
+    if _tr.is_enabled():
+        _tr.event(
+            "recall.multi_query.merged.async",
+            n_queries=len(queries),
+            per_lane_sizes=[len(l) for l in lanes],
+            merged_size=len(merged),
+            merge_strategy=merge,
+        )
+
+    return queries, merged
+
+
+async def _safe_async_call(
+    fn: Callable[[str], Awaitable[List[Dict[str, Any]]]],
+    arg: str,
+) -> List[Dict[str, Any]]:
+    """Await ``fn(arg)``; on exception, return ``[]`` so the lane
+    contributes empty to RRF rather than raising. Mirrors the helper
+    in ``attestor/retrieval/hyde.py`` — kept local to avoid a
+    circular import."""
+    try:
+        return list(await fn(arg))
+    except Exception as e:  # noqa: BLE001
+        logger.debug("multi_query_async: lane %r failed: %s", arg[:60], e)
+        return []

--- a/tests/async_retrieval/test_multi_query_async.py
+++ b/tests/async_retrieval/test_multi_query_async.py
@@ -46,7 +46,6 @@ pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
 
 
 @pytest.mark.asyncio
-@pytest.mark.xfail(reason="RED — async impl lands in next PR; remove when GREEN", strict=False)
 async def test_multi_query_async_parallelizes_n_lanes():
     """With n=3 paraphrases (so 4 lanes total: original + 3) and each
     vector search sleeping 200ms, sequential would be 800ms+; parallel
@@ -83,7 +82,6 @@ async def test_multi_query_async_parallelizes_n_lanes():
 
 
 @pytest.mark.asyncio
-@pytest.mark.xfail(reason="RED — async impl lands in next PR; remove when GREEN", strict=False)
 async def test_multi_query_async_preserves_RRF_order():
     """Async fan-out must produce the same RRF-ranked merged list as
     the sync version given identical inputs. Differences would mean
@@ -135,7 +133,6 @@ async def test_multi_query_async_preserves_RRF_order():
 
 
 @pytest.mark.asyncio
-@pytest.mark.xfail(reason="RED — async impl lands in next PR; remove when GREEN", strict=False)
 async def test_multi_query_async_handles_partial_lane_failure():
     """If the second-lane vector search raises, the original-question
     lane must still produce a merged result — gather(return_exceptions=True)


### PR DESCRIPTION
## TL;DR

**P2: per-lane fan-out for multi-query.** N+1 vector lanes parallelize; rewriter LLM call overlaps with the original-question vector search. Wallclock drops ~60% on multi-query recalls. All audit invariants preserved — same temperature=0 pin, same deterministic RRF.

Drives the **3 remaining xfailed P2 tests** from PR #108 to GREEN. The async retrieval rollout from `docs/plans/async-retrieval/PLAN.md` is now **fully GREEN through Phase 2** (0 xfailed across the whole `tests/async_retrieval/` suite — only P3-P5 phase placeholders remain skipped).

## What changed

### `attestor/retrieval/multi_query.py`

- **`rewrite_query_async()`** — uses `openai.AsyncOpenAI`, pins `temperature=0.0` (audit invariant **A7**). Same prompt, same JSON parser, same fallback semantics as the sync `rewrite_query`. Trace event `recall.multi_query.rewrites.async`.
- **`multi_query_search_async()`** — two-phase concurrency:
  - Phase A: rewriter LLM ‖ original-question vector search via `asyncio.create_task`
  - Phase B: N paraphrase lanes fanned out via `asyncio.gather(return_exceptions=True)`, joined with the already-running orig task
  - On rewriter timeout/exception, degrades to single-lane (original-question only) without raising
  - Per-lane failures isolated; RRF merges surviving lanes

## Audit-preservation argument

| Invariant | How it's preserved | Test |
|---|---|---|
| **A7** Rewriter LLM determinism | `temperature=0.0` pinned in `rewrite_query_async`; same prompt + same model = same paraphrases = same RRF order | (manual: trace inspection — async generator pins T=0) |
| Deterministic RRF over async lanes | RRF assigns ranks per-lane *independently before* merge; `asyncio.gather` order does NOT corrupt rank positions | `test_multi_query_async_preserves_RRF_order` (GREEN) |
| Partial-failure tolerance | `gather(return_exceptions=True)` — one failing lane does NOT cancel siblings; RRF degrades to surviving lanes | `test_multi_query_async_handles_partial_lane_failure` (GREEN) |
| Distinguishable trace events | `recall.multi_query.rewrites.async` / `recall.multi_query.merged.async` separate from sync events for audit-dashboard reconstruction | (manual inspection) |

A1-A6, A8 untouched — read-side enrichment only, no write-path changes.

## Latency story

With LLM and vector both ~200ms, n=3 → 4 lanes total:

```
sync:  rewriter(200) → orig(200) → para1(200) → para2(200) → para3(200) = 1000ms
async: [rewriter(200) ‖ orig(200)] → [para1(200) ‖ para2(200) ‖ para3(200)] ≈ 400ms (−60%)
```

## Test plan

- [x] **3 P2 RED tests → GREEN** (xfail markers removed in same commit):
  - `test_multi_query_async_parallelizes_n_lanes`
  - `test_multi_query_async_preserves_RRF_order`
  - `test_multi_query_async_handles_partial_lane_failure`
- [x] **All 11 async tests pass** (5 P1 hyde async + 3 P2 multi-query async + 3 perf+audit invariant)
- [x] **5 skipped** stay skipped (P3-P5 phase placeholders with PLAN refs)
- [x] **0 xfailed** — full P1+P2 suite is GREEN
- [x] Existing sync tests (`test_multi_query.py`, `test_hyde.py`, `test_v4_namespace_roundtrip.py`) all green — zero regression
- [x] Local: `11 passed, 5 skipped in 1.40s`

## What's next

- **PR-3** (P3) — trace schema bump: `recall_id` + monotonic `seq` + `parent_event_id`. Fills the audit-invariant placeholder for **A5** (trace reconstructable under async).
- **PR-4** (P4) — self-consistency K-fanout. Biggest single-feature latency win (~5× on K=5 sampling).
- **PR-5** (P5) — `recall_started_at` ceiling primitive + cross-store async (orchestrator). Activates **A2** invariant.