### PR TITLE
feat(retrieval): P6 — orchestrator recall_async with vector ‖ BM25 parallelism

### DIFF
--- a/attestor/retrieval/orchestrator.py
+++ b/attestor/retrieval/orchestrator.py
@@ -15,8 +15,9 @@ Every call writes a JSONL trace to ``logs/attestor_trace.jsonl``
 
 from __future__ import annotations
 
+import asyncio
 import time
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from attestor.models import Memory, RetrievalResult
 from attestor.retrieval.scorer import (
@@ -263,10 +264,127 @@ class RetrievalOrchestrator:
                       time_window=str(time_window) if time_window else None)
 
         # ── Step 0: Temporal pre-filter (RC4) ──
-        # When enabled and the question contains a relative time phrase,
-        # tighten the event-time window passed to subsequent lanes. Caller-
-        # supplied time_window takes precedence — never override an explicit
-        # bound. Falls through silently when no phrase matches.
+        time_window = self._step0_temporal_prefilter(query, time_window)
+
+        # ── Step 1: Vector top-K (single | hyde | multi_query) ──
+        vector_hits_raw, mq_used, path = self._compute_lane_vector(
+            query, namespace, as_of, time_window,
+        )
+
+        # ── Step 1b: BM25 lane ──
+        bm25_hits_raw = self._compute_lane_bm25(query, as_of, time_window)
+
+        # ── Steps 2–6 — extracted into ``_post_process_candidates`` so
+        # the same logic is reused by both the sync ``recall()`` and
+        # the async ``recall_async()`` (Phase 6 of the async retrieval
+        # rollout, see docs/plans/async-retrieval/PLAN.md).
+        return self._post_process_candidates(
+            query=query, namespace=namespace, as_of=as_of,
+            time_window=time_window,
+            question_entities=question_entities,
+            vector_hits_raw=vector_hits_raw,
+            bm25_hits_raw=bm25_hits_raw,
+            mq_used=mq_used, path=path,
+            token_budget=token_budget, t_total=t_total,
+        )
+
+    # ──────────────────────────────────────────────────────────────────
+    # Phase 6 — async sibling. Vector lane and BM25 lane run in parallel
+    # via asyncio.gather + asyncio.to_thread. Steps 2-6 (CPU-bound) run
+    # serially after both lanes return; no parallelism opportunity there.
+    #
+    # Audit-preservation argument:
+    #   - Opens a recall_started_at_scope_async() so the Postgres ceiling
+    #     (audit invariant A2) is active for the entire recall.
+    #   - The recall_id contextvar from trace.recall_scope, if opened by
+    #     a caller, propagates through asyncio.to_thread (contextvars
+    #     are copied onto threads via ContextVar.run() semantics).
+    #   - Lane failures are isolated via gather(return_exceptions=True);
+    #     a failing lane degrades to an empty list rather than aborting
+    #     the recall.
+    # ──────────────────────────────────────────────────────────────────
+
+    async def recall_async(
+        self,
+        query: str,
+        token_budget: int = 2000,
+        namespace: Optional[str] = None,
+        as_of: Optional[Any] = None,
+        time_window: Optional[Any] = None,
+    ) -> List[RetrievalResult]:
+        """Async sibling of ``recall()``. Runs the vector lane and BM25
+        lane concurrently via ``asyncio.gather`` + ``asyncio.to_thread``.
+
+        Latency story (with vector ~80ms and BM25 ~50ms):
+            sync:  ~130ms (vector → BM25 sequential)
+            async:  ~80ms (vector ‖ BM25 under gather, max wins)
+        """
+        from attestor.recall_context import recall_started_at_scope_async
+
+        async with recall_started_at_scope_async():
+            t_total = time.monotonic()
+            from attestor import trace as _tr
+            question_entities = self._question_entities(query)
+            if _tr.is_enabled():
+                _tr.event(
+                    "recall.start", query=query[:200], namespace=namespace,
+                    token_budget=token_budget,
+                    question_entities=question_entities,
+                    as_of=str(as_of) if as_of else None,
+                    time_window=str(time_window) if time_window else None,
+                    mode="async",
+                )
+
+            # Step 0 (sync, regex — cheap).
+            time_window = self._step0_temporal_prefilter(query, time_window)
+
+            # Steps 1 + 1b — the P6 win: parallel via gather.
+            lane_results = await asyncio.gather(
+                asyncio.to_thread(
+                    self._compute_lane_vector,
+                    query, namespace, as_of, time_window,
+                ),
+                asyncio.to_thread(
+                    self._compute_lane_bm25,
+                    query, as_of, time_window,
+                ),
+                return_exceptions=True,
+            )
+
+            if isinstance(lane_results[0], Exception):
+                vector_hits_raw, mq_used, path = [], None, "single"
+            else:
+                vector_hits_raw, mq_used, path = lane_results[0]
+
+            if isinstance(lane_results[1], Exception):
+                bm25_hits_raw = []
+            else:
+                bm25_hits_raw = lane_results[1]
+
+            # Steps 2-6 — sync post-processing (no I/O parallelism inside).
+            return self._post_process_candidates(
+                query=query, namespace=namespace, as_of=as_of,
+                time_window=time_window,
+                question_entities=question_entities,
+                vector_hits_raw=vector_hits_raw,
+                bm25_hits_raw=bm25_hits_raw,
+                mq_used=mq_used, path=path,
+                token_budget=token_budget, t_total=t_total,
+            )
+
+    # ──────────────────────────────────────────────────────────────────
+    # Step 0 helper — temporal pre-filter (RC4).
+    # ──────────────────────────────────────────────────────────────────
+
+    def _step0_temporal_prefilter(
+        self, query: str, time_window: Optional[Any],
+    ) -> Optional[Any]:
+        """When enabled and the question contains a relative time phrase,
+        tighten the event-time window passed to subsequent lanes. Caller-
+        supplied ``time_window`` takes precedence — never override an
+        explicit bound. Falls through silently when no phrase matches.
+        """
+        from attestor import trace as _tr
         tp_cfg = getattr(self, "temporal_prefilter_cfg", None)
         if (
             tp_cfg is not None
@@ -293,17 +411,28 @@ class RetrievalOrchestrator:
                             if detected.window.end else None
                         ),
                     )
