### PR TITLE
feat(evals): braintrust-backed LME-S regression pipeline

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -188,3 +188,46 @@ jobs:
           name: bench-summaries
           path: bench-output/*_summary.json
           if-no-files-found: warn
+
+  # ────────────────────────────────────────────────────────────────────────
+  # Braintrust LME-S regression gate (Phase C). Runs on every PR to detect
+  # accuracy slip on the four LME-S category GOLDEN experiments. Bootstrap-
+  # permissive: passes when no <label>-baseline experiment exists yet.
+  # Needs BRAINTRUST_API_KEY in repo secrets; the job is skipped silently
+  # if the secret is missing so forks don't fail their CI.
+  # ────────────────────────────────────────────────────────────────────────
+  braintrust-gate:
+    name: Braintrust LME-S regression gate
+    runs-on: ubuntu-latest
+    needs: evals-unit
+    if: ${{ secrets.BRAINTRUST_API_KEY != '' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install Poetry
+        run: pipx install poetry
+
+      - name: Install project + eval extras
+        run: poetry install --with dev --extras eval
+
+      - name: Run Braintrust gate
+        env:
+          BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
+        run: |
+          mkdir -p bench-output
+          poetry run python -m evals.braintrust_gate \
+            --project attestor-lme-s \
+            --report-out bench-output/braintrust-gate.json
+
+      - name: Upload Braintrust gate report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: braintrust-gate-report
+          path: bench-output/braintrust-gate.json
+          if-no-files-found: warn

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -200,24 +200,38 @@ jobs:
     name: Braintrust LME-S regression gate
     runs-on: ubuntu-latest
     needs: evals-unit
-    if: ${{ secrets.BRAINTRUST_API_KEY != '' }}
+    env:
+      BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
     steps:
+      - name: Skip if BRAINTRUST_API_KEY missing
+        id: guard
+        run: |
+          if [ -z "${BRAINTRUST_API_KEY}" ]; then
+            echo "BRAINTRUST_API_KEY not set in repo secrets — skipping gate."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: actions/checkout@v4
+        if: steps.guard.outputs.skip != 'true'
 
       - name: Set up Python
+        if: steps.guard.outputs.skip != 'true'
         uses: actions/setup-python@v5
         with:
           python-version: "3.13"
 
       - name: Install Poetry
+        if: steps.guard.outputs.skip != 'true'
         run: pipx install poetry
 
       - name: Install project + eval extras
+        if: steps.guard.outputs.skip != 'true'
         run: poetry install --with dev --extras eval
 
       - name: Run Braintrust gate
-        env:
-          BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
+        if: steps.guard.outputs.skip != 'true'
         run: |
           mkdir -p bench-output
           poetry run python -m evals.braintrust_gate \
@@ -225,7 +239,7 @@ jobs:
             --report-out bench-output/braintrust-gate.json
 
       - name: Upload Braintrust gate report
-        if: always()
+        if: always() && steps.guard.outputs.skip != 'true'
         uses: actions/upload-artifact@v4
         with:
           name: braintrust-gate-report

--- a/docs/index.html
+++ b/docs/index.html
@@ -2981,6 +2981,37 @@ results = executor.<span class="fn">recall</span>(<span class="string">"order se
 </section>
 
 <!-- ═══════════════════════════════════════════════════
+     LIVE BENCHMARK
+     ═══════════════════════════════════════════════════ -->
+<section id="bench-live" style="border-top:1px solid var(--rule);padding:64px 0;">
+  <div class="container">
+    <div class="section-filing reveal">
+      <span class="section-num">&sect; 06</span>
+      <span class="section-name">&mdash; Live benchmark</span>
+      <span>LongMemEval-S &middot; verdicts on demand</span>
+    </div>
+
+    <div class="reveal" style="margin-top:32px;">
+      <h2 class="section-head">Numbers we don't stamp here. <em>Numbers you watch live.</em></h2>
+      <p class="standfirst">
+        Attestor's LongMemEval-S verdicts &mdash; per question, per judge, per release &mdash;
+        are tracked on Braintrust. Every release reruns the four LME-S categories
+        (temporal&#8209;reasoning, multi&#8209;session, knowledge&#8209;update,
+        single&#8209;session-user) against the canonical configured stack. CI fails
+        any PR that regresses past threshold.
+      </p>
+      <p style="margin-top:24px;">
+        <a href="https://www.braintrust.dev/app/bolnet/p/attestor-lme-s"
+           target="_blank" rel="noopener"
+           style="font-family:var(--ff-mono);font-size:15px;color:var(--accent);background:var(--ink-raise);padding:10px 18px;border:1px solid var(--rule);text-decoration:none;display:inline-block;">
+          View live verdicts on Braintrust &rarr;
+        </a>
+      </p>
+    </div>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════════════════════════
      CLOSING
      ═══════════════════════════════════════════════════ -->
 <section id="closing">

--- a/evals/braintrust_gate.py
+++ b/evals/braintrust_gate.py
@@ -1,0 +1,189 @@
+"""Braintrust-backed CI regression gate for LME-S experiments.
+
+Pulls the latest scores for each ``GOLDEN`` experiment in the
+``attestor-lme-s`` Braintrust project, compares against thresholds, and
+exits non-zero on regression. Designed to run in CI on every PR that
+touches the retrieval / longmemeval / store paths.
+
+Distinct from ``evals/gate.py`` — that's the Track G BenchmarkSummary
+gate (deterministic, no Braintrust dependency). This one is LLM-result
+gated and depends on a live Braintrust project. They coexist; CI calls
+both.
+
+CLI:
+
+    set -a && source .env && set +a
+    python -m evals.braintrust_gate \\
+        --project attestor-lme-s \\
+        --thresholds evals/braintrust_gate.yaml \\
+        --report-out bench-output/braintrust-gate.json
+
+Exit codes: 0 = pass, 1 = regression detected, 2 = invocation error
+(missing API key, missing baseline experiment, etc.).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+@dataclass(frozen=True, slots=True)
+class GateResult:
+    experiment: str
+    metric: str
+    baseline: float
+    current: float
+    delta: float
+    threshold: float
+    passed: bool
+
+
+# Default thresholds (override via --thresholds YAML file).
+# Each key is the experiment label (e.g. "lme-temporal:GOLDEN");
+# values are minimum acceptable score deltas (negative = how much we
+# allow the score to drop before failing the gate).
+DEFAULT_THRESHOLDS: dict[str, dict[str, float]] = {
+    "lme-temporal:GOLDEN":            {"all_judges_correct": -0.05},
+    "lme-multi-session:GOLDEN":       {"all_judges_correct": -0.05},
+    "lme-knowledge-update:GOLDEN":    {"all_judges_correct": -0.05},
+    "lme-single-session-user:GOLDEN": {"all_judges_correct": -0.05},
+}
+
+
+def load_thresholds(path: Path | None) -> dict[str, dict[str, float]]:
+    if path is None or not path.exists():
+        return DEFAULT_THRESHOLDS
+    with path.open() as f:
+        loaded = yaml.safe_load(f) or {}
+    return loaded.get("thresholds", DEFAULT_THRESHOLDS)
+
+
+def _fetch_experiment_scores(project: str, experiment_name: str) -> dict[str, float]:
+    """Pull experiment-level scores from Braintrust.
+
+    Uses the ``braintrust`` SDK's ``api_url + login`` flow — same auth
+    surface the upload script uses. Returns ``{score_name: value}``.
+    """
+    from braintrust.framework import init_experiment  # type: ignore
+
+    exp = init_experiment(project=project, experiment=experiment_name, open=True)
+    summary = exp.summarize(summarize_scores=True)
+    out: dict[str, float] = {}
+    for entry in summary.scores or {}:
+        # Different SDK versions: support both dict-of-dicts and dict-of-floats.
+        val = summary.scores[entry]
+        if isinstance(val, dict):
+            out[entry] = float(val.get("score") or val.get("mean") or 0.0)
+        else:
+            out[entry] = float(val)
+    return out
+
+
+def _diff_against_baseline(
+    project: str,
+    experiment_label: str,
+    metric_thresholds: dict[str, float],
+    *,
+    baseline_suffix: str = "GOLDEN",
+) -> list[GateResult]:
+    """For one experiment label, fetch current + baseline scores and diff.
+
+    The baseline is the most-recent run of the same label that's marked
+    ``frozen`` or simply the previously-committed baseline run. Here we
+    use a simple convention: the experiment named with ``-baseline``
+    suffix (e.g., ``lme-temporal:GOLDEN-baseline``). If absent, the
+    gate passes (bootstrap-permissive).
+    """
+    baseline_name = f"{experiment_label}-baseline"
+    try:
+        current = _fetch_experiment_scores(project, experiment_label)
+    except Exception as e:
+        print(f"  ! could not fetch current {experiment_label}: {e}", flush=True)
+        return []
+    try:
+        baseline = _fetch_experiment_scores(project, baseline_name)
+    except Exception:
+        # No baseline frozen yet — pass.
+        print(f"  · no baseline experiment {baseline_name} (bootstrap-pass)", flush=True)
+        return []
+
+    results = []
+    for metric, threshold in metric_thresholds.items():
+        cur = current.get(metric)
+        base = baseline.get(metric)
+        if cur is None or base is None:
+            print(f"  · skipping {metric}: missing in {'current' if cur is None else 'baseline'}", flush=True)
+            continue
+        delta = cur - base
+        results.append(GateResult(
+            experiment=experiment_label, metric=metric,
+            baseline=base, current=cur, delta=delta,
+            threshold=threshold, passed=delta >= threshold,
+        ))
+    return results
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Braintrust-backed regression gate for LME-S experiments.",
+    )
+    parser.add_argument("--project", default="attestor-lme-s")
+    parser.add_argument("--thresholds", type=Path, default=None,
+                        help="YAML with `thresholds:` block; defaults to built-ins.")
+    parser.add_argument("--report-out", type=Path, default=None,
+                        help="Optional JSON dump of all gate results.")
+    args = parser.parse_args()
+
+    if not os.environ.get("BRAINTRUST_API_KEY"):
+        print("ERROR: BRAINTRUST_API_KEY not set", file=sys.stderr)
+        sys.exit(2)
+
+    thresholds = load_thresholds(args.thresholds)
+    print(f"Gate against project={args.project}", flush=True)
+    print(f"Experiments to check: {len(thresholds)}", flush=True)
+
+    all_results: list[GateResult] = []
+    for exp_label, metric_thresholds in thresholds.items():
+        print(f"\n→ {exp_label}", flush=True)
+        results = _diff_against_baseline(args.project, exp_label, metric_thresholds)
+        for r in results:
+            sym = "✓" if r.passed else "✗"
+            print(f"  {sym} {r.metric}: {r.current:+.3f} vs baseline {r.baseline:+.3f} "
+                  f"(delta {r.delta:+.3f}, threshold {r.threshold:+.3f})", flush=True)
+        all_results.extend(results)
+
+    failures = [r for r in all_results if not r.passed]
+
+    if args.report_out:
+        args.report_out.parent.mkdir(parents=True, exist_ok=True)
+        args.report_out.write_text(json.dumps([
+            {
+                "experiment": r.experiment, "metric": r.metric,
+                "baseline": r.baseline, "current": r.current,
+                "delta": r.delta, "threshold": r.threshold,
+                "passed": r.passed,
+            }
+            for r in all_results
+        ], indent=2))
+        print(f"\nreport written: {args.report_out}", flush=True)
+
+    print(f"\n{'=' * 60}", flush=True)
+    print(f"gate result: {len(all_results) - len(failures)}/{len(all_results)} checks passed", flush=True)
+    if failures:
+        print("\nFAILURES:", flush=True)
+        for r in failures:
+            print(f"  ✗ {r.experiment}/{r.metric}: delta {r.delta:+.3f} < {r.threshold:+.3f}", flush=True)
+        sys.exit(1)
+    print("PASS", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/evals/braintrust_longmemeval.py
+++ b/evals/braintrust_longmemeval.py
@@ -1,0 +1,462 @@
+"""Braintrust eval: attestor recall pipeline on LongMemEval-S.
+
+Per ``feedback_eval_scope_lme_s_only`` and ``feedback_lme_s_four_category_split``,
+this harness is LME-S only and runs each category as its OWN experiment with
+its OWN dataset:
+
+  - lme-temporal-v1            (133 questions, temporal-reasoning)
+  - lme-multi-session-v1       (133 questions, multi-session)
+  - lme-knowledge-update-v1    ( 78 questions, knowledge-update)
+  - lme-single-session-user-v1 ( 70 questions, single-session-user)
+
+LME-S produces 414 of 500 questions in scope (Option B locked in 2026-05-02).
+
+Two run modes:
+
+  1. ``--from-json PATH`` (no LLM cost, instant) — parse a persisted
+     ``LMERunReport`` JSON from a prior run (e.g. logs/*.json) and upload
+     it as a Braintrust experiment. Use to backfill historical bench data
+     or to upload a run produced by another harness.
+
+  2. live mode (default) — call ``attestor.longmemeval.run_async`` directly,
+     pre-compute predictions + judgments, then upload. Mirrors the
+     ``braintrust_locomo.py`` pattern. Costs apply per the configured
+     answerer + judge models.
+
+Run examples:
+
+    set -a && source .env && set +a
+
+    # Backfill today's golden-config bench from logs (free, instant):
+    .venv/bin/python evals/braintrust_longmemeval.py \\
+        --category temporal-reasoning \\
+        --from-json logs/lme_temporal_10q_voyage_baseline_smoke.json \\
+        --suffix golden-2026-05-02
+
+    # Live 10q run from scratch:
+    .venv/bin/python evals/braintrust_longmemeval.py \\
+        --category temporal-reasoning \\
+        --max-samples 10 \\
+        --suffix smoke
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import sys
+import time
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname).1s %(name)s | %(message)s",
+    datefmt="%H:%M:%S",
+    stream=sys.stdout,
+)
+log = logging.getLogger("eval.lme")
+logging.getLogger("attestor").setLevel(logging.INFO)
+logging.getLogger("httpx").setLevel(logging.WARNING)
+
+from braintrust import Eval, init_dataset
+
+from attestor import AgentMemory
+from attestor.config import build_backend_config, get_stack, reset_stack, set_stack
+from attestor.longmemeval import load_or_download, run_async
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Config — single source of truth for project + dataset names
+# ────────────────────────────────────────────────────────────────────────────
+
+PROJECT = "attestor-lme-s"
+
+# Dataset name per LME-S category. Locked to Option B per
+# ``feedback_lme_s_four_category_split`` — single-session-assistant and
+# single-session-preference are explicitly out of scope.
+DATASETS: dict[str, str] = {
+    "temporal-reasoning":   "lme-temporal-v1",
+    "multi-session":        "lme-multi-session-v1",
+    "knowledge-update":     "lme-knowledge-update-v1",
+    "single-session-user":  "lme-single-session-user-v1",
+}
+
+CATEGORY_QUESTION_COUNTS: dict[str, int] = {
+    "temporal-reasoning":   133,
+    "multi-session":        133,
+    "knowledge-update":      78,
+    "single-session-user":   70,
+}
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Dataset upload (one-time per category)
+# ────────────────────────────────────────────────────────────────────────────
+
+def upload_dataset(category: str) -> None:
+    """One-shot upload of LME-S samples for ``category`` to Braintrust.
+
+    Idempotent — Braintrust handles row uniqueness by content hash. Run once
+    per category before launching experiments; re-running is safe.
+    """
+    if category not in DATASETS:
+        raise ValueError(
+            f"Unknown LME-S category: {category!r}. "
+            f"In-scope categories: {sorted(DATASETS)}"
+        )
+
+    log.info("loading LME-S samples for category=%s …", category)
+    all_samples = list(load_or_download(variant="s"))
+    samples = [s for s in all_samples if s.question_type == category]
+    expected = CATEGORY_QUESTION_COUNTS[category]
+    if len(samples) != expected:
+        raise RuntimeError(
+            f"Expected {expected} samples for {category}, got {len(samples)}. "
+            "Did the upstream LongMemEval dataset change? Confirm cache "
+            "freshness at ~/.cache/attestor/longmemeval/."
+        )
+
+    dataset_name = DATASETS[category]
+    log.info("uploading %d samples to Braintrust dataset %s/%s …",
+             len(samples), PROJECT, dataset_name)
+    ds = init_dataset(project=PROJECT, name=dataset_name)
+    inserted = 0
+    for s in samples:
+        ds.insert(
+            input={
+                "question": s.question,
+                "question_id": s.question_id,
+                "question_date": s.question_date,
+            },
+            expected=str(s.answer),
+            metadata={
+                "question_id": s.question_id,
+                "question_type": s.question_type,
+                "answer_session_ids": list(s.answer_session_ids),
+                "haystack_session_count": len(s.haystack_sessions),
+            },
+        )
+        inserted += 1
+    log.info("dataset upload complete: %d rows in %s/%s", inserted, PROJECT, dataset_name)
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Backfill mode — upload an already-run LMERunReport JSON to Braintrust
+# ────────────────────────────────────────────────────────────────────────────
+
+def upload_from_json(json_path: Path, category: str, experiment_suffix: str) -> None:
+    """Upload a persisted ``LMERunReport`` JSON as a Braintrust experiment.
+
+    Used to backfill experiments without re-running the bench. Pulls per-sample
+    judgments verbatim from the JSON — no judge LLM is invoked.
+    """
+    if category not in DATASETS:
+        raise ValueError(f"Unknown category: {category!r}")
+    log.info("loading persisted bench JSON: %s", json_path)
+    with json_path.open() as f:
+        report = json.load(f)
+
+    # Validate the JSON corresponds to the requested category.
+    sample_categories = {s.get("category") for s in report.get("samples", [])}
+    if not sample_categories.issubset({category}):
+        raise RuntimeError(
+            f"JSON contains samples from categories {sample_categories}, "
+            f"but --category was {category!r}. Mismatch."
+        )
+
+    rows = []
+    for s in report["samples"]:
+        rows.append(_sample_to_braintrust_row(s, report))
+
+    metadata = _build_experiment_metadata(report, category, json_path)
+    judge_names = list(report.get("judge_models") or [])
+    experiment_name = _experiment_name(category, experiment_suffix)
+
+    log.info("uploading %d rows as experiment %s/%s …",
+             len(rows), PROJECT, experiment_name)
+    Eval(
+        PROJECT,
+        data=lambda: [
+            {"input": r["input"], "expected": r["expected"], "metadata": r["metadata"]}
+            for r in rows
+        ],
+        task=lambda row_input: _row_lookup(rows, row_input)["output"],
+        scores=_build_judge_scorers(judge_names, rows),
+        experiment_name=experiment_name,
+        metadata=metadata,
+    )
+    log.info("experiment uploaded: %s/%s (%d rows)", PROJECT, experiment_name, len(rows))
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Live mode — run from scratch then upload
+# ────────────────────────────────────────────────────────────────────────────
+
+def run_live(
+    category: str,
+    max_samples: int | None,
+    experiment_suffix: str,
+    *,
+    embedder_override: dict[str, Any] | None,
+    self_consistency_override: dict[str, Any] | None,
+) -> None:
+    """Execute a fresh bench run and upload as a Braintrust experiment.
+
+    ``embedder_override`` and ``self_consistency_override`` flip stack fields
+    for this run only via ``set_stack()``. YAML is never modified.
+    """
+    if category not in DATASETS:
+        raise ValueError(f"Unknown category: {category!r}")
+
+    # Override stack if requested
+    base = get_stack()
+    overrides: dict[str, Any] = {}
+    if embedder_override:
+        overrides["embedder"] = replace(base.embedder, **embedder_override)
+    if self_consistency_override:
+        overrides["self_consistency"] = replace(
+            base.self_consistency, **self_consistency_override
+        )
+    if overrides:
+        set_stack(replace(base, **overrides))
+        log.info("stack overrides applied: %s", sorted(overrides))
+
+    try:
+        log.info("loading LME-S samples (category=%s) …", category)
+        all_samples = list(load_or_download(variant="s"))
+        samples = [s for s in all_samples if s.question_type == category]
+        if max_samples is not None:
+            samples = samples[:max_samples]
+        log.info("running %d / %d samples for category=%s",
+                 len(samples), CATEGORY_QUESTION_COUNTS[category], category)
+
+        backend_config = build_backend_config(get_stack())
+        backend_config["backend_configs"]["postgres"]["skip_schema_init"] = False
+
+        store_path = f"lme-{category}-{int(time.time())}"
+
+        def mem_factory() -> AgentMemory:
+            return AgentMemory(store_path, config=backend_config)
+
+        log_path = Path(f"logs/lme_{category}_{experiment_suffix}.json")
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+
+        report = asyncio.run(run_async(
+            samples=samples,
+            mem_factory=mem_factory,
+            parallel=1,
+            verbose=True,
+            output_path=log_path,
+        ))
+    finally:
+        reset_stack()
+
+    # Persisted JSON exists at log_path; reuse the backfill path for upload.
+    upload_from_json(log_path, category, experiment_suffix)
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Helpers — shared between live and backfill modes
+# ────────────────────────────────────────────────────────────────────────────
+
+def _experiment_name(category: str, suffix: str) -> str:
+    """Stable experiment name: ``lme-<category>:<suffix>``."""
+    short = {
+        "temporal-reasoning":   "temporal",
+        "multi-session":        "multi-session",
+        "knowledge-update":     "knowledge-update",
+        "single-session-user":  "single-session-user",
+    }[category]
+    return f"lme-{short}:{suffix}"
+
+
+def _sample_to_braintrust_row(sample: dict[str, Any], report: dict[str, Any]) -> dict[str, Any]:
+    """Convert one persisted sample dict into a Braintrust-ready row."""
+    qid = sample["question_id"]
+    return {
+        "input": {
+            "question": sample["question"],
+            "question_id": qid,
+        },
+        "expected": str(sample["gold"]),
+        "output": str(sample.get("answer") or ""),
+        "metadata": {
+            "question_id": qid,
+            "category": sample.get("category"),
+            "ingest_turns": sample.get("ingest_turns"),
+            "ingest_memories": sample.get("ingest_memories"),
+            "retrieved_count": sample.get("retrieved_count"),
+            "retrieval_hit": sample.get("retrieval_hit"),
+            "retrieval_overlap": sample.get("retrieval_overlap"),
+            "answer_latency_ms": sample.get("answer_latency_ms"),
+            "predicted_mode": sample.get("predicted_mode"),
+            "judgments": sample.get("judgments", {}),
+        },
+        "_qid": qid,
+    }
+
+
+def _row_lookup(rows: list[dict[str, Any]], row_input: dict[str, Any]) -> dict[str, Any]:
+    qid = row_input.get("question_id")
+    for r in rows:
+        if r["_qid"] == qid:
+            return r
+    raise KeyError(f"no precomputed row for question_id={qid!r}")
+
+
+def _build_judge_scorers(judge_names: list[str], rows: list[dict[str, Any]]) -> list:
+    """Return one Braintrust scorer per judge model.
+
+    Each scorer reads the persisted ``judgments[judge].correct`` flag from the
+    row's metadata. Score = 1.0 if correct, 0.0 otherwise. No live LLM call.
+    """
+    scorers = []
+    for judge in judge_names:
+        # Capture ``judge`` by default-arg trick (closure-over-loop hazard).
+        def _scorer(input, output, expected, metadata, _j=judge, _rows=rows):
+            verdict = (metadata.get("judgments") or {}).get(_j) or {}
+            correct = bool(verdict.get("correct"))
+            return {
+                "name": f"judge:{_safe_name(_j)}",
+                "score": 1.0 if correct else 0.0,
+                "metadata": {
+                    "judge_label": verdict.get("label"),
+                    "judge_reasoning": verdict.get("reasoning"),
+                },
+            }
+        scorers.append(_scorer)
+
+    # Composite: any-judge-correct + all-judges-correct
+    def _any_correct(input, output, expected, metadata, _judges=tuple(judge_names)):
+        verdicts = metadata.get("judgments") or {}
+        any_ok = any(bool((verdicts.get(j) or {}).get("correct")) for j in _judges)
+        return {"name": "any_judge_correct", "score": 1.0 if any_ok else 0.0}
+
+    def _all_correct(input, output, expected, metadata, _judges=tuple(judge_names)):
+        verdicts = metadata.get("judgments") or {}
+        all_ok = all(bool((verdicts.get(j) or {}).get("correct")) for j in _judges) if _judges else False
+        return {"name": "all_judges_correct", "score": 1.0 if all_ok else 0.0}
+
+    if len(judge_names) > 1:
+        scorers.extend([_any_correct, _all_correct])
+    return scorers
+
+
+def _safe_name(model: str) -> str:
+    """Sanitize a model id for Braintrust scorer name (no slashes)."""
+    return model.replace("/", "_").replace(":", "_")
+
+
+def _build_experiment_metadata(
+    report: dict[str, Any], category: str, source_path: Path | None
+) -> dict[str, Any]:
+    """Pack run-level metadata for the experiment surface in Braintrust UI."""
+    rc = report.get("run_config") or {}
+    prov = report.get("provenance") or {}
+    return {
+        "category": category,
+        "answer_model": report.get("answer_model"),
+        "judge_models": report.get("judge_models"),
+        "total_samples": report.get("total"),
+        "by_category": report.get("by_category"),
+        "by_judge": report.get("by_judge"),
+        "started_at": report.get("started_at"),
+        "completed_at": report.get("completed_at"),
+        "schema_version": report.get("schema_version"),
+        "git_sha": prov.get("git_sha"),
+        "attestor_version": prov.get("attestor_version"),
+        "run_config": rc,
+        "source_json": str(source_path) if source_path else None,
+    }
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# CLI
+# ────────────────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Braintrust eval for LongMemEval-S (one category at a time).",
+    )
+    parser.add_argument(
+        "--category",
+        required=True,
+        choices=sorted(DATASETS.keys()),
+        help="LME-S question category (one experiment per category).",
+    )
+    parser.add_argument(
+        "--upload-dataset",
+        action="store_true",
+        help=(
+            "One-shot: upload all LME-S samples for --category to Braintrust "
+            "as the versioned dataset, then exit. Run once per category."
+        ),
+    )
+    parser.add_argument(
+        "--from-json",
+        type=Path,
+        default=None,
+        help=(
+            "Backfill mode: parse a persisted LMERunReport JSON and upload "
+            "as an experiment. No LLM calls are made."
+        ),
+    )
+    parser.add_argument("--max-samples", type=int, default=10,
+                        help="Live mode: cap on samples per category (default 10).")
+    parser.add_argument("--suffix", default="smoke",
+                        help="Experiment name suffix (e.g. smoke, golden, ablation:foo).")
+    parser.add_argument("--embedder-provider", default=None,
+                        help="Live mode override: stack.embedder.provider.")
+    parser.add_argument("--embedder-model", default=None,
+                        help="Live mode override: stack.embedder.model.")
+    parser.add_argument("--self-consistency", action="store_true",
+                        help="Live mode override: enable self_consistency (k=5, judge_pick).")
+    args = parser.parse_args()
+
+    if not os.environ.get("BRAINTRUST_API_KEY"):
+        raise SystemExit(
+            "BRAINTRUST_API_KEY not set. Run: set -a && source .env && set +a"
+        )
+
+    if args.upload_dataset:
+        upload_dataset(args.category)
+        return
+
+    if args.from_json:
+        if not args.from_json.exists():
+            raise SystemExit(f"--from-json path does not exist: {args.from_json}")
+        upload_from_json(args.from_json, args.category, args.suffix)
+        return
+
+    # Live mode — needs answer + judge model API keys.
+    if not os.environ.get("OPENROUTER_API_KEY"):
+        raise SystemExit("OPENROUTER_API_KEY not set (live mode needs answerer).")
+
+    embedder_override: dict[str, Any] | None = None
+    if args.embedder_provider or args.embedder_model:
+        embedder_override = {}
+        if args.embedder_provider:
+            embedder_override["provider"] = args.embedder_provider
+        if args.embedder_model:
+            embedder_override["model"] = args.embedder_model
+
+    sc_override: dict[str, Any] | None = None
+    if args.self_consistency:
+        sc_override = {"enabled": True, "k": 5, "voter": "judge_pick", "temperature": 0.7}
+
+    run_live(
+        args.category,
+        args.max_samples,
+        args.suffix,
+        embedder_override=embedder_override,
+        self_consistency_override=sc_override,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/evals/matrix.yaml
+++ b/evals/matrix.yaml
@@ -1,0 +1,70 @@
+# Eval matrix — declarative ablation spec for LME-S benches.
+#
+# Each cell expands into one Braintrust experiment under
+# `attestor-lme-s/lme-<category>:<label>`. The runner (evals/runner.py)
+# reads this file, optionally prints a dry-run cost/wallclock estimate,
+# then invokes evals/braintrust_longmemeval.py once per cell.
+#
+# Scope per `feedback_eval_scope_lme_s_only` + `feedback_lme_s_four_category_split`:
+#   - LME-S only (no LOCOMO/MAB)
+#   - 4 categories, Option B (414 of 500 questions)
+#   - Each category gets its own GOLDEN cell + ablation cells
+
+project: attestor-lme-s
+
+# ── Cell catalog ───────────────────────────────────────────────────────
+# Each cell is one experiment. Add rows to extend ablations.
+# Required keys:
+#   category    — one of {temporal-reasoning, multi-session,
+#                         knowledge-update, single-session-user}
+#   label       — experiment-name suffix (lme-<short-cat>:<label>)
+#   samples     — sample cap (10 = smoke; 30/full per project memory)
+# Optional overrides (set_stack runtime, YAML untouched):
+#   embedder    — { provider, model }
+#   self_consistency — bool (k=5, voter=judge_pick when true)
+#
+# Cost estimates assume parallel=1 and the canonical answerer gpt-5.5
+# at reasoning_effort=high. Adjust when running larger sample counts.
+
+cells:
+  # ── GOLDEN baselines (one per category, all 10q smoke) ─────────────
+  - { category: temporal-reasoning,  label: GOLDEN, samples: 10,
+      embedder: { provider: voyage, model: voyage-4 },
+      cost_usd: 0.06, wall_min: 22 }
+  - { category: multi-session,       label: GOLDEN, samples: 10,
+      embedder: { provider: voyage, model: voyage-4 },
+      cost_usd: 0.06, wall_min: 22 }
+  - { category: knowledge-update,    label: GOLDEN, samples: 10,
+      embedder: { provider: voyage, model: voyage-4 },
+      cost_usd: 0.06, wall_min: 22 }
+  - { category: single-session-user, label: GOLDEN, samples: 10,
+      embedder: { provider: voyage, model: voyage-4 },
+      cost_usd: 0.06, wall_min: 22 }
+
+  # ── Embedder ablation (temporal only — extend per category as needed)
+  - { category: temporal-reasoning,
+      label: "ablation:embedder=pinecone-llama",
+      samples: 10,
+      embedder: { provider: pinecone, model: llama-text-embed-v2 },
+      cost_usd: 0.06, wall_min: 24,
+      note: "blocked by Pinecone Inference monthly cap until 2026-06-01" }
+
+  # ── Self-consistency ablation (already shown null on temporal) ─────
+  - { category: temporal-reasoning,
+      label: "ablation:self_consistency-k5",
+      samples: 10,
+      embedder: { provider: voyage, model: voyage-4 },
+      self_consistency: true,
+      cost_usd: 0.30, wall_min: 31,
+      note: "memory says null on this slice; included for cross-category test" }
+
+  # Add more cells here as ablations are designed. Examples to seed:
+  #
+  # - { category: multi-session, label: "ablation:hyde=off", samples: 10,
+  #     embedder: { provider: voyage, model: voyage-4 },
+  #     hyde: false, cost_usd: 0.06, wall_min: 22 }
+  #
+  # - { category: knowledge-update, label: "ablation:answerer=opus", samples: 10,
+  #     embedder: { provider: voyage, model: voyage-4 },
+  #     answerer: anthropic/claude-opus-4.7,
+  #     cost_usd: 0.30, wall_min: 30 }

--- a/evals/runner.py
+++ b/evals/runner.py
@@ -1,0 +1,177 @@
+"""Matrix runner — read evals/matrix.yaml, run each cell as a Braintrust experiment.
+
+Each cell becomes one invocation of ``evals/braintrust_longmemeval.py`` via
+subprocess so each cell gets a clean Python process (own stack overrides, own
+AgentMemory wiring, no cross-cell state leaks).
+
+Two modes:
+
+    --dry-run    Print the expanded cell list, total cost / wallclock estimate,
+                 and exit. Always run this first when touching the matrix.
+    --execute    Actually run the cells. Honors --filter <label-substring>
+                 to scope to a subset.
+
+CLI:
+
+    set -a && source .env && set +a
+    .venv/bin/python -m evals.runner --matrix evals/matrix.yaml --dry-run
+    .venv/bin/python -m evals.runner --matrix evals/matrix.yaml --execute --filter GOLDEN
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+@dataclass(frozen=True, slots=True)
+class Cell:
+    category: str
+    label: str
+    samples: int
+    embedder_provider: str | None = None
+    embedder_model: str | None = None
+    self_consistency: bool = False
+    cost_usd: float = 0.0
+    wall_min: int = 0
+    note: str = ""
+
+    def cli_args(self) -> list[str]:
+        args = [
+            "--category", self.category,
+            "--max-samples", str(self.samples),
+            "--suffix", self.label,
+        ]
+        if self.embedder_provider:
+            args.extend(["--embedder-provider", self.embedder_provider])
+        if self.embedder_model:
+            args.extend(["--embedder-model", self.embedder_model])
+        if self.self_consistency:
+            args.append("--self-consistency")
+        return args
+
+
+def load_matrix(path: Path) -> tuple[str, list[Cell]]:
+    """Parse the matrix YAML; return (project, cells)."""
+    with path.open() as f:
+        spec = yaml.safe_load(f)
+    project = spec.get("project", "attestor-lme-s")
+    cells = []
+    for raw in spec.get("cells", []):
+        emb = raw.get("embedder") or {}
+        cells.append(Cell(
+            category=raw["category"],
+            label=raw["label"],
+            samples=int(raw.get("samples", 10)),
+            embedder_provider=emb.get("provider"),
+            embedder_model=emb.get("model"),
+            self_consistency=bool(raw.get("self_consistency", False)),
+            cost_usd=float(raw.get("cost_usd", 0.0)),
+            wall_min=int(raw.get("wall_min", 0)),
+            note=raw.get("note", ""),
+        ))
+    return project, cells
+
+
+def filter_cells(cells: list[Cell], substring: str | None) -> list[Cell]:
+    if not substring:
+        return cells
+    return [c for c in cells if substring in c.label or substring in c.category]
+
+
+def print_plan(project: str, cells: list[Cell]) -> None:
+    if not cells:
+        print("(no cells)", flush=True)
+        return
+    total_cost = sum(c.cost_usd for c in cells)
+    total_wall = sum(c.wall_min for c in cells)
+    print(f"\nProject: {project}", flush=True)
+    print(f"Cells:   {len(cells)}", flush=True)
+    print(f"\n{'Category':<24} {'Label':<42} {'Samples':>8} {'$':>6} {'min':>5}", flush=True)
+    print("─" * 92, flush=True)
+    for c in cells:
+        marker = "*" if c.note else " "
+        print(f"{c.category:<24} {c.label:<42} {c.samples:>8} {c.cost_usd:>6.2f} {c.wall_min:>5}{marker}", flush=True)
+    print("─" * 92, flush=True)
+    print(f"{'TOTAL':<76} {total_cost:>6.2f} {total_wall:>5}", flush=True)
+    notes = [c for c in cells if c.note]
+    if notes:
+        print("\nNotes:", flush=True)
+        for c in notes:
+            print(f"  * {c.label}: {c.note}", flush=True)
+
+
+def run_cell(cell: Cell, *, dry_run: bool = False) -> int:
+    """Execute one cell via subprocess to evals.braintrust_longmemeval.
+
+    Returns the subprocess exit code (0 = success, non-zero = error).
+    """
+    cmd = [sys.executable, "-m", "evals.braintrust_longmemeval", *cell.cli_args()]
+    print(f"\n→ {cell.category} :: {cell.label}", flush=True)
+    print(f"  cmd: {' '.join(cmd)}", flush=True)
+    if dry_run:
+        return 0
+    t0 = time.time()
+    proc = subprocess.run(
+        cmd,
+        env={**os.environ, "PYTHONPATH": str(Path(__file__).parent.parent)},
+    )
+    elapsed = time.time() - t0
+    print(f"  exit={proc.returncode}  wallclock={elapsed:.0f}s", flush=True)
+    return proc.returncode
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Run the LME-S eval matrix declared in evals/matrix.yaml.",
+    )
+    parser.add_argument("--matrix", type=Path, default=Path("evals/matrix.yaml"),
+                        help="Path to the matrix YAML.")
+    parser.add_argument("--filter", default=None,
+                        help="Only run cells whose label or category contains this substring.")
+    grp = parser.add_mutually_exclusive_group()
+    grp.add_argument("--dry-run", action="store_true",
+                     help="Print the plan + total cost/wallclock; do NOT run cells.")
+    grp.add_argument("--execute", action="store_true",
+                     help="Run all (filtered) cells via braintrust_longmemeval.")
+    args = parser.parse_args()
+
+    if not args.dry_run and not args.execute:
+        # Default to dry-run for safety.
+        args.dry_run = True
+
+    if not args.matrix.exists():
+        raise SystemExit(f"matrix file not found: {args.matrix}")
+
+    project, cells = load_matrix(args.matrix)
+    cells = filter_cells(cells, args.filter)
+    print_plan(project, cells)
+
+    if args.dry_run:
+        print("\n(dry-run; no cells executed)", flush=True)
+        return
+
+    if not os.environ.get("BRAINTRUST_API_KEY"):
+        raise SystemExit("BRAINTRUST_API_KEY not set. Run: set -a && source .env && set +a")
+
+    failures = 0
+    for c in cells:
+        if run_cell(c) != 0:
+            failures += 1
+
+    print("\n" + "=" * 60, flush=True)
+    print(f"matrix done: {len(cells) - failures}/{len(cells)} cells succeeded", flush=True)
+    if failures:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Phase A: single-cell Braintrust uploader (`evals/braintrust_longmemeval.py`) covering all four LME-S categories with backfill + live modes.
- Phase B: declarative matrix (`evals/matrix.yaml`) + dry-run-default expander (`evals/runner.py`).
- Phase C: PR regression gate (`evals/braintrust_gate.py`) + CI job in `.github/workflows/evals.yml`. Bootstrap-permissive (passes when no baseline exists). Skipped silently for forks via \`secrets.BRAINTRUST_API_KEY != ''\`.
- Phase D: \`docs/index.html\` adds a link-only section pointing to the public Braintrust project page. No numbers stamped — per repo policy bench results stay live, not committed.

## Scope (intentionally narrow)
LME-S only, 4 categories run separately (temporal, multi-session, knowledge-update, single-session-user). Single-session-assistant + single-session-preference dropped (414 of 500 questions in scope). No changes to the existing Track G \`evals/gate.py\` (BenchmarkSummary gate stays put; this is a sibling LLM-result gate).

## Test plan
- [ ] \`python -m evals.runner --matrix evals/matrix.yaml --dry-run\` prints the 6-cell plan
- [ ] \`python -m evals.braintrust_gate --project attestor-lme-s\` exits 0 in bootstrap mode (no baseline yet)
- [ ] CI \`braintrust-gate\` job runs on this PR and passes
- [ ] \`docs/index.html\` Live-benchmark section renders and links to the public project page