### PR TITLE
fix(test): import psycopg2.extras in test_orchestrator_bm25

### DIFF
--- a/tests/test_orchestrator_bm25.py
+++ b/tests/test_orchestrator_bm25.py
@@ -19,6 +19,7 @@ import pytest
 
 try:
     import psycopg2
+    import psycopg2.extras  # noqa: F401  — RealDictCursor used by StubDocStore.get
     HAVE_PSYCOPG2 = True
 except ImportError:
     HAVE_PSYCOPG2 = False


### PR DESCRIPTION
## Summary

`tests/test_orchestrator_bm25.py:117` calls `psycopg2.extras.RealDictCursor` but only imports `psycopg2` at module load. Submodules don't auto-bind, so every test in the file errors with `AttributeError: module 'psycopg2' has no attribute 'extras'`.

Pre-existing breakage on main (surfaced by the test-gap audit during PR #137 work, see PR #137 description).

## Test plan
- [x] `pytest tests/test_orchestrator_bm25.py -v` → 6/6 PASS (was 6/6 ERROR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)