+        return time_window
 
-        # ── Step 1: Vector top-K ──
-        # When multi_query is enabled, this step fans out: rewrite the
-        # question into N paraphrases via a small LLM call, run each
-        # through ``vector_store.search`` independently, and RRF-merge
-        # the N+1 ranked lists. The merged list flows into the rest
-        # of the cascade unchanged. Disabled (default) → single-query
-        # legacy path; behavior identical to before this change.
+    # ──────────────────────────────────────────────────────────────────
+    # Step 1 helper — vector lane (single | hyde | multi_query).
+    # ──────────────────────────────────────────────────────────────────
+
+    def _compute_lane_vector(
+        self,
+        query: str,
+        namespace: Optional[str],
+        as_of: Optional[Any],
+        time_window: Optional[Any],
+    ) -> tuple:
+        """Returns ``(vector_hits_raw, mq_used, path)``.
+
+        Path priority: multi_query > hyde > single — mutually exclusive.
+        If both flags are on, prefers multi_query (longer track record)
+        and logs a warning.
+        """
+        from attestor import trace as _tr
         vector_hits_raw: List[Dict] = []
-        results: List[RetrievalResult] = []
-        mq_used: Optional[List[str]] = None  # populated when multi_query fired
+        mq_used: Optional[List[str]] = None
 
         def _single_vector_search(q: str) -> List[Dict]:
             """One vector_store.search call with v3/v4 signature
@@ -324,10 +453,6 @@ class RetrievalOrchestrator:
             except Exception:
                 return []
 
-        # Path priority: multi_query > hyde > single. They are
-        # mutually exclusive in this PR — combining them is a future
-        # follow-up. If both flags are on, prefer multi_query (longer
-        # track record) and warn loudly so the operator notices.
         path = "single"
         if self.vector_store:
             mq_cfg = getattr(self, "multi_query_cfg", None)
@@ -366,6 +491,7 @@ class RetrievalOrchestrator:
                 path = "hyde"
             else:
                 vector_hits_raw = _single_vector_search(query)
+
         if _tr.is_enabled():
             _tr.event("recall.stage.vector",
                       top_k=self.vector_top_k, hit_count=len(vector_hits_raw),
@@ -376,10 +502,22 @@ class RetrievalOrchestrator:
                              "distance": round(float(h.get("distance", 1.0)), 4)}
                             for h in vector_hits_raw[:10]])
 
-        # ── Step 1b: BM25 lane (Phase 4.3) ──
-        # Runs alongside the vector lane; fused via RRF below. When the
-        # bm25_lane isn't configured (v3 deployments, custom backends),
-        # this is a no-op and recall behaves exactly as before.
+        return vector_hits_raw, mq_used, path
+
+    # ──────────────────────────────────────────────────────────────────
+    # Step 1b helper — BM25 lane.
+    # ──────────────────────────────────────────────────────────────────
+
+    def _compute_lane_bm25(
+        self,
+        query: str,
+        as_of: Optional[Any],
+        time_window: Optional[Any],
+    ) -> List:
+        """BM25 lane (Postgres FTS or in-memory rank_bm25 in
+        experiments). Runs alongside the vector lane; fused via RRF
+        in step 2b. No-op when the lane isn't configured."""
+        from attestor import trace as _tr
         bm25_hits_raw: List = []
         if self.bm25_lane is not None:
             try:
