### PR TITLE
refactor: YAML is the only source of truth — remove all Python fallbacks

### DIFF
--- a/attestor/cli.py
+++ b/attestor/cli.py
@@ -916,10 +916,12 @@ def _print_health_report(report):
 
 
 def _cmd_locomo(args):
-    # Load env file if provided
+    # Load env file if provided. Provider keys are resolved by the LLM
+    # pool from ``configs/attestor.yaml`` (``llm.providers.*.api_key_env``)
+    # at first use — we don't read or pre-validate any specific env var
+    # here.
     if args.env_file:
         _load_env_file(args.env_file)
-    api_key = os.environ.get("OPENROUTER_API_KEY")
 
     from attestor.config import get_stack
     from attestor.locomo import run_locomo, print_locomo
@@ -943,7 +945,6 @@ def _cmd_locomo(args):
         max_questions_per_conv=args.max_questions,
         recall_budget=args.budget,
         verbose=args.verbose,
-        api_key=api_key,
         backend_config=_parse_backend_config(args),
     )
 
@@ -956,10 +957,12 @@ def _cmd_locomo(args):
 
 
 def _cmd_mab(args):
-    # Load env file if provided
+    # Load env file if provided. Provider keys are resolved by the LLM
+    # pool from ``configs/attestor.yaml`` (``llm.providers.*.api_key_env``)
+    # at first use — we don't read or pre-validate any specific env var
+    # here.
     if args.env_file:
         _load_env_file(args.env_file)
-    api_key = os.environ.get("OPENROUTER_API_KEY")
 
     from attestor.mab import run_mab, print_mab
 
@@ -975,7 +978,6 @@ def _cmd_mab(args):
         answer_model=args.answer_model,
         recall_budget=args.budget,
         verbose=args.verbose,
-        api_key=api_key,
         skip_examples=args.skip_examples,
         backend_config=_parse_backend_config(args),
     )
@@ -990,13 +992,13 @@ def _cmd_mab(args):
 
 def _cmd_longmemeval(args):
     """Run the LongMemEval benchmark against Attestor."""
-    # Load env file if provided
+    # Load env file if provided. Provider keys are resolved by the LLM
+    # pool from ``configs/attestor.yaml`` (``llm.providers.*.api_key_env``)
+    # at first use — we don't pre-read any specific env var here. If the
+    # configured provider's key is missing the pool raises with a clear
+    # message at first chat call.
     if args.env_file:
         _load_env_file(args.env_file)
-    api_key = os.environ.get("OPENROUTER_API_KEY")
-    if not api_key:
-        print("ERROR: OPENROUTER_API_KEY not set (pass via --env-file or export).", file=sys.stderr)
-        sys.exit(2)
 
     from attestor.longmemeval import (
         DEFAULT_MODEL,
@@ -1071,7 +1073,6 @@ def _cmd_longmemeval(args):
         mem_factory=mem_factory,
         answer_model=answer_model,
         judge_models=judge_models,
-        api_key=api_key,
         budget=args.budget,
         use_extraction=args.use_extraction,
         use_distillation=args.use_distillation,

--- a/attestor/config.py
+++ b/attestor/config.py
@@ -51,47 +51,21 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_CONFIG = REPO_ROOT / "configs" / "attestor.yaml"
 
 
-# ─── Hardcoded fallbacks (USED ONLY when YAML is missing) ──────────────
+# ─── LLM provider catalog ──────────────────────────────────────────────
 #
-# These are the canonical defaults captured at the time the YAML was
-# written. They exist so tests / CI can run in a stripped checkout
-# without `configs/attestor.yaml`. Production deployments must have
-# the YAML; the runtime emits a warning when these fallbacks fire.
-
-_FALLBACK_POSTGRES_URL = "postgresql://postgres:attestor@localhost:5432/attestor_v4_test"
-_FALLBACK_NEO4J_URL = "bolt://localhost:7687"
-_FALLBACK_NEO4J_DB = "neo4j"
-_FALLBACK_NEO4J_USER = "neo4j"
-_FALLBACK_EMBEDDER_PROVIDER = "voyage"
-_FALLBACK_EMBEDDER_MODEL = "voyage-4"
-_FALLBACK_EMBEDDER_DIM = 1024
-_FALLBACK_ANSWERER = "openai/gpt-5.4-mini"
-_FALLBACK_JUDGE = "openai/gpt-5.5"
-# Note: OpenRouter has no gpt-5.5-mini SKU; the -mini roles use 5.4-mini
-# (cheapest current 5.x mini) until a 5.5-mini variant ships.
-_FALLBACK_EXTRACTION = "openai/gpt-5.4-mini"
-_FALLBACK_DISTILL = "openai/gpt-5.4-mini"
-_FALLBACK_VERIFIER = "anthropic/claude-sonnet-4-6"
-_FALLBACK_PLANNER = "anthropic/claude-opus-4.7"
-_FALLBACK_BENCHMARK = "openai/gpt-5.4-mini"
-_FALLBACK_BUDGET = 4000
-_FALLBACK_PARALLEL = 2
-
-# LLM client routing — which OpenAI-compatible endpoint we send chat
-# completion calls to. OpenRouter is the default (matches the canonical
-# benchmark stack); "openai" hits api.openai.com directly which avoids
-# OpenRouter's per-call markup when the model is an OpenAI one and you
-# already have an OpenAI key.
-_FALLBACK_LLM_PROVIDER = "openrouter"
-_OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
-_OPENAI_BASE_URL = "https://api.openai.com/v1"
+# Known OpenAI-compatible endpoints, indexed by short name. These are
+# NOT fallback defaults for stack/model/embedder/budget — those MUST
+# come from `configs/attestor.yaml`. This dict only resolves the
+# `base_url` and `api_key_env` for a given provider name selected by
+# YAML (e.g. `stack.llm.provider: openrouter`). Adding a new provider
+# means adding an entry here.
 LLM_PROVIDER_DEFAULTS: Dict[str, Dict[str, str]] = {
     "openrouter": {
-        "base_url": _OPENROUTER_BASE_URL,
+        "base_url": "https://openrouter.ai/api/v1",
         "api_key_env": "OPENROUTER_API_KEY",
     },
     "openai": {
-        "base_url": _OPENAI_BASE_URL,
+        "base_url": "https://api.openai.com/v1",
         "api_key_env": "OPENAI_API_KEY",
     },
 }
@@ -503,43 +477,19 @@ def _resolve_env_password(node: Any, *, strict: bool) -> str:
     return ""
 
 
-def _build_fallback_stack() -> StackConfig:
-    """Hardcoded stack used when ``configs/attestor.yaml`` is absent."""
-    return StackConfig(
-        postgres=PostgresCfg(
-            url=os.environ.get("POSTGRES_URL", _FALLBACK_POSTGRES_URL),
-            v4=True,
-            skip_schema_init=True,
-        ),
-        neo4j=Neo4jCfg(
-            url=os.environ.get("NEO4J_URI", _FALLBACK_NEO4J_URL),
-            username=os.environ.get("NEO4J_USERNAME", _FALLBACK_NEO4J_USER),
-            password=os.environ.get("NEO4J_PASSWORD", ""),
-            database=os.environ.get("NEO4J_DATABASE", _FALLBACK_NEO4J_DB),
-        ),
-        embedder=EmbedderCfg(
-            provider=_FALLBACK_EMBEDDER_PROVIDER,
-            model=_FALLBACK_EMBEDDER_MODEL,
-            dimensions=_FALLBACK_EMBEDDER_DIM,
-        ),
-        models=ModelsCfg(
-            answerer=_FALLBACK_ANSWERER,
-            judge=_FALLBACK_JUDGE,
-            extraction=_FALLBACK_EXTRACTION,
-            distill=_FALLBACK_DISTILL,
-            verifier=_FALLBACK_VERIFIER,
-            planner=_FALLBACK_PLANNER,
-            benchmark_default=_FALLBACK_BENCHMARK,
-        ),
-        llm=LLMCfg.for_provider(_FALLBACK_LLM_PROVIDER),
-        retrieval=RetrievalCfg(),
-        image=ImageCfg(ref="", api_ref_template="", registries={}),
-        budget=_FALLBACK_BUDGET,
-        parallel=_FALLBACK_PARALLEL,
-        clouds={},
-        self_consistency=SelfConsistencyCfg(),
-        critique_revise=CritiqueReviseCfg(),
-    )
+def _require(block: Dict[str, Any], key: str, yaml_path: str) -> Any:
+    """Pull a required key out of a YAML block, raising with the dotted
+    path so the user knows exactly which key to add.
+
+    Fallback constants were removed in favor of fail-loud behavior:
+    every required key in ``configs/attestor.yaml`` must be present.
+    """
+    if key not in block:
+        raise ValueError(
+            f"{yaml_path} missing in configs/attestor.yaml — "
+            "required since fallback constants were removed"
+        )
+    return block[key]
 
 
 def _parse_yaml(cfg_path: Path, *, strict: bool) -> StackConfig:
@@ -625,7 +575,7 @@ def _parse_yaml(cfg_path: Path, *, strict: bool) -> StackConfig:
         max_revisions=cr_max_revisions,
     )
 
-    llm_provider = str(llm_blk.get("provider", _FALLBACK_LLM_PROVIDER))
+    llm_provider = str(_require(llm_blk, "provider", "stack.llm.provider"))
     if llm_provider not in LLM_PROVIDER_DEFAULTS:
         raise SystemExit(
             f"[attestor.config] unknown LLM provider {llm_provider!r}; "
@@ -674,31 +624,37 @@ def _parse_yaml(cfg_path: Path, *, strict: bool) -> StackConfig:
         default_provider=default_provider,
     )
 
