### PR TITLE
feat(answerer): P4 — async self-consistency K-fanout (~5x on K=5)

### DIFF
--- a/attestor/longmemeval_consistency.py
+++ b/attestor/longmemeval_consistency.py
@@ -37,6 +37,7 @@ knob and flip per bench run only.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import re
 from dataclasses import dataclass, field
@@ -387,3 +388,141 @@ def _emit_elected_event(
         )
     except Exception:  # noqa: BLE001
         pass
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Async K-fanout (Phase 4 — docs/plans/async-retrieval/PLAN.md).
+#
+# K answerer samples run in parallel via asyncio.gather instead of the
+# sequential for-loop. With K=5 and per-call latency ~2s, wallclock
+# drops from ~10s to ~2s — roughly 5×.
+#
+# The voter logic (majority / judge_pick) is order-independent: counts
+# are bucketed by fingerprint and tiebreaks fall back to first-seen
+# (insertion order). Async gather order does NOT change which sample
+# wins because every sample is bucketed the same way regardless of
+# arrival order. Verified by test_self_consistency_consensus_order
+# _independent.
+#
+# Audit-preservation argument:
+#   - Voter determinism preserved (commutative bucketing).
+#   - Trace events still emit per-sample via _sample_once_async.
+#   - Per-sample failures isolated via gather(return_exceptions=True);
+#     surviving samples vote among themselves. K-1 failures still
+#     produce a result.
+# ──────────────────────────────────────────────────────────────────────
+
+
+async def _sample_once_async(
+    *,
+    client: Any,
+    model: str,
+    messages: List[Dict[str, Any]],
+    temperature: float,
+) -> str:
+    """Async sibling of ``_sample_once``. Awaits an async chat-completion
+    call. Returns the stripped content text, or ``""`` on any error
+    (errors swallowed by the caller via gather(return_exceptions=True))."""
+    response = await client.chat.completions.create(
+        model=model,
+        temperature=temperature,
+        messages=messages,
+    )
+    text = response.choices[0].message.content or ""
+    return text.strip()
+
+
+async def answer_with_self_consistency_async(
+    *,
+    client: Any,
+    model: str,
+    messages: List[Dict[str, Any]],
+    k: int = 5,
+    temperature: float = 0.7,
+    voter: str = "majority",
+    judge_client: Optional[Any] = None,
+    judge_model: Optional[str] = None,
+) -> ConsistencyResult:
+    """Async sibling of ``answer_with_self_consistency``. K answerer
+    samples are drawn CONCURRENTLY via ``asyncio.gather``; the voter
+    logic is identical (and provably order-independent — see test
+    ``test_self_consistency_consensus_order_independent``).
+
+    Latency story (with per-sample latency ~2s, K=5):
+        sync:  ~10s  (5 × 2s sequential)
+        async:  ~2s  (1 × max(per-sample) under gather) — roughly 5×
+
+    Per-sample failures are isolated via ``gather(return_exceptions=True)``;
+    K-1 sample failures still produce a result from the surviving sample.
+    """
+    if voter not in VALID_VOTERS:
+        raise ValueError(
+            f"unknown voter strategy {voter!r}; expected one of {VALID_VOTERS}"
+        )
+
+    if k <= 0:
+        return ConsistencyResult(samples=[], chosen="", voter=voter, vote_breakdown={})
+
+    # K samples in parallel.
+    tasks = [
+        asyncio.create_task(
+            _sample_once_async(
+                client=client,
+                model=model,
+                messages=messages,
+                temperature=temperature,
+            )
+        )
+        for _ in range(k)
+    ]
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+
+    samples: List[str] = []
+    for i, r in enumerate(results):
+        if isinstance(r, Exception):
+            logger.debug("self_consistency_async sample %d failed: %s", i, r)
+            continue
+        if r:
+            samples.append(r)
+
+    _emit_samples_event(
+        k=k, model=model, temperature=temperature, samples=samples,
+    )
+
+    if not samples:
+        return ConsistencyResult(samples=[], chosen="", voter=voter, vote_breakdown={})
+
+    if voter == "judge_pick" and judge_model:
+        try:
+            # Judge call stays sync today — the judge prompt is one
+            # call, no parallelism win to be had. P-future could swap
+            # this for an async sibling if the judge becomes a
+            # bottleneck.
+            idx = _judge_choice(
+                samples=samples,
+                question=_question_from_messages(messages),
+                judge_client=judge_client or client,
+                judge_model=judge_model,
+            )
+            chosen = samples[idx]
+            breakdown = {_fingerprint(s): 1 for s in samples}
+            _emit_elected_event(
+                voter="judge_pick", chosen=chosen, breakdown=breakdown,
+            )
+            return ConsistencyResult(
+                samples=samples, chosen=chosen,
+                voter="judge_pick", vote_breakdown=breakdown,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.debug(
+                "self_consistency_async judge_pick failed; falling back: %s", exc,
+            )
+
+    chosen, breakdown = _majority_choice(samples)
+    _emit_elected_event(
+        voter="majority", chosen=chosen, breakdown=breakdown,
+    )
+    return ConsistencyResult(
+        samples=samples, chosen=chosen,
+        voter="majority", vote_breakdown=breakdown,
+    )

--- a/tests/async_retrieval/test_self_consistency_async.py
+++ b/tests/async_retrieval/test_self_consistency_async.py
@@ -1,0 +1,218 @@
+"""Phase 4 — async self-consistency K-fanout tests.
+
+Target API:
+
+    from attestor.longmemeval_consistency import answer_with_self_consistency_async
+
+    result = await answer_with_self_consistency_async(
+        client=async_client,
+        model="...",
+        messages=[...],
+        k=5,
+        temperature=0.7,
+    )
+
+The async version must:
+  1. Run K answerer samples CONCURRENTLY via asyncio.gather; wallclock
+     ≈ max(per-sample), NOT K × per-sample.
+  2. Produce the same elected ``chosen`` answer as the sync version
+     given identical samples — voter logic is order-independent.
+  3. Survive K-1 sample failures: the one surviving sample becomes
+     the consensus.
+
+See docs/plans/async-retrieval/PLAN.md § 4 — Phase 4.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+pytestmark = [pytest.mark.unit]
+
+
+def _make_async_client(per_call_ms: int, content: str) -> MagicMock:
+    """Build an OpenAI-compatible async client whose
+    ``chat.completions.create`` sleeps then returns a fixed message
+    content. Each invocation sleeps independently, so we can observe
+    parallel vs sequential by total wallclock."""
+    client = MagicMock()
+
+    async def fake_create(**kwargs):
+        await asyncio.sleep(per_call_ms / 1000.0)
+        return MagicMock(
+            choices=[MagicMock(
+                message=MagicMock(content=content),
+            )]
+        )
+
+    client.chat.completions.create = fake_create
+    return client
+
+
+def _make_async_client_with_failures(
+    per_call_ms: int, success_content: str, fail_after: int,
+) -> MagicMock:
+    """Build an async client where the first ``fail_after`` calls raise
+    and subsequent calls succeed. Used to test K-1 failure tolerance.
+    """
+    client = MagicMock()
+    counter = {"n": 0}
+
+    async def fake_create(**kwargs):
+        await asyncio.sleep(per_call_ms / 1000.0)
+        counter["n"] += 1
+        if counter["n"] <= fail_after:
+            raise RuntimeError(f"intentional failure at call {counter['n']}")
+        return MagicMock(
+            choices=[MagicMock(message=MagicMock(content=success_content))]
+        )
+
+    client.chat.completions.create = fake_create
+    return client
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Concurrency
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_self_consistency_async_runs_K_concurrently():
+    """K=5 samples each sleeping 200ms must complete in ~250ms total
+    (parallel), NOT 1000ms (sequential)."""
+    from attestor.longmemeval_consistency import answer_with_self_consistency_async
+
+    client = _make_async_client(per_call_ms=200, content="Bob")
+    messages = [{"role": "user", "content": "Who is the CTO?"}]
+
+    t0 = time.perf_counter()
+    result = await answer_with_self_consistency_async(
+        client=client, model="stub", messages=messages, k=5, temperature=0.7,
+    )
+    elapsed_ms = (time.perf_counter() - t0) * 1000.0
+
+    assert elapsed_ms < 600, (
+        f"K=5 ran sequentially? wallclock={elapsed_ms:.0f}ms, "
+        f"expected < 600ms with gather"
+    )
+    assert len(result.samples) == 5
+    assert result.chosen == "Bob"
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Voter determinism — async order-independent
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_self_consistency_async_consensus_order_independent():
+    """Async gather order does NOT change which sample wins. Even when
+    samples complete in shuffled order, the majority bucket is the same.
+
+    This pins audit invariant: the voter (`_majority_choice`) is
+    commutative — it counts fingerprints, then picks max with first-seen
+    tiebreak. First-seen is in the order samples appear in the list
+    after gather, but since gather preserves submission order in its
+    return list, the bucket counts are deterministic regardless of
+    completion timing.
+    """
+    from attestor.longmemeval_consistency import answer_with_self_consistency_async
+
+    client = MagicMock()
+    # Cycle through 3 distinct answers; majority should still pick the
+    # most-frequent one regardless of arrival order.
+    sequence = ["Alice", "Bob", "Bob", "Bob", "Carol"]
+    counter = {"n": 0}
+
+    async def fake_create(**kwargs):
+        i = counter["n"]
+        counter["n"] += 1
+        # Vary the per-call sleep so gather completion order is non-monotonic.
+        sleeps_ms = [50, 10, 30, 5, 40]
+        await asyncio.sleep(sleeps_ms[i % len(sleeps_ms)] / 1000.0)
+        return MagicMock(
+            choices=[MagicMock(message=MagicMock(content=sequence[i]))]
+        )
+
+    client.chat.completions.create = fake_create
+
+    result = await answer_with_self_consistency_async(
+        client=client, model="stub",
+        messages=[{"role": "user", "content": "?"}],
+        k=5, temperature=0.7,
+    )
+
+    assert result.chosen == "Bob", (
+        f"majority winner must be 'Bob' (3/5), got {result.chosen!r}; "
+        f"breakdown={result.vote_breakdown}"
+    )
+    assert result.vote_breakdown.get("bob") == 3
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Failure tolerance
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_self_consistency_async_handles_K_minus_one_failures():
+    """K=5 with the first 4 calls failing — the surviving 1 sample
+    becomes the consensus (single-vote winner)."""
+    from attestor.longmemeval_consistency import answer_with_self_consistency_async
+
+    client = _make_async_client_with_failures(
+        per_call_ms=20, success_content="lone_survivor", fail_after=4,
+    )
+
+    result = await answer_with_self_consistency_async(
+        client=client, model="stub",
+        messages=[{"role": "user", "content": "?"}],
+        k=5, temperature=0.7,
+    )
+
+    assert len(result.samples) == 1
+    assert result.chosen == "lone_survivor"
+
+
+@pytest.mark.asyncio
+async def test_self_consistency_async_handles_all_failures():
+    """If ALL K calls fail, the result must be empty — no chosen,
+    voter degraded gracefully."""
+    from attestor.longmemeval_consistency import answer_with_self_consistency_async
+
+    client = _make_async_client_with_failures(
+        per_call_ms=10, success_content="never_returned", fail_after=999,
+    )
+
+    result = await answer_with_self_consistency_async(
+        client=client, model="stub",
+        messages=[{"role": "user", "content": "?"}],
+        k=5, temperature=0.7,
+    )
+
+    assert result.samples == []
+    assert result.chosen == ""
+
+
+@pytest.mark.asyncio
+async def test_self_consistency_async_k_zero_returns_empty():
+    """K=0 must short-circuit — no LLM calls, empty result."""
+    from attestor.longmemeval_consistency import answer_with_self_consistency_async
+
+    client = MagicMock()
+    client.chat.completions.create = AsyncMock()
+
+    result = await answer_with_self_consistency_async(
+        client=client, model="stub",
+        messages=[{"role": "user", "content": "?"}],
+        k=0, temperature=0.7,
+    )
+
+    assert result.samples == []
+    assert result.chosen == ""
+    client.chat.completions.create.assert_not_called()


### PR DESCRIPTION
## TL;DR

**P4: K answerer samples in parallel.** Sequential `for i in range(k)` → `asyncio.gather`. At K=5 with per-sample latency ~2s, wallclock drops from ~10s to ~2s — the **biggest single-feature win** in the async rollout. Voter logic is provably order-independent, audit unchanged.

## What changed

### `attestor/longmemeval_consistency.py`

- **`_sample_once_async()`** — async sibling of `_sample_once`; awaits an async chat-completion call.
- **`answer_with_self_consistency_async()`** — same surface API as the sync `answer_with_self_consistency`. Internally: K `asyncio.create_task` + `asyncio.gather(return_exceptions=True)`. Voter logic untouched — operates on the gathered samples list (preserves submission order), so the vote is deterministic regardless of completion order.

### `tests/async_retrieval/test_self_consistency_async.py` — 5 GREEN tests

| Test | What it pins |
|---|---|
| `test_self_consistency_async_runs_K_concurrently` | wallclock < K × per-sample (gather wins) |
| `test_self_consistency_async_consensus_order_independent` | shuffled completion order → identical majority winner |
| `test_self_consistency_async_handles_K_minus_one_failures` | K-1 calls fail; the 1 survivor wins single-vote |
| `test_self_consistency_async_handles_all_failures` | All K fail; result is empty, no raise |
| `test_self_consistency_async_k_zero_returns_empty` | K=0 short-circuits; no LLM calls |

## Audit-preservation argument

| Invariant | How it's preserved | Test |
|---|---|---|
| Voter determinism under async | `_majority_choice` is COMMUTATIVE — counts fingerprints, picks max with first-seen tiebreak. `asyncio.gather` returns in **submission** order regardless of completion timing, so first-seen is deterministic. | `test_self_consistency_async_consensus_order_independent` |
| Per-sample failure tolerance | `gather(return_exceptions=True)` — failing samples become exceptions in the result list, swallowed by the caller. Surviving samples vote among themselves. | `test_self_consistency_async_handles_K_minus_one_failures` + `test_..._all_failures` |
| Trace continuity | `answer.self_consistency.samples` / `.elected` events emit once per call as before. Same audit-dashboard signal — gather order doesn't affect the trace shape. | (manual: trace inspection) |

A1/A4/A6/A8 untouched — answerer-side change, doesn't touch the document store.

## Latency story

```
K=5, per-sample 2s:
  sync:  10s  (5 × 2s sequential)
  async:  2s  (1 × max(per-sample) under gather) — ~5×
```

This makes self-consistency *interactive-grade* — a feature that's barely usable today (10s wait per answer) becomes interactive (2s) without changing accuracy.

## Test plan

- [x] **5 P4 tests GREEN**
- [x] **All 51 async tests pass** (8 P1 + 3 P2 + 5 P3 + 5 P4 + 30 unrelated sync)
- [x] **4 skipped** stays for P5 (A1, A4, A6, A8)
- [x] **0 xfailed** — full P1+P2+P3+P4 suite is GREEN
- [x] Existing sync `test_longmemeval_consistency.py` (if present) untouched — sync API unchanged
- [x] Local: `51 passed, 4 skipped in 1.79s`

## What's next

- **PR-5** (P5) — `recall_started_at` ceiling + cross-store async (orchestrator). Activates the final 4 audit invariants (A1, A4, A6, A8) and parallelizes vector ‖ BM25 ‖ graph + graph BFS ‖ doc fetch.