@@ -401,24 +539,40 @@ class RetrievalOrchestrator:
                       hits=[{"id": h.memory_id,
                              "rank": getattr(h, "rank", None)}
                             for h in bm25_hits_raw[:10]])
+        return bm25_hits_raw
+
+    # ──────────────────────────────────────────────────────────────────
+    # Post-processing helper (Phase 6 — shared by sync recall + async
+    # recall_async). Pure CPU-bound work after the two I/O lanes return:
+    # candidate materialization, RRF blend, graph narrow, triples,
+    # MMR, confidence decay, budget fit. No parallelism opportunities
+    # inside; just deduplication of code between sync and async paths.
+    # ──────────────────────────────────────────────────────────────────
+
+    def _post_process_candidates(
+        self,
+        *,
+        query: str,
+        namespace: Optional[str],
+        as_of: Optional[Any],
+        time_window: Optional[Any],
+        question_entities: List[str],
+        vector_hits_raw: List[Dict],
+        bm25_hits_raw: List,
+        mq_used: Optional[List[str]],
+        path: str,
+        token_budget: int,
+        t_total: float,
+    ) -> List[RetrievalResult]:
+        from attestor import trace as _tr
+        results: List[RetrievalResult] = []
 
         # ── Step 2: Materialise vector candidates with preliminary vector_sim
-        # status='active' is current-state filtering. When as_of is set,
-        # the lane SQL has already restricted by t_created/t_expired so a
-        # row that's now 'superseded' but was active at as_of must pass.
-        # When time_window is set, the lane filtered by event-time overlap;
-        # a fact that was true during the window may now be superseded too.
         require_active = (as_of is None and time_window is None)
         candidates: List[Dict] = []
         seen_ids: set = set()
         _drop = {"missing": 0, "inactive": 0, "namespace": 0, "kept": 0,
                  "first_drop_status": None, "first_drop_namespace": None}
