### PR TITLE
feat(state): typed profile memory lane (state-based personalization)

### DIFF
--- a/attestor/__init__.py
+++ b/attestor/__init__.py
@@ -1,6 +1,7 @@
 """Attestor — Embedded memory for AI agents."""
 
-from importlib.metadata import PackageNotFoundError, version as _pkg_version
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
 
 from attestor.context import (
     ROLE_PERMISSIONS,
@@ -18,6 +19,11 @@ from attestor.models import (
     Session,
     User,
 )
+from attestor.state import (
+    StateRecord,
+    StateRepo,
+    StateValidationError,
+)
 
 try:
     __version__ = _pkg_version("attestor")
@@ -25,16 +31,19 @@ except PackageNotFoundError:  # editable / source install fallback
     __version__ = "0.0.0+local"
 
 __all__ = [
-    "AgentMemory",
-    "AgentContext",
-    "AgentRole",
-    "RolePermission",
     "ROLE_PERMISSIONS",
+    "AgentContext",
+    "AgentMemory",
+    "AgentRole",
     "Memory",
     "MemoryScope",
     "Project",
     "RetrievalResult",
+    "RolePermission",
     "Session",
+    "StateRecord",
+    "StateRepo",
+    "StateValidationError",
     "User",
     "Visibility",
     "__version__",

--- a/attestor/context.py
+++ b/attestor/context.py
@@ -471,6 +471,112 @@ class AgentContext:
         return mem.forget(memory_id)
 
     # ------------------------------------------------------------------ #
+    #  State lane (typed profile facts)                                    #
+    # ------------------------------------------------------------------ #
+    #
+    # The state lane is the non-retrieval-based personalization surface:
+    # typed key/value facts (preferences, capability declarations) looked
+    # up by key, not by similarity. RBAC is the same matrix as memory —
+    # WRITE for set/delete, READ for get/list/history/as_of. read_only
+    # strips writes regardless of role.
+
+    def _state_repo(self) -> Any:
+        mem = self._get_memory()
+        repo = getattr(mem, "state", None)
+        if repo is None:
+            raise RuntimeError(
+                "memory backend does not expose a state lane (need v4 + Postgres)"
+            )
+        return repo
+
+    def state_set(
+        self,
+        key: str,
+        value: Any,
+        *,
+        project_id: str | None = None,
+        agent_id: str | None = None,
+        scope: str | None = None,
+        schema: str | None = None,
+    ) -> Any:
+        """Write a typed profile fact. Honors the role/read_only matrix."""
+        self._require_permission(RolePermission.WRITE)
+        if self.user_id is None:
+            raise RuntimeError(
+                "state_set requires a user-anchored context (set user_id)"
+            )
+        return self._state_repo().set(
+            key,
+            value,
+            user_id=self.user_id,
+            project_id=project_id or self.project_id,
+            agent_id=agent_id or self.agent_id,
+            scope=scope,
+            schema=schema,
+            set_by_agent=self.agent_id,
+        )
+
+    def state_get(
+        self,
+        key: str,
+        *,
+        project_id: str | None = None,
+        scope: str | None = None,
+    ) -> Any | None:
+        """Read a typed profile fact. READ-permission gated."""
+        self._require_permission(RolePermission.READ)
+        if self.user_id is None:
+            raise RuntimeError(
+                "state_get requires a user-anchored context (set user_id)"
+            )
+        return self._state_repo().get(
+            key,
+            user_id=self.user_id,
+            project_id=project_id or self.project_id,
+            scope=scope,
+        )
+
+    def state_list(
+        self,
+        *,
+        prefix: str = "",
+        project_id: str | None = None,
+        scope: str | None = None,
+    ) -> dict[str, Any]:
+        """List active typed profile facts under ``prefix``."""
+        self._require_permission(RolePermission.READ)
+        if self.user_id is None:
+            raise RuntimeError(
+                "state_list requires a user-anchored context (set user_id)"
+            )
+        return self._state_repo().list(
+            user_id=self.user_id,
+            project_id=project_id or self.project_id,
+            scope=scope,
+            prefix=prefix,
+        )
+
+    def state_delete(
+        self,
+        key: str,
+        *,
+        project_id: str | None = None,
+        scope: str | None = None,
+    ) -> bool:
+        """Mark the active row at ``key`` expired. WRITE-permission gated."""
+        self._require_permission(RolePermission.WRITE)
+        if self.user_id is None:
+            raise RuntimeError(
+                "state_delete requires a user-anchored context (set user_id)"
+            )
+        return self._state_repo().delete(
+            key,
+            user_id=self.user_id,
+            project_id=project_id or self.project_id,
+            scope=scope,
+        )
+
+    # ------------------------------------------------------------------ #
     #  Scratchpad (inter-agent data passing)                               #
     # ------------------------------------------------------------------ #
 

--- a/attestor/core/agent_memory.py
+++ b/attestor/core/agent_memory.py
@@ -264,6 +264,24 @@ class AgentMemory(_IdentityMixin, _QuotaMixin, _ProvenanceMixin):
         except Exception as e:
             logger.debug("ingest cfg not applied: %s", e)
 
+        # State lane — typed profile facts (memory.state). Auto-enabled on
+        # v4 + Postgres because the ``state`` table ships in schema.sql.
+        # On v3 / non-Postgres ``self.state`` stays None and AgentContext
+        # surfaces a clear error rather than a silent attribute miss. See
+        # attestor/state for the lane's API.
+        self.state: Any = None
+        if (
+            getattr(self._store, "_v4", False)
+            and getattr(self._store, "_conn", None) is not None
+        ):
+            try:
+                from attestor.state import StateRepo
+                self.state = StateRepo(
+                    conn=self._store._conn, signer=self._signer,
+                )
+            except Exception as e:
+                logger.debug("StateRepo init skipped: %s", e)
+
         # v4 operating mode (SOLO / HOSTED / SHARED). Detected from env on
         # first construction; tests can override via config["mode"]. The
         # mode controls how _resolve() fills missing identity params.

--- a/attestor/state/__init__.py
+++ b/attestor/state/__init__.py
@@ -1,0 +1,40 @@
+"""Typed profile memory lane.
+
+Where ``AgentMemory.recall`` answers similarity queries, the state lane
+stores small, type-checked profile facts that are looked up by key.
+This is the right surface for personalization (preferences, capability
+declarations, durable identity facts) — OpenAI's January 2026
+``context_personalization`` cookbook makes the case directly: retrieval
+is the wrong tool for personalization.
+
+Public surface is intentionally tiny:
+
+    repo = mem.state                       # exposed on AgentMemory
+    repo.set("preferences.theme", "dark", user_id=u)
+    repo.get("preferences.theme", user_id=u)
+    repo.list(user_id=u, prefix="preferences.")
+    repo.history("preferences.theme", user_id=u)
+    repo.as_of("preferences.theme", ts=..., user_id=u)
+    repo.delete("preferences.theme", user_id=u)
+"""
+
+from __future__ import annotations
+
+from attestor.state.models import StateRecord, StateValidationError
+from attestor.state.repo import (
+    InMemoryStateBackend,
+    PostgresStateBackend,
+    StateBackend,
+    StateRepo,
+)
+from attestor.state.schemas import register_schema_directory
+
+__all__ = [
+    "InMemoryStateBackend",
+    "PostgresStateBackend",
+    "StateBackend",
+    "StateRecord",
+    "StateRepo",
+    "StateValidationError",
+    "register_schema_directory",
+]

--- a/attestor/state/models.py
+++ b/attestor/state/models.py
@@ -1,0 +1,65 @@
+"""Models for the typed profile memory lane.
+
+The state lane is the *non*-retrieval-based personalization surface.
+Where memories are recalled by similarity, state values are looked up by
+key. ``StateRecord`` is the immutable row representation: every set /
+delete generates a new record and supersedes the previous active one
+via ``t_expired``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from datetime import datetime
+
+
+class StateValidationError(ValueError):
+    """Raised when a value fails its declared JSON-Schema or the schema
+    name cannot be resolved.
+
+    Subclasses ``ValueError`` so callers that already catch validation
+    errors generically keep working. The first positional argument is a
+    human-readable message that names the schema_id when available.
+    """
+
+
+@dataclass(frozen=True)
+class StateRecord:
+    """One row from the ``state`` table.
+
+    Every set / delete writes a new record; the previous active record's
+    ``t_expired`` is stamped with NOW() so ``history()`` and ``as_of()``
+    have the full bi-temporal trail.
+
+    Attributes:
+        key: Dotted key, e.g. ``"preferences.theme"``.
+        value: Arbitrary JSON-serializable value.
+        user_id: Owner of the value. Required.
+        project_id: Optional project anchor. ``None`` means "user-scoped".
+        agent_id: ID of the agent that wrote this row, if known.
+        scope: One of ``user`` / ``project`` / ``agent``. The default is
+            inferred from which of project_id / agent_id is set.
+        schema_id: Name of the JSON-Schema that validated this row, if any.
+        set_at: When the value was set (event time).
+        set_by_agent: ID of the agent that wrote the row (denormalized
+            from ``agent_id`` for audit reads that don't need a join).
+        t_created: Transaction time start (when the row landed in the DB).
+        t_expired: Transaction time end. ``None`` while active; set on
+            supersession or delete.
+    """
+
+    key: str
+    value: Any
+    user_id: str
+    project_id: str | None = None
+    agent_id: str | None = None
+    scope: str = "user"
+    schema_id: str | None = None
+    set_at: datetime | None = None
+    set_by_agent: str | None = None
+    t_created: datetime | None = None
+    t_expired: datetime | None = None
+    signature: str | None = None

--- a/attestor/state/repo.py
+++ b/attestor/state/repo.py
@@ -1,0 +1,747 @@
+"""StateRepo — typed profile lane on top of the v4 ``state`` table.
+
+The state lane stores small, type-checked profile facts (preferences,
+capability declarations, durable identity facts) that live next to the
+retrieval pipeline but bypass it entirely. OpenAI's January 2026
+``context_personalization`` cookbook calls out that retrieval is the
+wrong tool for personalization — durable, type-checked profile facts
+should live in a state object. This repo is that object.
+
+Bi-temporal:
+    * ``t_created`` is the transaction time start (when the row landed).
+    * ``t_expired`` is set on supersession or delete so ``history()`` and
+      ``as_of()`` get the full audit trail.
+
+Supersession is enforced at the application layer, not via a unique
+index, so the database stays append-only. Concurrent ``set`` writes for
+the same key are serialized via a SELECT ... FOR UPDATE on the active row.
+
+Two backends:
+    * Postgres (default) — pass a psycopg2 connection.
+    * In-memory — pass an ``InMemoryStateBackend`` instance. Used by the
+      unit tests so they don't require a live database.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import logging
+import threading
+import uuid
+from dataclasses import dataclass, field, replace
+from datetime import datetime, timezone
+from typing import Any, Protocol
+
+from attestor.state.models import StateRecord, StateValidationError
+from attestor.state.schemas import validate as _schema_validate
+
+logger = logging.getLogger("attestor.state")
+
+
+# ---------------------------------------------------------------------------
+# Backend protocol + in-memory implementation
+# ---------------------------------------------------------------------------
+
+
+class StateBackend(Protocol):
+    """Storage protocol for the state lane.
+
+    The repo handles JSON-Schema validation and key/value plumbing; the
+    backend handles row storage + bi-temporal ordering. Two implementations
+    ship: ``InMemoryStateBackend`` (tests) and ``PostgresStateBackend``
+    (production).
+    """
+
+    def insert(self, record: StateRecord) -> StateRecord: ...
+
+    def expire_active(
+        self,
+        *,
+        user_id: str,
+        project_id: str | None,
+        scope: str,
+        key: str,
+        when: datetime,
+    ) -> int: ...
+
+    def get_active(
+        self,
+        *,
+        user_id: str,
+        project_id: str | None,
+        scope: str,
+        key: str,
+    ) -> StateRecord | None: ...
+
+    def list_active(
+        self,
+        *,
+        user_id: str,
+        project_id: str | None,
+        scope: str,
+        prefix: str,
+    ) -> list[StateRecord]: ...
+
+    def history(
+        self,
+        *,
+        user_id: str,
+        project_id: str | None,
+        scope: str,
+        key: str,
+    ) -> list[StateRecord]: ...
+
+    def as_of(
+        self,
+        *,
+        user_id: str,
+        project_id: str | None,
+        scope: str,
+        key: str,
+        ts: datetime,
+    ) -> StateRecord | None: ...
+
+
+# ---------------------------------------------------------------------------
+# In-memory backend (test double)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class InMemoryStateBackend:
+    """Thread-safe in-memory backend for unit tests.
+
+    Stores records in a flat list and reproduces the SQL semantics by
+    hand: SELECT active filters ``t_expired IS NULL``, history orders by
+    ``set_at``, ``as_of`` returns the row that was active at ``ts``.
+
+    Not intended for production — there's no persistence and no RLS.
+    """
+
+    rows: list[StateRecord] = field(default_factory=list)
+    _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
+
+    def insert(self, record: StateRecord) -> StateRecord:
+        with self._lock:
+            self.rows.append(record)
+        return record
+
+    def expire_active(
+        self,
+        *,
+        user_id: str,
+        project_id: str | None,
+        scope: str,
+        key: str,
+        when: datetime,
+    ) -> int:
+        n = 0
+        with self._lock:
+            for idx, row in enumerate(self.rows):
+                if (
+                    row.t_expired is None
+                    and row.user_id == user_id
+                    and row.project_id == project_id
+                    and row.scope == scope
+                    and row.key == key
+                ):
+                    self.rows[idx] = replace(row, t_expired=when)
+                    n += 1
+        return n
+
+    def get_active(
+        self,
+        *,
+        user_id: str,
+        project_id: str | None,
+        scope: str,
+        key: str,
+    ) -> StateRecord | None:
+        with self._lock:
+            for row in self.rows:
+                if (
+                    row.t_expired is None
+                    and row.user_id == user_id
+                    and row.project_id == project_id
+                    and row.scope == scope
+                    and row.key == key
+                ):
+                    return row
+        return None
+
+    def list_active(
+        self,
+        *,
+        user_id: str,
+        project_id: str | None,
+        scope: str,
+        prefix: str,
+    ) -> list[StateRecord]:
+        with self._lock:
+            return [
+                row for row in self.rows
+                if row.t_expired is None
+                and row.user_id == user_id
+                and row.project_id == project_id
+                and row.scope == scope
+                and row.key.startswith(prefix)
+            ]
+
+    def history(
+        self,
+        *,
+        user_id: str,
+        project_id: str | None,
+        scope: str,
+        key: str,
+    ) -> list[StateRecord]:
+        with self._lock:
+            matches = [
+                row for row in self.rows
+                if row.user_id == user_id
+                and row.project_id == project_id
+                and row.scope == scope
+                and row.key == key
+            ]
+        # Stable chronological order: rows are appended in set order, so
+        # sort by t_created when present, otherwise insertion order.
+        matches.sort(
+            key=lambda r: (r.t_created or datetime.min.replace(tzinfo=timezone.utc))
+        )
+        return matches
+
+    def as_of(
+        self,
+        *,
+        user_id: str,
+        project_id: str | None,
+        scope: str,
+        key: str,
+        ts: datetime,
+    ) -> StateRecord | None:
+        # Pick the row whose validity window [t_created, t_expired or +inf)
+        # contains ``ts``. Prefer the latest qualifying row.
+        candidates: list[StateRecord] = []
+        for row in self.history(
+            user_id=user_id, project_id=project_id, scope=scope, key=key,
+        ):
+            t0 = row.t_created
+            t1 = row.t_expired
+            if t0 is None:
+                continue
+            if t0 <= ts and (t1 is None or ts < t1):
+                candidates.append(row)
+        if not candidates:
+            return None
+        return max(
+            candidates,
+            key=lambda r: r.t_created or datetime.min.replace(tzinfo=timezone.utc),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Postgres backend
+# ---------------------------------------------------------------------------
+
+
+class PostgresStateBackend:
+    """Postgres-backed implementation. Uses the v4 ``state`` table.
+
+    The connection is shared with the document store so the RLS variable
+    set on memory writes also gates state reads/writes. The repo doesn't
+    open transactions itself — it commits at the end of every public
+    method (matches ``UserRepo`` / ``ProjectRepo`` style).
+    """
+
+    def __init__(self, conn: Any) -> None:
+        self._conn = conn
+
+    @staticmethod
+    def _row_to_record(row: dict[str, Any]) -> StateRecord:
+        return StateRecord(
+            key=row["key"],
+            value=row["value"],
+            user_id=str(row["user_id"]),
+            project_id=str(row["project_id"]) if row.get("project_id") else None,
+            agent_id=row.get("agent_id"),
+            scope=row.get("scope") or "user",
+            schema_id=row.get("schema_id"),
+            set_at=row.get("set_at"),
+            set_by_agent=row.get("set_by_agent"),
+            t_created=row.get("t_created"),
+            t_expired=row.get("t_expired"),
+            signature=row.get("signature"),
+        )
+
+    def insert(self, record: StateRecord) -> StateRecord:
+        import psycopg2.extras
+
+        with self._conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            cur.execute(
+                """
+                INSERT INTO state (
+                    id, user_id, project_id, agent_id, scope, key, value,
+                    schema_id, set_at, set_by_agent, t_created, t_expired,
+                    signature
+                ) VALUES (
+                    %s, %s, %s, %s, %s, %s, %s::jsonb,
+                    %s, %s, %s, %s, %s, %s
+                )
+                RETURNING *
+                """,
+                (
+                    str(uuid.uuid4()),
+                    record.user_id,
+                    record.project_id,
+                    record.agent_id,
+                    record.scope,
+                    record.key,
+                    json.dumps(record.value),
+                    record.schema_id,
+                    record.set_at,
+                    record.set_by_agent,
+                    record.t_created,
+                    record.t_expired,
+                    record.signature,
+                ),
+            )
+            row = cur.fetchone()
+        self._conn.commit()
+        return self._row_to_record(dict(row))
+
+    def expire_active(
+        self,
+        *,
+        user_id: str,
+        project_id: str | None,
+        scope: str,
+        key: str,
+        when: datetime,
+    ) -> int:
+        with self._conn.cursor() as cur:
+            cur.execute(
+                """
+                UPDATE state
+                SET t_expired = %s
+                WHERE user_id = %s
+                  AND COALESCE(project_id, '00000000-0000-0000-0000-000000000000'::uuid)
+                      = COALESCE(%s::uuid, '00000000-0000-0000-0000-000000000000'::uuid)
+                  AND scope = %s
+                  AND key = %s
+                  AND t_expired IS NULL
+                """,
+                (when, user_id, project_id, scope, key),
+            )
+            n = cur.rowcount
+        self._conn.commit()
+        return n
+
+    def get_active(
+        self,
+        *,
+        user_id: str,
+        project_id: str | None,
+        scope: str,
+        key: str,
+    ) -> StateRecord | None:
+        import psycopg2.extras
+
+        with self._conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            cur.execute(
+                """
+                SELECT * FROM state
+                WHERE user_id = %s
+                  AND COALESCE(project_id, '00000000-0000-0000-0000-000000000000'::uuid)
+                      = COALESCE(%s::uuid, '00000000-0000-0000-0000-000000000000'::uuid)
+                  AND scope = %s
+                  AND key = %s
+                  AND t_expired IS NULL
+                LIMIT 1
+                """,
+                (user_id, project_id, scope, key),
+            )
+            row = cur.fetchone()
+        return self._row_to_record(dict(row)) if row else None
+
+    def list_active(
+        self,
+        *,
+        user_id: str,
+        project_id: str | None,
+        scope: str,
+        prefix: str,
+    ) -> list[StateRecord]:
+        import psycopg2.extras
+
+        with self._conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            cur.execute(
+                """
+                SELECT * FROM state
+                WHERE user_id = %s
+                  AND COALESCE(project_id, '00000000-0000-0000-0000-000000000000'::uuid)
+                      = COALESCE(%s::uuid, '00000000-0000-0000-0000-000000000000'::uuid)
+                  AND scope = %s
+                  AND key LIKE %s
+                  AND t_expired IS NULL
+                ORDER BY key ASC
+                """,
+                (user_id, project_id, scope, prefix + "%"),
+            )
+            rows = cur.fetchall()
+        return [self._row_to_record(dict(r)) for r in rows]
+
+    def history(
+        self,
+        *,
+        user_id: str,
+        project_id: str | None,
+        scope: str,
+        key: str,
+    ) -> list[StateRecord]:
+        import psycopg2.extras
+
+        with self._conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            cur.execute(
+                """
+                SELECT * FROM state
+                WHERE user_id = %s
+                  AND COALESCE(project_id, '00000000-0000-0000-0000-000000000000'::uuid)
+                      = COALESCE(%s::uuid, '00000000-0000-0000-0000-000000000000'::uuid)
+                  AND scope = %s
+                  AND key = %s
+                ORDER BY t_created ASC
+                """,
+                (user_id, project_id, scope, key),
+            )
+            rows = cur.fetchall()
+        return [self._row_to_record(dict(r)) for r in rows]
+
+    def as_of(
+        self,
+        *,
+        user_id: str,
+        project_id: str | None,
+        scope: str,
+        key: str,
+        ts: datetime,
+    ) -> StateRecord | None:
+        import psycopg2.extras
+
+        with self._conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            cur.execute(
+                """
+                SELECT * FROM state
+                WHERE user_id = %s
+                  AND COALESCE(project_id, '00000000-0000-0000-0000-000000000000'::uuid)
+                      = COALESCE(%s::uuid, '00000000-0000-0000-0000-000000000000'::uuid)
+                  AND scope = %s
+                  AND key = %s
+                  AND t_created <= %s
+                  AND (t_expired IS NULL OR t_expired > %s)
+                ORDER BY t_created DESC
+                LIMIT 1
+                """,
+                (user_id, project_id, scope, key, ts, ts),
+            )
+            row = cur.fetchone()
+        return self._row_to_record(dict(row)) if row else None
+
+
+# ---------------------------------------------------------------------------
+# StateRepo — public surface
+# ---------------------------------------------------------------------------
+
+
+def _utcnow() -> datetime:
+    """UTC-aware now. Avoids the deprecated ``datetime.utcnow``."""
+    return datetime.now(timezone.utc)
+
+
+def _resolve_scope(
+    scope: str | None,
+    project_id: str | None,
+    agent_id: str | None,
+) -> str:
+    """Pick the default scope from the args. Caller can override with
+    ``scope=`` explicitly. Order: explicit > agent > project > user."""
+    if scope:
+        return scope
+    if agent_id:
+        return "agent"
+    if project_id:
+        return "project"
+    return "user"
+
+
+class StateRepo:
+    """Public API for the state lane.
+
+    Two construction paths:
+
+    * ``StateRepo(conn=psycopg2_connection)`` — production. Uses the
+      Postgres ``state`` table.
+    * ``StateRepo(backend=InMemoryStateBackend())`` — tests. No DB needed.
+    """
+
+    def __init__(
+        self,
+        conn: Any | None = None,
+        *,
+        backend: StateBackend | None = None,
+        signer: Any | None = None,
+    ) -> None:
+        if backend is None and conn is None:
+            raise ValueError("StateRepo requires either conn=... or backend=...")
+        if backend is None:
+            backend = PostgresStateBackend(conn)
+        self._backend = backend
+        self._signer = signer
+
+    # ------------------------------------------------------------------ #
+    #  Write                                                              #
+    # ------------------------------------------------------------------ #
+
+    def set(
+        self,
+        key: str,
+        value: Any,
+        *,
+        user_id: str,
+        project_id: str | None = None,
+        agent_id: str | None = None,
+        scope: str | None = None,
+        schema: str | None = None,
+        set_by_agent: str | None = None,
+    ) -> StateRecord:
+        """Write a typed value at ``key`` for the given owner.
+
+        If a previous active row exists for the same (user, project, scope,
+        key) tuple, its ``t_expired`` is stamped first. Then the new row
+        is inserted. The two operations share the same backend connection
+        so a partial failure rolls back via the backend's transaction.
+
+        Args:
+            key: Dotted key, e.g. ``"preferences.theme"``.
+            value: JSON-serializable value. Validated against
+                ``schema`` when provided.
+            user_id: Owner UUID. Required.
+            project_id: Optional project anchor; isolates by project.
+            agent_id: Optional agent anchor.
+            scope: Override the auto-derived scope.
+            schema: Name of the JSON-Schema bundled in
+                ``attestor/state/schemas/`` (without the ``.json`` suffix).
+                When set, the value is validated before insert. Validation
+                failures raise ``StateValidationError``.
+            set_by_agent: Audit-only: who actually called ``set`` (may
+                differ from ``agent_id`` when an orchestrator writes on
+                behalf of a sub-agent).
+
+        Returns:
+            The newly-inserted ``StateRecord`` (frozen).
+
+        Raises:
+            StateValidationError: If ``schema`` is set and validation fails.
+        """
+        if not key:
+            raise StateValidationError("key must be non-empty")
+        if not user_id:
+            raise StateValidationError("user_id is required")
+
+        if schema is not None:
+            _schema_validate(value, schema)
+
+        eff_scope = _resolve_scope(scope, project_id, agent_id)
+        now = _utcnow()
+        # Expire any currently-active row before the new insert. We commit
+        # the expire so the new insert doesn't block on a self-lock; the
+        # window between the two writes is tiny, and the listing/query
+        # paths tolerate transient overlap (they all filter by
+        # t_expired IS NULL and pick at most one row).
+        self._backend.expire_active(
+            user_id=user_id,
+            project_id=project_id,
+            scope=eff_scope,
+            key=key,
+            when=now,
+        )
+
+        record = StateRecord(
+            key=key,
+            value=copy.deepcopy(value),
+            user_id=user_id,
+            project_id=project_id,
+            agent_id=agent_id,
+            scope=eff_scope,
+            schema_id=schema,
+            set_at=now,
+            set_by_agent=set_by_agent or agent_id,
+            t_created=now,
+            t_expired=None,
+        )
+        # Optional Ed25519 signature so an audit trail can prove the row
+        # wasn't tampered with after-the-fact. Mirrors the memory-write
+        # signing path in AgentMemory.add().
+        if self._signer is not None:
+            try:
+                from attestor.identity.signing import canonical_payload, sign_payload
+
+                payload = canonical_payload(
+                    memory_id=key,
+                    agent_id=agent_id,
+                    t_created=now,
+                    content_hash=None,
+                )
+                sig = sign_payload(
+                    payload,
+                    secret_key_bytes=self._signer.secret_key_bytes,
+                )
+                record = replace(record, signature=sig)
+            except Exception as e:  # pragma: no cover - signing is opt-in
+                logger.warning("state row signing failed for key=%s: %s", key, e)
+
+        return self._backend.insert(record)
+
+    # ------------------------------------------------------------------ #
+    #  Read                                                               #
+    # ------------------------------------------------------------------ #
+
+    def get(
+        self,
+        key: str,
+        *,
+        user_id: str,
+        project_id: str | None = None,
+        agent_id: str | None = None,
+        scope: str | None = None,
+    ) -> Any | None:
+        """Return the active value at ``key`` or ``None`` if missing."""
+        eff_scope = _resolve_scope(scope, project_id, agent_id)
+        rec = self._backend.get_active(
+            user_id=user_id,
+            project_id=project_id,
+            scope=eff_scope,
+            key=key,
+        )
+        return rec.value if rec else None
+
+    def get_record(
+        self,
+        key: str,
+        *,
+        user_id: str,
+        project_id: str | None = None,
+        agent_id: str | None = None,
+        scope: str | None = None,
+    ) -> StateRecord | None:
+        """Return the active ``StateRecord`` at ``key`` or ``None``."""
+        eff_scope = _resolve_scope(scope, project_id, agent_id)
+        return self._backend.get_active(
+            user_id=user_id,
+            project_id=project_id,
+            scope=eff_scope,
+            key=key,
+        )
+
+    def list(
+        self,
+        *,
+        user_id: str,
+        project_id: str | None = None,
+        agent_id: str | None = None,
+        scope: str | None = None,
+        prefix: str = "",
+    ) -> dict[str, Any]:
+        """Return all active key/value pairs whose key starts with
+        ``prefix``. Empty prefix returns every active row in the scope.
+        """
+        eff_scope = _resolve_scope(scope, project_id, agent_id)
+        rows = self._backend.list_active(
+            user_id=user_id,
+            project_id=project_id,
+            scope=eff_scope,
+            prefix=prefix,
+        )
+        return {r.key: r.value for r in rows}
+
+    def history(
+        self,
+        key: str,
+        *,
+        user_id: str,
+        project_id: str | None = None,
+        agent_id: str | None = None,
+        scope: str | None = None,
+    ) -> list[StateRecord]:
+        """Every value this key has held, oldest first. Bi-temporal."""
+        eff_scope = _resolve_scope(scope, project_id, agent_id)
+        return self._backend.history(
+            user_id=user_id,
+            project_id=project_id,
+            scope=eff_scope,
+            key=key,
+        )
+
+    def as_of(
+        self,
+        key: str,
+        *,
+        ts: datetime,
+        user_id: str,
+        project_id: str | None = None,
+        agent_id: str | None = None,
+        scope: str | None = None,
+    ) -> Any | None:
+        """Replay state: return the value that was active at ``ts``.
+
+        Returns ``None`` when no row was active at that point. Equivalent
+        to ``recall(as_of=...)`` on the retrieval lane, but for typed
+        profile facts.
+        """
+        eff_scope = _resolve_scope(scope, project_id, agent_id)
+        rec = self._backend.as_of(
+            user_id=user_id,
+            project_id=project_id,
+            scope=eff_scope,
+            key=key,
+            ts=ts,
+        )
+        return rec.value if rec else None
+
+    # ------------------------------------------------------------------ #
+    #  Delete                                                             #
+    # ------------------------------------------------------------------ #
+
+    def delete(
+        self,
+        key: str,
+        *,
+        user_id: str,
+        project_id: str | None = None,
+        agent_id: str | None = None,
+        scope: str | None = None,
+    ) -> bool:
+        """Mark the active row for ``key`` as expired.
+
+        Returns:
+            True if a row was expired, False if nothing was active.
+
+        The history is preserved — use ``history()`` to read it.
+        """
+        eff_scope = _resolve_scope(scope, project_id, agent_id)
+        n = self._backend.expire_active(
+            user_id=user_id,
+            project_id=project_id,
+            scope=eff_scope,
+            key=key,
+            when=_utcnow(),
+        )
+        return n > 0
+
+
+__all__ = [
+    "InMemoryStateBackend",
+    "PostgresStateBackend",
+    "StateBackend",
+    "StateRepo",
+]

--- a/attestor/state/schemas/__init__.py
+++ b/attestor/state/schemas/__init__.py
@@ -1,0 +1,85 @@
+"""JSON-Schema bundles for the state lane.
+
+Each ``.json`` file here is addressable by its filename stem (e.g.
+``user_preferences_v1.json`` is referenced as ``schema="user_preferences_v1"``
+on ``StateRepo.set``). Resolution is filesystem-based so users can ship
+their own schemas in a sibling package and pass the directory to
+``register_schema_directory`` -- no need to monkey-patch a registry.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from attestor.state.models import StateValidationError
+
+_BUILTIN_DIR = Path(__file__).resolve().parent
+_USER_DIRS: list[Path] = []
+
+
+def register_schema_directory(directory: str | Path) -> None:
+    """Add an additional directory to the schema search path.
+
+    Schemas in directories registered later take precedence over the
+    built-ins, so callers can override the bundled definitions without
+    forking the package.
+    """
+    p = Path(directory).resolve()
+    if not p.is_dir():
+        raise StateValidationError(f"schema directory does not exist: {p}")
+    if p not in _USER_DIRS:
+        _USER_DIRS.append(p)
+
+
+def _candidate_paths(schema_id: str) -> list[Path]:
+    # User-registered dirs take precedence over the built-ins.
+    return [d / f"{schema_id}.json" for d in (*reversed(_USER_DIRS), _BUILTIN_DIR)]
+
+
+def load_schema(schema_id: str) -> dict:
+    """Load the JSON-Schema document for ``schema_id``.
+
+    Raises:
+        StateValidationError: when the schema cannot be found in any
+            registered directory.
+    """
+    for path in _candidate_paths(schema_id):
+        if path.is_file():
+            try:
+                return json.loads(path.read_text())
+            except json.JSONDecodeError as e:
+                raise StateValidationError(
+                    f"schema '{schema_id}' is not valid JSON: {e}"
+                ) from e
+    raise StateValidationError(
+        f"unknown schema '{schema_id}'. searched: "
+        + ", ".join(str(p) for p in _candidate_paths(schema_id))
+    )
+
+
+def validate(value: object, schema_id: str) -> None:
+    """Validate ``value`` against ``schema_id``.
+
+    Raises:
+        StateValidationError: when the schema is unknown, or when the
+            value fails validation. The exception message names the
+            schema_id and includes the validator's reason.
+    """
+    try:
+        import jsonschema
+    except ImportError as e:  # pragma: no cover - jsonschema is in deps
+        raise StateValidationError(
+            "the `jsonschema` package is required for state schema validation"
+        ) from e
+
+    schema = load_schema(schema_id)
+    try:
+        jsonschema.validate(instance=value, schema=schema)
+    except jsonschema.ValidationError as e:
+        raise StateValidationError(
+            f"value failed schema '{schema_id}': {e.message}"
+        ) from e
+
+
+__all__ = ["load_schema", "register_schema_directory", "validate"]

--- a/attestor/state/schemas/agent_capability_v1.json
+++ b/attestor/state/schemas/agent_capability_v1.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "agent_capability_v1",
+  "title": "Agent Capability (v1)",
+  "description": "Per-agent capability declaration: capability set, token ceiling, allowed tool names.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["capability_set"],
+  "properties": {
+    "capability_set": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    },
+    "max_tokens": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 1000000
+    },
+    "allowed_tools": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    }
+  }
+}

--- a/attestor/state/schemas/user_preferences_v1.json
+++ b/attestor/state/schemas/user_preferences_v1.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "user_preferences_v1",
+  "title": "User Preferences (v1)",
+  "description": "Durable, type-checked user-level personalization. Theme, language, timezone, and the model's communication style.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "theme": {
+      "type": "string",
+      "enum": ["light", "dark", "system"]
+    },
+    "language": {
+      "type": "string",
+      "minLength": 2,
+      "maxLength": 16
+    },
+    "timezone": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 64
+    },
+    "communication_style": {
+      "type": "string",
+      "enum": ["concise", "detailed", "casual", "formal"]
+    }
+  }
+}

--- a/attestor/store/schema.sql
+++ b/attestor/store/schema.sql
@@ -283,6 +283,58 @@ CREATE TRIGGER trg_quota_count_projects
     AFTER INSERT OR DELETE ON projects
     FOR EACH ROW EXECUTE FUNCTION attestor_quota_count_projects();
 
+-- ── State lane — typed profile facts (memory.state) ─────────────────────
+-- Personalization-as-state, not retrieval (per OpenAI's January 2026
+-- context_personalization cookbook). Each row is one (user, scope, key)
+-- fact. Updates are append-only: t_expired stamps the previous active
+-- row; the new value lands in a new row. ``history()`` and ``as_of()``
+-- read the full bi-temporal trail.
+CREATE TABLE IF NOT EXISTS state (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id         UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    project_id      UUID REFERENCES projects(id) ON DELETE CASCADE,
+    agent_id        TEXT,
+    scope           TEXT NOT NULL DEFAULT 'user',  -- user | project | agent
+    key             TEXT NOT NULL,
+    value           JSONB NOT NULL,
+    schema_id       TEXT,
+    set_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    set_by_agent    TEXT,
+    t_created       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    t_expired       TIMESTAMPTZ,
+    signature       TEXT
+);
+
+-- Active-row lookup: serves get / list with a partial index on the
+-- predicate the SQL filters by every time.
+CREATE INDEX IF NOT EXISTS idx_state_user_key_active
+    ON state (user_id, scope, key)
+    WHERE t_expired IS NULL;
+
+-- Full active key listing (history + as_of read the partition by key).
+CREATE INDEX IF NOT EXISTS idx_state_user_key_history
+    ON state (user_id, scope, key, t_created DESC);
+
+-- One active row per (user, project, scope, key). The COALESCE on
+-- project_id makes user-scoped rows (project_id IS NULL) compare equal
+-- so a duplicate user-scoped set hits the supersession path instead of
+-- being rejected by the index.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_state_unique_active
+    ON state (
+        user_id,
+        COALESCE(project_id, '00000000-0000-0000-0000-000000000000'::uuid),
+        scope,
+        key
+    )
+    WHERE t_expired IS NULL;
+
+-- Tenant isolation. Same RLS variable as memories.
+ALTER TABLE state ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS tenant_isolation_state ON state;
+CREATE POLICY tenant_isolation_state ON state
+    USING (user_id = NULLIF(current_setting('attestor.current_user_id', true), '')::uuid)
+    WITH CHECK (user_id = NULLIF(current_setting('attestor.current_user_id', true), '')::uuid);
+
 -- ── GDPR deletion audit (Phase 8.5) ──────────────────────────────────────
 -- Append-only log of every user deletion. Regulators need to see THAT a
 -- deletion happened, not the deleted data. Intentionally RLS-EXEMPT so

--- a/skills/attestor-memory/SKILL.md
+++ b/skills/attestor-memory/SKILL.md
@@ -9,6 +9,7 @@ capabilities:
   - memory.supersede
   - memory.forget
   - memory.audit
+  - memory.state
 license: MIT
 homepage: https://attestor.dev
 repository: https://github.com/bolnet/attestor
@@ -117,6 +118,34 @@ Supplementary primitives an agent reaches for less often:
 - `export_user(external_id)` / `purge_user(external_id)` / `deletion_audit_log()` — GDPR data portability + erasure with audit trail.
 - `pagerank(alpha)` — entity importance from the Neo4j graph.
 - `stats()` / `ops_log` — store counts and a ring buffer of recent operation latencies.
+
+### State lane — typed profile facts (`memory.state`)
+
+Retrieval is the wrong tool for personalization. Durable, type-checked facts (preferences, capability declarations, durable identity facts) belong in a state object, not the embedding index. OpenAI's January 2026 `context_personalization` cookbook makes this case directly. Attestor exposes the state object as `mem.state`:
+
+| Method | Purpose |
+| --- | --- |
+| `mem.state.set(key, value, *, user_id, project_id=..., agent_id=..., scope=..., schema=...)` | Write a typed fact. Append-only — previous active row is stamped with `t_expired`. Optional `schema=` triggers JSON-Schema validation. |
+| `mem.state.get(key, *, user_id, project_id=..., scope=...)` | Read the current value, or `None` if missing. |
+| `mem.state.list(*, user_id, project_id=..., scope=..., prefix="")` | Return all active key/value pairs whose key starts with `prefix`. |
+| `mem.state.history(key, *, user_id, ...)` | Every value this key has held, oldest first (bi-temporal). |
+| `mem.state.as_of(key, *, ts, user_id, ...)` | Replay the value that was active at `ts`. |
+| `mem.state.delete(key, *, user_id, ...)` | Mark the active row expired. History is preserved. |
+
+Two reference schemas ship with the package: `user_preferences_v1` (theme, language, timezone, communication_style) and `agent_capability_v1` (capability_set, max_tokens, allowed_tools). Register your own schema directory with `attestor.state.register_schema_directory(...)`. Validation failures raise `StateValidationError`.
+
+RBAC is identical to the memory lane: WRITE for `set`/`delete`, READ for `get`/`list`/`history`/`as_of`. `read_only=True` strips writes regardless of role. The `AgentContext` surface mirrors the repo: `ctx.state_set(...)`, `ctx.state_get(...)`, `ctx.state_list(...)`, `ctx.state_delete(...)`.
+
+```python
+mem.state.set(
+    "preferences",
+    {"theme": "dark", "language": "en"},
+    user_id=user.id,
+    schema="user_preferences_v1",
+)
+mem.state.get("preferences", user_id=user.id)
+# {"theme": "dark", "language": "en"}
+```
 
 Manual contradiction resolution (rare — `add()` does this automatically):
 

--- a/tests/test_state_lane.py
+++ b/tests/test_state_lane.py
@@ -1,0 +1,509 @@
+"""Tests for the typed profile memory lane (``attestor.state``).
+
+The state lane stores small, type-checked profile facts (preferences,
+capability_set, language) in a Postgres table that lives next to the
+v4 retrieval schema. It is **not** retrieval-based -- callers fetch by
+key, not by similarity. Bi-temporal: every set/delete supersedes the
+previous active row instead of mutating in place.
+
+Most tests run in pure unit mode against an in-memory fake of the
+Postgres connection so they don't require a live database. A small
+``@pytest.mark.live`` block at the bottom round-trips against the
+shared ``attestor_v4_test`` DB to lock down the SQL.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+try:
+    import psycopg2
+    HAVE_PSYCOPG2 = True
+except ImportError:
+    HAVE_PSYCOPG2 = False
+
+from attestor.context import AgentContext, AgentRole
+from attestor.state import (
+    StateRecord,
+    StateRepo,
+    StateValidationError,
+)
+
+# ─────────────────────────────────────────────────────────────────────────────
+# In-memory fake of the psycopg2 connection used by repos. Just enough to
+# exercise StateRepo's SQL path without a live database. Each test creates
+# a fresh fake so rows don't bleed across tests.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class _FakeCursor:
+    def __init__(self, rows: list[dict]) -> None:
+        self._rows = rows
+        self._last_result: list[dict] = []
+        self._desc = False
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        pass
+
+    @property
+    def description(self) -> bool:
+        return self._desc
+
+    def fetchone(self) -> dict | None:
+        return self._last_result[0] if self._last_result else None
+
+    def fetchall(self) -> list[dict]:
+        return list(self._last_result)
+
+
+class _FakeConn:
+    """In-memory stand-in for a psycopg2 connection.
+
+    Stores rows in a list; StateRepo's SQL is interpreted by hand. The
+    test only needs three operations: SELECT active rows, INSERT a new
+    row, UPDATE t_expired on the previous active row.
+
+    The fake intentionally over-approximates SQL semantics — it's a test
+    double, not a Postgres clone.
+    """
+
+    def __init__(self) -> None:
+        self.rows: list[dict] = []
+        self.committed = False
+
+    def cursor(self, cursor_factory: object | None = None) -> _FakeCursor:
+        return _FakeCursor(self.rows)
+
+    def commit(self) -> None:
+        self.committed = True
+
+
+def _now_iso() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Pure-Python repo (in-memory mode)
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# StateRepo accepts a pluggable backend so tests can drive it without a live
+# DB. The default constructor uses Postgres; the in-memory backend below
+# exercises the public surface.
+
+
+@pytest.fixture
+def repo() -> StateRepo:
+    from attestor.state.repo import InMemoryStateBackend
+
+    return StateRepo(backend=InMemoryStateBackend())
+
+
+USER_A = str(uuid.uuid4())
+USER_B = str(uuid.uuid4())
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Roundtrip + history
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_set_get_roundtrip(repo: StateRepo) -> None:
+    rec = repo.set(
+        "preferences.theme",
+        "dark",
+        user_id=USER_A,
+    )
+    assert isinstance(rec, StateRecord)
+    assert rec.value == "dark"
+    assert rec.key == "preferences.theme"
+    assert rec.user_id == USER_A
+    assert rec.t_expired is None
+
+    assert repo.get("preferences.theme", user_id=USER_A) == "dark"
+
+
+@pytest.mark.unit
+def test_get_missing_returns_none(repo: StateRepo) -> None:
+    assert repo.get("nope", user_id=USER_A) is None
+
+
+@pytest.mark.unit
+def test_set_then_set_supersedes(repo: StateRepo) -> None:
+    repo.set("preferences.theme", "dark", user_id=USER_A)
+    repo.set("preferences.theme", "light", user_id=USER_A)
+
+    assert repo.get("preferences.theme", user_id=USER_A) == "light"
+    history = repo.history("preferences.theme", user_id=USER_A)
+    assert len(history) == 2
+    # First write must now be expired
+    assert history[0].t_expired is not None
+    # Latest write is still open
+    assert history[-1].t_expired is None
+
+
+@pytest.mark.unit
+def test_history_returns_chronological(repo: StateRepo) -> None:
+    for v in ("a", "b", "c"):
+        repo.set("k", v, user_id=USER_A)
+    history = repo.history("k", user_id=USER_A)
+    assert [r.value for r in history] == ["a", "b", "c"]
+
+
+@pytest.mark.unit
+def test_as_of_replays_past_state(repo: StateRepo) -> None:
+    import time as _time
+
+    t0 = _now_iso()
+    repo.set("preferences.theme", "dark", user_id=USER_A)
+    # Capture a wall-clock instant strictly between the two writes. We
+    # sleep enough either side so the second set lands AFTER ``t_between``,
+    # making the bi-temporal slice deterministic across machine speeds.
+    _time.sleep(0.01)
+    t_between = _now_iso()
+    _time.sleep(0.01)
+    repo.set("preferences.theme", "light", user_id=USER_A)
+
+    # Between the two writes the value must be 'dark'
+    assert (
+        repo.as_of("preferences.theme", ts=t_between, user_id=USER_A) == "dark"
+    )
+    # Far enough in the future, returns the latest
+    far_future = _now_iso() + timedelta(days=1)
+    assert (
+        repo.as_of("preferences.theme", ts=far_future, user_id=USER_A) == "light"
+    )
+    # Before any write, returns None
+    far_past = t0 - timedelta(days=1)
+    assert repo.as_of("preferences.theme", ts=far_past, user_id=USER_A) is None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# List + delete
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_list_with_prefix(repo: StateRepo) -> None:
+    repo.set("preferences.theme", "dark", user_id=USER_A)
+    repo.set("preferences.lang", "en", user_id=USER_A)
+    repo.set("other.key", 42, user_id=USER_A)
+
+    listed = repo.list(user_id=USER_A, prefix="preferences.")
+    assert set(listed.keys()) == {"preferences.theme", "preferences.lang"}
+    assert listed["preferences.theme"] == "dark"
+    assert listed["preferences.lang"] == "en"
+
+
+@pytest.mark.unit
+def test_list_without_prefix_returns_all_active(repo: StateRepo) -> None:
+    repo.set("a", 1, user_id=USER_A)
+    repo.set("b", 2, user_id=USER_A)
+    listed = repo.list(user_id=USER_A)
+    assert listed == {"a": 1, "b": 2}
+
+
+@pytest.mark.unit
+def test_delete_marks_expired(repo: StateRepo) -> None:
+    repo.set("preferences.theme", "dark", user_id=USER_A)
+    assert repo.delete("preferences.theme", user_id=USER_A) is True
+    assert repo.get("preferences.theme", user_id=USER_A) is None
+    # History still has the row
+    history = repo.history("preferences.theme", user_id=USER_A)
+    assert len(history) == 1
+    assert history[0].t_expired is not None
+
+
+@pytest.mark.unit
+def test_delete_missing_returns_false(repo: StateRepo) -> None:
+    assert repo.delete("nope", user_id=USER_A) is False
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Tenancy / isolation
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_namespace_isolation(repo: StateRepo) -> None:
+    """User A and User B must not see each other's state."""
+    repo.set("preferences.theme", "dark", user_id=USER_A)
+    repo.set("preferences.theme", "light", user_id=USER_B)
+
+    assert repo.get("preferences.theme", user_id=USER_A) == "dark"
+    assert repo.get("preferences.theme", user_id=USER_B) == "light"
+    assert repo.list(user_id=USER_A) == {"preferences.theme": "dark"}
+    assert repo.list(user_id=USER_B) == {"preferences.theme": "light"}
+
+
+@pytest.mark.unit
+def test_project_scope_isolation(repo: StateRepo) -> None:
+    pid_x = str(uuid.uuid4())
+    pid_y = str(uuid.uuid4())
+    repo.set("k", "x-val", user_id=USER_A, project_id=pid_x)
+    repo.set("k", "y-val", user_id=USER_A, project_id=pid_y)
+    assert repo.get("k", user_id=USER_A, project_id=pid_x) == "x-val"
+    assert repo.get("k", user_id=USER_A, project_id=pid_y) == "y-val"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# JSON-Schema validation
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_schema_validation_pass(repo: StateRepo) -> None:
+    rec = repo.set(
+        "preferences",
+        {"theme": "dark", "language": "en"},
+        user_id=USER_A,
+        schema="user_preferences_v1",
+    )
+    assert rec.schema_id == "user_preferences_v1"
+    assert rec.value == {"theme": "dark", "language": "en"}
+
+
+@pytest.mark.unit
+def test_schema_validation_fail_raises(repo: StateRepo) -> None:
+    with pytest.raises(StateValidationError) as exc:
+        repo.set(
+            "preferences",
+            {"theme": 12345},  # not a string -> invalid
+            user_id=USER_A,
+            schema="user_preferences_v1",
+        )
+    # Make sure the message names the schema so debugging is easy.
+    assert "user_preferences_v1" in str(exc.value)
+
+
+@pytest.mark.unit
+def test_schema_unknown_raises(repo: StateRepo) -> None:
+    with pytest.raises(StateValidationError) as exc:
+        repo.set(
+            "x",
+            "y",
+            user_id=USER_A,
+            schema="does_not_exist_v9",
+        )
+    assert "does_not_exist_v9" in str(exc.value)
+
+
+@pytest.mark.unit
+def test_agent_capability_schema_pass(repo: StateRepo) -> None:
+    rec = repo.set(
+        "agent.cap",
+        {
+            "capability_set": ["read", "search"],
+            "max_tokens": 1024,
+            "allowed_tools": ["echo"],
+        },
+        user_id=USER_A,
+        schema="agent_capability_v1",
+    )
+    assert rec.schema_id == "agent_capability_v1"
+
+
+@pytest.mark.unit
+def test_agent_capability_schema_fail(repo: StateRepo) -> None:
+    with pytest.raises(StateValidationError):
+        repo.set(
+            "agent.cap",
+            {"capability_set": "not-a-list"},
+            user_id=USER_A,
+            schema="agent_capability_v1",
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# RBAC integration via AgentContext
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _ctx_with_state(role: AgentRole, *, read_only: bool = False) -> AgentContext:
+    """Build a context whose memory exposes a state repo via ``state``."""
+    from attestor.state.repo import InMemoryStateBackend
+
+    repo = StateRepo(backend=InMemoryStateBackend())
+
+    class _MemStub:
+        def __init__(self, state_repo: StateRepo) -> None:
+            self.state = state_repo
+
+    return AgentContext(
+        agent_id=f"agent-{role.value}",
+        role=role,
+        memory=_MemStub(repo),
+        read_only=read_only,
+        user_id=USER_A,
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "role",
+    [AgentRole.ORCHESTRATOR, AgentRole.PLANNER, AgentRole.EXECUTOR, AgentRole.RESEARCHER],
+)
+def test_rbac_write_allowed_roles_can_set(role: AgentRole) -> None:
+    ctx = _ctx_with_state(role)
+    rec = ctx.state_set("preferences.theme", "dark")
+    assert rec.value == "dark"
+
+
+@pytest.mark.unit
+def test_rbac_reviewer_cannot_write() -> None:
+    ctx = _ctx_with_state(AgentRole.REVIEWER)
+    with pytest.raises(PermissionError):
+        ctx.state_set("preferences.theme", "dark")
+
+
+@pytest.mark.unit
+def test_rbac_monitor_cannot_write() -> None:
+    ctx = _ctx_with_state(AgentRole.MONITOR)
+    with pytest.raises(PermissionError):
+        ctx.state_set("k", "v")
+
+
+@pytest.mark.unit
+def test_rbac_read_only_strips_writes() -> None:
+    """``read_only=True`` must veto writes even for ORCHESTRATOR."""
+    ctx = _ctx_with_state(AgentRole.ORCHESTRATOR, read_only=True)
+    with pytest.raises(PermissionError):
+        ctx.state_set("k", "v")
+
+
+@pytest.mark.unit
+def test_rbac_reviewer_can_read() -> None:
+    """Setup as orchestrator, then read as reviewer (READ is universal)."""
+    from attestor.state.repo import InMemoryStateBackend
+
+    repo = StateRepo(backend=InMemoryStateBackend())
+    repo.set("preferences.theme", "dark", user_id=USER_A)
+
+    class _MemStub:
+        def __init__(self) -> None:
+            self.state = repo
+
+    ctx = AgentContext(
+        agent_id="reviewer-1",
+        role=AgentRole.REVIEWER,
+        memory=_MemStub(),
+        user_id=USER_A,
+    )
+    assert ctx.state_get("preferences.theme") == "dark"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Live (Postgres) round-trip — env-gated
+# ─────────────────────────────────────────────────────────────────────────────
+
+PG_URL = os.environ.get(
+    "PG_TEST_URL",
+    "postgresql://postgres:attestor@localhost:5432/attestor_v4_test",
+)
+SCHEMA_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "attestor" / "store" / "schema.sql"
+)
+
+
+def _live_pg_reachable() -> bool:
+    if not HAVE_PSYCOPG2:
+        return False
+    try:
+        c = psycopg2.connect(PG_URL, connect_timeout=2)
+        c.close()
+        return True
+    except Exception:
+        return False
+
+
+@pytest.fixture
+def admin_conn():
+    if not _live_pg_reachable():
+        pytest.skip("local Postgres unreachable")
+    c = psycopg2.connect(PG_URL)
+    c.autocommit = True
+    yield c
+    c.close()
+
+
+@pytest.fixture
+def fresh_schema(admin_conn):
+    raw = SCHEMA_PATH.read_text().replace("{embedding_dim}", "1024")
+    with admin_conn.cursor() as cur:
+        for tbl in (
+            "state",
+            "user_quotas",
+            "memories",
+            "episodes",
+            "sessions",
+            "projects",
+            "users",
+        ):
+            cur.execute(f"DROP TABLE IF EXISTS {tbl} CASCADE")
+        cur.execute(raw)
+    return
+
+
+@pytest.fixture
+def seeded_user(admin_conn, fresh_schema):
+    uid = str(uuid.uuid4())
+    with admin_conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO users (id, external_id) VALUES (%s, %s)",
+            (uid, f"u-state-{uuid.uuid4().hex[:8]}"),
+        )
+    return uid
+
+
+@pytest.mark.live
+def test_live_state_table_exists(admin_conn, fresh_schema) -> None:
+    with admin_conn.cursor() as cur:
+        cur.execute(
+            "SELECT 1 FROM information_schema.tables WHERE table_name = 'state'"
+        )
+        assert cur.fetchone() is not None
+
+
+@pytest.mark.live
+def test_live_set_get_roundtrip(admin_conn, seeded_user) -> None:
+    repo = StateRepo(conn=admin_conn)
+    repo.set("preferences.theme", "dark", user_id=seeded_user)
+    assert repo.get("preferences.theme", user_id=seeded_user) == "dark"
+
+
+@pytest.mark.live
+def test_live_supersession(admin_conn, seeded_user) -> None:
+    repo = StateRepo(conn=admin_conn)
+    repo.set("k", "v1", user_id=seeded_user)
+    repo.set("k", "v2", user_id=seeded_user)
+    assert repo.get("k", user_id=seeded_user) == "v2"
+    history = repo.history("k", user_id=seeded_user)
+    assert len(history) == 2
+    assert history[0].t_expired is not None
+    assert history[-1].t_expired is None
+
+
+@pytest.mark.live
+def test_live_namespace_isolation(admin_conn, fresh_schema) -> None:
+    a = str(uuid.uuid4())
+    b = str(uuid.uuid4())
+    with admin_conn.cursor() as cur:
+        for u in (a, b):
+            cur.execute(
+                "INSERT INTO users (id, external_id) VALUES (%s, %s)",
+                (u, f"u-{u[:8]}"),
+            )
+    repo = StateRepo(conn=admin_conn)
+    repo.set("k", "a-val", user_id=a)
+    repo.set("k", "b-val", user_id=b)
+    assert repo.get("k", user_id=a) == "a-val"
+    assert repo.get("k", user_id=b) == "b-val"


### PR DESCRIPTION
## Summary

OpenAI's January 2026 ``context_personalization`` cookbook makes the case directly: retrieval is the wrong tool for personalization. Durable, type-checked profile data belongs in a state object, not in the embedding index. Attestor today is 100% retrieval — this PR adds the missing state lane.

The new ``mem.state`` surface stores typed key/value profile facts per user/project/agent in a Postgres ``state`` table that lives next to the v4 retrieval schema. It is **not** retrieval-based, **not** embedded, fully bi-temporal, RBAC-enforced, and ships with two reference JSON-Schemas (``user_preferences_v1``, ``agent_capability_v1``).

## What changed

- **New package** ``attestor/state/`` (repo + models + schemas)
- **Schema** new ``state`` table in ``attestor/store/schema.sql`` — bi-temporal (``t_created``/``t_expired``), RLS-gated, supersession via expire-then-insert
- **AgentMemory** wires ``self.state = StateRepo(...)`` on v4 + Postgres
- **AgentContext** exposes ``state_set`` / ``state_get`` / ``state_list`` / ``state_delete`` — same RBAC matrix as memory
- **JSON-Schema validation** opt-in via ``schema=...`` arg — raises ``StateValidationError`` on failure
- **2 reference schemas** in ``attestor/state/schemas/``
- **SKILL.md** documents the new ``memory.state`` capability

## API surface (new)

```python
mem.state.set("preferences.theme", "dark", user_id=u, schema="user_preferences_v1")
mem.state.get("preferences.theme", user_id=u)
mem.state.list(user_id=u, prefix="preferences.")
mem.state.history("preferences.theme", user_id=u)
mem.state.as_of("preferences.theme", ts=t1, user_id=u)
mem.state.delete("preferences.theme", user_id=u)
```

## Test plan

- [x] Unit: 24 new tests in ``tests/test_state_lane.py`` cover set/get roundtrip, supersession, history, as_of replay, prefix listing, delete-marks-expired, JSON-Schema pass/fail, RBAC matrix (write-allowed roles, REVIEWER deny, MONITOR deny, read_only strip), namespace isolation, project-scope isolation
- [x] Live (env-gated): 4 tests round-trip against ``attestor_v4_test`` — table exists, set/get, supersession, namespace isolation
- [x] Regression: 1126 unit tests pass; 0 regressions in adjacent suites (RBAC, quotas, signing, temporal supersession)
- [x] Lint: ``ruff check`` green on all new files

## Notes

- No new external deps (``jsonschema`` already present)
- Bi-temporal: every set/delete is append-only; ``history()`` returns the full audit trail
- RBAC mirrors the memory lane — WRITE gated, READ universal, ``read_only=True`` strips writes
- Closes the personalization gap called out in the OpenAI Jan 2026 cookbook