### PR TITLE
fix(llm): 60s timeout + 2 retries on OpenAI clients (caught hung distill call)

### DIFF
--- a/attestor/extraction/llm_extractor.py
+++ b/attestor/extraction/llm_extractor.py
@@ -33,7 +33,7 @@ def _get_client(api_key: Optional[str] = None):
         raise ValueError(
             "OPENROUTER_API_KEY not set. Pass api_key or set the env var."
         )
-    return OpenAI(base_url=OPENROUTER_BASE_URL, api_key=key)
+    return make_client(base_url=OPENROUTER_BASE_URL, api_key=key)
 
 _EXTRACTION_PROMPT = """Extract atomic facts from this conversation that would be useful to remember across sessions.
 
@@ -166,7 +166,7 @@ def llm_extract(
         if msg.get("content")
     )
 
-    from attestor.llm_trace import traced_create
+    from attestor.llm_trace import traced_create, make_client
     response = traced_create(
         client,
         role="extraction",

--- a/attestor/llm_trace.py
+++ b/attestor/llm_trace.py
@@ -44,6 +44,51 @@ import time
 from typing import Any, Optional
 
 
+def make_client(
+    *,
+    base_url: str,
+    api_key: str,
+    timeout: float = 60.0,
+    max_retries: int = 2,
+):
+    """Construct a default-configured OpenAI/OpenRouter client.
+
+    Centralizes the timeout + retry policy so a hung LLM call cannot
+    block the pipeline indefinitely (caught 2026-04-30 — a 133q LME-S
+    smoke hung for 5+ hours on a single distill call with no timeout;
+    process slept on socket recv with no deadline). 60s is well above
+    any healthy reasoning-effort=high call (observed median 2-9s);
+    2 retries cover transient transport errors. Callers can override
+    per-call via ``traced_create(client, ..., timeout=N)`` when a
+    longer-running role needs it.
+    """
+    from openai import OpenAI
+    return OpenAI(
+        base_url=base_url,
+        api_key=api_key,
+        timeout=timeout,
+        max_retries=max_retries,
+    )
+
+
+def make_async_client(
+    *,
+    base_url: str,
+    api_key: str,
+    timeout: float = 60.0,
+    max_retries: int = 2,
+):
+    """Async sibling of ``make_client`` — used by the P1/P2 async
+    HyDE + multi-query rewriter paths."""
+    from openai import AsyncOpenAI
+    return AsyncOpenAI(
+        base_url=base_url,
+        api_key=api_key,
+        timeout=timeout,
+        max_retries=max_retries,
+    )
+
+
 def traced_create(
     client: Any,
     *,

--- a/attestor/locomo.py
+++ b/attestor/locomo.py
@@ -46,13 +46,13 @@ def _get_client(api_key: Optional[str] = None):
         raise ValueError(
             "OPENROUTER_API_KEY not set. Pass api_key or set the env var."
         )
-    return OpenAI(base_url=OPENROUTER_BASE_URL, api_key=key)
+    return make_client(base_url=OPENROUTER_BASE_URL, api_key=key)
 
 
 def _chat(client, model: str, prompt: str, max_tokens: int = 200,
           *, role: str = "locomo.chat") -> str:
     """Send a chat completion request and return the text."""
-    from attestor.llm_trace import traced_create
+    from attestor.llm_trace import traced_create, make_client
     response = traced_create(
         client,
         role=role,

--- a/attestor/longmemeval.py
+++ b/attestor/longmemeval.py
@@ -1212,7 +1212,7 @@ def _get_client(api_key: Optional[str] = None) -> Any:
                 f"or set LME_LLM_BASE_URL=http://localhost:11434/v1 to "
                 f"run against local Ollama instead."
             )
-    return OpenAI(base_url=base_url, api_key=key)
+    return make_client(base_url=base_url, api_key=key)
 
 
 def _chat(
@@ -1254,7 +1254,7 @@ def _chat(
     if reasoning_effort:
         create_kwargs["reasoning_effort"] = reasoning_effort
 
-    from attestor.llm_trace import traced_create
+    from attestor.llm_trace import traced_create, make_client
     response = traced_create(client, role=role or "lme.chat", **create_kwargs)
     return response.choices[0].message.content or ""
 

--- a/attestor/mab.py
+++ b/attestor/mab.py
@@ -647,11 +647,11 @@ def answer_question(
 
     prompt_template = MAB_EXACT_PROMPT if use_exact else MAB_ANSWER_PROMPT
     prompt = prompt_template.format(context=context, question=question)
-    client = OpenAI(base_url=OPENROUTER_BASE_URL, api_key=key)
+    client = make_client(base_url=OPENROUTER_BASE_URL, api_key=key)
 
     # Retry with exponential backoff on rate limits
     import time as _time
-    from attestor.llm_trace import traced_create
+    from attestor.llm_trace import traced_create, make_client
     for attempt in range(5):
         try:
             response = traced_create(

--- a/attestor/retrieval/planner.py
+++ b/attestor/retrieval/planner.py
@@ -103,7 +103,7 @@ def _get_client(api_key: Optional[str] = None):
     key = api_key or os.environ.get("OPENROUTER_API_KEY")
     if not key:
         raise ValueError("OPENROUTER_API_KEY not set")
-    return OpenAI(base_url=OPENROUTER_BASE_URL, api_key=key)
+    return make_client(base_url=OPENROUTER_BASE_URL, api_key=key)
 
 
 def _sanitize_plan(raw: Dict[str, Any]) -> QueryPlan:
@@ -153,7 +153,7 @@ def plan_query(
 
     prompt = _PLANNER_PROMPT.format(question=question)
     try:
-        from attestor.llm_trace import traced_create
+        from attestor.llm_trace import traced_create, make_client
         response = traced_create(
             client,
             role="planner",

--- a/attestor/retrieval/temporal_query.py
+++ b/attestor/retrieval/temporal_query.py
@@ -161,7 +161,7 @@ class TemporalQueryExpander:
         if client is None:
             return None
         try:
-            from attestor.llm_trace import traced_create
+            from attestor.llm_trace import traced_create, make_client
             response = traced_create(
                 client,
                 role="temporal_query",
@@ -217,8 +217,8 @@ def _default_client() -> Optional[Any]:
         return None
     or_key = os.environ.get("OPENROUTER_API_KEY")
     if or_key:
-        return OpenAI(base_url="https://openrouter.ai/api/v1", api_key=or_key)
+        return make_client(base_url="https://openrouter.ai/api/v1", api_key=or_key)
     oa_key = os.environ.get("OPENAI_API_KEY")
     if oa_key:
-        return OpenAI(api_key=oa_key)
+        return make_client(api_key=oa_key)
     return None


### PR DESCRIPTION
## Why

A 133q LME-S temporal smoke today hung for **5+ hours on a single distill chat.completion**. The OpenAI client was instantiated without an explicit timeout in 7 sync call sites, so a hung HTTP connection blocked the pipeline indefinitely (process slept on socket recv() with no deadline; only SIGINT broke it).

## What

Centralizes client construction in `attestor.llm_trace.make_client()` with `timeout=60.0` + `max_retries=2` defaults, then sweeps 7 production call sites:
- `locomo.py`, `longmemeval.py`, `mab.py`
- `retrieval/planner.py`, `retrieval/temporal_query.py` (×2)
- `extraction/llm_extractor.py`

`hyde.py` + `multi_query.py` already had explicit timeouts (no change). `extraction/round_extractor.py` deferred to a follow-up — its `OpenAI(api_key=oa_key)` path is uncommon and didn't trigger today's hang.

## Test plan

- [x] 66 unit tests pass — no regression
- [x] All 7 patched modules import cleanly
- [x] make_client() honors timeout + max_retries kwargs
- [ ] Re-run 133q LME-S temporal — hung distill calls now fail at 60s rather than blocking forever (next session)