### PR TITLE
feat(embedder): switch default to Pinecone Inference llama-text-embed-v2

### DIFF
--- a/attestor/config.py
+++ b/attestor/config.py
@@ -752,6 +752,19 @@ def configure_embedder(stack: StackConfig) -> None:
         os.environ.pop("VOYAGE_API_KEY", None)
         os.environ["OPENAI_EMBEDDING_MODEL"] = stack.embedder.model
         os.environ["OPENAI_EMBEDDING_DIMENSIONS"] = str(stack.embedder.dimensions)
+    elif stack.embedder.provider == "pinecone":
+        # Pinecone Inference (cloud-only). Drop Voyage so its _try_voyage
+        # probe doesn't beat the Pinecone preference, then pin model/dim
+        # via env so PineconeEmbeddingProvider picks them up.
+        os.environ.pop("VOYAGE_API_KEY", None)
+        if not os.environ.get("PINECONE_API_KEY"):
+            raise SystemExit(
+                "[attestor.config] embedder=pinecone but PINECONE_API_KEY "
+                "not set (cloud key from app.pinecone.io required — Local "
+                "Docker doesn't serve the Inference API)"
+            )
+        os.environ["PINECONE_EMBEDDING_MODEL"] = stack.embedder.model
+        os.environ["PINECONE_EMBEDDING_DIMENSIONS"] = str(stack.embedder.dimensions)
     else:
         raise SystemExit(
             f"[attestor.config] unknown embedder provider: {stack.embedder.provider!r}"

--- a/attestor/store/embeddings.py
+++ b/attestor/store/embeddings.py
@@ -545,6 +545,35 @@ def _try_voyage() -> Optional[EmbeddingProvider]:
         return None
 
 
+def _try_pinecone_inference() -> Optional[EmbeddingProvider]:
+    """Try Pinecone Inference (cloud-only — Local Docker doesn't serve it).
+
+    Activated by ATTESTOR_PREFER_EMBEDDER=pinecone OR by configure_embedder
+    setting PINECONE_EMBEDDING_MODEL when stack.embedder.provider="pinecone".
+    Configurable via:
+        PINECONE_API_KEY                   required (cloud key from app.pinecone.io)
+        PINECONE_EMBEDDING_MODEL           default ``llama-text-embed-v2``
+        PINECONE_EMBEDDING_DIMENSIONS      default 1024 (matches v4 schema)
+        PINECONE_EMBEDDING_INPUT_TYPE      default ``passage``
+    """
+    if not os.environ.get("PINECONE_API_KEY"):
+        return None
+    if os.environ.get("PINECONE_API_KEY") == "pclocal":
+        return None  # Local Docker stub doesn't serve Inference
+    try:
+        provider = PineconeEmbeddingProvider(
+            input_type=os.environ.get("PINECONE_EMBEDDING_INPUT_TYPE", "passage"),
+        )
+        logger.info(
+            "Using %s embeddings (%dD)",
+            provider.provider_name, provider.dimension,
+        )
+        return provider
+    except Exception as e:
+        logger.debug("Pinecone Inference unavailable: %s", e)
+        return None
+
+
 def _try_ollama() -> Optional[EmbeddingProvider]:
     """Probe local Ollama. Returns None if daemon unreachable or model
     missing — caller falls through to the next provider."""
@@ -647,6 +676,7 @@ def _try_openai() -> Optional[EmbeddingProvider]:
 
 _CLOUD_PROVIDERS = {
     "voyage": _try_voyage,
+    "pinecone": _try_pinecone_inference,
     "bedrock": _try_bedrock,
     "azure_openai": _try_azure_openai,
     "vertex_ai": _try_vertex_ai,

--- a/configs/attestor.yaml
+++ b/configs/attestor.yaml
@@ -64,15 +64,24 @@ stack:
     database: neo4j
 
   # ─── Embedder ────────────────────────────────────────────────────────
-  # Voyage AI is the canonical embedder (Anthropic's recommended partner).
-  # voyage-4 outputs 1024-D natively — drops into the v4 pgvector schema
-  # `vector(1024)` with no Matryoshka truncation. The auto-detect chain
-  # in `attestor/store/embeddings.py` prefers Voyage when its key is set.
+  # Pinecone Inference llama-text-embed-v2 is the canonical embedder
+  # (Meta × Pinecone partnership; English-strong; 1024-D matches the
+  # v4 pgvector schema and the Pinecone index dim). Pairs naturally with
+  # the Pinecone vector store above, so the embedder + index live in
+  # the same provider — no extra cross-vendor egress, free up to the
+  # Pinecone Inference free-tier monthly cap (5M tokens for llama-text-
+  # embed-v2 as of 2026-04-29; check app.pinecone.io for current).
+  #
+  # Alternatives (flip `provider`):
+  #   - voyage   — voyage-4, 1024-D (Anthropic recommended; paid).
+  #                Set VOYAGE_API_KEY. Soft rate-limit under sustained
+  #                burst — caught 2026-04-30 in a parallel=50 LME run.
+  #   - openai   — text-embedding-3-small @ 1024-D via OPENAI_API_KEY.
   embedder:
-    provider: voyage
-    model: voyage-4
+    provider: pinecone
+    model: llama-text-embed-v2
     dimensions: 1024
-    api_key_env: VOYAGE_API_KEY        # resolved from environment
+    api_key_env: PINECONE_API_KEY      # resolved from environment
 
   # ─── LLM client routing ───────────────────────────────────────────────
   # Where chat-completion calls land. Two providers wired:


### PR DESCRIPTION
## Summary
- Default embedder Voyage → Pinecone Inference llama-text-embed-v2 (1024-D)
- Adds `_try_pinecone_inference` probe to the auto-detect chain
- `configure_embedder` learns a `pinecone` branch

## Why
Voyage hit soft rate-limit during the 14-hr 133q LME-S run on 2026-04-30 (parallel=50): `Read timed out (30.0s)` + `ConnectionResetError`. ~67% of samples degraded to all-WRONG. Pinecone Inference is bounded only by the monthly token cap, not burst — and pairs naturally with the Pinecone vector index (same provider, no cross-vendor egress, dim-aligned).

## Test plan
- [x] Live embed call: `pinecone:llama-text-embed-v2@1024d` returns 1024-D vector
- [ ] CI green