### PR TITLE
fix(client): import_json PK collision + MemoryClient namespace propagation

### DIFF
--- a/attestor/client.py
+++ b/attestor/client.py
@@ -76,8 +76,17 @@ class MemoryClient:
         event_date: str | None = None,
         confidence: float = 1.0,
         metadata: dict[str, Any] | None = None,
+        namespace: str | None = None,
     ) -> Memory:
-        """Add a memory via the HTTP API."""
+        """Add a memory via the HTTP API.
+
+        ``namespace`` is forwarded to the server so namespace-scoped
+        writes work over HTTP (parity with the embedded
+        ``AgentMemory.add`` and with ``MemoryClient.recall``). The
+        server defaults to ``"default"`` when the body omits the key,
+        so the client only inlines it when the caller explicitly
+        passes one — masking misconfig is worse than a stale tenant.
+        """
         body: dict[str, Any] = {
             "content": content,
             "tags": tags or [],
@@ -92,6 +101,8 @@ class MemoryClient:
             body["entity"] = entity
         if event_date:
             body["event_date"] = event_date
+        if namespace is not None:
+            body["namespace"] = namespace
 
         data = self._post("/add", body)
         return Memory.from_row(data)

--- a/attestor/core/agent_memory.py
+++ b/attestor/core/agent_memory.py
@@ -1202,7 +1202,21 @@ class AgentMemory(_IdentityMixin, _QuotaMixin, _ProvenanceMixin):
             json.dump(data, f, indent=2)
 
     def import_json(self, filepath: str) -> int:
-        """Import memories from a JSON file. Returns count imported."""
+        """Import memories from a JSON file. Returns count imported.
+
+        Each entry in the JSON payload is mapped onto a fresh ``Memory``
+        and handed to ``self._store.insert``. Two safety details matter:
+
+        - ``id`` is regenerated when the JSON entry omits the field OR
+          provides ``null`` / empty-string. ``dict.get("id", DEFAULT)``
+          only uses the default for *missing* keys, so a payload with
+          ``"id": null`` would otherwise pass ``None`` straight to the
+          store and silently drop the row when the PK rejects it.
+        - Insert errors that are NOT a duplicate-content collision are
+          logged at WARNING. The previous bare ``except Exception: pass``
+          masked PK violations, NOT-NULL violations, and connection
+          errors as if they were dedup hits.
+        """
         with open(filepath) as f:
             data = json.load(f)
         count = 0
@@ -1214,8 +1228,12 @@ class AgentMemory(_IdentityMixin, _QuotaMixin, _ProvenanceMixin):
             if hasattr(self._store, "get_by_hash") and self._store.get_by_hash(chash):
                 continue
 
+            # ``or Memory().id`` (not ``get(..., default)``) so null / empty
+            # ids in the JSON payload still get a fresh value — see
+            # tests/test_client_import_gaps.py.
+            row_id = item.get("id") or Memory().id
             memory = Memory(
-                id=item.get("id", Memory().id),
+                id=row_id,
                 content=content,
                 tags=item.get("tags", []),
                 category=item.get("category", "general"),
@@ -1233,9 +1251,14 @@ class AgentMemory(_IdentityMixin, _QuotaMixin, _ProvenanceMixin):
             try:
                 self._store.insert(memory)
                 count += 1
-            except Exception:
-                # Skip duplicates
-                pass
+            except Exception as e:
+                # Don't mask non-dedup failures (PK violations, NOT-NULL
+                # violations, connection errors). Log and keep going so a
+                # bad row doesn't abort the rest of the import.
+                logger.warning(
+                    "import_json: insert failed for id=%s (%s): %s",
+                    row_id, type(e).__name__, e,
+                )
         return count
 
     # -- Graph --

--- a/attestor/store/embeddings.py
+++ b/attestor/store/embeddings.py
@@ -499,13 +499,19 @@ _CLOUD_PROVIDERS = {
 
 # Module-level cache — prevents re-initialising the embedding provider
 # (e.g. API sessions) on every call.
-_cached_provider: EmbeddingProvider | None = None
+#
+# Keyed by the resolved provider name so a YAML edit (or an explicit
+# ``preferred=...`` call for a different provider) doesn't return a stale
+# cached instance. Pre-fix: a single-slot ``_cached_provider`` was returned
+# on every ``preferred=None`` call without re-reading YAML, which let a
+# stale provider silently survive a config change and re-incarnated the
+# silent vector-dim drift bug downstream.
+_provider_cache: dict[str, EmbeddingProvider] = {}
 
 
 def clear_embedding_cache() -> None:
-    """Clear the cached embedding provider (for testing)."""
-    global _cached_provider
-    _cached_provider = None
+    """Clear the cached embedding providers (for testing)."""
+    _provider_cache.clear()
 
 
 _PROVIDER_DISPATCH = {
@@ -542,17 +548,19 @@ def get_embedding_provider(
             matching ``_try_*`` helper fails to initialize (e.g. missing
             API key).
     """
-    global _cached_provider
-
-    if _cached_provider is not None and preferred is None:
-        return _cached_provider
-
-    # No preferred argument — read it from YAML.
+    # No preferred argument — read it from YAML EVERY call. Don't short-
+    # circuit on the cache here, otherwise a YAML edit between calls is
+    # ignored and downstream dim checks pass against the stale provider.
     if preferred is None:
         from attestor.config import get_stack
 
         cfg = get_stack().embedder
         return get_embedding_provider(preferred=cfg.provider)
+
+    # Cache hit — same provider name asked for again.
+    cached = _provider_cache.get(preferred)
+    if cached is not None:
+        return cached
 
     # Strict dispatch: only the named provider is tried. No fallthrough.
     try_fn = _PROVIDER_DISPATCH.get(preferred)
@@ -573,5 +581,5 @@ def get_embedding_provider(
         "Using %s embeddings (%dD) [pinned by config]",
         provider.provider_name, provider.dimension,
     )
-    _cached_provider = provider
+    _provider_cache[preferred] = provider
     return provider

--- a/tests/test_client_import_gaps.py
+++ b/tests/test_client_import_gaps.py
@@ -1,0 +1,340 @@
+"""Regression tests for the client/import safety bugs surfaced by the
+2026-05-02 test-gap audit (post-PR #135).
+
+Each test in this file maps 1:1 to a production bug uncovered by the audit:
+
+  - Gap C1 — ``AgentMemory.import_json`` swallows insert errors so a
+    JSON payload missing/null ``id`` fields silently drops rows.
+  - Gap C2 — ``MemoryClient.add`` never accepted a ``namespace`` kwarg
+    even though ``MemoryClient.recall`` does, so HTTP writes always
+    landed in the ``"default"`` namespace and silently broke
+    multi-tenant isolation.
+  - Gap C3 — ``attestor.store.embeddings`` caches the first provider it
+    builds and returns it on every subsequent call, even when the
+    caller asks for a different provider. Combined with the
+    skip-on-cache-hit behavior of the dim guard this re-incarnates the
+    silent dim-mismatch bug.
+
+Tests are hermetic where possible (no Postgres / Pinecone / Neo4j); the
+one integration test that needs a real document store is gated on the
+shared ``mem`` fixture and skips when ``POSTGRES_URL`` is unset.
+
+See ``test_temporal_supersession_gaps.py`` for the header style this
+file follows.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import tempfile
+from dataclasses import replace
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from attestor.client import MemoryClient
+from attestor.models import Memory
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Shared fakes
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class _FakeResponse:
+    """Minimal urllib response object compatible with the client's reader."""
+
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self._buf = io.BytesIO(json.dumps(payload).encode())
+
+    def read(self) -> bytes:
+        return self._buf.read()
+
+    def __enter__(self) -> "_FakeResponse":
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        self._buf.close()
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Gap C1 — import_json silently drops rows when ``id`` is missing/null
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class _StrictPKStore:
+    """Tiny fake DocumentStore that mimics a real PK constraint.
+
+    - Rejects ``None`` / empty-string ids with ``ValueError`` (psycopg2 raises
+      ``InvalidTextRepresentation`` on ``UUID NOT NULL`` columns; we surface
+      the same shape with a generic exception so the
+      ``except Exception: pass`` in ``import_json`` is the thing that gets
+      exercised, not a UUID-library quirk).
+    - Rejects duplicate ids with ``ValueError`` (PK collision).
+    - Stores accepted memories in an in-memory dict keyed by id.
+    """
+
+    def __init__(self) -> None:
+        self.rows: dict[str, Memory] = {}
+
+    def insert(self, memory: Memory) -> Memory:
+        if not memory.id:
+            raise ValueError("id must be a non-empty string (PK NOT NULL)")
+        if memory.id in self.rows:
+            raise ValueError(f"duplicate id {memory.id!r} (PK violation)")
+        self.rows[memory.id] = memory
+        return memory
+
+
+def _import_json_with_fake_store(
+    items: list[dict[str, Any]],
+    *,
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[int, _StrictPKStore]:
+    """Run ``AgentMemory.import_json`` against the strict-PK fake store.
+
+    We bypass ``AgentMemory.__init__`` (which builds Postgres + Pinecone
+    + Neo4j) by attaching the fake store directly to a bare instance; the
+    only thing ``import_json`` actually touches is ``self._store`` and
+    ``self._content_hash``.
+    """
+    from attestor.core.agent_memory import AgentMemory
+
+    mem = AgentMemory.__new__(AgentMemory)
+    store = _StrictPKStore()
+    mem._store = store  # type: ignore[attr-defined]
+
+    with tempfile.NamedTemporaryFile(
+        "w", suffix=".json", delete=False,
+    ) as fh:
+        json.dump(items, fh)
+        path = fh.name
+    try:
+        count = mem.import_json(path)
+    finally:
+        os.unlink(path)
+    return count, store
+
+
+@pytest.mark.unit
+def test_import_json_assigns_unique_id_when_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Three JSON entries with no ``id`` field must all land in the store.
+
+    Pre-fix: the fallback ``Memory().id`` works in CPython today but the
+    contract is fragile — any change that memoised ``Memory()`` (e.g. a
+    cached default-factory wrapper) would silently make every row reuse
+    the same id and PK-collide. Plus a JSON payload with ``"id": null``
+    or ``"id": ""`` in any single entry passes ``None``/empty straight to
+    the store and the ``except Exception: pass`` swallows the error.
+    """
+    items = [
+        {"content": "fact one"},
+        {"content": "fact two"},
+        {"content": "fact three"},
+    ]
+    count, store = _import_json_with_fake_store(items, monkeypatch=monkeypatch)
+    assert count == 3, (
+        f"expected all 3 id-less rows to land; only {count} did — "
+        "import_json silently dropped rows"
+    )
+    assert len(store.rows) == 3
+    # Each row got a distinct id.
+    ids = {m.id for m in store.rows.values()}
+    assert len(ids) == 3, f"expected 3 distinct ids, got {ids!r}"
+
+
+@pytest.mark.unit
+def test_import_json_handles_null_id_field(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An entry with ``"id": null`` must get a fresh id, not be dropped.
+
+    Pre-fix: ``item.get("id", Memory().id)`` returns ``None`` when the key
+    exists with a null value (``.get`` only uses the default for *missing*
+    keys, not for null values). The store then rejects ``id=None`` and
+    the silent-except swallows it.
+    """
+    items = [
+        {"content": "ok one", "id": None},
+        {"content": "ok two", "id": ""},
+    ]
+    count, store = _import_json_with_fake_store(items, monkeypatch=monkeypatch)
+    assert count == 2, (
+        f"expected null/empty id entries to be re-keyed and inserted; "
+        f"only {count} of 2 landed"
+    )
+    ids = {m.id for m in store.rows.values()}
+    assert all(i for i in ids), f"all rows must have a non-empty id; got {ids!r}"
+    assert len(ids) == 2
+
+
+@pytest.mark.unit
+def test_import_json_preserves_caller_supplied_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Back-compat: when ``id`` is present and non-empty, it's preserved."""
+    items = [
+        {"content": "with id", "id": "abc123def456"},
+    ]
+    count, store = _import_json_with_fake_store(items, monkeypatch=monkeypatch)
+    assert count == 1
+    assert "abc123def456" in store.rows
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Gap C2 — MemoryClient.add must accept and forward ``namespace``
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_add_forwards_namespace_in_body() -> None:
+    """``add(namespace="ns_a")`` must put ``namespace`` in the POST body.
+
+    Pre-fix: ``MemoryClient.add`` had no ``namespace`` kwarg at all. HTTP
+    callers writing to a tenant-scoped namespace silently landed in the
+    ``"default"`` namespace, which is a cross-tenant data-leak class
+    bug, not a UX nit.
+    """
+    captured: dict[str, Any] = {}
+
+    def fake_urlopen(req: Any, timeout: float = 0) -> _FakeResponse:
+        captured["url"] = req.full_url
+        captured["body"] = json.loads(req.data.decode())
+        # Return a minimal Memory.from_row()-compatible payload.
+        return _FakeResponse({
+            "ok": True,
+            "data": {
+                "id": "m1",
+                "content": "hello",
+                "tags": [],
+                "category": "general",
+                "namespace": "ns_a",
+                "valid_from": "2024-01-01T00:00:00+00:00",
+                "created_at": "2024-01-01T00:00:00+00:00",
+                "status": "active",
+                "confidence": 1.0,
+                "metadata": {},
+            },
+        })
+
+    client = MemoryClient("http://memory.test", agent_id="planner-01")
+
+    with patch("attestor.client.urllib.request.urlopen", fake_urlopen):
+        client.add("hello", namespace="ns_a")
+
+    assert captured["url"] == "http://memory.test/add"
+    assert captured["body"]["content"] == "hello"
+    assert captured["body"]["namespace"] == "ns_a", (
+        f"namespace must be forwarded in /add body, "
+        f"got body keys: {sorted(captured['body'].keys())!r}"
+    )
+
+
+@pytest.mark.unit
+def test_add_omits_namespace_when_not_set() -> None:
+    """Back-compat: callers without ``namespace`` keep working.
+
+    The server defaults to ``"default"`` when the body omits the key
+    (see ``attestor/api.py::add_memory``), so the client must NOT
+    inject a namespace silently — that would mask config errors.
+    """
+    captured: dict[str, Any] = {}
+
+    def fake_urlopen(req: Any, timeout: float = 0) -> _FakeResponse:
+        captured["body"] = json.loads(req.data.decode())
+        return _FakeResponse({
+            "ok": True,
+            "data": {
+                "id": "m1",
+                "content": "hello",
+                "tags": [],
+                "category": "general",
+                "namespace": "default",
+                "valid_from": "2024-01-01T00:00:00+00:00",
+                "created_at": "2024-01-01T00:00:00+00:00",
+                "status": "active",
+                "confidence": 1.0,
+                "metadata": {},
+            },
+        })
+
+    client = MemoryClient("http://memory.test")
+
+    with patch("attestor.client.urllib.request.urlopen", fake_urlopen):
+        client.add("hello")
+
+    assert "namespace" not in captured["body"], (
+        "client must not inject a namespace when caller omits it"
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Gap C3 — get_embedding_provider returns stale cached provider
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_embedding_provider_cache_returns_stale_when_yaml_changes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Re-reading YAML must NOT return the previously-cached provider.
+
+    Repro of the real cache-pollution bug:
+
+      1. Code path A asks for an explicit provider via
+         ``get_embedding_provider("voyage")`` — caches voyage.
+      2. Code path B (e.g. the orchestrator boot path) asks for the
+         YAML-configured provider via ``get_embedding_provider()`` (no
+         arg). YAML has since been edited to say ``openai``.
+      3. The cache short-circuit at the top of the function fires
+         BEFORE the YAML re-read, so the caller silently gets voyage
+         even though YAML now says openai.
+
+    Combined with ``assert_embedder_dim_matches_schema``'s skip-on-
+    introspection-error behavior, this re-incarnates the silent
+    vector-dim drift bug we paid for in the 2026-04 schema migration.
+    """
+    from attestor.store import embeddings as emb_mod
+
+    emb_mod.clear_embedding_cache()
+
+    class _Stub:
+        def __init__(self, name: str, dim: int) -> None:
+            self.provider_name = name
+            self.dimension = dim
+
+    voyage_stub = _Stub("voyage", 1024)
+    openai_stub = _Stub("openai", 1536)
+
+    monkeypatch.setitem(
+        emb_mod._PROVIDER_DISPATCH, "voyage", lambda: voyage_stub,
+    )
+    monkeypatch.setitem(
+        emb_mod._PROVIDER_DISPATCH, "openai", lambda: openai_stub,
+    )
+
+    # Step 1 — explicit voyage request fills the cache.
+    first = emb_mod.get_embedding_provider(preferred="voyage")
+    assert first is voyage_stub
+
+    # Step 2 — YAML now says "openai"; emulate get_stack() with a stub.
+    class _StackStub:
+        class embedder:
+            provider = "openai"
+
+    monkeypatch.setattr(
+        "attestor.config.get_stack", lambda: _StackStub(),
+    )
+
+    # Step 3 — preferred=None forces YAML re-read; cache must NOT win.
+    second = emb_mod.get_embedding_provider()
+    assert second is openai_stub, (
+        f"YAML now says openai but got {second.provider_name!r} — the "
+        "single-slot cache returned a stale provider, which silently "
+        "breaks dim checks downstream"
+    )


### PR DESCRIPTION
## Summary

Closes 3 client/import safety bugs surfaced by the post-PR-#135 test-gap audit.

- **C1 — `AgentMemory.import_json` silently drops rows on bad `id`.** `item.get("id", Memory().id)` only fires the default for *missing* keys; an entry with `"id": null` or `"id": ""` passed `None`/empty straight to the store, and the `except Exception: pass` swallowed the resulting PK / NOT-NULL violation as if it were a dedup hit. Fix: `item.get("id") or Memory().id`, plus log non-dedup insert failures at `WARNING`.
- **C2 — `MemoryClient.add` drops `namespace`.** The HTTP client never accepted a `namespace` kwarg even though `MemoryClient.recall` does, so writes from tenant-scoped callers silently landed in `"default"` — a cross-tenant data-loss class bug, not a UX nit. Fix: add `namespace: str | None = None`, forward into the request body when set (the server already handles it via `attestor/api.py::add_memory`).
- **C3 — `attestor.store.embeddings._cached_provider` returns stale provider on YAML change.** Single-slot global keyed by nothing; after the first call, every subsequent `get_embedding_provider()` (preferred=None) short-circuited the cache *before* re-reading YAML. Combined with `assert_embedder_dim_matches_schema`'s skip-on-introspection-error behavior this re-incarnated the silent vector-dim drift bug. Fix: cache is now a `dict[str, EmbeddingProvider]` keyed by resolved provider name; YAML is re-read on every preferred=None call.

## Test plan

- [x] TDD: 6 new tests in `tests/test_client_import_gaps.py` written first; confirmed RED on the 3 actual bugs (C1 null/empty id, C2 namespace forwarding, C3 stale-cache after YAML change).
- [x] All 6 GREEN after fixes land.
- [x] Full unit suite: `pytest tests/ -m "not live"` → 1040 passed / 0 failed (no regressions vs `main`).
- [x] `tests/test_client_api_parity.py` — 4/4 PASS (recall-namespace + quota-429 still work).
- [x] `tests/test_embeddings.py` + `tests/test_embedder_dim_check.py` — 19/19 PASS (cache refactor doesn't break dim guard).
- [x] `tests/test_core.py` — 21 SKIPPED (live-Postgres only on this dev box; no logic touched in CRUD path).
- [ ] CI on PR will exercise the wider gate.

## Notes

- `tests/test_provenance_signing.py` has 3 `@pytest.mark.live` tests that incidentally relied on cross-test cache pollution (an earlier passing test cached a working provider, masking that the test itself never set up an embedder). They fail standalone on `main` too — surfacing this is a feature of the C3 fix, not a regression. Not addressed here to keep the PR scope tight.