-        # When multi-query merged the lanes via RRF, the hit order
-        # encodes consensus signal that the per-hit ``distance`` field
-        # (carried over from one lane only) does NOT. Convert merged
-        # rank → similarity so a consensus hit at rank-3 outranks a
-        # lone-top hit at rank-1 even though its lane-0 distance was
-        # worse. Inactive when no rrf_score is present (legacy path).
         _merged_via_rrf = (
             bool(vector_hits_raw)
             and "rrf_score" in vector_hits_raw[0]
@@ -445,9 +599,6 @@ class RetrievalOrchestrator:
             distance = float(vr.get("distance", 1.0))
             distance_sim = max(0.0, 1.0 - distance)
             if _merged_via_rrf:
-                # Rank-derived sim from RRF order. Item at idx=0 →
-                # 1.0; last → near 0. Use max() so a consensus item
-                # also gets credit for any genuinely-good distance.
                 rank_sim = 1.0 - (_idx / _total_merged)
                 vector_sim = max(distance_sim, rank_sim)
             else:
@@ -469,8 +620,7 @@ class RetrievalOrchestrator:
                       require_active=require_active,
                       filter_namespace=namespace)
 
-        # Pull BM25-only hits into the candidate set (vector_sim=0 for those).
-        # The RRF-style boost below rewards them based on their BM25 rank.
+        # Pull BM25-only hits.
         for hit in bm25_hits_raw:
             if hit.memory_id in seen_ids:
                 continue
@@ -492,10 +642,7 @@ class RetrievalOrchestrator:
             vector_ranked = [vr["memory_id"] for vr in vector_hits_raw]
             bm25_ranked = [h.memory_id for h in bm25_hits_raw]
             fused = reciprocal_rank_fusion(vector_ranked, bm25_ranked)
-            # Map id → fused position (0-based)
             fused_rank = {mid: i for i, mid in enumerate(fused)}
-            # Convert fused position into a normalized [0, 1] bonus that we
-            # add to vector_sim. Top of fused list ≈ 1.0, tail decays slowly.
             n = max(1, len(fused))
             for c in candidates:
                 pos = fused_rank.get(c["memory"].id)
@@ -510,9 +657,6 @@ class RetrievalOrchestrator:
                                      for i, mid in enumerate(fused[:10])])
 
         # ── Step 2: Graph narrow ──
-        # Pass namespace through so the BFS can't pull affinity from
-        # entities written by another tenant. Pre-namespace nodes still
-        # recall under namespace="default" via coalesce in the backend.
         affinity_map = self._graph_affinity_map(
             question_entities, namespace=namespace,
         )
@@ -546,7 +690,6 @@ class RetrievalOrchestrator:
                 "content_preview": mem.content[:160],
             })
 
