### PR TITLE
feat(distribution): SKILL.md for attestor-memory (2026 agent SDK alignment)

### DIFF
--- a/README.md
+++ b/README.md
@@ -814,6 +814,24 @@ Then it installs `attestor` via pipx, writes the MCP config, optionally writes `
 
 ---
 
+## Install as a Skill (2026 agent SDKs)
+
+Attestor ships with a canonical `SKILL.md` at [`skills/attestor-memory/SKILL.md`](skills/attestor-memory/SKILL.md). Both Anthropic (`skills-2025-10-02`) and OpenAI's Responses API converged on this format — a markdown file with YAML frontmatter — for distributing reusable agent expertise. The wheel ships the SKILL.md, so every 2026-grade harness can auto-discover it after a single `pip install attestor`.
+
+The skill teaches the agent the six core primitives (`recall`, `add`, `timeline`, `current_facts`, `forget`, `audit`) plus the v4 enterprise surface (bi-temporal `as_of` replay, RBAC roles, namespace isolation, provenance signing, GDPR export / purge). Every code example references methods that actually exist on `attestor.AgentMemory`, and a CI test (`tests/test_skill_md.py`) keeps the SKILL.md from drifting from the live API.
+
+To pin the contract in your own host:
+
+```bash
+pip install attestor
+python -c "import attestor, importlib.resources as r; print(r.files('attestor'))"   # confirm wheel installed
+# Point your agent harness at the bundled SKILL.md or read it directly:
+python -c "from pathlib import Path; import attestor; \
+  print((Path(attestor.__file__).parent.parent / 'skills' / 'attestor-memory' / 'SKILL.md').read_text())"
+```
+
+---
+
 ## Evaluation
 
 > **Boundary statement.** The dual-LLM judge stack is a **benchmarking** mechanism, *not* the runtime contract. Recall in production is single-pipeline and deterministic. Multiple judges score answers in evaluation only — never in user-facing reads.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,11 @@ packages = [{ include = "attestor" }]
 # and survives any future packaging-format changes.
 include = [
     { path = "attestor/extraction/prompts/*.md", format = ["sdist", "wheel"] },
+    # 2026 agent SDK distribution surface — Anthropic skills-2025-10-02 +
+    # OpenAI Responses API both auto-discover SKILL.md by canonical path.
+    # Shipping it inside the wheel means `pip install attestor` is enough
+    # for any 2026 agent harness to pick the skill up.
+    { path = "skills/*/SKILL.md", format = ["sdist", "wheel"] },
 ]
 
 [tool.poetry.group.dev.dependencies]

--- a/skills/attestor-memory/SKILL.md
+++ b/skills/attestor-memory/SKILL.md
@@ -1,0 +1,277 @@
+---
+name: attestor-memory
+description: Enterprise memory layer for agent teams — durable, deterministic recall with bi-temporal facts, RBAC, and audit trails. Self-hosted Postgres + Pinecone + Neo4j; zero LLM in the critical path.
+version: 4.0.0
+capabilities:
+  - memory.recall
+  - memory.add
+  - memory.timeline
+  - memory.supersede
+  - memory.forget
+  - memory.audit
+license: MIT
+homepage: https://attestor.dev
+repository: https://github.com/bolnet/attestor
+mcp_server: attestor
+authors:
+  - aarjay
+---
+
+# attestor-memory
+
+## What this skill does
+
+Attestor is a shared, tenant-isolated memory store for agent teams. It persists every fact across three storage roles (Postgres for documents, Pinecone for vectors, Neo4j for graph) and serves recall through a deterministic six-step cascade — same query, same ranking, no LLM in the hot path. Every fact carries a bi-temporal validity window so an agent can replay any past belief, and every supersession is auditable to its evidence episode.
+
+## When to use it
+
+Use attestor when the agent's job depends on memory that survives:
+
+- Multi-session conversations where the user expects continuity weeks or months later (preferences, ongoing projects, durable identity facts).
+- Multi-agent products where many agents — orchestrator, planner, executor, reviewer — share state and must not stomp on each other's writes.
+- Regulated chat (healthcare, finance, legal) that needs point-in-time reconstruction: "what did the agent know on date X?" or "show every fact that ever superseded this one."
+- Workflows where contradictions must be tracked, not silently overwritten — supersession produces an audit chain instead of mutation.
+- Self-hosted deployments where the memory data must stay inside the customer's VPC.
+
+## When NOT to use it
+
+- **Short-lived single-session context.** If the relevant memory dies when the conversation ends, put it in the system prompt. Attestor is overkill.
+- **Pure document retrieval.** If you need to chunk and rerank a corpus of PDFs, use a dedicated RAG framework or `file_search`. Attestor is for *facts*, not *passages*.
+- **An LLM agent runtime.** Attestor is the memory backend; the orchestration loop is the caller's responsibility.
+- **Inline tool use that doesn't need persistence.** Direct tool definitions are simpler.
+
+## How to install
+
+### 1. Install the Python package
+
+```bash
+pip install attestor
+```
+
+The wheel ships with this SKILL.md so any 2026 agent SDK that scans for skills will discover `attestor-memory` automatically.
+
+### 2. Bring up the storage stack (local dev)
+
+```bash
+attestor setup local
+docker compose -f attestor/infra/local/docker-compose.yml up -d
+attestor doctor          # verifies Postgres + Pinecone + Neo4j are reachable
+```
+
+For production, point the same client at managed Postgres (Neon, RDS, Cloud SQL), Pinecone Cloud, and Neo4j AuraDB via `configs/attestor.yaml` or env vars — the API surface is identical.
+
+### 3. Wire the MCP server
+
+Attestor publishes an MCP server (`mcp_server: attestor` in the frontmatter above). Add it to the host harness:
+
+#### Claude Code / Claude Desktop
+
+```json
+{
+  "mcpServers": {
+    "attestor": {
+      "command": "attestor",
+      "args": ["mcp"],
+      "env": {
+        "PINECONE_API_KEY": "${PINECONE_API_KEY}",
+        "NEO4J_URI": "bolt://localhost:7687",
+        "POSTGRES_DSN": "postgresql://attestor:attestor@localhost:5432/attestor"
+      }
+    }
+  }
+}
+```
+
+Or run the interactive installer once and let it write the config:
+
+```bash
+attestor doctor                # confirm storage is up
+# In Claude Code, type:  install attestor
+```
+
+#### OpenAI Agents SDK / Responses API
+
+Point the agent's MCP transport at the same `attestor mcp` stdio command, or at the Starlette HTTP sidecar (`attestor api` on `localhost:8080`) if the SDK prefers HTTP.
+
+## API reference
+
+The skill exposes six primitives on `attestor.AgentMemory`. Every signature below is verbatim from the codebase — no aliases, no aspirational names.
+
+| Method | Purpose |
+| --- | --- |
+| `add(content, tags, category, entity, namespace, event_date, confidence, metadata, ...)` | Persist one fact. Auto-detects contradictions and supersedes the older one. Returns the stored `Memory`. |
+| `recall(query, budget, namespace, user_id, as_of, time_window)` | Six-step retrieval cascade (vector + BM25 + RRF + graph + MMR + token-budget pack). Returns `list[RetrievalResult]`. |
+| `timeline(entity, namespace)` | Chronological replay of every memory about an entity (active + superseded). Returns `list[Memory]`. |
+| `current_facts(category, entity, namespace)` | Active, non-superseded memories only. The "what does the agent believe right now" view. |
+| `forget(memory_id)` / `forget_before(date)` | Archive a single memory by id, or every memory created before a date. Returns `bool` / `int`. |
+| `health()` | Structured status of all three backends + retrieval pipeline. Always call before integrating. |
+
+Supplementary primitives an agent reaches for less often:
+
+- `get(memory_id)` — fetch a single memory by id.
+- `update(memory_id, content=..., tags=..., ...)` — edit fields in place. Re-indexes vectors when content changes.
+- `search(query, category, entity, namespace, status, after, before, limit)` — filtered listing without the recall pipeline.
+- `recall_as_pack(query, budget, user_id, as_of, time_window)` — `ContextPack` with citations + Chain-of-Note prompt for cite-or-abstain agents.
+- `extract(messages, model, use_llm, namespace)` — pull facts out of a conversation transcript and store them.
+- `consolidate(limit, ...)` — drain the sleep-time consolidation queue.
+- `export_user(external_id)` / `purge_user(external_id)` / `deletion_audit_log()` — GDPR data portability + erasure with audit trail.
+- `pagerank(alpha)` — entity importance from the Neo4j graph.
+- `stats()` / `ops_log` — store counts and a ring buffer of recent operation latencies.
+
+Manual contradiction resolution (rare — `add()` does this automatically):
+
+```python
+# Underlying surface lives at mem._temporal.supersede(old_memory, new_memory_id).
+# Use it only when add()'s auto-detection missed a paraphrased contradiction.
+```
+
+## Examples
+
+### Example 1 — Write a fact, then recall it
+
+```python
+from attestor import AgentMemory
+
+mem = AgentMemory("./agent-store")
+
+mem.add(
+    "The user prefers Python over Go",
+    tags=["preference", "language"],
+    category="preference",
+    entity="user",
+)
+
+results = mem.recall("what programming language does the user like?", budget=1024)
+for r in results:
+    print(r.score, r.memory.content)
+```
+
+### Example 2 — Track an entity's history through time
+
+```python
+from attestor import AgentMemory
+
+mem = AgentMemory("./agent-store")
+
+mem.add("Acme Corp uses Postgres 14",  entity="Acme Corp", category="stack",
+        event_date="2024-01-10")
+mem.add("Acme Corp uses Postgres 15",  entity="Acme Corp", category="stack",
+        event_date="2025-03-01")
+mem.add("Acme Corp uses Postgres 16",  entity="Acme Corp", category="stack",
+        event_date="2026-02-14")
+
+# All three rows, oldest first; the first two are auto-superseded.
+for m in mem.timeline("Acme Corp"):
+    print(m.event_date, m.status, m.content)
+
+# Just the live belief.
+for m in mem.current_facts(entity="Acme Corp"):
+    print(m.content)        # → "Acme Corp uses Postgres 16"
+```
+
+### Example 3 — Replay a past belief (bi-temporal recall)
+
+```python
+from datetime import datetime, timezone
+from attestor import AgentMemory
+
+mem = AgentMemory("./agent-store")
+
+# What did the agent believe about Acme Corp's stack on 2025-06-01?
+as_of = datetime(2025, 6, 1, tzinfo=timezone.utc)
+past_results = mem.recall("Acme Corp postgres version", as_of=as_of)
+for r in past_results:
+    print(r.memory.content)  # → "Acme Corp uses Postgres 15"
+```
+
+`as_of` resolves on event time (`valid_from` / `valid_until`), so the answer reflects what was true *then*, not what the agent learned later.
+
+### Example 4 — Multi-agent shared state with RBAC + namespace isolation
+
+```python
+from attestor import AgentContext, AgentMemory, AgentRole
+
+shared_store = AgentMemory("./team-store")
+
+orchestrator = AgentContext(
+    agent_id="orchestrator-01",
+    namespace="project:acme",
+    role=AgentRole.ORCHESTRATOR,        # READ + WRITE + FORGET
+    memory=shared_store,
+)
+
+# Hand off to a researcher (READ + WRITE only — no forget).
+researcher = orchestrator.as_agent("researcher-01", role=AgentRole.RESEARCHER)
+researcher.add_memory("Vendor X has SOC2 Type II since 2024-09",
+                       tags=["compliance"], category="vendor")
+
+# A reviewer can only read — write attempts raise PermissionError.
+reviewer = orchestrator.as_agent("reviewer-01", role=AgentRole.REVIEWER)
+hits = reviewer.recall("vendor SOC2 status")
+print(orchestrator.agent_trail)         # full handoff chain for audit
+```
+
+Roles enforced at the context layer (`attestor/context.py`): `ORCHESTRATOR` = full perms; `PLANNER` / `EXECUTOR` / `RESEARCHER` = read + write; `REVIEWER` / `MONITOR` = read-only. `read_only=True` is an independent kill switch that strips writes regardless of role.
+
+### Example 5 — Audit + GDPR
+
+```python
+from attestor import AgentMemory
+
+mem = AgentMemory("./agent-store")
+
+# Show every memory the agent stored about a user, ready for export.
+dump = mem.export_user("user-1234")
+
+# Honor a delete request (CASCADEs through Postgres, returns audit row).
+result = mem.purge_user("user-1234", reason="gdpr_request",
+                         deleted_by="support-agent-7")
+
+# Verify it landed in the audit trail.
+recent = mem.deletion_audit_log(limit=10)
+```
+
+## Configuration
+
+The single source of truth is `configs/attestor.yaml`. It carries:
+
+- `stack.backends` — which backend handles which role (document / vector / graph).
+- `stack.embedder` — provider + model + dimension. Default: Pinecone Inference `llama-text-embed-v2` (1024-D).
+- `stack.models` — LLM ids for extraction, conflict resolution, judge.
+- `stack.retrieval` — recall hot-path tunables (`vector_top_k`, `mmr_lambda`, BM25 / HyDE / multi-query lane configs).
+
+Override per-instance via the `config` kwarg on `AgentMemory(path, config=...)`. Environment variables (`PINECONE_API_KEY`, `NEO4J_URI`, `POSTGRES_DSN`, etc.) are resolved by `attestor/store/connection.py`. Run `attestor doctor` to surface any missing or mismatched values.
+
+## Audit + compliance
+
+Attestor is built for regulated workloads:
+
+- **Bi-temporal storage.** Every memory has both event time (`valid_from` / `valid_until`) and transaction time (`t_created` / `t_expired`). Nothing is deleted on contradiction — the older fact is marked `superseded` and stays queryable forever via `timeline()` and `recall(as_of=...)`.
+- **Provenance signing.** Opt-in Ed25519 signature on every memory (`signing` block in config). `mem.verify_memory(memory_id)` re-checks the signature against the canonical payload.
+- **Audit trail via traces.** OpenTelemetry-style spans on every ingest / recall / supersede call (`attestor/trace.py`). Toggle with `ATTESTOR_TRACE=1`.
+- **Tenancy.** Postgres row-level security scoped by `user_id`; namespaces are first-class; Neo4j namespace enforcement is partial (graph entity nodes are still global as of v4.0.0 — see CLAUDE.md).
+- **GDPR-compatible erasure.** `purge_user()` issues a CASCADE delete and writes an audit row; export via `export_user()` produces a JSON-portable dump.
+- **No LLM in the critical path.** The recall cascade is fully deterministic — same query, same ranking — which is what regulators want when they audit a recommendation.
+
+## Health check
+
+Always call `health()` first when integrating. The MCP server exposes the same probe as `memory_health`.
+
+```python
+from attestor import AgentMemory
+
+mem = AgentMemory("./agent-store")
+report = mem.health()
+assert report["healthy"], report
+```
+
+`report["checks"]` lists Postgres, Pinecone, Neo4j, and the retrieval pipeline status with per-store latencies. If a backend was down at startup, `health()` attempts recovery before reporting — long-running processes self-heal without a restart.
+
+## Further reading
+
+- `README.md` — full quickstart, benchmark numbers, deployment topologies.
+- `CLAUDE.md` — architecture notes for agents working on the codebase.
+- `attestor/core/agent_memory.py` — the canonical AgentMemory implementation.
+- `attestor/retrieval/orchestrator.py` — the deterministic six-step cascade.
+- `attestor/temporal/manager.py` — supersession + `as_of` replay.
+- `attestor/context.py` — RBAC matrix + AgentContext handoff semantics.

--- a/tests/test_skill_md.py
+++ b/tests/test_skill_md.py
@@ -1,0 +1,202 @@
+# tests/test_skill_md.py
+"""Contract tests for the canonical 2026-agent-SDK SKILL.md packaging.
+
+Both Anthropic (skills-2025-10-02) and OpenAI (Responses API, March 2026)
+converged on a SKILL.md file with YAML frontmatter + markdown body as the
+distribution format for reusable agent expertise. This test pins the
+contract:
+
+    1. The file exists at the canonical path ``skills/attestor-memory/SKILL.md``.
+    2. The frontmatter has the fields a 2026 agent SDK will look for
+       (``name``, ``description``, ``version``, ``capabilities``).
+    3. The body covers the sections an installer will surface to its agent
+       (when to use, how to install, API reference, examples).
+    4. Every Python example uses methods that ACTUALLY exist on
+       ``attestor.AgentMemory`` — preventing the SKILL.md drifting from the
+       real public surface.
+    5. The SKILL.md version matches ``pyproject.toml`` so wheel + skill never
+       advertise different versions.
+    6. The ``skills/`` tree is wired into the Poetry ``include`` block so the
+       SKILL.md actually ships with the wheel — otherwise the file is dead
+       weight in the repo.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # pragma: no cover
+    import tomli as tomllib
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SKILL_PATH = REPO_ROOT / "skills" / "attestor-memory" / "SKILL.md"
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+
+
+# ---------- helpers ---------------------------------------------------------
+
+_FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n(.*)$", re.DOTALL)
+
+
+def _load_skill() -> tuple[dict, str]:
+    """Return ``(frontmatter_dict, body_str)`` from the SKILL.md file."""
+    text = SKILL_PATH.read_text(encoding="utf-8")
+    match = _FRONTMATTER_RE.match(text)
+    assert match, "SKILL.md must start with a YAML frontmatter block (---\\n...\\n---)"
+    fm = yaml.safe_load(match.group(1)) or {}
+    body = match.group(2)
+    return fm, body
+
+
+def _pyproject_version() -> str:
+    return tomllib.loads(PYPROJECT.read_text())["project"]["version"]
+
+
+# ---------- existence + structure ------------------------------------------
+
+
+def test_skill_md_exists() -> None:
+    """Canonical layout: skills/<skill-name>/SKILL.md."""
+    assert SKILL_PATH.exists(), (
+        f"SKILL.md missing at {SKILL_PATH.relative_to(REPO_ROOT)}; "
+        "this is the path 2026 agent SDKs auto-discover."
+    )
+
+
+def test_frontmatter_has_required_fields() -> None:
+    """Frontmatter is the machine-readable contract — installers parse it."""
+    fm, _ = _load_skill()
+    required = {"name", "description", "version", "capabilities"}
+    missing = required - set(fm.keys())
+    assert not missing, f"SKILL.md frontmatter missing required fields: {sorted(missing)}"
+
+    assert fm["name"] == "attestor-memory", (
+        "Skill name must match the directory; auto-discovery is name-keyed."
+    )
+    assert isinstance(fm["description"], str) and fm["description"].strip(), (
+        "description must be a non-empty string"
+    )
+    assert isinstance(fm["capabilities"], list) and fm["capabilities"], (
+        "capabilities must be a non-empty list of capability strings"
+    )
+
+
+def test_capabilities_cover_core_primitives() -> None:
+    """Every public memory primitive an agent reaches for must be advertised."""
+    fm, _ = _load_skill()
+    caps = set(fm["capabilities"])
+    required_caps = {
+        "memory.recall",
+        "memory.add",
+        "memory.timeline",
+        "memory.supersede",
+        "memory.forget",
+    }
+    missing = required_caps - caps
+    assert not missing, f"capabilities must include {sorted(missing)}; got {sorted(caps)}"
+
+
+def test_body_has_required_sections() -> None:
+    """An installer + a human reading the file both need the same anchors."""
+    _, body = _load_skill()
+    required_headings = [
+        "When to use",
+        "How to install",
+        "API reference",
+        "Examples",
+    ]
+    for heading in required_headings:
+        # Match any heading level (## / ### / ####) that contains the phrase.
+        pattern = re.compile(rf"^#{{1,4}}\s+.*{re.escape(heading)}", re.MULTILINE | re.IGNORECASE)
+        assert pattern.search(body), (
+            f"SKILL.md body missing required section heading: {heading!r}"
+        )
+
+
+def test_version_matches_pyproject() -> None:
+    """Wheel and SKILL.md must advertise the same version."""
+    fm, _ = _load_skill()
+    pyproject_version = _pyproject_version()
+    assert str(fm["version"]) == pyproject_version, (
+        f"SKILL.md version {fm['version']!r} drifted from "
+        f"pyproject {pyproject_version!r}"
+    )
+
+
+# ---------- examples reference real methods --------------------------------
+
+
+_PY_FENCE_RE = re.compile(r"```python\n(.*?)```", re.DOTALL)
+# Match `mem.<method>(`  — only on a public-looking name (no leading underscore).
+_MEM_CALL_RE = re.compile(r"\bmem\.([a-z_][a-z0-9_]*)\s*\(")
+
+
+def _public_agentmemory_methods() -> set[str]:
+    from attestor import AgentMemory
+
+    return {
+        name
+        for name in dir(AgentMemory)
+        if not name.startswith("_") and callable(getattr(AgentMemory, name, None))
+    }
+
+
+def test_examples_reference_real_methods() -> None:
+    """Every ``mem.<method>(...)`` in the SKILL.md must exist on AgentMemory.
+
+    This is the anti-drift rail. SKILL.md is the public face of attestor for
+    2026 — we cannot ship hallucinated APIs into a file that 2026 agent SDKs
+    will install verbatim.
+    """
+    _, body = _load_skill()
+    real_methods = _public_agentmemory_methods()
+
+    seen: set[str] = set()
+    for block in _PY_FENCE_RE.findall(body):
+        for method in _MEM_CALL_RE.findall(block):
+            seen.add(method)
+
+    if not seen:
+        pytest.fail(
+            "Examples section parsed zero `mem.<method>(...)` calls — either "
+            "the SKILL.md has no python examples or the convention drifted."
+        )
+
+    missing = seen - real_methods
+    assert not missing, (
+        f"SKILL.md examples reference methods that don't exist on AgentMemory: "
+        f"{sorted(missing)}. Either fix the example or expose the method."
+    )
+
+
+# ---------- packaging: wheel must ship the skill ---------------------------
+
+
+def test_skill_md_in_package_data() -> None:
+    """Poetry ``include`` block must ship skills/**/SKILL.md with the wheel.
+
+    A SKILL.md that doesn't ride the wheel is invisible to ``pip install
+    attestor`` users, which defeats the entire 2026-agent-SDK plumbing.
+    """
+    pyproject = tomllib.loads(PYPROJECT.read_text())
+    poetry_cfg = pyproject.get("tool", {}).get("poetry", {})
+    include = poetry_cfg.get("include", [])
+
+    # Each entry can be a string or a dict with a "path" key.
+    paths = [
+        (entry["path"] if isinstance(entry, dict) else entry)
+        for entry in include
+    ]
+    assert any("skills" in p and "SKILL.md" in p for p in paths), (
+        "pyproject [tool.poetry].include must contain an entry that ships "
+        "skills/**/SKILL.md (e.g. 'skills/*/SKILL.md'); current include="
+        f"{paths!r}"
+    )


### PR DESCRIPTION
## Summary

- Adds `skills/attestor-memory/SKILL.md` (277 lines) — the canonical 2026 agent SDK distribution format that both Anthropic (skills-2025-10-02) and OpenAI Responses API (Mar 2026) converged on. Frontmatter declares `name`, `description`, `version`, `capabilities`, `license`, `mcp_server`; body covers When-to-use, When-NOT, Install (Claude Code + OpenAI Agents SDK MCP snippets), API reference for all six core primitives + the v4 enterprise surface, four worked examples (write+recall, entity timeline, bi-temporal `as_of` replay, multi-agent RBAC), configuration, audit + compliance, and `health()` integration.
- Wires `skills/*/SKILL.md` into `[tool.poetry].include` for both sdist + wheel — verified by `poetry build` (file lands at `skills/attestor-memory/SKILL.md` in both archives).
- Ships TDD-first contract tests at `tests/test_skill_md.py` (7 tests, RED → GREEN). Beyond existence + frontmatter checks, the suite parses every Python code block and asserts each `mem.<method>(...)` call resolves to a real public method on `attestor.AgentMemory` — preventing the SKILL.md drifting from the live API.
- Pins the SKILL.md version against `pyproject.toml` so wheel and skill never advertise different versions.
- Extends `README.md` with an "Install as a Skill (2026 agent SDKs)" section pointing at the SKILL.md path and the anti-drift CI rail.

## Test plan

- [x] `pytest tests/test_skill_md.py -v` — 7 / 7 pass (RED → GREEN documented in commit).
- [x] `pytest tests/ -q -k "not live"` — 1076 passed, 0 failed (no regressions on the unit suite).
- [x] `poetry build -f sdist` — SKILL.md present at `attestor-4.0.0/skills/attestor-memory/SKILL.md`.
- [x] `poetry build -f wheel` — SKILL.md present in `attestor-4.0.0-py3-none-any.whl` at the same path.
- [x] Verified existing `tests/test_pyproject_extras.py` still passes after the include-block change.

## Notes for reviewers

- **API surface gaps caught while writing the skill:** none. Every method documented in the SKILL.md (`recall`, `add`, `timeline`, `current_facts`, `forget`, `forget_before`, `health`, `recall_as_pack`, `extract`, `consolidate`, `export_user`, `purge_user`, `deletion_audit_log`, `pagerank`, `stats`, `search`, `get`, `update`) exists today on `attestor.AgentMemory`. Manual `supersede` is documented as `mem._temporal.supersede(...)` because that's the actual surface — there is no public `mem.supersede()` shortcut.
- **Distribution surfaces still pending after this PR:** PyPI metadata + classifier update for "Skills" once Anthropic / OpenAI publish a Trove classifier; MCP registry (`server.json` already present, unchanged); Glama / mcp.so submissions (separate PRs).