### PR TITLE
feat(trace): OpenTelemetry bridge — opt-in spans for the recall pipeline

### DIFF
--- a/attestor/otel.py
+++ b/attestor/otel.py
@@ -1,0 +1,195 @@
+"""OpenTelemetry bridge — opt-in spans for the recall pipeline.
+
+Off by default. Enable with one of:
+
+  OTEL_EXPORTER=console               # write spans to stderr (dev)
+  OTEL_EXPORTER=otlp                  # write to OTEL_EXPORTER_OTLP_ENDPOINT
+                                      # (default http://localhost:4318)
+
+When enabled:
+  - Every ``trace.recall_scope()`` opens an OTel span named "recall".
+  - Every ``trace.event(name, **fields)`` adds an OTel event to the
+    active span with ``recall_id`` / ``seq`` / ``parent_event_id`` as
+    attributes (mapped from our existing contextvars).
+  - The OTel span_id is added back into the JSONL trace event so
+    operators can correlate JSONL ↔ OTel by span_id.
+
+When disabled (default), this module is a no-op — no overhead on the
+hot path beyond a single env-var lookup at import.
+
+Audit-preservation:
+  OTel spans CARRY the audit metadata (recall_id, seq) but are NOT the
+  source of truth — JSONL remains canonical. OTel is one consumer of
+  the audit trail, not the audit trail itself. This keeps OTel
+  optional and the audit replay path unchanged.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Optional
+
+
+_ENABLED: bool = bool(os.environ.get("OTEL_EXPORTER"))
+_TRACER: Any = None  # opentelemetry.trace.Tracer when enabled
+
+
+def is_enabled() -> bool:
+    return _ENABLED
+
+
+def _init_tracer() -> Any:
+    """Initialize the OTel tracer based on env. Idempotent — safe to
+    call multiple times. Returns the tracer or None when disabled.
+    """
+    global _TRACER
+    if not _ENABLED or _TRACER is not None:
+        return _TRACER
+
+    try:
+        from opentelemetry import trace as ot
+        from opentelemetry.sdk.resources import Resource
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import (
+            BatchSpanProcessor,
+            ConsoleSpanExporter,
+            SimpleSpanProcessor,
+        )
+
+        exporter_kind = os.environ.get("OTEL_EXPORTER", "").lower()
+        service_name = os.environ.get("OTEL_SERVICE_NAME", "attestor")
+
+        resource = Resource.create({"service.name": service_name})
+        provider = TracerProvider(resource=resource)
+
+        if exporter_kind == "console":
+            exporter = ConsoleSpanExporter()
+            processor = SimpleSpanProcessor(exporter)
+        elif exporter_kind == "otlp":
+            from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
+                OTLPSpanExporter,
+            )
+            endpoint = os.environ.get(
+                "OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4318",
+            )
+            exporter = OTLPSpanExporter(endpoint=f"{endpoint}/v1/traces")
+            processor = BatchSpanProcessor(exporter)
+        else:
+            return None
+
+        provider.add_span_processor(processor)
+        ot.set_tracer_provider(provider)
+        _TRACER = ot.get_tracer("attestor")
+        return _TRACER
+
+    except Exception:  # noqa: BLE001 — never break the hot path on init failure
+        return None
+
+
+def reset_for_test() -> None:
+    """Test helper: re-read env, drop cached tracer. Used when tests
+    toggle OTEL_EXPORTER between tests."""
+    global _ENABLED, _TRACER
+    _ENABLED = bool(os.environ.get("OTEL_EXPORTER"))
+    _TRACER = None
+
+
+def start_span(name: str, **attributes: Any) -> Any:
+    """Return a span context manager. No-op when OTel is disabled.
+
+    Usage:
+        with otel.start_span("recall", recall_id=rid):
+            ...
+    """
+    if not _ENABLED:
+        return _NoopSpan()
+    tracer = _init_tracer()
+    if tracer is None:
+        return _NoopSpan()
+    span_ctx = tracer.start_as_current_span(name)
+    return _SpanWrapper(span_ctx, attributes)
+
+
+def add_event(name: str, **attributes: Any) -> None:
+    """Add an event to the currently active span. No-op when OTel is
+    disabled or no span is active.
+    """
+    if not _ENABLED:
+        return
+    tracer = _init_tracer()
+    if tracer is None:
+        return
+    try:
+        from opentelemetry import trace as ot
+        span = ot.get_current_span()
+        if span is None:
+            return
+        # Coerce attributes to OTel-compatible types.
+        attrs = {}
+        for k, v in attributes.items():
+            if isinstance(v, (str, bool, int, float)):
+                attrs[k] = v
+            elif v is None:
+                continue
+            else:
+                attrs[k] = str(v)[:500]
+        span.add_event(name, attributes=attrs)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def current_span_id() -> Optional[str]:
+    """Return the current span's span_id as a hex string, or None when
+    no span is active. Used by ``trace.event`` to add a ``span_id``
+    field to the JSONL payload so operators can correlate the two
+    streams."""
+    if not _ENABLED:
+        return None
+    try:
+        from opentelemetry import trace as ot
+        span = ot.get_current_span()
+        if span is None:
+            return None
+        ctx = span.get_span_context()
+        if not ctx.is_valid:
+            return None
+        return f"{ctx.span_id:016x}"
+    except Exception:  # noqa: BLE001
+        return None
+
+
+class _NoopSpan:
+    def __enter__(self) -> "_NoopSpan":
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        return None
+
+    def set_attribute(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+
+class _SpanWrapper:
+    """Bridge between our context manager API and OTel's start_as_current_span."""
+    def __init__(self, span_ctx: Any, initial_attrs: dict) -> None:
+        self._span_ctx = span_ctx
+        self._initial_attrs = initial_attrs
+        self._span: Any = None
+
+    def __enter__(self) -> "_SpanWrapper":
+        self._span = self._span_ctx.__enter__()
+        for k, v in self._initial_attrs.items():
+            if v is None:
+                continue
+            if isinstance(v, (str, bool, int, float)):
+                self._span.set_attribute(k, v)
+            else:
+                self._span.set_attribute(k, str(v)[:500])
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        self._span_ctx.__exit__(*exc)
+
+    def set_attribute(self, key: str, value: Any) -> None:
+        if self._span is not None:
+            self._span.set_attribute(key, value)

