### PR TITLE
feat(orchestrator): auto-open audit scopes for sync + async recall (close A2/A5 gap)

### DIFF
--- a/attestor/retrieval/orchestrator.py
+++ b/attestor/retrieval/orchestrator.py
@@ -253,40 +253,52 @@ class RetrievalOrchestrator:
         that don't support them ignore them silently. Behavior unchanged
         when both are None.
         """
-        t_total = time.monotonic()
+        # Audit invariants A2 + A5 are enforced via two scopes opened
+        # at the very top of the recall — recall_started_at_scope sets
+        # the t_created ceiling that flows into store WHERE clauses;
+        # trace.recall_scope tags every event below with a unique
+        # recall_id + monotonic seq so the audit dashboard can
+        # reconstruct the per-recall event tree from the JSONL log
+        # even when concurrent recalls interleave. ContextVar
+        # propagation makes both work for sync callers (here) and
+        # async callers (recall_async below).
         from attestor import trace as _tr
-        question_entities = self._question_entities(query)
-        if _tr.is_enabled():
-            _tr.event("recall.start", query=query[:200], namespace=namespace,
-                      token_budget=token_budget,
-                      question_entities=question_entities,
-                      as_of=str(as_of) if as_of else None,
-                      time_window=str(time_window) if time_window else None)
+        from attestor.recall_context import recall_started_at_scope
 
-        # ── Step 0: Temporal pre-filter (RC4) ──
-        time_window = self._step0_temporal_prefilter(query, time_window)
+        with recall_started_at_scope(), _tr.recall_scope():
+            t_total = time.monotonic()
+            question_entities = self._question_entities(query)
+            if _tr.is_enabled():
+                _tr.event("recall.start", query=query[:200], namespace=namespace,
+                          token_budget=token_budget,
+                          question_entities=question_entities,
+                          as_of=str(as_of) if as_of else None,
+                          time_window=str(time_window) if time_window else None)
 
-        # ── Step 1: Vector top-K (single | hyde | multi_query) ──
-        vector_hits_raw, mq_used, path = self._compute_lane_vector(
-            query, namespace, as_of, time_window,
-        )
+            # ── Step 0: Temporal pre-filter (RC4) ──
+            time_window = self._step0_temporal_prefilter(query, time_window)
 
-        # ── Step 1b: BM25 lane ──
-        bm25_hits_raw = self._compute_lane_bm25(query, as_of, time_window)
+            # ── Step 1: Vector top-K (single | hyde | multi_query) ──
+            vector_hits_raw, mq_used, path = self._compute_lane_vector(
+                query, namespace, as_of, time_window,
+            )
 
-        # ── Steps 2–6 — extracted into ``_post_process_candidates`` so
-        # the same logic is reused by both the sync ``recall()`` and
-        # the async ``recall_async()`` (Phase 6 of the async retrieval
-        # rollout, see docs/plans/async-retrieval/PLAN.md).
-        return self._post_process_candidates(
-            query=query, namespace=namespace, as_of=as_of,
-            time_window=time_window,
-            question_entities=question_entities,
-            vector_hits_raw=vector_hits_raw,
-            bm25_hits_raw=bm25_hits_raw,
-            mq_used=mq_used, path=path,
-            token_budget=token_budget, t_total=t_total,
-        )
+            # ── Step 1b: BM25 lane ──
+            bm25_hits_raw = self._compute_lane_bm25(query, as_of, time_window)
+
+            # ── Steps 2–6 — extracted into ``_post_process_candidates`` so
+            # the same logic is reused by both the sync ``recall()`` and
+            # the async ``recall_async()`` (Phase 6 of the async retrieval
+            # rollout, see docs/plans/async-retrieval/PLAN.md).
+            return self._post_process_candidates(
+                query=query, namespace=namespace, as_of=as_of,
+                time_window=time_window,
+                question_entities=question_entities,
+                vector_hits_raw=vector_hits_raw,
+                bm25_hits_raw=bm25_hits_raw,
+                mq_used=mq_used, path=path,
+                token_budget=token_budget, t_total=t_total,
+            )
 
     # ──────────────────────────────────────────────────────────────────
     # Phase 6 — async sibling. Vector lane and BM25 lane run in parallel
@@ -321,56 +333,58 @@ class RetrievalOrchestrator:
         """
         from attestor.recall_context import recall_started_at_scope_async
 
+        from attestor import trace as _tr
+        # Both audit scopes opened together — A2 ceiling + A5 trace tree.
         async with recall_started_at_scope_async():
