### PR TITLE
fix(test): hook handler config + xfail legacy CLI + v4-skip repos race

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,12 @@
-"""Tests for CLI — require a live Postgres backend (no embedded stack)."""
+"""Tests for CLI — require a live Postgres backend (no embedded stack).
+
+NOTE: this file pre-dates the v3→v4 schema cut and the removal of the
+embedded SQLite stack (PR #125). The fixture overwrites a non-existent
+``config.json`` (the new init writes ``config.toml``) and several
+asserts check for ``memory.db`` (the legacy SQLite path that no longer
+exists). Marked xfail at module level until rewritten against the
+canonical Postgres+Pinecone+Neo4j stack and config.toml format.
+"""
 
 import json
 import os
@@ -10,10 +18,18 @@ from attestor.cli import main
 
 from .conftest import TEST_CONFIG
 
-pytestmark = pytest.mark.skipif(
-    not os.environ.get("POSTGRES_URL"),
-    reason="CLI tests require POSTGRES_URL (embedded stack removed)",
-)
+pytestmark = [
+    pytest.mark.skipif(
+        not os.environ.get("POSTGRES_URL"),
+        reason="CLI tests require POSTGRES_URL (embedded stack removed)",
+    ),
+    pytest.mark.xfail(
+        reason="CLI tests assert legacy v3 embedded-stack artifacts "
+        "(config.json, memory.db) that don't exist post-PR #125; needs "
+        "rewrite against config.toml + Postgres",
+        strict=False,
+    ),
+]
 
 
 @pytest.fixture

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -29,18 +29,34 @@ def _write_store_config(attestor_path) -> None:
     Hooks construct ``AgentMemory(store_path)`` without a config arg, which
     falls back to ENGINE_DEFAULTS (empty password) and fails with
     ``no password supplied``. Persisting the URL on disk lets the hook's
-    own AgentMemory boot succeed.
+    own AgentMemory boot succeed. Writes an explicit ``[postgres.auth]``
+    block — URL-embedded credentials don't always make it through every
+    layer of the connection-config merge.
     """
     from pathlib import Path
+    from urllib.parse import urlparse
 
     pg_url = os.environ.get("POSTGRES_URL")
     if not pg_url:
         return
+    parsed = urlparse(pg_url)
+    host = parsed.hostname or "localhost"
+    port = parsed.port or 5432
+    db = (parsed.path or "/attestor").lstrip("/") or "attestor"
+    user = parsed.username or "postgres"
+    pw = parsed.password or ""
+    base_url = f"postgresql://{host}:{port}"
     path = Path(attestor_path)
     path.mkdir(parents=True, exist_ok=True)
     (path / "config.toml").write_text(
         'backends = ["postgres"]\n'
-        f'[postgres]\nurl = "{pg_url}"\nembedding_dim = 1024\n'
+        '[postgres]\n'
+        f'url = "{base_url}"\n'
+        f'database = "{db}"\n'
+        'embedding_dim = 1024\n'
+        '[postgres.auth]\n'
+        f'username = "{user}"\n'
+        f'password = "{pw}"\n'
     )
 
 

--- a/tests/test_repos_race.py
+++ b/tests/test_repos_race.py
@@ -28,9 +28,34 @@ import pytest
 
 
 POSTGRES_URL = os.environ.get("POSTGRES_URL")
+
+
+def _v4_schema_present() -> bool:
+    """Check if the active POSTGRES_URL points at a v4 schema.
+
+    These tests use ``UserRepo`` which only exists on v4. Skip cleanly
+    when running against a v3-only test database (otherwise the
+    fixture errors with ``UndefinedTable: users``).
+    """
+    if not POSTGRES_URL:
+        return False
+    try:
+        import psycopg2
+        with psycopg2.connect(POSTGRES_URL, connect_timeout=2) as c:
+            with c.cursor() as cur:
+                cur.execute(
+                    "SELECT 1 FROM information_schema.tables "
+                    "WHERE table_schema='public' AND table_name='users' LIMIT 1"
+                )
+                return cur.fetchone() is not None
+    except Exception:
+        return False
+
+
 pytestmark = pytest.mark.skipif(
-    not POSTGRES_URL,
-    reason="repos race tests need POSTGRES_URL set to a live v4 Postgres",
+    not _v4_schema_present(),
+    reason="repos race tests need POSTGRES_URL set to a live v4 Postgres "
+    "(set to attestor_v4_test for these to run)",
 )
 
 


### PR DESCRIPTION
Closes 7 hook-handler tests + cleanly classifies 10 legacy CLI tests + skips 2 v4-only race tests on v3. Suite: 1354/16/11 → **1360/8/0** (+6 passes, -8 failures, -11 errors). Remaining 8 failures all need genuine external services.