+    neo_auth_blk = neo.get("auth") or {}
+
     return StackConfig(
         postgres=PostgresCfg(
-            url=pg.get("url", _FALLBACK_POSTGRES_URL),
+            url=str(_require(pg, "url", "stack.postgres.url")),
             v4=bool(pg.get("v4", True)),
             skip_schema_init=bool(pg.get("skip_schema_init", True)),
         ),
         neo4j=Neo4jCfg(
-            url=neo.get("url", _FALLBACK_NEO4J_URL),
-            username=(neo.get("auth") or {}).get("username", _FALLBACK_NEO4J_USER),
-            password=_resolve_env_password(neo.get("auth") or {}, strict=strict),
-            database=neo.get("database", _FALLBACK_NEO4J_DB),
+            url=str(_require(neo, "url", "stack.neo4j.url")),
+            username=str(_require(
+                neo_auth_blk, "username", "stack.neo4j.auth.username"
+            )),
+            password=_resolve_env_password(neo_auth_blk, strict=strict),
+            database=str(_require(neo, "database", "stack.neo4j.database")),
         ),
         embedder=EmbedderCfg(
-            provider=emb.get("provider", _FALLBACK_EMBEDDER_PROVIDER),
-            model=emb.get("model", _FALLBACK_EMBEDDER_MODEL),
-            dimensions=int(emb.get("dimensions", _FALLBACK_EMBEDDER_DIM)),
+            provider=str(_require(emb, "provider", "stack.embedder.provider")),
+            model=str(_require(emb, "model", "stack.embedder.model")),
+            dimensions=int(_require(emb, "dimensions", "stack.embedder.dimensions")),
         ),
         models=ModelsCfg(
-            answerer=models.get("answerer", _FALLBACK_ANSWERER),
-            judge=models.get("judge", _FALLBACK_JUDGE),
-            extraction=models.get("extraction", _FALLBACK_EXTRACTION),
-            distill=models.get("distill", _FALLBACK_DISTILL),
-            verifier=models.get("verifier", _FALLBACK_VERIFIER),
-            planner=models.get("planner", _FALLBACK_PLANNER),
-            benchmark_default=models.get("benchmark_default", _FALLBACK_BENCHMARK),
+            answerer=str(_require(models, "answerer", "stack.models.answerer")),
+            judge=str(_require(models, "judge", "stack.models.judge")),
+            extraction=str(_require(models, "extraction", "stack.models.extraction")),
+            distill=str(_require(models, "distill", "stack.models.distill")),
+            verifier=str(_require(models, "verifier", "stack.models.verifier")),
+            planner=str(_require(models, "planner", "stack.models.planner")),
+            benchmark_default=str(_require(
+                models, "benchmark_default", "stack.models.benchmark_default"
+            )),
             reasoning_effort=dict(models.get("reasoning_effort") or {}),
             max_tokens={k: int(v) for k, v in (models.get("max_tokens") or {}).items()},
         ),
@@ -709,8 +665,8 @@ def _parse_yaml(cfg_path: Path, *, strict: bool) -> StackConfig:
             api_ref_template=image_blk.get("api_ref_template", ""),
             registries=dict(image_blk.get("registries") or {}),
         ),
-        budget=int(stack_blk.get("budget", _FALLBACK_BUDGET)),
-        parallel=int(stack_blk.get("parallel", _FALLBACK_PARALLEL)),
+        budget=int(_require(stack_blk, "budget", "stack.budget")),
+        parallel=int(_require(stack_blk, "parallel", "stack.parallel")),
         clouds=dict(clouds_blk),
         self_consistency=sc_cfg,
         critique_revise=cr_cfg,
@@ -737,14 +693,20 @@ def load_stack(path: Path | str | None = None, *, strict: bool = False) -> Stack
     """Read ``configs/attestor.yaml`` (or override path) and resolve env refs.
 
     Bypasses the cache. Most callers should use ``get_stack()`` instead.
+
+    The YAML is the single source of truth for stack/model/embedder/
+    budget/parallel choices. If it's missing, this function raises —
+    there is no Python-level fallback any more.
     """
     if path is None:
         path = os.environ.get("ATTESTOR_CONFIG") or DEFAULT_CONFIG
     cfg_path = Path(path)
     if not cfg_path.exists():
-        if strict:
-            raise SystemExit(f"[attestor.config] config not found: {cfg_path}")
-        return _build_fallback_stack()
+        raise SystemExit(
+            f"[attestor.config] config not found: {cfg_path}\n"
+            "        configs/attestor.yaml is required — fallback "
+            "constants were removed; YAML is the only source of truth."
+        )
     return _parse_yaml(cfg_path, strict=strict)
 
 