-            t_total = time.monotonic()
-            from attestor import trace as _tr
-            question_entities = self._question_entities(query)
-            if _tr.is_enabled():
-                _tr.event(
-                    "recall.start", query=query[:200], namespace=namespace,
-                    token_budget=token_budget,
-                    question_entities=question_entities,
-                    as_of=str(as_of) if as_of else None,
-                    time_window=str(time_window) if time_window else None,
-                    mode="async",
+            with _tr.recall_scope():
+                t_total = time.monotonic()
+                question_entities = self._question_entities(query)
+                if _tr.is_enabled():
+                    _tr.event(
+                        "recall.start", query=query[:200], namespace=namespace,
+                        token_budget=token_budget,
+                        question_entities=question_entities,
+                        as_of=str(as_of) if as_of else None,
+                        time_window=str(time_window) if time_window else None,
+                        mode="async",
+                    )
+
+                # Step 0 (sync, regex — cheap).
+                time_window = self._step0_temporal_prefilter(query, time_window)
+
+                # Steps 1 + 1b — the P6 win: parallel via gather.
+                lane_results = await asyncio.gather(
+                    asyncio.to_thread(
+                        self._compute_lane_vector,
+                        query, namespace, as_of, time_window,
+                    ),
+                    asyncio.to_thread(
+                        self._compute_lane_bm25,
+                        query, as_of, time_window,
+                    ),
+                    return_exceptions=True,
                 )
 
-            # Step 0 (sync, regex — cheap).
-            time_window = self._step0_temporal_prefilter(query, time_window)
+                if isinstance(lane_results[0], Exception):
+                    vector_hits_raw, mq_used, path = [], None, "single"
+                else:
+                    vector_hits_raw, mq_used, path = lane_results[0]
 
-            # Steps 1 + 1b — the P6 win: parallel via gather.
-            lane_results = await asyncio.gather(
-                asyncio.to_thread(
-                    self._compute_lane_vector,
-                    query, namespace, as_of, time_window,
-                ),
-                asyncio.to_thread(
-                    self._compute_lane_bm25,
-                    query, as_of, time_window,
-                ),
-                return_exceptions=True,
-            )
+                if isinstance(lane_results[1], Exception):
+                    bm25_hits_raw = []
+                else:
+                    bm25_hits_raw = lane_results[1]
 
-            if isinstance(lane_results[0], Exception):
-                vector_hits_raw, mq_used, path = [], None, "single"
-            else:
-                vector_hits_raw, mq_used, path = lane_results[0]
-
-            if isinstance(lane_results[1], Exception):
-                bm25_hits_raw = []
-            else:
-                bm25_hits_raw = lane_results[1]
-
-            # Steps 2-6 — sync post-processing (no I/O parallelism inside).
-            return self._post_process_candidates(
-                query=query, namespace=namespace, as_of=as_of,
-                time_window=time_window,
-                question_entities=question_entities,
-                vector_hits_raw=vector_hits_raw,
-                bm25_hits_raw=bm25_hits_raw,
-                mq_used=mq_used, path=path,
-                token_budget=token_budget, t_total=t_total,
-            )
+                # Steps 2-6 — sync post-processing (no I/O parallelism inside).
+                return self._post_process_candidates(
+                    query=query, namespace=namespace, as_of=as_of,
+                    time_window=time_window,
+                    question_entities=question_entities,
+                    vector_hits_raw=vector_hits_raw,
+                    bm25_hits_raw=bm25_hits_raw,
+                    mq_used=mq_used, path=path,
+                    token_budget=token_budget, t_total=t_total,
+                )
 
     # ──────────────────────────────────────────────────────────────────
     # Step 0 helper — temporal pre-filter (RC4).

--- a/tests/async_retrieval/test_orchestrator_auto_scopes.py
+++ b/tests/async_retrieval/test_orchestrator_auto_scopes.py
@@ -1,0 +1,179 @@
+"""Audit-completeness tests — both sync ``recall()`` and async
+``recall_async()`` must auto-open ``recall_started_at_scope`` and
+``trace.recall_scope`` so audit invariants A2 and A5 are enforced
+for ALL callers (production smoke runners, the LME pipeline, etc.),
+not just async-aware tests that explicitly wrap their recalls.
+
+Closes the gap surfaced in `logs/lme_smoke_20260430_005019.jsonl`
+where 1458 sync-recall events emitted ZERO recall_id / seq fields
+because no caller opened the scopes manually.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from attestor.models import Memory
+
+
+pytestmark = [pytest.mark.unit]
+
+
+def _build_minimal_orchestrator():
+    """Minimal orchestrator stub with stubbed-but-non-empty lanes so
+    ``_post_process_candidates`` produces at least one event."""
+    from attestor.retrieval.orchestrator import RetrievalOrchestrator
+
+    orch = RetrievalOrchestrator.__new__(RetrievalOrchestrator)
+    orch.store = MagicMock()
+    orch.store.get = lambda mid: Memory(
+        id=mid, content="x", entity="alice", category="role",
+        namespace="default", status="active", confidence=1.0,
+    )
+    orch.vector_top_k = 50
+    orch.bm25_top_k = 50
+    orch.bm25_min_rank = 0.0
+    orch.enable_temporal_boost = False
+    orch.enable_mmr = False
+    orch.mmr_lambda = 0.7
+    orch.mmr_top_n = None
+    orch.confidence_decay_rate = 0.0
+    orch.confidence_boost_rate = 0.0
+    orch.confidence_gate = 0.0
+    orch.temporal_prefilter_cfg = None
+    orch.multi_query_cfg = None
+    orch.hyde_cfg = None
+    orch.bm25_lane = None  # disable BM25 to keep events count predictable
+
+    vec_store = MagicMock()
+    vec_store.search = lambda q, **kwargs: [
+        {"memory_id": "m1", "distance": 0.1},
+    ]
+    orch.vector_store = vec_store
+
+    orch._question_entities = lambda q: []
+    orch._graph_affinity_map = lambda ents, namespace=None: {}
+    orch._graph_context_triples = lambda ents, namespace=None: []
+    orch._blend_score = lambda sim, hop: (sim, 0.0)
+    return orch
+
+
+def test_sync_recall_auto_opens_scopes(tmp_path, monkeypatch):
+    """Sync ``recall()`` must auto-open both audit scopes — every event
+    emitted has ``recall_id``, ``seq``, and the same ``recall_id`` is
+    shared by all events from a single recall (so they reconstruct as
+    a tree)."""
+    log_path = tmp_path / "trace.jsonl"
+    monkeypatch.setenv("ATTESTOR_TRACE", "1")
+    monkeypatch.setenv("ATTESTOR_TRACE_FILE", str(log_path))
+    import attestor.trace as tr
+    tr.reset_for_test()
+
+    orch = _build_minimal_orchestrator()
+    orch.recall("query")
+
+    events = [
+        json.loads(line) for line in log_path.read_text().splitlines() if line
+    ]
+    assert len(events) >= 1, "sync recall must emit at least one trace event"
+
+    # Every event must have a recall_id.
+    rids = {e.get("recall_id") for e in events}
+    assert None not in rids, (
+        f"sync recall emitted events WITHOUT recall_id; "
+        f"recall_ids seen: {rids}"
+    )
+    # All events share the same recall_id (one recall = one tree).
+    assert len(rids) == 1, (
+        f"sync recall must produce exactly ONE recall_id; got {rids}"
+    )
+    # seq is monotonic per-recall, starting at 1.
+    seqs = [e.get("seq") for e in events]
+    assert seqs == sorted(seqs), f"seqs must be monotonic; got {seqs}"
+    assert min(seqs) == 1, "seq must start at 1"
+
+
+def test_sync_recall_auto_activates_recall_started_at_ceiling():
+    """Sync ``recall()`` must auto-open ``recall_started_at_scope``
+    so ``current_recall_started_at()`` returns a non-None value during
+    the recall — verified by reading the contextvar from inside the
+    vector_store stub."""
+    from attestor.recall_context import current_recall_started_at
+
+    orch = _build_minimal_orchestrator()
+
+    seen_inside: list = []
+    def vec_search(q, **kwargs):
+        seen_inside.append(current_recall_started_at())
+        return [{"memory_id": "m1", "distance": 0.1}]
+    orch.vector_store.search = vec_search
+
+    assert current_recall_started_at() is None  # outside scope
+    orch.recall("query")
+    assert current_recall_started_at() is None  # back to None
+
+    assert len(seen_inside) == 1
+    assert seen_inside[0] is not None, (
+        "ceiling must be active inside vector lane during sync recall"
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_recall_auto_opens_trace_scope(tmp_path, monkeypatch):
+    """``recall_async()`` already opened the ceiling scope (P6); this
+    test pins that it now ALSO opens ``trace.recall_scope`` so async
+    events get recall_id / seq tagging too."""
+    log_path = tmp_path / "trace.jsonl"
+    monkeypatch.setenv("ATTESTOR_TRACE", "1")
+    monkeypatch.setenv("ATTESTOR_TRACE_FILE", str(log_path))
+    import attestor.trace as tr
+    tr.reset_for_test()
+
+    orch = _build_minimal_orchestrator()
+    await orch.recall_async("query")
+
+    events = [
+        json.loads(line) for line in log_path.read_text().splitlines() if line
+    ]
+    assert len(events) >= 1
+    rids = {e.get("recall_id") for e in events}
+    assert None not in rids, (
+        f"async recall emitted events WITHOUT recall_id; recall_ids seen: {rids}"
+    )
+    assert len(rids) == 1
+    # mode=async should appear on the recall.start event.
+    starts = [e for e in events if e.get("event") == "recall.start"]
+    assert len(starts) == 1
+    assert starts[0].get("mode") == "async"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_async_recalls_get_distinct_recall_ids(tmp_path, monkeypatch):
+    """Two concurrent ``recall_async`` calls must get DIFFERENT
+    recall_ids — proves the contextvar is per-task, not shared."""
+    log_path = tmp_path / "trace.jsonl"
+    monkeypatch.setenv("ATTESTOR_TRACE", "1")
+    monkeypatch.setenv("ATTESTOR_TRACE_FILE", str(log_path))
+    import attestor.trace as tr
+    tr.reset_for_test()
+
+    orch = _build_minimal_orchestrator()
+    await asyncio.gather(
+        orch.recall_async("q1"),
+        orch.recall_async("q2"),
+        orch.recall_async("q3"),
+    )
+
+    events = [
+        json.loads(line) for line in log_path.read_text().splitlines() if line
+    ]
+    rids = {e.get("recall_id") for e in events if e.get("recall_id")}
+    assert len(rids) == 3, (
+        f"3 concurrent recalls must produce 3 distinct recall_ids; got {len(rids)}: {rids}"
+    )


### PR DESCRIPTION
## TL;DR

**Closes the audit gap surfaced by today's smoke trace analysis.** The 2026-04-30 smoke produced 1458 events with **0 `recall_id`s** because sync `recall()` didn't auto-open any audit scopes — A2 (no post-recall writes leak in) and A5 (trace reconstructable under async) were silently inactive for every production caller (LME smoke, AgentMemory, etc.).

After this PR: **same smoke run produces 1 unique `recall_id` across all events + 9 monotonic `seq` values**. Audit invariants now enforced for every recall, regardless of caller.

## What changed

### `attestor/retrieval/orchestrator.py`

- **`recall()`** wraps its body in `with recall_started_at_scope(), tr.recall_scope():` — sync callers get both audit scopes for free.
- **`recall_async()`** adds `with tr.recall_scope():` inside the existing `recall_started_at_scope_async()` — async callers also get the trace scope (was missing).

ContextVar-based scopes are invisible to callers that don't read them, so this is a **zero-API-change fix**. No production code needs to know about the scopes.

### Tests — 4 new GREEN

| Test | What it pins |
|---|---|
| `test_sync_recall_auto_opens_scopes` | Every event from one sync recall shares the same `recall_id`; `seq` is monotonic from 1 |
| `test_sync_recall_auto_activates_recall_started_at_ceiling` | `current_recall_started_at()` non-None inside vector lane during sync recall |
| `test_async_recall_auto_opens_trace_scope` | Async recall events have `recall_id` + `mode=async` |
| `test_concurrent_async_recalls_get_distinct_recall_ids` | 3 concurrent `recall_async` → 3 distinct `recall_id`s (contextvar is per-task) |

## End-to-end verification

```
scripts/lme_smoke_local.py --n 1 --variant oracle  (real PG+pgvector+Neo4j stack)

PRE-fix:   1458 events, 0 unique recall_ids, 0 events with seq, 0 ceiling clauses
POST-fix:  1233 events, 1 unique recall_id, 9 events with seq, ceiling active

LME accuracy: 1/1, both judges agree (no behavior change)
```

## Audit-preservation argument

| Invariant | How it's preserved | Test |
|---|---|---|
| **A2** ceiling active for EVERY recall (sync or async) | Both code paths now open `recall_started_at_scope` automatically | `test_sync_recall_auto_activates_recall_started_at_ceiling` |
| **A5** trace tree reconstructable for EVERY recall | Both code paths now open `tr.recall_scope` automatically | `test_sync_recall_auto_opens_scopes` + `test_async_recall_auto_opens_trace_scope` |
| Per-task isolation | `contextvars` propagate per-task, not shared across recalls | `test_concurrent_async_recalls_get_distinct_recall_ids` |
| No behavior change | All 42 existing orchestrator tests still GREEN; LME smoke still 1/1 | (regression suite) |

## Test plan

- [x] **4 new audit-completeness tests GREEN**
- [x] **108 total passed** (4 new + 104 existing async + sync orchestrator)
- [x] **2 skipped** (A4 + A8 — explicit non-goals, write-side stays sync)
- [x] **0 xfailed**
- [x] Real-stack smoke (`scripts/lme_smoke_local.py`) confirms `recall_id` now appears in production trace
- [x] Local: `108 passed, 2 skipped in 8.93s`

## Cumulative async retrieval rollout — DONE through Phase 6 + audit completeness

After this lands, **5 of 8 audit invariants** (A1, A2, A5, A6, A7) are not just enforced by tests — they're enforced for **every production caller**, automatically, with no opt-in required. 2 explicit non-goals (A4, A8 — write-side). 1 passive (A3 — provenance immutability unaffected by async).