### PR TITLE
fix(test): close 14 latent backend gaps surfaced by full-suite run

### DIFF
--- a/attestor/cli/commands/memory.py
+++ b/attestor/cli/commands/memory.py
@@ -39,7 +39,15 @@ def _cmd_init(args: argparse.Namespace) -> None:
             if interactive:
                 result = init_store_interactive(store_path, verify=args.verify)
             else:
-                result = init_store(store_path, backend=args.backend, verify=args.verify)
+                backend_options: dict | None = None
+                if getattr(args, "postgres_url", None):
+                    backend_options = {"url": args.postgres_url}
+                result = init_store(
+                    store_path,
+                    backend=args.backend,
+                    backend_options=backend_options,
+                    verify=args.verify,
+                )
             print(
                 f"  config.toml: {result.config_path} "
                 f"(backend={result.backend}, verified={result.verified})"

--- a/attestor/cli/main.py
+++ b/attestor/cli/main.py
@@ -84,6 +84,12 @@ def main(argv=None):
         help="Skip interactive prompts; use only CLI flags",
     )
     p_init.add_argument(
+        "--postgres-url",
+        default=None,
+        help="Override Postgres connection URL written to config.toml "
+        "(non-interactive mode)",
+    )
+    p_init.add_argument(
         "--install",
         action="store_true",
         dest="install_mcp",

--- a/attestor/store/_postgres_document.py
+++ b/attestor/store/_postgres_document.py
@@ -128,12 +128,14 @@ class _PostgresDocumentMixin:
         # v3 path — id provided by Memory dataclass default (12-char hex)
         self._execute(
             """
-            INSERT INTO memories (id, content, tags, category, entity, namespace,
-                created_at, event_date, valid_from, valid_until,
-                superseded_by, confidence, status, metadata)
-            VALUES (%(id)s, %(content)s, %(tags)s, %(category)s, %(entity)s, %(namespace)s,
-                %(created_at)s, %(event_date)s, %(valid_from)s, %(valid_until)s,
-                %(superseded_by)s, %(confidence)s, %(status)s, %(metadata)s::jsonb)
+            INSERT INTO memories (id, content, content_hash, tags, category,
+                entity, namespace, created_at, event_date, valid_from,
+                valid_until, superseded_by, confidence, status, metadata)
+            VALUES (%(id)s, %(content)s, %(content_hash)s, %(tags)s,
+                %(category)s, %(entity)s, %(namespace)s, %(created_at)s,
+                %(event_date)s, %(valid_from)s, %(valid_until)s,
+                %(superseded_by)s, %(confidence)s, %(status)s,
+                %(metadata)s::jsonb)
             """,
             p,
         )
@@ -353,6 +355,58 @@ class _PostgresDocumentMixin:
         )
         return len(rows)
 
+    def list_all(
+        self,
+        namespace: str | None = None,
+        limit: int = 100_000,
+    ) -> list[Memory]:
+        """List every memory regardless of status. Thin wrapper around
+        ``list_memories`` with status=None so callers (LME bench, audit
+        tooling) can grab the full population in a namespace without
+        excluding superseded/archived rows."""
+        return self.list_memories(
+            status=None, namespace=namespace, limit=limit,
+        )
+
+    def get_by_hash(
+        self,
+        content_hash: str,
+        namespace: str | None = None,
+    ) -> Memory | None:
+        """Return an existing active memory whose content_hash matches.
+
+        Used by ``AgentMemory.add()`` for content-hash dedup — without
+        this method, the dedup branch silently skips (the call site
+        guards with ``hasattr(self._store, "get_by_hash")``) and every
+        identical add creates a duplicate row.
+        """
+        if self._v4:
+            ns_filter = ""
+            params: list[Any] = [content_hash]
+            if namespace:
+                ns_filter = " AND metadata->>'_namespace' = %s"
+                params.append(namespace)
+            sql = (
+                "SELECT * FROM memories "
+                "WHERE content_hash = %s AND status = 'active'"
+                f"{ns_filter} LIMIT 1"
+            )
+        else:
+            ns_filter = ""
+            params = [content_hash]
+            if namespace:
+                ns_filter = " AND namespace = %s"
+                params.append(namespace)
+            sql = (
+                "SELECT * FROM memories "
+                "WHERE content_hash = %s AND status = 'active'"
+                f"{ns_filter} LIMIT 1"
+            )
+        rows = self._execute(sql, params)
+        if not rows:
+            return None
+        return self._row_to_memory(rows[0])
+
     def stats(self) -> dict[str, Any]:
         total = self._execute_scalar("SELECT COUNT(*) FROM memories")
 
@@ -368,8 +422,22 @@ class _PostgresDocumentMixin:
         ):
             by_category[row["category"]] = row["cnt"]
 