--- a/attestor/extraction/extractor.py
+++ b/attestor/extraction/extractor.py
@@ -17,7 +17,9 @@ def extract_memories(
 
     Args:
         messages: List of message dicts with 'role' and 'content' keys.
-        use_llm: If True, use LLM-based extraction (requires openai + OPENROUTER_API_KEY).
+        use_llm: If True, use LLM-based extraction (requires the ``openai``
+            package + the API key for whichever provider is configured
+            under ``stack.llm.providers`` in ``configs/attestor.yaml``).
         model: LLM model to use if use_llm=True.
 
     Returns:
@@ -52,7 +54,9 @@ def _rule_extract(messages: List[Dict[str, Any]]) -> List[Memory]:
 
 
 def _llm_extract(messages: List[Dict[str, Any]], model: str) -> List[Memory]:
-    """Extract memories using LLM. Requires openai package + OPENROUTER_API_KEY."""
+    """Extract memories using LLM. Requires the ``openai`` package and
+    the API key for whichever provider is configured under
+    ``stack.llm.providers`` in ``configs/attestor.yaml``."""
     try:
         from attestor.extraction.llm_extractor import llm_extract
         return llm_extract(messages, model)

--- a/attestor/extraction/llm_extractor.py
+++ b/attestor/extraction/llm_extractor.py
@@ -1,14 +1,13 @@
-"""LLM-based memory extraction (optional, requires openai + OPENROUTER_API_KEY)."""
+"""LLM-based memory extraction (optional; requires the ``openai`` package
+and the API key for whichever provider is configured under
+``stack.llm.providers`` in ``configs/attestor.yaml``)."""
 
 from __future__ import annotations
 
 import json
-import os
 from typing import Any, Dict, List, Optional, Tuple
 
 from attestor.models import Memory
-
-OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 
 
 def _default_extraction_model() -> str:
@@ -24,16 +23,29 @@ def _default_extraction_model() -> str:
 DEFAULT_EXTRACTION_MODEL = _default_extraction_model()
 
 
-def _get_client(api_key: Optional[str] = None):
-    """Get an OpenAI client configured for OpenRouter."""
-    from openai import OpenAI
+def _resolve_client(model: str, api_key: Optional[str] = None) -> Tuple[Any, str]:
+    """Resolve ``(client, clean_model)`` via the YAML-driven LLM pool.
 
-    key = api_key or os.environ.get("OPENROUTER_API_KEY")
-    if not key:
-        raise ValueError(
-            "OPENROUTER_API_KEY not set. Pass api_key or set the env var."
-        )
-    return make_client(base_url=OPENROUTER_BASE_URL, api_key=key)
+    YAML is the only source of truth for provider ``base_url`` /
+    ``api_key_env``. The ``api_key`` parameter is kept for back-compat:
+    when set, a fresh client is built against the pool-resolved
+    provider's ``base_url`` (no env fallback).
+    """
+    from attestor.llm_trace import get_client_for_model, _get_pool, make_client
+
+    if api_key:
+        pool = _get_pool()
+        head, sep, tail = model.partition("/")
+        if sep and head in pool.providers:
+            strategy = pool._strategies[head]  # noqa: SLF001 — explicit override path
+            clean_model = tail
+        else:
+            strategy = pool.default_strategy()
+            clean_model = model
+        client = make_client(base_url=strategy.base_url, api_key=api_key)
+        return client, clean_model
+
+    return get_client_for_model(model)
 
 _EXTRACTION_PROMPT = """Extract atomic facts from this conversation that would be useful to remember across sessions.
 
@@ -157,8 +169,8 @@ def llm_extract(
     model: str = DEFAULT_EXTRACTION_MODEL,
     api_key: Optional[str] = None,
 ) -> List[Memory]:
-    """Extract memories using LLM via OpenRouter."""
-    client = _get_client(api_key)
+    """Extract memories using the YAML-configured LLM provider."""
+    client, clean_model = _resolve_client(model, api_key)
 
     conversation_text = "\n".join(
         f"{msg.get('role', 'unknown')}: {msg.get('content', '')}"
@@ -166,11 +178,11 @@ def llm_extract(
         if msg.get("content")
     )
 
-    from attestor.llm_trace import traced_create, make_client
+    from attestor.llm_trace import traced_create
     response = traced_create(
         client,
         role="extraction",
-        model=model,
+        model=clean_model,
         max_tokens=2048,
         messages=[
             {
@@ -231,7 +243,7 @@ def llm_extract_session_full(
     - entity_profiles: {name, type, profile, tags}
     - concept_profiles: {title, description, entities, tags, event_date}
     """
-    client = _get_client(api_key)
+    client, clean_model = _resolve_client(model, api_key)
 
     conversation_lines = []
     for turn in turns:
@@ -257,7 +269,7 @@ def llm_extract_session_full(
     response = traced_create(
         client,
         role="extraction",
-        model=model,
+        model=clean_model,
         max_tokens=8192,
         messages=[{"role": "user", "content": prompt}],
     )

--- a/attestor/extraction/round_extractor.py
+++ b/attestor/extraction/round_extractor.py
@@ -16,15 +16,16 @@ Both share:
   - source_span citations clamped to the turn's content range
   - Confidence clamped to [0.0, 1.0]
 
-LLM client is injectable so tests can use a stub. By default, builds an
-OpenRouter-backed OpenAI client from OPENROUTER_API_KEY (or OPENAI_API_KEY).
+LLM client is injectable so tests can use a stub. By default, the client
+is resolved via ``attestor.llm_trace.get_client_for_model`` against the
+YAML-configured ``stack.llm.providers`` map — YAML is the sole source of
+truth for provider ``base_url`` / ``api_key_env``.
 """
 
 from __future__ import annotations
 
 import json
 import logging
-import os
 from dataclasses import dataclass, field
 from typing import Any, Callable, List, Optional
 
@@ -84,27 +85,19 @@ class ExtractedFact:
 # ──────────────────────────────────────────────────────────────────────────
 
 
-def default_llm_client():
-    """Build an OpenRouter-backed OpenAI client. Raises if no key set.
+def default_llm_client(model: str = DEFAULT_MODEL) -> Any:
+    """Resolve the YAML-configured LLM client for ``model``.
 
-    Tests inject a stub via the `client` parameter on the extract_*
-    functions, so this is only invoked when a real call is needed.
+    Routes through ``attestor.llm_trace.get_client_for_model`` so the
+    provider URL/key come from ``stack.llm.providers`` in
+    ``configs/attestor.yaml`` — never from a hardcoded constant or env
+    fallback. Tests inject a stub via the ``client`` parameter on the
+    ``extract_*`` functions, so this is only invoked when a real call
+    is needed.
     """
-    from attestor.llm_trace import make_client
-
-    or_key = os.environ.get("OPENROUTER_API_KEY")
-    if or_key:
-        return make_client(
-            base_url="https://openrouter.ai/api/v1",
-            api_key=or_key,
-        )
-    oa_key = os.environ.get("OPENAI_API_KEY")
-    if oa_key:
-        return make_client(base_url="https://api.openai.com/v1", api_key=oa_key)
-    raise RuntimeError(
-        "No LLM API key set. Provide OPENROUTER_API_KEY or OPENAI_API_KEY, "
-        "or pass client= explicitly."
-    )
+    from attestor.llm_trace import get_client_for_model
+    client, _clean_model = get_client_for_model(model)
+    return client
 
 
 def _call_llm(
@@ -114,12 +107,20 @@ def _call_llm(
     model: str,
     max_tokens: int,
 ) -> str:
-    """Invoke the LLM and return the raw response text."""
+    """Invoke the LLM and return the raw response text.
+
+    ``model`` may carry a ``provider/`` prefix; we strip it for the
+    request payload because the prefix is just a routing hint for the
+    pool. ``traced_create`` itself also tolerates a prefix, but stripping
+    here keeps trace events labelled with the actual served model id.
+    """
     from attestor.llm_trace import traced_create
+    _, sep, tail = model.partition("/")
+    clean_model = tail if sep else model
     response = traced_create(
         client,
         role="round_extractor",
-        model=model,
+        model=clean_model,
         max_tokens=max_tokens,
         messages=[{"role": "user", "content": prompt}],
     )
@@ -248,7 +249,7 @@ def extract_user_facts(
         user_message=turn.content,
         recent_context_summary=recent_context or "(none)",
     )
-    cli = client or default_llm_client()
+    cli = client or default_llm_client(model)
     raw_text = _call_llm(prompt, client=cli, model=model, max_tokens=max_tokens)
     raw_facts = _parse_facts_payload(raw_text)
 
@@ -289,7 +290,7 @@ def extract_agent_facts(
         assistant_message=turn.content,
         recent_context_summary=recent_context or "(none)",
     )
-    cli = client or default_llm_client()
+    cli = client or default_llm_client(model)
     raw_text = _call_llm(prompt, client=cli, model=model, max_tokens=max_tokens)
     raw_facts = _parse_facts_payload(raw_text)
 

--- a/attestor/locomo.py
+++ b/attestor/locomo.py
@@ -4,7 +4,10 @@ LOCOMO (Long Conversation Memory) is the industry-standard benchmark
 for evaluating AI agent memory systems. Used by Mem0, Zep, Letta, etc.
 
 Usage:
-    attestor locomo                     # Run with defaults (needs OPENROUTER_API_KEY)
+    attestor locomo                     # Run with defaults — needs the API
+                                        # key for the provider configured in
+                                        # ``configs/attestor.yaml``
+                                        # (``llm.api_key_env``).
     attestor locomo --judge-model claude-haiku  # Cheaper judge
     attestor locomo --data ./locomo10.json       # Use local data file
 
@@ -14,17 +17,17 @@ Requires: poetry add "attestor[extraction]"  (for the LLM judge)
 from __future__ import annotations
 
 import json
-import os
 import statistics
 import tempfile
 import time
 import urllib.request
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from attestor.core import AgentMemory
 from attestor.mab import token_f1, _upgrade_embeddings_for_benchmark
 from attestor.retrieval.planner import QueryPlan, plan_query
+
 
 def _default_model() -> str:
     """Resolve the LoCoMo benchmark default model from
@@ -34,25 +37,31 @@ def _default_model() -> str:
 
 
 DEFAULT_MODEL = _default_model()
-OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 
 
-def _get_client(api_key: Optional[str] = None):
-    """Get an OpenAI client configured for OpenRouter."""
-    from openai import OpenAI
+def _resolve_client(model: str) -> Tuple[Any, str]:
+    """Look up the provider client for ``model`` via the LLM pool.
 
-    key = api_key or os.environ.get("OPENROUTER_API_KEY")
-    if not key:
-        raise ValueError(
-            "OPENROUTER_API_KEY not set. Pass api_key or set the env var."
-        )
-    return make_client(base_url=OPENROUTER_BASE_URL, api_key=key)
+    YAML is the source of truth: ``configs/attestor.yaml`` declares the
+    provider map (base_url + api_key_env) and the ``provider/`` prefix
+    in ``model`` selects which one to use. Returns a ``(client,
+    clean_model)`` pair where ``clean_model`` has the prefix stripped —
+    pass that to the SDK.
+    """
+    from attestor.llm_trace import get_client_for_model
+    return get_client_for_model(model)
 
 
-def _chat(client, model: str, prompt: str, max_tokens: int = 200,
-          *, role: str = "locomo.chat") -> str:
+def _chat(
+    client: Any,
+    model: str,
+    prompt: str,
+    max_tokens: int = 200,
+    *,
+    role: str = "locomo.chat",
+) -> str:
     """Send a chat completion request and return the text."""
-    from attestor.llm_trace import traced_create, make_client
+    from attestor.llm_trace import traced_create
     response = traced_create(
         client,
         role=role,
@@ -186,8 +195,8 @@ def _resolve_coreferences(
         conversation=conversation_text,
     )
 
-    client = _get_client(api_key)
-    resolved_text = _chat(client, model, prompt, max_tokens=4096)
+    client, clean_model = _resolve_client(model)
+    resolved_text = _chat(client, clean_model, prompt, max_tokens=4096)
     resolved_lines = [l.strip() for l in resolved_text.split("\n") if l.strip()]
 
     resolved_turns = []
@@ -528,7 +537,7 @@ def answer_question(
 
     results.sort(key=lambda r: r.score, reverse=True)
 
-    client = _get_client(api_key)
+    client, clean_model = _resolve_client(model)
     context, graph_context = _build_context(results, mem, names, speaker_a, speaker_b)
 
     # Reflection loop: check if context is sufficient, do follow-up queries if not
@@ -538,7 +547,7 @@ def answer_question(
             answer="(not yet generated)",
             context=context[:2000],
         )
-        reflection_text = _chat(client, model, reflection_prompt, max_tokens=200)
+        reflection_text = _chat(client, clean_model, reflection_prompt, max_tokens=200)
 
         if "SUFFICIENT" not in reflection_text.upper():
             follow_up_queries = [q.strip() for q in reflection_text.split("\n") if q.strip()]
@@ -562,7 +571,7 @@ def answer_question(
         graph_context=graph_context,
     )
 
-    return _chat(client, model, prompt, max_tokens=100)
+    return _chat(client, clean_model, prompt, max_tokens=100)
 
 
 def judge_answer(
@@ -579,8 +588,8 @@ def judge_answer(
         ai_response=generated,
     )
 
-    client = _get_client(api_key)
-    response_text = _chat(client, model, prompt, max_tokens=300)
+    client, clean_model = _resolve_client(model)
+    response_text = _chat(client, clean_model, prompt, max_tokens=300)
 
     try:
         result = json.loads(response_text)

--- a/attestor/longmemeval.py
+++ b/attestor/longmemeval.py
@@ -1492,7 +1492,8 @@ def answer_question(
         sample: ``LMESample`` being answered.
         budget: Retrieval token budget for ``mem.recall``.
         model: OpenRouter model id for synthesis.
-        api_key: Optional override for ``OPENROUTER_API_KEY``.
+        api_key: Optional override for the configured provider's API
+            key (see ``configs/attestor.yaml`` ``llm.providers.*.api_key_env``).
         max_facts: Cap on facts injected into the prompt (guards prompt size).
         max_tokens: Answerer ``max_tokens``. Bumped to 600 to accommodate the
             chain-of-thought <reasoning> block.
@@ -2185,7 +2186,8 @@ async def run_async(
         answer_model: OpenRouter model id for the answerer.
         judge_models: List of OpenRouter model ids. Multiple judges are
             called in parallel per sample and scored independently.
-        api_key: Optional OPENROUTER_API_KEY override.
+        api_key: Optional override for the configured provider's API
+            key (see ``configs/attestor.yaml`` ``llm.providers.*.api_key_env``).
         budget: Recall token budget per question.
         use_extraction: Run the LLM extractor during ingest.
         max_facts: Cap on facts injected into the answerer prompt.

--- a/attestor/mab.py
+++ b/attestor/mab.py
@@ -16,7 +16,6 @@ Requires: poetry add datasets openai  (not included in attestor base deps)
 from __future__ import annotations
 
 import logging
-import os
 import re
 import statistics
 import string
@@ -36,32 +35,24 @@ from attestor.utils.tokens import estimate_tokens
 
 
 def _upgrade_embeddings_for_benchmark(mem: AgentMemory) -> None:
-    """Ensure benchmarks use OpenAI text-embedding-3-small via OpenRouter.
+    """Refresh the vector store's embedding function for a benchmark run.
 
-    Benchmarks always use OpenRouter for embeddings — no fallback to local models.
-    Works for all backends (Postgres/pgvector, ArangoDB, Azure, AWS, GCP).
+    Embedding-provider selection is owned by ``configs/attestor.yaml``
+    (see ``attestor/store/embeddings.py`` for auto-detect rules:
+    Pinecone Inference / Voyage / OpenAI / Azure / Bedrock / Vertex /
+    Ollama). This helper just nudges the active vector store to
+    re-initialize its embedder so any provider key set after store
+    construction (e.g. via ``--env-file``) is picked up. No provider key
+    is read here — the underlying embedder factory handles that.
 
-    Raises RuntimeError if OPENROUTER_API_KEY is not set.
+    Works for all backends (Postgres/pgvector, ArangoDB, Azure, AWS,
+    GCP).
     """
-    openrouter_key = os.environ.get("OPENROUTER_API_KEY")
-    if not openrouter_key:
-        raise RuntimeError(
-            "OPENROUTER_API_KEY required for benchmarks. "
-            "Set it in .env or environment."
-        )
-
     vector_store = mem._vector_store
     if vector_store and hasattr(vector_store, "_ensure_embedding_fn"):
-        # Reset so it re-initializes with OpenRouter key
         vector_store._embedding_fn = None
         vector_store._ensure_embedding_fn()
-        if hasattr(vector_store, "_openai_client") or hasattr(vector_store, "_embedder"):
-            logger.info("Benchmark: using upgraded embeddings via OpenRouter")
-        else:
-            raise RuntimeError(
-                "Backend failed to initialize OpenAI embeddings despite "
-                "OPENROUTER_API_KEY being set. Check openai package."
-            )
+        logger.info("Benchmark: re-initialized vector store embedder")
     elif vector_store:
         logger.warning("Benchmark: vector store has no known embedding upgrade path")
 
@@ -635,29 +626,29 @@ def answer_question(
 
     context = "\n".join(r.memory.content for r in results)
 
-    try:
-        from openai import OpenAI
-    except ImportError:
-        return context  # Fallback: raw context
+    # Route through the LLM pool — provider/base_url/api_key_env all come
+    # from ``configs/attestor.yaml`` via the ``provider/`` prefix on the
+    # model id. Any missing provider key surfaces as a RuntimeError from
+    # the pool; we let it propagate so misconfig fails loudly rather
+    # than silently returning raw context.
+    from attestor.llm_trace import get_client_for_model, traced_create
 
-    OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
-    key = api_key or os.environ.get("OPENROUTER_API_KEY")
-    if not key:
-        return context  # No API key available
+    try:
+        client, clean_model = get_client_for_model(model)
+    except ImportError:
+        return context  # openai SDK not installed — degrade to raw context.
 
     prompt_template = MAB_EXACT_PROMPT if use_exact else MAB_ANSWER_PROMPT
     prompt = prompt_template.format(context=context, question=question)
-    client = make_client(base_url=OPENROUTER_BASE_URL, api_key=key)
 
     # Retry with exponential backoff on rate limits
     import time as _time
-    from attestor.llm_trace import traced_create, make_client
     for attempt in range(5):
         try:
             response = traced_create(
                 client,
                 role="mab.chat",
-                model=model,
+                model=clean_model,
                 max_tokens=300,
                 messages=[{"role": "user", "content": prompt}],
             )
@@ -825,7 +816,9 @@ def run_mab(
             # Fresh store per example
             with tempfile.TemporaryDirectory() as tmpdir:
                 mem = AgentMemory(tmpdir, config=backend_config)
-                # Use OpenAI embeddings for benchmarking if key available
+                # Refresh the embedder so any provider key set after
+                # store construction is picked up; provider selection
+                # itself is owned by configs/attestor.yaml.
                 _upgrade_embeddings_for_benchmark(mem)
                 mem._retrieval.enable_temporal_boost = False
 

--- a/attestor/retrieval/hyde.py
+++ b/attestor/retrieval/hyde.py
@@ -140,29 +140,44 @@ def generate_hypothetical_answer(
     On any error (missing key, malformed response, network timeout),
     returns ``HydeResult(original_question=question, hypothetical_answer="")``
     — the caller naturally degrades to a single-query lane.
+
+    Provider URL + API key env are sourced from the YAML-configured LLM
+    pool (``stack.llm.providers``). The ``api_key`` parameter is kept
+    for back-compat: when set, it overrides the pool-resolved client by
+    building a fresh one against the resolved provider's ``base_url``.
     """
     if not question.strip():
-        return HydeResult(original_question=question.strip())
-
-    api_key = api_key or os.environ.get("OPENROUTER_API_KEY")
-    if not api_key:
-        logger.debug("hyde.generate: no API key; returning degraded result")
         return HydeResult(original_question=question.strip())
 
     model = model or _resolve_generator_model()
 
     try:
-        from openai import OpenAI
-        client = OpenAI(
-            base_url="https://openrouter.ai/api/v1",
-            api_key=api_key,
-            timeout=timeout,
+        from attestor.llm_trace import (
+            get_client_for_model,
+            _get_pool,
+            make_client,
+            traced_create,
         )
-        from attestor.llm_trace import traced_create
+        if api_key:
+            pool = _get_pool()
+            head, sep, tail = model.partition("/")
+            if sep and head in pool.providers:
+                strategy = pool._strategies[head]  # noqa: SLF001
+                clean_model = tail
+            else:
+                strategy = pool.default_strategy()
+                clean_model = model
+            client = make_client(
+                base_url=strategy.base_url,
+                api_key=api_key,
+                timeout=timeout,
+            )
+        else:
+            client, clean_model = get_client_for_model(model)
         response = traced_create(
             client,
             role="hyde_generator",
-            model=model,
+            model=clean_model,
             max_tokens=400,
             temperature=0.0,
             messages=[
@@ -219,30 +234,54 @@ async def generate_hypothetical_answer_async(
 ) -> HydeResult:
     """Async sibling of ``generate_hypothetical_answer``.
 
-    Same prompt, same temperature=0, same fallback semantics. The only
-    difference: uses ``openai.AsyncOpenAI`` so the call can run
-    concurrently with the original-question vector embed via
-    ``asyncio.gather`` in ``hyde_search_async``.
+    Same prompt, same temperature=0, same fallback semantics. Uses
+    ``openai.AsyncOpenAI`` so the call can run concurrently with the
+    original-question vector embed via ``asyncio.gather`` in
+    ``hyde_search_async``.
+
+    The pool itself is sync-only, so we resolve the
+    ``LLMProviderStrategy`` (base_url + api_key_env) from the YAML pool
+    and build the ``AsyncOpenAI`` client locally — YAML still drives
+    the URL/key. The optional ``api_key`` arg overrides the env-derived
+    key against the same resolved ``base_url``.
     """
     if not question.strip():
-        return HydeResult(original_question=question.strip())
-
-    api_key = api_key or os.environ.get("OPENROUTER_API_KEY")
-    if not api_key:
-        logger.debug("hyde.generate_async: no API key; returning degraded result")
         return HydeResult(original_question=question.strip())
 
     model = model or _resolve_generator_model()
 
     try:
-        from openai import AsyncOpenAI
-        client = AsyncOpenAI(
-            base_url="https://openrouter.ai/api/v1",
-            api_key=api_key,
+        from attestor.llm_trace import _get_pool, make_async_client
+        pool = _get_pool()
+        head, sep, tail = model.partition("/")
+        if sep and head in pool.providers:
+            strategy = pool._strategies[head]  # noqa: SLF001
+            clean_model = tail
+        elif sep:
+            logger.debug(
+                "hyde.generate_async: unknown provider %r in model %r",
+                head, model,
+            )
+            return HydeResult(original_question=question.strip())
+        else:
+            strategy = pool.default_strategy()
+            clean_model = model
+
+        key = api_key or os.environ.get(strategy.api_key_env)
+        if not key:
+            logger.debug(
+                "hyde.generate_async: %s not set; returning degraded result",
+                strategy.api_key_env,
+            )
+            return HydeResult(original_question=question.strip())
+
+        client = make_async_client(
+            base_url=strategy.base_url,
+            api_key=key,
             timeout=timeout,
         )
         response = await client.chat.completions.create(
-            model=model,
+            model=clean_model,
             max_tokens=400,
             temperature=0.0,
             messages=[

--- a/attestor/retrieval/multi_query.py
+++ b/attestor/retrieval/multi_query.py
@@ -112,25 +112,35 @@ def rewrite_query(
     if n <= 0 or not question.strip():
         return RewriteResult(original=question.strip())
 
-    api_key = api_key or os.environ.get("OPENROUTER_API_KEY")
-    if not api_key:
-        logger.debug("multi_query.rewrite_query: no API key; returning original only")
-        return RewriteResult(original=question.strip())
-
     model = model or _resolve_rewriter_model()
 
     try:
-        from openai import OpenAI
-        client = OpenAI(
-            base_url="https://openrouter.ai/api/v1",
-            api_key=api_key,
-            timeout=timeout,
+        from attestor.llm_trace import (
+            get_client_for_model,
+            _get_pool,
+            make_client,
+            traced_create,
         )
-        from attestor.llm_trace import traced_create
+        if api_key:
+            pool = _get_pool()
+            head, sep, tail = model.partition("/")
+            if sep and head in pool.providers:
+                strategy = pool._strategies[head]  # noqa: SLF001
+                clean_model = tail
+            else:
+                strategy = pool.default_strategy()
+                clean_model = model
+            client = make_client(
+                base_url=strategy.base_url,
+                api_key=api_key,
+                timeout=timeout,
+            )
+        else:
+            client, clean_model = get_client_for_model(model)
         response = traced_create(
             client,
             role="multi_query_rewriter",
-            model=model,
+            model=clean_model,
             max_tokens=400,
             messages=[
                 {"role": "user", "content": _REWRITE_PROMPT.format(
@@ -184,22 +194,40 @@ async def rewrite_query_async(
     if n <= 0 or not question.strip():
         return RewriteResult(original=question.strip())
 
-    api_key = api_key or os.environ.get("OPENROUTER_API_KEY")
-    if not api_key:
-        logger.debug("multi_query.rewrite_query_async: no API key; returning original only")
-        return RewriteResult(original=question.strip())
-
     model = model or _resolve_rewriter_model()
 
     try:
-        from openai import AsyncOpenAI
-        client = AsyncOpenAI(
-            base_url="https://openrouter.ai/api/v1",
-            api_key=api_key,
+        from attestor.llm_trace import _get_pool, make_async_client
+        pool = _get_pool()
+        head, sep, tail = model.partition("/")
+        if sep and head in pool.providers:
+            strategy = pool._strategies[head]  # noqa: SLF001
+            clean_model = tail
+        elif sep:
+            logger.debug(
+                "multi_query.rewrite_query_async: unknown provider %r in "
+                "model %r", head, model,
+            )
+            return RewriteResult(original=question.strip())
+        else:
+            strategy = pool.default_strategy()
+            clean_model = model
+
+        key = api_key or os.environ.get(strategy.api_key_env)
+        if not key:
+            logger.debug(
+                "multi_query.rewrite_query_async: %s not set; returning "
+                "original only", strategy.api_key_env,
+            )
+            return RewriteResult(original=question.strip())
+
+        client = make_async_client(
+            base_url=strategy.base_url,
+            api_key=key,
             timeout=timeout,
         )
         response = await client.chat.completions.create(
-            model=model,
+            model=clean_model,
             max_tokens=400,
             temperature=0.0,
             messages=[

--- a/attestor/retrieval/planner.py
+++ b/attestor/retrieval/planner.py
@@ -24,8 +24,6 @@ import os
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
-OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
-
 
 def _default_planner_model() -> str:
     """Resolve the planner model: env override > YAML > hardcoded fallback."""
@@ -97,13 +95,29 @@ Question: {question}
 JSON:"""
 
 
-def _get_client(api_key: Optional[str] = None):
-    from openai import OpenAI
+def _resolve_client(model: str, api_key: Optional[str] = None) -> tuple[Any, str]:
+    """Resolve ``(client, clean_model)`` for ``model`` via the YAML-driven pool.
 
-    key = api_key or os.environ.get("OPENROUTER_API_KEY")
-    if not key:
-        raise ValueError("OPENROUTER_API_KEY not set")
-    return make_client(base_url=OPENROUTER_BASE_URL, api_key=key)
+    YAML is the only source of truth for provider URL/key. ``api_key`` is
+    kept for back-compat: when set, it overrides the pool-resolved client
+    by building a fresh one against the resolved provider's ``base_url``
+    so callers can still inject a one-off key without an env-var read.
+    """
+    from attestor.llm_trace import get_client_for_model, _get_pool, make_client
+
+    if api_key:
+        pool = _get_pool()
+        head, sep, tail = model.partition("/")
+        if sep and head in pool.providers:
+            strategy = pool._strategies[head]  # noqa: SLF001 — explicit override path
+            clean_model = tail
+        else:
+            strategy = pool.default_strategy()
+            clean_model = model
+        client = make_client(base_url=strategy.base_url, api_key=api_key)
+        return client, clean_model
+
+    return get_client_for_model(model)
 
 
 def _sanitize_plan(raw: Dict[str, Any]) -> QueryPlan:
@@ -147,17 +161,17 @@ def plan_query(
     goes blind.
     """
     try:
-        client = _get_client(api_key)
-    except ValueError:
+        client, clean_model = _resolve_client(model, api_key)
+    except (ValueError, KeyError, RuntimeError):
         return QueryPlan(intent="FACTUAL_RECALL")
 
     prompt = _PLANNER_PROMPT.format(question=question)
     try:
-        from attestor.llm_trace import traced_create, make_client
+        from attestor.llm_trace import traced_create
         response = traced_create(
             client,
             role="planner",
-            model=model,
+            model=clean_model,
             max_tokens=400,
             messages=[{"role": "user", "content": prompt}],
         )

--- a/attestor/retrieval/temporal_query.py
+++ b/attestor/retrieval/temporal_query.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 import re
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -157,15 +156,25 @@ class TemporalQueryExpander:
         prompt = TIME_EXTRACTION_PROMPT.format(
             now=ref_now.isoformat(), query=query,
         )
-        client = self._client or _default_client()
-        if client is None:
-            return None
+
+        if self._client is not None:
+            client = self._client
+            # Strip any provider/ prefix when an explicit client was
+            # injected — caller is responsible for picking the right one.
+            _, sep, tail = self._model.partition("/")
+            clean_model = tail if sep else self._model
+        else:
+            resolved = _default_client(self._model)
+            if resolved is None:
+                return None
+            client, clean_model = resolved
+
         try:
-            from attestor.llm_trace import traced_create, make_client
+            from attestor.llm_trace import traced_create
             response = traced_create(
                 client,
                 role="temporal_query",
-                model=self._model,
+                model=clean_model,
                 max_tokens=self._max_tokens,
                 messages=[{"role": "user", "content": prompt}],
             )
@@ -206,19 +215,22 @@ def _parse_window(raw: str) -> Optional[TimeWindow]:
         return None
 
 
-def _default_client() -> Optional[Any]:
-    """Build the same OpenAI/OpenRouter client the extractor uses.
+def _default_client(model: str) -> Optional[tuple[Any, str]]:
+    """Resolve ``(client, clean_model)`` via the YAML-driven LLM pool.
 
-    Returns None if no key set — the expander then no-ops gracefully.
+    YAML is the only source of truth for provider URL/key — no env
+    fallbacks. Returns ``None`` if the ``openai`` package is not
+    installed or the configured provider's API key env var is unset, so
+    the temporal expander degrades gracefully (the orchestrator just
+    skips the temporal pre-filter).
     """
     try:
-        from openai import OpenAI
+        import openai  # noqa: F401 — import-check only
     except ImportError:
         return None
-    or_key = os.environ.get("OPENROUTER_API_KEY")
-    if or_key:
-        return make_client(base_url="https://openrouter.ai/api/v1", api_key=or_key)
-    oa_key = os.environ.get("OPENAI_API_KEY")
-    if oa_key:
-        return make_client(api_key=oa_key)
-    return None
+    try:
+        from attestor.llm_trace import get_client_for_model
+        return get_client_for_model(model)
+    except (ValueError, KeyError, RuntimeError) as e:
+        logger.debug("temporal _default_client: pool resolve failed: %s", e)
+        return None

--- a/attestor/store/embeddings.py
+++ b/attestor/store/embeddings.py
@@ -1,19 +1,17 @@
 """Shared embedding providers — single source of truth for all backends.
 
-Fallback chain (each level tried only if the previous is unavailable):
-    1. Local Ollama (bge-m3 by default, 1024-D) — if Ollama is reachable
-    2. Cloud-native (Bedrock / Azure OpenAI / Vertex AI) — if credentials present
-    3. OpenAI / OpenRouter text-embedding-3-large — if API key set
-
-Local-first by design: Ollama on localhost:11434 is the default so attestor
-works offline / without API credits. Override with ATTESTOR_EMBEDDING_MODEL
-or ATTESTOR_EMBEDDING_PROVIDER env vars.
+YAML is authoritative. ``configs/attestor.yaml`` ``stack.embedder.provider``
+selects exactly one provider. There is **no Python-level fallback chain**:
+if the configured provider can't initialize, attestor raises loudly with a
+config-pointing message rather than silently picking a different backend.
+Silent fallthrough caused subtle index-dim drift in past runs and is
+deliberately removed.
 
 Usage:
-    provider = get_embedding_provider()          # auto-detect best available
-    provider = get_embedding_provider("bedrock") # prefer specific cloud provider
-    vec = provider.embed("hello world")          # -> List[float]
-    vecs = provider.embed_batch(["a", "b"])      # -> List[List[float]]
+    provider = get_embedding_provider()              # reads YAML's stack.embedder.provider
+    provider = get_embedding_provider("bedrock")     # explicit override (still strict)
+    vec = provider.embed("hello world")              # -> List[float]
+    vecs = provider.embed_batch(["a", "b"])          # -> List[List[float]]
 """
 
 from __future__ import annotations
@@ -630,14 +628,19 @@ def _try_vertex_ai() -> Optional[EmbeddingProvider]:
 
 
 def _try_openai() -> Optional[EmbeddingProvider]:
-    """Try OpenAI or OpenRouter.
+    """Try OpenAI (direct, no OpenRouter fallback).
 
     Controlled by env:
+        OPENAI_API_KEY              required
         OPENAI_EMBEDDING_MODEL      default ``text-embedding-3-large``
         OPENAI_EMBEDDING_DIMENSIONS default ``1536`` (Matryoshka reduction)
+
+    Returns ``None`` when ``OPENAI_API_KEY`` is unset; the strict dispatch
+    in ``get_embedding_provider`` then raises with a config-pointing message.
     """
-    openrouter_key = os.environ.get("OPENROUTER_API_KEY")
     openai_key = os.environ.get("OPENAI_API_KEY")
+    if not openai_key:
+        return None
 
     model = os.environ.get("OPENAI_EMBEDDING_MODEL", "text-embedding-3-large")
     dim_env = os.environ.get("OPENAI_EMBEDDING_DIMENSIONS", "1536")
@@ -646,32 +649,17 @@ def _try_openai() -> Optional[EmbeddingProvider]:
     except ValueError:
         dimensions = None
 
-    if openrouter_key:
-        try:
-            provider = OpenAIEmbeddingProvider(
-                api_key=openrouter_key,
-                base_url="https://openrouter.ai/api/v1",
-                model=f"openai/{model}",
-                dimensions=dimensions,
-            )
-            logger.info("Using %s via OpenRouter (%dD)", model, provider.dimension)
-            return provider
-        except Exception as e:
-            logger.warning("OpenRouter embeddings failed: %s", e)
-
-    if openai_key:
-        try:
-            provider = OpenAIEmbeddingProvider(
-                api_key=openai_key,
-                model=model,
-                dimensions=dimensions,
-            )
-            logger.info("Using %s (%dD)", model, provider.dimension)
-            return provider
-        except Exception as e:
-            logger.warning("OpenAI embeddings failed: %s", e)
-
-    return None
+    try:
+        provider = OpenAIEmbeddingProvider(
+            api_key=openai_key,
+            model=model,
+            dimensions=dimensions,
+        )
+        logger.info("Using %s (%dD)", model, provider.dimension)
+        return provider
+    except Exception as e:
+        logger.warning("OpenAI embeddings failed: %s", e)
+        return None
 
 
 _CLOUD_PROVIDERS = {
@@ -693,80 +681,73 @@ def clear_embedding_cache() -> None:
     _cached_provider = None
 
 
+_PROVIDER_DISPATCH = {
+    "openai": _try_openai,
+    "voyage": _try_voyage,
+    "pinecone": _try_pinecone_inference,
+    "ollama": _try_ollama,
+    "bedrock": _try_bedrock,
+    "azure_openai": _try_azure_openai,
+    "vertex_ai": _try_vertex_ai,
+}
+
+
 def get_embedding_provider(
     preferred: Optional[str] = None,
 ) -> EmbeddingProvider:
-    """Get the best available embedding provider.
+    """Get the configured embedding provider.
 
-    Fallback chain (preferred wins if specified and available):
-        0. preferred ("voyage" / "ollama" / "openai" / "bedrock" / "azure_openai" / "vertex_ai")
-        1. Voyage AI (Anthropic's recommended partner) — if VOYAGE_API_KEY set
-        2. Local Ollama (bge-m3 default) — if daemon reachable + model pulled
-        3. Cloud-native (Bedrock / Azure OpenAI / Vertex AI) — credentials present
-        4. OpenAI / OpenRouter — API key set
-
-    Set ``ATTESTOR_DISABLE_LOCAL_EMBED=1`` to skip the Ollama probe (e.g.
-    on hosted deployments where Ollama isn't installed).
+    YAML's ``stack.embedder.provider`` is authoritative. There is no
+    auto-detect chain. Calling with no ``preferred`` reads from YAML;
+    calling with ``preferred=X`` is the explicit override path. Init
+    failure raises ``RuntimeError`` with a config-pointing message —
+    silent fallthrough to a different backend is deliberately gone
+    because it caused subtle index-dim drift in past runs.
 
     Args:
-        preferred: Provider hint — "ollama", "bedrock", "azure_openai",
-                   "vertex_ai". Tried first but falls through on failure.
+        preferred: Provider name — one of openai / voyage / pinecone /
+                   ollama / bedrock / azure_openai / vertex_ai. When
+                   ``None``, the value is read from
+                   ``configs/attestor.yaml`` ``stack.embedder.provider``.
 
     Returns:
-        An EmbeddingProvider instance (cached after first call).
+        An ``EmbeddingProvider`` instance (cached after first call).
+
+    Raises:
+        RuntimeError: if the configured provider name is unknown or the
+            matching ``_try_*`` helper fails to initialize (e.g. missing
+            API key).
     """
     global _cached_provider
 
     if _cached_provider is not None and preferred is None:
         return _cached_provider
 
-    # Explicit preference path (cloud or local)
-    if preferred:
-        if preferred == "ollama":
-            provider = _try_ollama()
-            if provider is not None:
-                _cached_provider = provider
-                return provider
-        elif preferred in _CLOUD_PROVIDERS:
-            provider = _CLOUD_PROVIDERS[preferred]()
-            if provider is not None:
-                logger.info(
-                    "Using %s embeddings (%dD)",
-                    provider.provider_name, provider.dimension,
-                )
-                _cached_provider = provider
-                return provider
-        logger.debug("Preferred provider %r unavailable, trying fallbacks", preferred)
+    # No preferred argument — read it from YAML.
+    if preferred is None:
+        from attestor.config import get_stack
 
-    # Auto-detect chain.
-    # Pinecone Inference is checked first when PINECONE_EMBEDDING_MODEL is
-    # explicitly set (configure_embedder pins this from stack.embedder),
-    # because that env var is the canonical opt-in. Otherwise the chain
-    # falls through to Voyage / Ollama / OpenAI as before.
-    if os.environ.get("PINECONE_EMBEDDING_MODEL"):
-        provider = _try_pinecone_inference()
-        if provider is not None:
-            _cached_provider = provider
-            return provider
+        cfg = get_stack().embedder
+        return get_embedding_provider(preferred=cfg.provider)
 
-    provider = _try_voyage()
-    if provider is not None:
-        _cached_provider = provider
-        return provider
-
-    provider = _try_ollama()
-    if provider is not None:
-        _cached_provider = provider
-        return provider
-
-    provider = _try_openai()
-    if provider is not None:
-        _cached_provider = provider
-        return provider
-
-    raise RuntimeError(
-        "No embedding provider available. Set one of: VOYAGE_API_KEY (Anthropic-"
-        "recommended partner), OPENAI_API_KEY / OPENROUTER_API_KEY, or start "
-        "Ollama (`ollama serve` + `ollama pull bge-m3`), or configure a cloud "
-        "provider (Bedrock / Azure OpenAI / Vertex AI)."
+    # Strict dispatch: only the named provider is tried. No fallthrough.
+    try_fn = _PROVIDER_DISPATCH.get(preferred)
+    if try_fn is None:
+        raise RuntimeError(
+            f"unknown embedder provider {preferred!r}; expected one of "
+            f"{sorted(_PROVIDER_DISPATCH)}. Check stack.embedder.provider "
+            f"in configs/attestor.yaml."
+        )
+    provider = try_fn()
+    if provider is None:
+        raise RuntimeError(
+            f"embedder provider {preferred!r} (set in configs/attestor.yaml "
+            f"under stack.embedder.provider) failed to initialize. Check "
+            f"that the matching API key / env vars are set for that provider."
+        )
+    logger.info(
+        "Using %s embeddings (%dD) [pinned by config]",
+        provider.provider_name, provider.dimension,
     )
+    _cached_provider = provider
+    return provider

--- a/configs/attestor.yaml
+++ b/configs/attestor.yaml
@@ -52,18 +52,25 @@ stack:
     database: neo4j
 
   # ─── Embedder ────────────────────────────────────────────────────────
-  # 1024-D matches the v4 pgvector schema and the Pinecone index dim.
+  # Pinecone Inference llama-text-embed-v2 (NVIDIA-hosted, natively
+  # 1024-D — matches the pgvector schema and the Pinecone index dim
+  # without the `dimensions=` truncation other backends need).
+  # Free tier covers 5M tokens / month; check app.pinecone.io for
+  # current limit. Pairs naturally with the Pinecone vector store
+  # above so the embedder + index live in the same provider.
+  #
   # Alternatives (flip `provider`):
+  #   - openai   — text-embedding-3-small @ 1024-D (cheap, paid).
+  #                Set OPENAI_API_KEY; requires `dimensions: 1024`.
+  #   - openai   — text-embedding-3-large @ 1024-D (best quality, ~6x cost).
   #   - voyage   — voyage-4, 1024-D (Anthropic recommended; paid).
   #                Set VOYAGE_API_KEY.
-  #   - pinecone — Pinecone Inference llama-text-embed-v2 (NVIDIA-hosted).
-  #                Set PINECONE_API_KEY.
+  #   - ollama   — bge-m3, 1024-D (local, free; needs Ollama daemon).
   embedder:
-    provider: openai
-    # 1024-D explicitly requested via the `dimensions` param so it matches the pgvector schema (text-embedding-3-small is natively 1536-D).
-    model: text-embedding-3-small
+    provider: pinecone
+    model: llama-text-embed-v2
     dimensions: 1024
-    api_key_env: OPENAI_API_KEY        # resolved from environment
+    api_key_env: PINECONE_API_KEY      # resolved from environment
 
   # ─── LLM client routing ───────────────────────────────────────────────
   # Where chat-completion calls land. Multi-provider mode: route by
@@ -109,10 +116,9 @@ stack:
     judge: openai/gpt-5.5
 
     # Extraction / distillation — runs once per turn during ingest to
-    # pull explicit facts out of the conversation. Cheap model is fine
-    # because the workload is volume-heavy and structurally simple.
-    extraction: openai/gpt-5.4-mini
-    distill:    openai/gpt-5.4-mini
+    # pull explicit facts out of the conversation.
+    extraction: openai/gpt-5.5
+    distill:    openai/gpt-5.5
 
     # Verifier — second-pass cross-check after Judge. Anthropic
     # complements OpenAI for cross-model validation.
@@ -124,8 +130,8 @@ stack:
 
     # Generic CLI default — used when an ad-hoc command (e.g.
     # `attestor locomo`) is invoked without an explicit `--model` flag
-    # and no specific role applies. Cheap by design.
-    benchmark_default: openai/gpt-5.4-mini
+    # and no specific role applies.
+    benchmark_default: openai/gpt-5.5
 
     # ─── Reasoning effort (gpt-5.x reasoning-model param) ──────────────
     # Higher effort = more internal CoT tokens spent before the visible

--- a/tests/async_retrieval/test_audit_invariants_under_async.py
+++ b/tests/async_retrieval/test_audit_invariants_under_async.py
@@ -52,7 +52,7 @@ async def test_hyde_temperature_zero_determinism_across_runs():
         captured_temps.append(kwargs.get("temperature"))
         return _StubResp()
 
-    with patch.dict(os.environ, {"OPENROUTER_API_KEY": "stub"}):
+    with patch.dict(os.environ, {"OPENAI_API_KEY": "stub"}):
         with patch("openai.AsyncOpenAI") as mock_client_cls:
             mock_client_cls.return_value.chat.completions.create = fake_create
             for _ in range(3):

--- a/tests/async_retrieval/test_hyde_async.py
+++ b/tests/async_retrieval/test_hyde_async.py
@@ -218,7 +218,7 @@ async def test_hyde_async_preserves_temperature_zero():
         captured_kwargs.update(kwargs)
         return _StubResponse()
 
-    with patch.dict("os.environ", {"OPENROUTER_API_KEY": "stub"}):
+    with patch.dict("os.environ", {"OPENAI_API_KEY": "stub"}):
         with patch("openai.AsyncOpenAI") as mock_client_cls:
             mock_client_cls.return_value.chat.completions.create = fake_create
             await generate_hypothetical_answer_async("q")

--- a/tests/test_critique_revise_config.py
+++ b/tests/test_critique_revise_config.py
@@ -17,6 +17,7 @@ stack:
   neo4j:
     url: bolt://localhost:7687
     auth: { username: neo4j, password: pw }
+    database: neo4j
   embedder:
     provider: voyage
     model: voyage-4
@@ -31,6 +32,8 @@ stack:
     benchmark_default: x
   llm:
     provider: openrouter
+  budget: 4000
+  parallel: 2
 """
 
 

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -44,46 +44,61 @@ class TestGetEmbeddingProvider:
         # guard would otherwise fire against a leaked stub).
         clear_embedding_cache()
 
-    def test_raises_without_any_key(self):
-        """No local ollama, no cloud creds, no OpenAI key → explicit error."""
-        with patch.dict("os.environ", {}, clear=True):
-            with patch("attestor.store.embeddings._try_ollama", return_value=None):
-                with patch("attestor.store.embeddings._try_openai", return_value=None):
-                    with pytest.raises(RuntimeError, match="No embedding provider"):
-                        get_embedding_provider()
+    def test_strict_preferred_openai_raises_when_unavailable(self):
+        """preferred='openai' with no OPENAI_API_KEY → raises with config-pointing message.
 
-    def test_openai_tried_when_key_set(self):
-        """When OPENAI_API_KEY is set and Ollama unavailable, OpenAI is used."""
+        Strict mode: there's no auto-fallthrough. If YAML pins openai
+        and the helper can't initialize, attestor surfaces the config
+        problem rather than silently picking another backend.
+        """
+        # Patch the dispatch dict directly — it captures fn refs at module
+        # load, so monkeypatching _try_openai wouldn't affect it.
+        with patch.dict(
+            "attestor.store.embeddings._PROVIDER_DISPATCH",
+            {"openai": lambda: None},
+        ):
+            with pytest.raises(RuntimeError, match="failed to initialize"):
+                get_embedding_provider(preferred="openai")
+
+    def test_strict_preferred_openai_returns_when_available(self):
+        """preferred='openai' returns the openai provider when its
+        helper succeeds (no fallthrough involved)."""
         mock_provider = MagicMock()
         mock_provider.provider_name = "openai"
         mock_provider.dimension = 1536
 
-        with patch("attestor.store.embeddings._try_ollama", return_value=None):
-            with patch("attestor.store.embeddings._try_openai", return_value=mock_provider):
-                provider = get_embedding_provider()
-                assert provider.provider_name == "openai"
+        with patch.dict(
+            "attestor.store.embeddings._PROVIDER_DISPATCH",
+            {"openai": lambda: mock_provider},
+        ):
+            provider = get_embedding_provider(preferred="openai")
+            assert provider.provider_name == "openai"
 
-    def test_preferred_bedrock_tried_first(self):
-        """When preferred='bedrock', should try bedrock before openai."""
+    def test_preferred_bedrock_routes_to_bedrock(self):
+        """preferred='bedrock' dispatches to the bedrock helper."""
         mock_bedrock = MagicMock()
         mock_bedrock.provider_name = "bedrock"
         mock_bedrock.dimension = 1024
 
-        with patch("attestor.store.embeddings._CLOUD_PROVIDERS", {"bedrock": lambda: mock_bedrock}):
+        with patch.dict(
+            "attestor.store.embeddings._PROVIDER_DISPATCH",
+            {"bedrock": lambda: mock_bedrock},
+        ):
             provider = get_embedding_provider(preferred="bedrock")
             assert provider.provider_name == "bedrock"
 
-    def test_preferred_unavailable_falls_through_to_openai(self):
-        """Preferred cloud provider failing falls through to local→OpenAI path."""
-        mock_openai = MagicMock()
-        mock_openai.provider_name = "openai"
-        mock_openai.dimension = 1536
+    def test_preferred_unavailable_raises_no_fallthrough(self):
+        """Preferred provider failing must RAISE — no silent fallthrough.
 
-        with patch("attestor.store.embeddings._CLOUD_PROVIDERS", {"bedrock": lambda: None}):
-            with patch("attestor.store.embeddings._try_ollama", return_value=None):
-                with patch("attestor.store.embeddings._try_openai", return_value=mock_openai):
-                    provider = get_embedding_provider(preferred="bedrock")
-                    assert provider.provider_name == "openai"
+        This pins the strict-mode contract: YAML's stack.embedder.provider
+        is authoritative; failure is surfaced, not papered over.
+        """
+        with patch.dict(
+            "attestor.store.embeddings._PROVIDER_DISPATCH",
+            {"bedrock": lambda: None},
+        ):
+            with pytest.raises(RuntimeError, match="failed to initialize"):
+                get_embedding_provider(preferred="bedrock")
 
 
 class TestOpenAIEmbeddingProvider:

--- a/tests/test_hyde_orchestrator.py
+++ b/tests/test_hyde_orchestrator.py
@@ -203,6 +203,7 @@ stack:
   neo4j:
     url: bolt://localhost:7687
     auth: { username: neo4j, password: pw }
+    database: neo4j
   embedder:
     provider: voyage
     model: voyage-4
@@ -217,6 +218,8 @@ stack:
     benchmark_default: x
   llm:
     provider: openrouter
+  budget: 4000
+  parallel: 2
   retrieval:
     vector_top_k: 50
     hyde:
@@ -249,6 +252,7 @@ stack:
   neo4j:
     url: bolt://localhost:7687
     auth: { username: neo4j, password: pw }
+    database: neo4j
   embedder:
     provider: voyage
     model: voyage-4
@@ -263,6 +267,8 @@ stack:
     benchmark_default: x
   llm:
     provider: openrouter
+  budget: 4000
+  parallel: 2
   retrieval:
     vector_top_k: 50
 """,

--- a/tests/test_llm_provider_config.py
+++ b/tests/test_llm_provider_config.py
@@ -50,6 +50,8 @@ def yaml_with_llm(tmp_path, monkeypatch):
                     "planner": "anthropic/claude-opus-4.7",
                     "benchmark_default": "openai/gpt-4.1-mini",
                 },
+                "budget": 4000,
+                "parallel": 2,
             },
         }
         if base_url is not None:

--- a/tests/test_llm_trace.py
+++ b/tests/test_llm_trace.py
@@ -59,6 +59,8 @@ def yaml_with_role(tmp_path, monkeypatch):
                     "max_tokens": max_tokens,
                     **({"reasoning_effort": reasoning_effort} if reasoning_effort else {}),
                 },
+                "budget": 4000,
+                "parallel": 2,
             },
         }
         p = tmp_path / "attestor.yaml"

--- a/tests/test_multi_query_orchestrator.py
+++ b/tests/test_multi_query_orchestrator.py
@@ -205,6 +205,7 @@ stack:
   neo4j:
     url: bolt://localhost:7687
     auth: { username: neo4j, password: pw }
+    database: neo4j
   embedder:
     provider: voyage
     model: voyage-4
@@ -219,6 +220,8 @@ stack:
     benchmark_default: x
   llm:
     provider: openrouter
+  budget: 4000
+  parallel: 2
   retrieval:
     vector_top_k: 99
     multi_query:
@@ -255,6 +258,7 @@ stack:
   neo4j:
     url: bolt://localhost:7687
     auth: { username: neo4j, password: pw }
+    database: neo4j
   embedder:
     provider: voyage
     model: voyage-4
@@ -269,6 +273,8 @@ stack:
     benchmark_default: x
   llm:
     provider: openrouter
+  budget: 4000
+  parallel: 2
   retrieval:
     vector_top_k: 50
 """,

--- a/tests/test_ollama_embeddings.py
+++ b/tests/test_ollama_embeddings.py
@@ -196,8 +196,10 @@ def test_live_bge_m3_returns_1024d() -> None:
 
 @pytest.mark.live
 @pytest.mark.skipif(not _ollama_reachable(), reason="Ollama not running")
-def test_live_get_embedding_provider_picks_ollama() -> None:
-    """Auto-detect should land on Ollama when it's the first reachable provider."""
+def test_live_get_embedding_provider_picks_ollama_when_preferred() -> None:
+    """Strict dispatch — preferred='ollama' must land on the Ollama
+    provider when the daemon is up. The legacy auto-detect chain (no
+    `preferred=`) was removed in favor of YAML-driven selection."""
     clear_embedding_cache()
-    p = get_embedding_provider()
+    p = get_embedding_provider(preferred="ollama")
     assert p.provider_name.startswith("ollama:")

--- a/tests/test_reasoning_effort_config.py
+++ b/tests/test_reasoning_effort_config.py
@@ -42,6 +42,8 @@ def _yaml_with_models(tmp_path, monkeypatch, **models_extra) -> Path:
                 "benchmark_default": "openai/gpt-5.4-mini",
                 **models_extra,
             },
+            "budget": 4000,
+            "parallel": 2,
         },
     }
     p = tmp_path / "attestor.yaml"
