### PR TITLE
fix(core): capture insert() return so v4 UUID flows downstream

### DIFF
--- a/attestor/core/agent_memory.py
+++ b/attestor/core/agent_memory.py
@@ -522,9 +522,13 @@ class AgentMemory(_IdentityMixin, _QuotaMixin, _ProvenanceMixin):
         # Check for contradictions before insert
         contradictions = self._temporal.check_contradictions(memory)
 
-        # Insert new memory first (so FK reference is valid)
+        # Insert new memory first (so FK reference is valid).
+        # In v4 mode the document backend assigns a fresh UUID and returns
+        # a new (frozen) Memory; we MUST capture that return so the local
+        # `memory` variable carries the DB-generated id forward to vector
+        # add, graph extract, signing UPDATE, and the caller.
         t0 = time.monotonic()
-        self._store.insert(memory)
+        memory = self._store.insert(memory) or memory
         store_timings["document_ms"] = round((time.monotonic() - t0) * 1000, 2)
         from attestor import trace as _tr
         if _tr.is_enabled():


### PR DESCRIPTION
## Summary

One-line fix to a regression introduced by wave 3.A of #127. Surfaced by an E2E smoke against the live PG + Pinecone + Neo4j stack — every recall after that PR returned a short-hex id that PG's `uuid` column rejected.

## Why

Wave 3.A made `Memory` frozen and converted `PostgresBackend.insert()` from in-place mutation to:
```python
return dataclasses.replace(memory, id=str(rows[0]["id"]), t_created=...)
```

…but the caller `agent_memory.add()` at line 527 was never updated to capture the return value:

```python
self._store.insert(memory)   # ← lost the DB-generated UUID
```

Pre-freeze, in-place mutation meant the caller's `memory` reference saw the new id. Post-freeze, the new (replaced) Memory is on the stack inside `insert()` — discarded on return. The local `memory` keeps its pre-insert short-hex id from `Memory.id = uuid4().hex[:12]`. Every downstream consumer (vector store add, graph extract, signing UPDATE, trace, the returned Memory the user sees) used the stale id. Recall then failed when post-process tried to fetch from PG by that id.

## What

```python
memory = self._store.insert(memory) or memory
```

The `or memory` keeps backward-compat with backends that don't return — only v4 Postgres needs the new id today.

## Test plan

- [x] E2E smoke against live PG + Pinecone + Neo4j: 7/7 stages green
- [x] Unit suite: 1064 passed, 0 failed (baseline preserved)
- [x] Recall returns properly-keyed UUID memories (top hit `score=0.85` for "capital of France" vs the planted memory)

## Out of scope

- The bulk `import_json` path at line 1248 also calls `self._store.insert(memory)` without capturing — left as-is because that path doesn't use `memory.id` downstream.
- Other callers of `_store.insert` were audited and don't have the same downstream-id problem.