-        # Sort by blended score
         results.sort(key=lambda r: r.score, reverse=True)
         ranked_preview = [
             {"id": r.memory.id, "score": round(r.score, 4),
@@ -579,8 +722,6 @@ class RetrievalOrchestrator:
         if self.enable_mmr:
             _pre_mmr_count = len(results)
             results = mmr_rerank(results, lambda_param=self.mmr_lambda)
-            # Apply post-MMR cap if configured. None = legacy behavior
-            # (no cap; let mmr_rerank's own diversity trim decide).
             if self.mmr_top_n is not None and len(results) > self.mmr_top_n:
                 results = results[: self.mmr_top_n]
             if _tr.is_enabled():

--- a/tests/async_retrieval/test_orchestrator_async.py
+++ b/tests/async_retrieval/test_orchestrator_async.py
@@ -1,0 +1,196 @@
+"""Phase 6 — orchestrator-level async recall tests.
+
+Pins three contracts:
+
+  1. ``recall_async()`` runs the vector lane and BM25 lane concurrently
+     via ``asyncio.gather`` — wallclock < sum.
+
+  2. A failing lane does NOT abort the recall — the surviving lane's
+     hits flow through to the standard post-processing.
+
+  3. ``recall_async()`` opens a ``recall_started_at_scope_async`` so
+     the Postgres ceiling (audit invariant **A2**) is active for the
+     entire async recall — no concurrent writes leak in mid-flight.
+
+See ``docs/plans/async-retrieval/PLAN.md`` § 4 — Phase 6.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from attestor.models import Memory
+
+
+pytestmark = [pytest.mark.unit]
+
+
+def _make_orchestrator_with_slow_lanes(
+    vec_sleep_ms: int, bm25_sleep_ms: int,
+):
+    """Build a stub orchestrator whose vector lane and BM25 lane each
+    sleep for the configured duration, then return a fixed hit list.
+    Used to assert the lanes actually overlap in wallclock under
+    ``asyncio.gather``."""
+    from attestor.retrieval.orchestrator import RetrievalOrchestrator
+
+    # Bypass __init__ — set just the attributes recall_async() needs.
+    orch = RetrievalOrchestrator.__new__(RetrievalOrchestrator)
+    orch.store = MagicMock()
+    orch.store.get = lambda mid: Memory(
+        id=mid, content=f"content {mid}", entity="alice", category="role",
+        namespace="default", status="active", confidence=1.0,
+    )
+    orch.vector_top_k = 50
+    orch.bm25_top_k = 50
+    orch.bm25_min_rank = 0.0
+    orch.enable_temporal_boost = False
+    orch.enable_mmr = False
+    orch.mmr_lambda = 0.7
+    orch.mmr_top_n = None
+    orch.confidence_decay_rate = 0.0
+    orch.confidence_boost_rate = 0.0
+    orch.confidence_gate = 0.0
+    orch.temporal_prefilter_cfg = None
+    orch.multi_query_cfg = None
+    orch.hyde_cfg = None
+
+    # vector_store stub: sleep then return one hit per query.
+    vec_store = MagicMock()
+    def slow_vec_search(q, **kwargs):
+        time.sleep(vec_sleep_ms / 1000.0)
+        return [{"memory_id": "mem-vec-1", "distance": 0.1}]
+    vec_store.search = slow_vec_search
+    orch.vector_store = vec_store
+
+    # bm25_lane stub: sleep then return one hit.
+    bm25_lane = MagicMock()
+    def slow_bm25_search(q, **kwargs):
+        time.sleep(bm25_sleep_ms / 1000.0)
+        h = MagicMock()
+        h.memory_id = "mem-bm25-1"
+        h.rank = 0.5
+        return [h]
+    bm25_lane.search = slow_bm25_search
+    orch.bm25_lane = bm25_lane
+
+    # Stub graph helpers used inside _post_process_candidates.
+    orch._question_entities = lambda q: []
+    orch._graph_affinity_map = lambda ents, namespace=None: {}
+    orch._graph_context_triples = lambda ents, namespace=None: []
+    orch._blend_score = lambda sim, hop: (sim, 0.0)
+
+    return orch
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Concurrency
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_recall_async_runs_vector_and_bm25_concurrently():
+    """With both lanes sleeping 200ms, sequential = 400ms;
+    parallel via gather + to_thread = ~200ms."""
+    orch = _make_orchestrator_with_slow_lanes(
+        vec_sleep_ms=200, bm25_sleep_ms=200,
+    )
+
+    t0 = time.perf_counter()
+    results = await orch.recall_async("test query", token_budget=2000)
+    elapsed_ms = (time.perf_counter() - t0) * 1000.0
+
+    # Sequential would be ~400ms; parallel ~200ms + a little overhead.
+    assert elapsed_ms < 350, (
+        f"vector ‖ BM25 ran sequentially? wallclock={elapsed_ms:.0f}ms, "
+        f"expected < 350ms with gather"
+    )
+    # Both lanes contributed candidates → final results non-empty.
+    assert len(results) >= 1
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_recall_async_handles_one_lane_failure():
+    """If the vector lane raises, the BM25 lane still produces results.
+    `gather(return_exceptions=True)` ensures siblings keep running."""
+    orch = _make_orchestrator_with_slow_lanes(
+        vec_sleep_ms=10, bm25_sleep_ms=10,
+    )
+
+    # Make the vector lane explode; BM25 lane still works.
+    def vec_explodes(q, **kwargs):
+        raise RuntimeError("vector store down")
+    orch.vector_store.search = vec_explodes
+
+    # Should NOT raise. BM25-only path produces at least one result.
+    results = await orch.recall_async("test query")
+    assert isinstance(results, list)
+    # BM25 lane returns one hit → one result via the BM25-only path.
+    assert any(r.memory.id == "mem-bm25-1" for r in results), (
+        "BM25 lane's hit must surface even when vector lane errors"
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Audit invariant A2 — recall_started_at scope active during async
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_recall_async_opens_recall_started_at_scope():
+    """A2 — ``recall_async`` must open a ``recall_started_at_scope_async``
+    so the Postgres ceiling is active throughout. We verify this by
+    reading ``current_recall_started_at()`` from inside the vector_store
+    stub — it must be non-None during the recall and None afterwards."""
+    from attestor.recall_context import current_recall_started_at
+
+    orch = _make_orchestrator_with_slow_lanes(
+        vec_sleep_ms=5, bm25_sleep_ms=5,
+    )
+
+    seen: list = []
+
+    def vec_search_with_ceiling_check(q, **kwargs):
+        seen.append(current_recall_started_at())
+        return [{"memory_id": "x", "distance": 0.1}]
+    orch.vector_store.search = vec_search_with_ceiling_check
+
+    assert current_recall_started_at() is None  # outside scope
+    await orch.recall_async("test query")
+    assert current_recall_started_at() is None  # back to None
+
+    # Inside the lane, the ceiling was active (non-None datetime).
+    assert len(seen) == 1
+    assert seen[0] is not None, (
+        "ceiling must be active inside vector lane during recall_async"
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Behavioral parity — sync recall() and recall_async() produce the
+# same final results given identical inputs
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_recall_async_matches_sync_recall_results():
+    """Given identical stubs (no sleep), recall() and recall_async()
+    must produce the same list of memory IDs in the same order. The
+    async version is a latency optimization, not a behavior change."""
+    orch_sync = _make_orchestrator_with_slow_lanes(
+        vec_sleep_ms=0, bm25_sleep_ms=0,
+    )
+    orch_async = _make_orchestrator_with_slow_lanes(
+        vec_sleep_ms=0, bm25_sleep_ms=0,
+    )
+
+    sync_results = orch_sync.recall("test query")
+    async_results = await orch_async.recall_async("test query")
+
+    assert [r.memory.id for r in sync_results] == [
+        r.memory.id for r in async_results
+    ], "sync and async recall must produce identical rankings"


### PR DESCRIPTION
## TL;DR

**P6 — the final phase of the async retrieval rollout.** Adds `recall_async()` to `RetrievalOrchestrator` that runs the vector lane and BM25 lane concurrently via `asyncio.gather` + `asyncio.to_thread`. Opens `recall_started_at_scope_async()` so audit invariant **A2** (no post-recall writes leak in) is enforced at the orchestrator scope. Sync `recall()` unchanged in behavior — 42 existing orchestrator tests still GREEN.

## What changed

### `attestor/retrieval/orchestrator.py`

**Refactor (no behavior change):** extracted 4 helpers from `recall()` to share with `recall_async()`:
- `_step0_temporal_prefilter()` — Step 0
- `_compute_lane_vector()` — Step 1, returns `(vector_hits_raw, mq_used, path)`
- `_compute_lane_bm25()` — Step 1b, returns `bm25_hits_raw`
- `_post_process_candidates()` — Steps 2-6 (CPU-bound; no I/O parallelism opportunity inside)

`recall()` reduces from ~400 LOC to ~30 LOC orchestration. Same behavior — pinned by the 42-test regression baseline.

**New (parallel async path):** `recall_async()` runs Steps 1 + 1b in parallel:

```python
lane_results = await asyncio.gather(
    asyncio.to_thread(self._compute_lane_vector, query, namespace, as_of, time_window),
    asyncio.to_thread(self._compute_lane_bm25,   query,            as_of, time_window),
    return_exceptions=True,
)
```

### Tests — 4 new GREEN

| Test | What it pins |
|---|---|
| `test_orchestrator_recall_async_runs_vector_and_bm25_concurrently` | 200ms+200ms lanes → ~200ms total under gather (NOT 400ms) |
| `test_orchestrator_recall_async_handles_one_lane_failure` | Vector lane raises; BM25 hit still surfaces in final results |
| `test_orchestrator_recall_async_opens_recall_started_at_scope` | **A2** — `current_recall_started_at()` non-None inside the vector lane |
| `test_orchestrator_recall_async_matches_sync_recall_results` | Parity — sync + async produce identical rankings given identical inputs |

## Latency story

```
vector ~200ms, BM25 ~200ms (simulated):
  sync:  ~400ms (vector → BM25 sequential)
  async: ~200ms (vector ‖ BM25 under gather, max wins) — 50% reduction
```

## Audit-preservation argument

The **load-bearing claim** of this PR:

| Invariant | How it's preserved | Test |
|---|---|---|
| **A2** ceiling active for entire async recall | `recall_async()` opens `recall_started_at_scope_async()` first; both lanes (in `to_thread` workers) inherit the contextvar via `asyncio.to_thread`'s context-copy semantics | `test_orchestrator_recall_async_opens_recall_started_at_scope` |
| **A5** trace_id/seq propagate | Same contextvar copy mechanism — works for `recall_id` from P3 too | (verified by P3 test under async gather) |
| Sync `recall()` unchanged | Behavior preserved by extracted helpers; 42-test regression baseline still GREEN | `tests/test_*orchestrator*.py` (42 tests, all green) |
| Parity sync ↔ async | Given identical stubs, both paths produce the same final result list | `test_orchestrator_recall_async_matches_sync_recall_results` |
| Lane failure isolation | `gather(return_exceptions=True)` — a failing vector lane does NOT abort the recall; BM25 hits surface | `test_orchestrator_recall_async_handles_one_lane_failure` |

## Test plan

- [x] **4 P6 tests GREEN**
- [x] **104 total passed** (P1-P6 all GREEN + 42 existing orchestrator + 30 existing namespace/HyDE)
- [x] **2 skipped** (A4 supersession serial, A8 deletion_audit — write-side, EXPLICIT non-goals)
- [x] **0 xfailed**
- [x] Local: `104 passed, 2 skipped in 9.23s`

## Cumulative async retrieval rollout — DONE through Phase 6

| PR | Phase | Latency win | Audit invariants |
|---|---|---|---|
| #109 | P1 — async HyDE | −33% | A7 |
| #110 | P2 — async multi-query | −60% | A7 |
| #111 | P3 — recall_scope + event_scope | (audit only) | **A5** |
| #112+#113 | P4 + P5 — self-consistency K-fanout + recall_started_at ceiling | 5× at K=5 | **A1, A2, A6** |
| **this** | **P6 — orchestrator vector ‖ BM25** | **−50%** | **A2 enforced at orchestrator scope** |

**5 of 8 audit invariants enforced by GREEN tests** (A1, A2, A5, A6, A7).
**2 explicit non-goals** (A4 supersession serial, A8 deletion_audit — write-side stays sync).
**1 passive** (A3 provenance immutability — unaffected by async).

## What's deferred

**P7 (graph BFS ‖ doc fetch)** — graph BFS sits inside `_post_process_candidates` Step 2 (Graph narrow) and Postgres doc fetch is the per-id `self.store.get()` call in the candidate loop. True parallelism there requires batching `store.get()` across all candidate IDs first, which is its own ~80 LOC refactor. Best done as a focused follow-up PR after observing P6 in production.