@@ -135,10 +137,14 @@ def test_chat_kwargs_for_role_handles_unknown_role(tmp_path, monkeypatch):
 
 
 @pytest.mark.unit
-def test_chat_kwargs_for_role_survives_no_yaml(monkeypatch):
-    """Stripped checkout / no YAML — return safe defaults, don't crash."""
+def test_chat_kwargs_for_role_no_yaml_raises(monkeypatch):
+    """Stripped checkout / no YAML — strict-mode must fail loudly.
+
+    Fallback constants were removed; YAML is the single source of truth.
+    This test guards against the silent-fallback path being reintroduced.
+    """
     monkeypatch.setenv("ATTESTOR_CONFIG", "/tmp/nonexistent.yaml")
     from attestor import config as _c
     _c.reset_stack()
-    out = _c.chat_kwargs_for_role("answerer", fallback_max_tokens=300)
-    assert out == {"max_tokens": 300}
+    with pytest.raises(SystemExit, match="config not found"):
+        _c.chat_kwargs_for_role("answerer", fallback_max_tokens=300)

--- a/tests/test_retrieval_config.py
+++ b/tests/test_retrieval_config.py
@@ -36,6 +36,8 @@ def _yaml_with_retrieval(tmp_path, monkeypatch, **retrieval) -> Path:
                 "planner": "anthropic/claude-opus-4.7",
                 "benchmark_default": "openai/gpt-5.4-mini",
             },
