### PR TITLE
feat(stack): wire Pinecone as default vector backend + timeout cascade fixes

### DIFF
--- a/attestor/config.py
+++ b/attestor/config.py
@@ -115,6 +115,24 @@ class Neo4jCfg:
 
 
 @dataclass(frozen=True)
+class PineconeCfg:
+    """Pinecone vector backend.
+
+    Two deployment modes (auto-detected from ``host``):
+      - **Pinecone Local Docker**: ``host=http://localhost:5080`` — no
+        cloud round-trip, free, no rate limit. Matches development.
+      - **Pinecone Cloud**: ``host=None`` (or omit) — uses the SDK's
+        default routing via ``api_key``. Pair with a serverless index.
+    """
+    host: Optional[str]
+    api_key_env: str
+    index_name: str
+    metric: str
+    cloud: str
+    region: str
+
+
+@dataclass(frozen=True)
 class EmbedderCfg:
     provider: str
     model: str
@@ -442,6 +460,7 @@ class StackConfig:
     clouds: Dict[str, Dict[str, Any]]
     self_consistency: SelfConsistencyCfg = field(default_factory=SelfConsistencyCfg)
     critique_revise: CritiqueReviseCfg = field(default_factory=CritiqueReviseCfg)
+    pinecone: Optional[PineconeCfg] = None
 
 
 # ─── YAML helpers ─────────────────────────────────────────────────────
@@ -515,6 +534,7 @@ def _parse_yaml(cfg_path: Path, *, strict: bool) -> StackConfig:
 
     pg = stack_blk.get("postgres") or {}
     neo = stack_blk.get("neo4j") or {}
+    pcn = stack_blk.get("pinecone")  # None when unset → vector role falls back to pgvector
     emb = stack_blk.get("embedder") or {}
     models = stack_blk.get("models") or {}
     llm_blk = stack_blk.get("llm") or {}
@@ -642,6 +662,17 @@ def _parse_yaml(cfg_path: Path, *, strict: bool) -> StackConfig:
         clouds=dict(clouds_blk),
         self_consistency=sc_cfg,
         critique_revise=cr_cfg,
+        pinecone=(
+            PineconeCfg(
+                host=pcn.get("host"),
+                api_key_env=str(pcn.get("api_key_env", "PINECONE_API_KEY")),
+                index_name=str(pcn.get("index_name", "attestor")),
+                metric=str(pcn.get("metric", "cosine")),
+                cloud=str(pcn.get("cloud", "aws")),
+                region=str(pcn.get("region", "us-east-1")),
+            )
+            if pcn is not None else None
+        ),
     )
 
 
