### PR TITLE
feat(evals): add --parallel flag to braintrust_longmemeval

### DIFF
--- a/evals/braintrust_longmemeval.py
+++ b/evals/braintrust_longmemeval.py
@@ -204,6 +204,7 @@ def run_live(
     *,
     embedder_override: dict[str, Any] | None,
     self_consistency_override: dict[str, Any] | None,
+    parallel: int = 1,
 ) -> None:
     """Execute a fresh bench run and upload as a Braintrust experiment.
 
@@ -240,6 +241,14 @@ def run_live(
 
         store_path = f"lme-{category}-{int(time.time())}"
 
+        # Warm-up: apply schema once with a single AgentMemory so parallel
+        # workers can skip init and avoid AccessExclusiveLock deadlocks on the
+        # catalog when parallel > 1.
+        if parallel > 1:
+            log.info("warming up schema (parallel=%d)…", parallel)
+            AgentMemory(store_path, config=backend_config)
+            backend_config["backend_configs"]["postgres"]["skip_schema_init"] = True
+
         def mem_factory() -> AgentMemory:
             return AgentMemory(store_path, config=backend_config)
 
@@ -249,7 +258,7 @@ def run_live(
         report = asyncio.run(run_async(
             samples=samples,
             mem_factory=mem_factory,
-            parallel=1,
+            parallel=parallel,
             verbose=True,
             output_path=log_path,
         ))
@@ -416,6 +425,8 @@ def main() -> None:
                         help="Live mode override: stack.embedder.model.")
     parser.add_argument("--self-consistency", action="store_true",
                         help="Live mode override: enable self_consistency (k=5, judge_pick).")
+    parser.add_argument("--parallel", type=int, default=1,
+                        help="Live mode: concurrent samples in run_async (default 1).")
     args = parser.parse_args()
 
     if not os.environ.get("BRAINTRUST_API_KEY"):
@@ -455,6 +466,7 @@ def main() -> None:
         args.suffix,
         embedder_override=embedder_override,
         self_consistency_override=sc_override,
+        parallel=args.parallel,
     )
 
 


### PR DESCRIPTION
## Summary

Adds \`--parallel N\` to \`evals/braintrust_longmemeval.py\` live mode, with a schema warm-up that prevents the Postgres catalog deadlock that bit the 2026-04-30 parallel=16 run.

## What's in the change (13 lines)

- New CLI flag \`--parallel\` (default 1; fully back-compat).
- When \`parallel > 1\`: instantiate one \`AgentMemory\` up front to apply the v4 schema once, then set \`backend_configs.postgres.skip_schema_init = True\` so each parallel worker reuses the existing schema and skips DDL.
- The flag flows through to \`run_async(parallel=…)\`.

## Why

Without the warm-up, parallel workers race on Postgres catalog locks (\`AccessExclusiveLock\` on the relation oid during \`CREATE INDEX IF NOT EXISTS\`). The 2026-04-30 parallel=16 attempt deadlocked and we had to fall back to parallel=4 + retry-on-429. Serialising schema work into one up-front transaction closes the contention window before any worker starts.

## Test plan

- [x] At \`--parallel 1\` (default), behaviour unchanged — no warm-up, no skip flag, single-process path.
- [ ] At \`--parallel 4\` on a 10-sample temporal smoke: completes without deadlock, all 10 samples uploaded to Braintrust.
- [ ] CI: unit tests + build-and-push green.