### PR TITLE
feat(temporal): access-tracking on PostgresBackend + pgvector recall fallback

### DIFF
--- a/attestor/core/agent_memory.py
+++ b/attestor/core/agent_memory.py
@@ -163,10 +163,18 @@ class AgentMemory(_IdentityMixin, _QuotaMixin, _ProvenanceMixin):
         except Exception as _e:
             logger.debug("retrieval cfg not applied: %s", _e)
 
+        # Vector lane fallback: when no separate vector backend is wired
+        # (e.g. tests without Pinecone, single-binary deploys), use the
+        # document store's pgvector mixin so recall stays functional
+        # instead of silently returning zero hits. PostgresBackend exposes
+        # `.search(query_text, limit, namespace)` via _PostgresVectorMixin.
+        _orchestrator_vec = self._vector_store
+        if _orchestrator_vec is None and hasattr(self._store, "_embedding_dim"):
+            _orchestrator_vec = self._store  # type: ignore[assignment]
         self._retrieval = RetrievalOrchestrator(
             self._store,
             min_results=self.config.min_results,
-            vector_store=self._vector_store,
+            vector_store=_orchestrator_vec,
             graph=self._graph,
             bm25_lane=bm25_lane,
             config=_runtime_cfg,
@@ -547,10 +555,16 @@ class AgentMemory(_IdentityMixin, _QuotaMixin, _ProvenanceMixin):
         # the exception via logger.warning so the failure is debuggable
         # (silent pass made dim-mismatch / embedder-down / schema-drift bugs
         # invisible until recall returned 0 hits).
-        if self._vector_store:
+        # Vector sink fallback (mirrors orchestrator wiring above): if no
+        # separate vector backend is wired, write to the document store's
+        # pgvector mixin so recall has embeddings to query against.
+        _vec_sink = self._vector_store
+        if _vec_sink is None and hasattr(self._store, "_embedding_dim"):
+            _vec_sink = self._store  # type: ignore[assignment]
+        if _vec_sink:
             try:
                 t0 = time.monotonic()
-                self._vector_store.add(memory.id, content, namespace=namespace)
+                _vec_sink.add(memory.id, content, namespace=namespace)
                 store_timings["vector_ms"] = round((time.monotonic() - t0) * 1000, 2)
                 if _tr.is_enabled():
                     _tr.event("ingest.write.vector",

--- a/attestor/store/_postgres_document.py
+++ b/attestor/store/_postgres_document.py
@@ -368,6 +368,37 @@ class _PostgresDocumentMixin:
             status=None, namespace=namespace, limit=limit,
         )
 
+    def increment_access(self, memory_ids: list[str]) -> None:
+        """Bump ``access_count`` and stamp ``last_accessed`` for each id.
+
+        Wired from ``AgentMemory.recall()`` (already hasattr-guarded).
+        Used by confidence-decay scoring: memories accessed more recently
+        carry a slight boost. No-ops on empty input. Wraps the v4 timestamp
+        column type difference (TIMESTAMPTZ in v4, TEXT in v3) by formatting
+        Python ISO strings on both paths so the column accepts the value.
+        """
+        if not memory_ids:
+            return
+        from datetime import datetime, timezone
+
+        now_iso = datetime.now(timezone.utc).isoformat()
+        if self._v4:
+            self._execute(
+                "UPDATE memories SET "
+                "access_count = COALESCE(access_count, 0) + 1, "
+                "last_accessed = %s::timestamptz "
+                "WHERE id = ANY(%s::uuid[])",
+                (now_iso, list(memory_ids)),
+            )
+        else:
+            self._execute(
+                "UPDATE memories SET "
+                "access_count = COALESCE(access_count, 0) + 1, "
+                "last_accessed = %s "
+                "WHERE id = ANY(%s)",
+                (now_iso, list(memory_ids)),
+            )
+
     def get_by_hash(
         self,
         content_hash: str,


### PR DESCRIPTION
## Summary

Two related gaps surfaced by the PR #141 test-suite audit:

1. **\`AgentMemory.recall()\` already calls \`self._store.increment_access(ids)\` but PostgresBackend never implemented the method.** Schema columns \`access_count\` + \`last_accessed\` (added in #141) sat unused — every recall silently no-op'd through the \`hasattr\`-guarded call site. Now wired with proper v3 (TEXT) and v4 (TIMESTAMPTZ + UUID[]) typing.

2. **Recall returned 0 in single-binary deploys without a separate vector backend.** AgentMemory wired \`vector_store=self._vector_store\` into the orchestrator, but \`_vector_store\` is None when Pinecone isn't configured. PostgresBackend has the \`_PostgresVectorMixin\` (the embedding column has been provisioned for years!) — just unused as a sink. Now falls back to \`self._store\` for both writes (\`mem.add()\`) and reads (\`orchestrator.recall()\`).

## Why it matters

Closes 3 access-tracking regression tests that have been failing since the \`access_count\` column was added — they couldn't possibly pass because (a) recall returned 0 results, so (b) the increment hook had no ids to update. Same root cause masked both.

## Test plan
- [x] \`pytest tests/test_ruflo_features.py::TestAccessTracking tests/test_retrieval_enhancements.py::TestAccessTracking\` → 3/3 PASS (was 0/3)
- [x] Full suite: 1341 → **1345 passed** (+4 net), 24 → **20 failed**, errors unchanged
- [x] No regressions in supersession / tenancy / determinism / v4 backend tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)