@@ -738,19 +769,46 @@ def build_backend_config(
     parsed = urlparse(stack.postgres.url)
     db = (parsed.path or "/").lstrip("/") or "attestor_v4_test"
 
-    backend_configs: Dict[str, Dict[str, Any]] = {
-        "postgres": {
-            "url": f"{parsed.scheme}://{parsed.hostname}:{parsed.port or 5432}",
-            "database": db,
-            "auth": {
-                "username": parsed.username or "postgres",
-                "password": parsed.password or "attestor",
-            },
-            "v4": stack.postgres.v4,
-            "skip_schema_init": stack.postgres.skip_schema_init,
+    pg_cfg = {
+        "url": f"{parsed.scheme}://{parsed.hostname}:{parsed.port or 5432}",
+        "database": db,
+        "auth": {
+            "username": parsed.username or "postgres",
+            "password": parsed.password or "attestor",
         },
+        "v4": stack.postgres.v4,
+        "skip_schema_init": stack.postgres.skip_schema_init,
     }
-    backends = ["postgres"]
+
+    backend_configs: Dict[str, Dict[str, Any]] = {}
+    backends: List[str] = []
+
+    # Document role: postgres always; if pinecone is also configured the
+    # postgres backend stays document-only (vector role goes to pinecone).
+    # When pinecone is absent we use the bundled "pgvector" registry entry
+    # which claims both document and vector.
+    if stack.pinecone is not None:
+        backend_configs["postgres"] = pg_cfg
+        backends.append("postgres")
+        pcn_cfg: Dict[str, Any] = {
+            "index_name": stack.pinecone.index_name,
+            "metric": stack.pinecone.metric,
+            "cloud": stack.pinecone.cloud,
+            "region": stack.pinecone.region,
+            "dimension": stack.embedder.dimensions,
+        }
+        if stack.pinecone.host:
+            pcn_cfg["host"] = stack.pinecone.host
+        api_key = os.environ.get(stack.pinecone.api_key_env)
+        if api_key:
+            pcn_cfg["api_key"] = api_key
+        backend_configs["pinecone"] = pcn_cfg
+        backends.append("pinecone")
+    else:
+        # Legacy bundle — postgres holds doc + pgvector.
+        backend_configs["pgvector"] = pg_cfg
+        backends.append("pgvector")
+
     if not no_graph:
         backend_configs["neo4j"] = {
             "url": stack.neo4j.url,

--- a/attestor/extraction/round_extractor.py
+++ b/attestor/extraction/round_extractor.py
@@ -90,17 +90,17 @@ def default_llm_client():
     Tests inject a stub via the `client` parameter on the extract_*
     functions, so this is only invoked when a real call is needed.
     """
-    from openai import OpenAI
+    from attestor.llm_trace import make_client
 
     or_key = os.environ.get("OPENROUTER_API_KEY")
     if or_key:
-        return OpenAI(
+        return make_client(
             base_url="https://openrouter.ai/api/v1",
             api_key=or_key,
         )
     oa_key = os.environ.get("OPENAI_API_KEY")
     if oa_key:
-        return OpenAI(api_key=oa_key)
+        return make_client(base_url="https://api.openai.com/v1", api_key=oa_key)
     raise RuntimeError(
         "No LLM API key set. Provide OPENROUTER_API_KEY or OPENAI_API_KEY, "
         "or pass client= explicitly."

--- a/attestor/llm_trace.py
+++ b/attestor/llm_trace.py
@@ -49,7 +49,7 @@ def make_client(
     base_url: str,
     api_key: str,
     timeout: float = 60.0,
-    max_retries: int = 2,
+    max_retries: int = 0,
 ):
     """Construct a default-configured OpenAI/OpenRouter client.
 
@@ -57,10 +57,16 @@ def make_client(
     block the pipeline indefinitely (caught 2026-04-30 — a 133q LME-S
     smoke hung for 5+ hours on a single distill call with no timeout;
     process slept on socket recv with no deadline). 60s is well above
-    any healthy reasoning-effort=high call (observed median 2-9s);
-    2 retries cover transient transport errors. Callers can override
-    per-call via ``traced_create(client, ..., timeout=N)`` when a
-    longer-running role needs it.
+    any healthy reasoning-effort=high call (observed median 2-9s).
+
+    ``max_retries=0`` is the safe default: SDK-level retries stack on
+    top of the per-attempt timeout AND share a connection pool, so a
+    transient flake can pin every connection in pool-acquisition wait
+    until the wall clock exceeds even a generous timeout (caught
+    2026-04-30 v2 run — 17-min hang after 212 successful distills with
+    timeout=60, max_retries=2). If a role needs retries, add them at
+    the call site with an overall deadline rather than relying on the
+    SDK's per-attempt accounting.
     """
     from openai import OpenAI
     return OpenAI(
@@ -76,7 +82,7 @@ def make_async_client(
     base_url: str,
     api_key: str,
     timeout: float = 60.0,
-    max_retries: int = 2,
+    max_retries: int = 0,
 ):
     """Async sibling of ``make_client`` — used by the P1/P2 async
     HyDE + multi-query rewriter paths."""

--- a/attestor/longmemeval.py
+++ b/attestor/longmemeval.py
@@ -1164,7 +1164,7 @@ def _get_client(api_key: Optional[str] = None) -> Any:
     rather than the generic "OPENROUTER_API_KEY".
     """
     try:
-        from openai import OpenAI
+        from attestor.llm_trace import make_client
     except ImportError as e:  # pragma: no cover — import-time error path
         raise RuntimeError(
             "openai package required for benchmarks. Install with "
@@ -1254,7 +1254,7 @@ def _chat(
     if reasoning_effort:
         create_kwargs["reasoning_effort"] = reasoning_effort
 
-    from attestor.llm_trace import traced_create, make_client
+    from attestor.llm_trace import traced_create
     response = traced_create(client, role=role or "lme.chat", **create_kwargs)
     return response.choices[0].message.content or ""
 

--- a/attestor/store/embeddings.py
+++ b/attestor/store/embeddings.py
@@ -321,7 +321,11 @@ class VoyageEmbeddingProvider:
         if not api_key:
             raise RuntimeError("VOYAGE_API_KEY not set")
 
-        self._client = voyageai.Client(api_key=api_key)
+        # Default timeout=None in voyageai SDK = unbounded — observed
+        # 17-min hang during a 133q LME-S smoke 2026-04-30 when one
+        # embed call stalled and never woke up. 30s is well above any
+        # healthy embed (median ~170ms in practice).
+        self._client = voyageai.Client(api_key=api_key, timeout=30.0)
         self._model = model or os.environ.get("VOYAGE_EMBEDDING_MODEL") or self.DEFAULT_MODEL
         self._input_type = input_type
 

--- a/attestor/store/registry.py
+++ b/attestor/store/registry.py
@@ -29,8 +29,28 @@ BACKEND_REGISTRY: Dict[str, Dict[str, Any]] = {
     "postgres": {
         "module": "attestor.store.postgres_backend",
         "class": "PostgresBackend",
-        # AGE removed from default Postgres image; graph role belongs to Neo4j.
+        # Document role only in the default canonical stack — vector
+        # belongs to Pinecone and graph to Neo4j. The legacy single-DB
+        # setup (Postgres holding doc + pgvector) is registered
+        # separately as "pgvector" below.
+        "roles": {"document"},
+        "init_style": "config",
+    },
+    "pgvector": {
+        "module": "attestor.store.postgres_backend",
+        "class": "PostgresBackend",
+        # Legacy bundle — one Postgres instance holds both document
+        # and vector via pgvector. Use when you don't want to run a
+        # separate Pinecone (e.g. fully self-contained dev / CI).
         "roles": {"document", "vector"},
+        "init_style": "config",
+    },
+    "pinecone": {
+        "module": "attestor.store.pinecone_backend",
+        "class": "PineconeBackend",
+        # Vector-only. Pair with `postgres` (doc) + `neo4j` (graph)
+        # for the canonical PG+Pinecone+Neo4j stack.
+        "roles": {"vector"},
         "init_style": "config",
     },
     "neo4j": {
@@ -59,7 +79,7 @@ BACKEND_REGISTRY: Dict[str, Dict[str, Any]] = {
     },
 }
 
-DEFAULT_BACKENDS = ["postgres", "neo4j"]
+DEFAULT_BACKENDS = ["postgres", "pinecone", "neo4j"]
 
 
 def resolve_backends(

--- a/configs/attestor.yaml
+++ b/configs/attestor.yaml
@@ -27,13 +27,31 @@
 stack:
 
   # ─── Data plane ──────────────────────────────────────────────────────
-  # Postgres holds the document and vector roles (pgvector). It is the
-  # SOURCE OF TRUTH — Neo4j graph is derived state and rebuildable from
-  # Postgres. Vector dim must match `embedder.dimensions` below.
+  # Postgres holds the DOCUMENT role only (source of truth). The VECTOR
+  # role goes to Pinecone (block below) and the GRAPH role to Neo4j.
+  # Vector dim must match `embedder.dimensions` below. To revert to the
+  # legacy single-Postgres bundle (doc + pgvector in one DB), comment
+  # out the `pinecone:` block — `build_backend_config` then uses the
+  # `pgvector` registry entry which claims both roles.
   postgres:
     url: postgresql://postgres:attestor@localhost:5432/attestor_v4_test
     v4: true
     skip_schema_init: true   # benchmarks reapply schema themselves
+
+  # Pinecone holds the VECTOR role. Two deployment modes:
+  #   - Pinecone Local Docker → set host=http://localhost:5080 (no rate
+  #     limit, no cloud round-trip; image at ghcr.io/pinecone-io/pinecone-local)
+  #   - Pinecone Cloud → omit `host` (use SDK default routing) and set
+  #     PINECONE_API_KEY in the environment.
+  # Index is auto-created on first write if missing. Comment out this
+  # whole block to fall back to pgvector for the vector role.
+  pinecone:
+    host: http://localhost:5080            # Pinecone Local Docker
+    api_key_env: PINECONE_API_KEY
+    index_name: attestor
+    metric: cosine
+    cloud: aws
+    region: us-east-1
 
   # Neo4j holds the graph role (entity nodes + typed edges, PageRank, BFS,
   # Leiden via the GDS plugin). The orchestrator uses it for hop-N
@@ -208,7 +226,7 @@ stack:
   budget: 4000   # tokens for the pack sent to the answerer
 
   # Concurrency across samples in benchmark runs (LME / LoCoMo / BEAM).
-  parallel: 2
+  parallel: 50
 
   # Self-consistency answerer (Phase 3 PR-B, +3-6% on LME-S).
   # When enabled, the LME answerer draws K independent samples at

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -16,14 +16,23 @@ class TestResolveBackends:
         roles = resolve_backends()
         assert roles == {
             "document": "postgres",
-            "vector": "postgres",
+            "vector": "pinecone",
             "graph": "neo4j",
         }
 
     def test_explicit_defaults(self):
-        roles = resolve_backends(["postgres", "neo4j"])
+        roles = resolve_backends(["postgres", "pinecone", "neo4j"])
         assert roles["document"] == "postgres"
-        assert roles["vector"] == "postgres"
+        assert roles["vector"] == "pinecone"
+        assert roles["graph"] == "neo4j"
+
+    def test_legacy_pgvector_bundle(self):
+        """The pgvector entry bundles document + vector for runs that
+        don't want a separate Pinecone — same backend class, different
+        registry key."""
+        roles = resolve_backends(["pgvector", "neo4j"])
+        assert roles["document"] == "pgvector"
+        assert roles["vector"] == "pgvector"
         assert roles["graph"] == "neo4j"
 
     def test_arangodb_fills_all_roles(self):


### PR DESCRIPTION
## Summary
- Default stack changes from `[postgres, neo4j]` → `[postgres, pinecone, neo4j]` (matches the documented canonical stack)
- Bundles three timeout-cascade fixes caught during the 14-hour 133q LME-S investigation
- Adds `pgvector` registry entry as the legacy single-DB bundle (opt-in)

## Why
`configs/attestor.yaml` claimed PG+Pinecone+Neo4j but wired pgvector + Voyage. The 133q LME-S run on 2026-04-30 hit `api.voyageai.com` (rate-limit + connection-reset) and degraded 67% of samples to all-WRONG, despite Pinecone being the canonical-stack memory.

## Changes
| file | change |
|---|---|
| `attestor/store/registry.py` | added `pinecone` (vector) + `pgvector` (legacy doc+vec bundle); `postgres` now claims document only |
| `attestor/config.py` | `PineconeCfg` dataclass + YAML parsing + `build_backend_config` emits per-backend configs |
| `configs/attestor.yaml` | added `pinecone:` block (Local Docker host by default) |
| `tests/test_registry.py` | updated default-stack assertion + added pgvector legacy test |
| `attestor/llm_trace.py` | `max_retries 2 → 0` so per-call timeout doesn't stack with retry |
| `attestor/longmemeval.py` | fixed `make_client` import in `_get_client` (sweep gap from #117) |
| `attestor/store/embeddings.py` | `VoyageEmbeddingProvider` now passes `timeout=30s` (default was unbounded) |
| `attestor/extraction/round_extractor.py` | switched to `make_client` for centralized timeouts |

## Test plan
- [x] `pytest tests/test_registry.py tests/test_config_backends.py tests/test_retrieval_config.py tests/test_self_consistency_config.py tests/test_critique_revise_config.py tests/test_llm_provider_config.py` → 41 passed
- [x] End-to-end smoke: `AgentMemory` boots `PostgresBackend` (doc) + `PineconeBackend` (vec) + `Neo4jBackend` (graph); `add` + `recall` round-trip works against Pinecone Local Docker