--- a/attestor/trace.py
+++ b/attestor/trace.py
@@ -150,6 +150,12 @@ def event(name: str, **fields: Any) -> None:
         seq = counter[0]
     eid = str(uuid.uuid4())
 
+    # OTel correlation: when an OTel span is active, include its
+    # span_id in the JSONL payload so operators can join JSONL events
+    # to OTel spans by span_id.
+    from attestor import otel as _otel
+    otel_span_id = _otel.current_span_id()
+
     payload = {
         "ts": datetime.now(timezone.utc).isoformat(timespec="milliseconds"),
         "event": name,
@@ -157,8 +163,12 @@ def event(name: str, **fields: Any) -> None:
         **({"recall_id": rid} if rid is not None else {}),
         **({"seq": seq} if seq is not None else {}),
         **({"parent_event_id": parent_eid} if parent_eid is not None else {}),
+        **({"otel_span_id": otel_span_id} if otel_span_id is not None else {}),
         **scrubbed,
     }
+
+    # Mirror to OTel: every JSONL event also becomes an OTel span event.
+    _otel.add_event(name, **scrubbed)
 
     pretty = " ".join(f"{k}={v!r}" if isinstance(v, str) else f"{k}={v}"
                       for k, v in scrubbed.items())
@@ -184,6 +194,11 @@ def recall_scope(recall_id: Optional[str] = None) -> Iterator[str]:
     monotonic ``seq`` counter. ``contextvars`` propagation makes this
     work for both sync and async callers — same API.
 
+    When OpenTelemetry is enabled (``OTEL_EXPORTER`` env), this also
+    opens an OTel span named ``recall`` with ``recall_id`` as an
+    attribute — so every event() call inside auto-bridges to the OTel
+    backend. Disabled by default; opt-in via env.
+
     Usage:
         with tr.recall_scope() as rid:
             tr.event("recall.start", query=q)
@@ -194,11 +209,16 @@ def recall_scope(recall_id: Optional[str] = None) -> Iterator[str]:
     counter: List[int] = [0]  # mutable list — shared across child tasks
     rid_token = _RECALL_ID.set(rid)
     seq_token = _SEQ_COUNTER.set(counter)
-    try:
-        yield rid
-    finally:
-        _RECALL_ID.reset(rid_token)
-        _SEQ_COUNTER.reset(seq_token)
+    # Bridge to OTel: open a span so every event() inside this scope
+    # also lands as an OTel event on the active span. Disabled by
+    # default; enabled when OTEL_EXPORTER env is set.
+    from attestor import otel as _otel
+    with _otel.start_span("recall", recall_id=rid):
+        try:
+            yield rid
+        finally:
+            _RECALL_ID.reset(rid_token)
+            _SEQ_COUNTER.reset(seq_token)
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
Off by default. Enable with OTEL_EXPORTER=console (stderr) or OTEL_EXPORTER=otlp (OTLP collector at $OTEL_EXPORTER_OTLP_ENDPOINT, default localhost:4318).

Bridges from existing trace.py scopes:
- recall_scope() opens an OTel span when OTel is enabled
- trace.event() mirrors to OTel span events automatically
- JSONL events gain otel_span_id field for cross-stream correlation

Audit-preservation: OTel is a CONSUMER of the audit trail, not the trail itself. JSONL remains canonical for replay; OTel is for observability dashboards (Jaeger/Grafana/Datadog).

Single env-var lookup overhead when disabled. 59 tests still GREEN.