+        # `db_size_bytes` is part of the public stats() contract used by
+        # health checks + the legacy v3 callers. Compute via pg_database_size
+        # on the active connection's database.
+        db_size_bytes = 0
+        try:
+            db_size_bytes = int(
+                self._execute_scalar(
+                    "SELECT pg_database_size(current_database())"
+                ) or 0
+            )
+        except Exception:  # pragma: no cover - permission-bound; degrade silently
+            db_size_bytes = 0
+
         return {
             "total_memories": total,
             "by_status": by_status,
             "by_category": by_category,
+            "db_size_bytes": db_size_bytes,
         }

--- a/attestor/store/postgres_backend.py
+++ b/attestor/store/postgres_backend.py
@@ -179,6 +179,7 @@ class PostgresBackend(
                 CREATE TABLE IF NOT EXISTS memories (
                     id TEXT PRIMARY KEY,
                     content TEXT NOT NULL,
+                    content_hash TEXT,
                     tags TEXT[] NOT NULL DEFAULT '{{}}'::text[],
                     category TEXT NOT NULL DEFAULT 'general',
                     entity TEXT,
@@ -190,16 +191,31 @@ class PostgresBackend(
                     superseded_by TEXT,
                     confidence REAL DEFAULT 1.0,
                     status TEXT DEFAULT 'active',
+                    access_count INTEGER NOT NULL DEFAULT 0,
+                    last_accessed TEXT,
                     metadata JSONB DEFAULT '{{}}'::jsonb,
                     embedding vector({dim})
                 );
             """)
+            # Backfill: ALTER for pre-existing v3 schemas missing the
+            # content_hash / access tracking columns added 2026-05-03.
+            cur.execute(
+                "ALTER TABLE memories "
+                "ADD COLUMN IF NOT EXISTS content_hash TEXT, "
+                "ADD COLUMN IF NOT EXISTS access_count INTEGER NOT NULL DEFAULT 0, "
+                "ADD COLUMN IF NOT EXISTS last_accessed TEXT"
+            )
         # Indexes
         for col in ["status", "category", "entity", "created_at"]:
             self._execute(f"""
                 CREATE INDEX IF NOT EXISTS idx_memories_{col}
                 ON memories ({col});
             """)
+        # content_hash dedup lookup
+        self._execute(
+            "CREATE INDEX IF NOT EXISTS idx_memories_content_hash "
+            "ON memories (content_hash) WHERE content_hash IS NOT NULL"
+        )
         # HNSW index for vector cosine search
         self._execute("""
             CREATE INDEX IF NOT EXISTS idx_memories_embedding_hnsw

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -219,8 +219,9 @@ class TestExportImport:
 class TestRawSQL:
     def test_execute(self, mem):
         mem.add("test fact", category="test_cat")
+        # Postgres uses %s placeholders, not SQLite-style ?
         rows = mem.execute(
-            "SELECT * FROM memories WHERE category = ?", ["test_cat"]
+            "SELECT * FROM memories WHERE category = %s", ["test_cat"]
         )
         assert len(rows) == 1
         assert rows[0]["content"] == "test fact"

--- a/tests/test_retrieval_enhancements.py
+++ b/tests/test_retrieval_enhancements.py
@@ -228,7 +228,8 @@ class TestAccessTracking:
 class TestConfigWiring:
     def test_mmr_config_wired(self, mem_dir):
         from attestor import AgentMemory
-        cfg = {"enable_mmr": False, "mmr_lambda": 0.5}
+        from .conftest import _build_test_config
+        cfg = {**_build_test_config(), "enable_mmr": False, "mmr_lambda": 0.5}
         m = AgentMemory(mem_dir, config=cfg)
         assert m._retrieval.enable_mmr is False
         assert m._retrieval.mmr_lambda == 0.5
@@ -236,14 +237,16 @@ class TestConfigWiring:
 
     def test_fusion_mode_config(self, mem_dir):
         from attestor import AgentMemory
-        cfg = {"fusion_mode": "graph_blend"}
+        from .conftest import _build_test_config
+        cfg = {**_build_test_config(), "fusion_mode": "graph_blend"}
         m = AgentMemory(mem_dir, config=cfg)
         assert m._retrieval.fusion_mode == "graph_blend"
         m.close()
 
     def test_confidence_config(self, mem_dir):
         from attestor import AgentMemory
-        cfg = {"confidence_gate": 0.5, "confidence_decay_rate": 0.002}
+        from .conftest import _build_test_config
+        cfg = {**_build_test_config(), "confidence_gate": 0.5, "confidence_decay_rate": 0.002}
         m = AgentMemory(mem_dir, config=cfg)
         assert m._retrieval.confidence_gate == 0.5
         assert m._retrieval.confidence_decay_rate == 0.002

--- a/tests/test_ruflo_features.py
+++ b/tests/test_ruflo_features.py
@@ -193,7 +193,8 @@ class TestContentHashDedup:
         """Adding the same content twice should return the existing memory."""
         from attestor.core import AgentMemory
 
-        with AgentMemory(tmp_path / "dedup_test") as mem:
+        from .conftest import _build_test_config
+        with AgentMemory(tmp_path / "dedup_test", config=_build_test_config()) as mem:
             m1 = mem.add("The sky is blue", tags=["fact"])
             m2 = mem.add("The sky is blue", tags=["fact"])
             assert m1.id == m2.id
@@ -202,7 +203,8 @@ class TestContentHashDedup:
         """Content differing only by leading/trailing whitespace should dedup."""
         from attestor.core import AgentMemory
 
-        with AgentMemory(tmp_path / "ws_test") as mem:
+        from .conftest import _build_test_config
+        with AgentMemory(tmp_path / "ws_test", config=_build_test_config()) as mem:
             m1 = mem.add("hello world", tags=["test"])
             m2 = mem.add("  hello world  ", tags=["test"])
             assert m1.id == m2.id
@@ -211,7 +213,8 @@ class TestContentHashDedup:
         """Different content should create separate memories."""
         from attestor.core import AgentMemory
 
-        with AgentMemory(tmp_path / "diff_test") as mem:
+        from .conftest import _build_test_config
+        with AgentMemory(tmp_path / "diff_test", config=_build_test_config()) as mem:
             m1 = mem.add("The sky is blue", tags=["fact"])
             m2 = mem.add("The sky is red", tags=["fact"])
             assert m1.id != m2.id
@@ -220,7 +223,8 @@ class TestContentHashDedup:
         """Memory should have content_hash set after add."""
         from attestor.core import AgentMemory
 
-        with AgentMemory(tmp_path / "hash_test") as mem:
+        from .conftest import _build_test_config
+        with AgentMemory(tmp_path / "hash_test", config=_build_test_config()) as mem:
             m = mem.add("test content", tags=["test"])
             assert m.content_hash is not None
             expected = hashlib.sha256(b"test content").hexdigest()
@@ -240,7 +244,8 @@ class TestAccessTracking:
         """Recalling memories should increment their access_count."""
         from attestor.core import AgentMemory
 
-        with AgentMemory(tmp_path / "access_test") as mem:
+        from .conftest import _build_test_config
+        with AgentMemory(tmp_path / "access_test", config=_build_test_config()) as mem:
             m = mem.add("Python is a programming language",
                         tags=["python", "language"], entity="Python")
             # Recall to trigger access tracking


### PR DESCRIPTION
## Summary

Test-suite cleanup after the supersession + tenancy + Ollama-removal PRs (#135-#140). Touches the actual backend gaps the full-suite run revealed rather than just patching test scaffolding.

## Backend (production code)

**\`attestor/store/_postgres_document.py\`:**
- Add \`list_all(namespace, limit)\` — thin \`list_memories(status=None)\` wrapper. Every caller used \`hasattr\` guards; LME bench tests silently failed on \`'PostgresBackend' object has no attribute 'list_all'\` for weeks
- Add \`get_by_hash(content_hash, namespace)\` — proper v3 + v4 lookup used by \`AgentMemory.add()\` for content-hash dedup. Pre-fix the dedup branch silently no-op'd because PostgresBackend never implemented it (storage audit gap C1)
- Add \`db_size_bytes\` to \`stats()\` via \`pg_database_size()\`
- Update v3 INSERT to write \`content_hash\` (was being dropped)

**\`attestor/store/postgres_backend.py:_init_schema\`:**
- Add \`content_hash\`, \`access_count\`, \`last_accessed\` columns to v3 schema
- \`ALTER ADD COLUMN IF NOT EXISTS\` for pre-existing schemas
- Index on \`content_hash\` for dedup lookup

**\`attestor/cli/main.py\` + \`attestor/cli/commands/memory.py\`:**
- Add \`--postgres-url\` flag to \`init\` subcommand; pipe into \`init_store(backend_options={"url": ...})\`

## Tests

- \`tests/test_core.py\`: fix \`test_execute\` SQL placeholder (\`?\` → \`%s\`)
- \`tests/test_ruflo_features.py\`: thread \`_build_test_config()\` through ad-hoc AgentMemory constructions
- \`tests/test_retrieval_enhancements.py::TestConfigWiring\`: same

## Impact

| | Before | After |
|---|---|---|
| passed | 1327 | **1341** |
| failed | 38 | **24** |
| errors | 16 | 16 |

**+14 net passes.** Remaining failures + errors are all environmental (subprocess CLI env, live Voyage, live Neo4j auth, hooks subprocess) — not caused by code under test.

## Test plan

- [x] \`pytest tests/\` → 1341 / 24 / 16
- [x] No regressions in \`test_temporal\`, \`test_temporal_supersession_gaps\`, \`test_v4_postgres_backend\`, \`test_orchestrator_bm25\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)