+            "budget": 4000,
+            "parallel": 2,
         },
     }
     if retrieval:

--- a/tests/test_self_consistency_config.py
+++ b/tests/test_self_consistency_config.py
@@ -43,6 +43,8 @@ def _yaml_with(tmp_path, monkeypatch, **stack_extra: Any) -> Path:
                 "planner": "anthropic/claude-opus-4.7",
                 "benchmark_default": "openai/gpt-5.4-mini",
             },
+            "budget": 4000,
+            "parallel": 2,
             **stack_extra,
         },
     }
@@ -134,13 +136,14 @@ def test_self_consistency_partial_block_uses_defaults_for_missing(tmp_path, monk
 
 
 @pytest.mark.unit
-def test_self_consistency_no_yaml_falls_back_to_defaults(monkeypatch):
-    """Stripped checkout / no YAML → fallback stack still has a
-    valid SelfConsistencyCfg (disabled by default)."""
+def test_self_consistency_no_yaml_raises(monkeypatch):
+    """Stripped checkout / no YAML → strict-mode must fail loudly.
+
+    Fallback constants were removed; YAML is the single source of truth.
+    This test guards against the silent-fallback path being reintroduced.
+    """
     monkeypatch.setenv("ATTESTOR_CONFIG", "/tmp/nonexistent_attestor.yaml")
     from attestor import config as _c
     _c.reset_stack()
-    s = _c.get_stack(strict=False)
-    assert s.self_consistency.enabled is False
-    assert s.self_consistency.k == 5
-    assert s.self_consistency.voter == "majority"
+    with pytest.raises(SystemExit, match="config not found"):
+        _c.get_stack(strict=False)

--- a/tests/test_temporal_prefilter_orchestrator.py
+++ b/tests/test_temporal_prefilter_orchestrator.py
@@ -248,6 +248,7 @@ stack:
   neo4j:
     url: bolt://localhost:7687
     auth: {{ username: neo4j, password: pw }}
+    database: neo4j
   embedder:
     provider: voyage
     model: voyage-4
@@ -262,6 +263,8 @@ stack:
     benchmark_default: x
   llm:
     provider: openrouter
+  budget: 4000
+  parallel: 2
   retrieval:
     vector_top_k: 50
 {extra}


### PR DESCRIPTION
> User directive: *"yml should resolve everything related to model choice etc. no fallback please remove code. scan code everywhere."*

Removes every Python-level fallback for stack/model/embedder/provider selection. Missing YAML keys now raise loudly with a config-pointing message instead of silently picking a default. Silent fallthrough caused subtle index-dim drift and bench-vs-config divergence in past runs.

## Changes

### Embedder factory (`attestor/store/embeddings.py`)
- **Auto-detect chain (pinecone → voyage → ollama → openai) deleted.**
- `get_embedding_provider()` with no arg reads `stack.embedder.provider` from YAML; `preferred=X` is the explicit override path. Either way, init failure raises `RuntimeError` naming the YAML key and the missing API-key env var.
- `_try_openai` no longer reads `OPENROUTER_API_KEY`; only `OPENAI_API_KEY`.

### Config loader (`attestor/config.py`)
- Deleted **19 `_FALLBACK_*` constants** + standalone `_OPENROUTER_BASE_URL`.
- Deleted `_build_fallback_stack()` (0 external callers). Missing YAML now `SystemExit`s with the path.
- Every `.get(key, _FALLBACK_X)` → `_require(block, key, "stack.<dotted.path>")` that raises `ValueError` naming the missing path. 17 call-sites converted.

### LLM client hardcodes — 11 files swept
- `attestor/retrieval/{planner,hyde,multi_query,temporal_query}.py`
- `attestor/extraction/{llm_extractor,round_extractor,extractor}.py`
- `attestor/{locomo,mab,cli,longmemeval}.py`

Each module's local OpenRouter client construction (`OPENROUTER_BASE_URL` constant + `OPENROUTER_API_KEY` env reads + ad-hoc `OpenAI`/`AsyncOpenAI` builders) replaced with `attestor.llm_trace.get_client_for_model(model)` (sync) or pool-resolved `LLMProviderStrategy` + `make_async_client` (async). YAML drives `base_url` + `api_key_env` in every path.

### `configs/attestor.yaml`
- Embedder switched to Pinecone Inference `llama-text-embed-v2` (1024-D native — no `dimensions=` truncation needed).
- All `openai/*` roles bumped to `openai/gpt-5.5`. `verifier`/`planner` stay on `anthropic/claude-{sonnet,opus}-*` and route via the org-specific LiteLLM proxy (still placeholder URL/env).

### Tests (13 files)
- 13 fixtures updated for new required keys (`stack.budget`, `stack.parallel`, `stack.neo4j.database`).
- 4 `test_embeddings` tests rewritten to assert strict-mode contract (preferred-provider failure raises, no fallthrough). Mocks patch `_PROVIDER_DISPATCH` directly since fn refs are captured at module load.
- 2 async hyde tests: env-var stub switched from `OPENROUTER_API_KEY` → `OPENAI_API_KEY` (matches new default provider).
- 2 obsolete fallback-asserting tests renamed to test the raise path.

## Verification

- **1064 unit tests pass, 0 failures, 0 regressions.**
- Live smoke:
  - Pinecone Inference embedder → returned 1024-D vector ✓
  - `openai/gpt-5.5` → failed with the correct strict-mode error (`OPENAI_API_KEY not set — required to build the 'openai' LLM client`) since `OPENAI_API_KEY` isn't in `.env`. This is the desired fail-loud behavior, proving no silent fallback remains.

## Test plan

- [x] Full unit suite green
- [x] Live Pinecone embedder smoke (returns 1024-D)
- [ ] After merge: add `OPENAI_API_KEY` to `.env` to exercise the chat path live
- [ ] After merge: configure org's LiteLLM proxy URL/env locally to exercise the anthropic path