### PR TITLE
feat(retrieval): long-context fit mode (alternate step 6 for big-budget queries)

### DIFF
--- a/attestor/config/loader.py
+++ b/attestor/config/loader.py
@@ -159,6 +159,9 @@ def _parse_yaml(cfg_path: Path, *, strict: bool) -> StackConfig:
         graph_unreachable_penalty=float(
             retrieval_blk.get("graph_unreachable_penalty", -0.05),
         ),
+        long_context_default_max_tokens=int(
+            retrieval_blk.get("long_context_default_max_tokens", 200_000),
+        ),
         multi_query=mq_cfg,
         temporal_prefilter=tp_cfg,
         hyde=hyde_cfg,

--- a/attestor/config/models.py
+++ b/attestor/config/models.py
@@ -462,6 +462,10 @@ class RetrievalCfg:
         default_factory=lambda: {0: 0.30, 1: 0.20, 2: 0.10},
     )
     graph_unreachable_penalty: float = -0.05
+    # Default cap when ``recall(long_context=True)`` omits an explicit
+    # ``long_context_max_tokens``. Sized for 1M-context answerers — see
+    # ``attestor.retrieval.orchestrator.postprocess._long_context_pack``.
+    long_context_default_max_tokens: int = 200_000
     multi_query: MultiQueryCfg = field(default_factory=MultiQueryCfg)
     temporal_prefilter: TemporalPrefilterCfg = field(
         default_factory=TemporalPrefilterCfg,

--- a/attestor/core/agent_memory.py
+++ b/attestor/core/agent_memory.py
@@ -218,6 +218,18 @@ class AgentMemory(_IdentityMixin, _QuotaMixin, _ProvenanceMixin):
             else GlobalQueryCfg()
         )
 
+        # Long-context fit (alternate Step 6) — opt-in per recall via
+        # ``mem.recall(long_context=True)``. The instance-level default
+        # below lets eval harnesses flip the mode on at construction
+        # time (matrix cells with ``long_context: true``) without
+        # touching every call site. Always False by default → legacy
+        # behavior unchanged.
+        self._default_long_context: bool = False
+        self._default_long_context_max_tokens: int = (
+            getattr(_retrieval_cfg, "long_context_default_max_tokens", 200_000)
+            if _retrieval_cfg is not None else 200_000
+        )
+
         # Operation ring buffer for latency observability
         self._ops_log: deque[dict[str, Any]] = deque(maxlen=200)
 
@@ -949,6 +961,9 @@ class AgentMemory(_IdentityMixin, _QuotaMixin, _ProvenanceMixin):
         user_id: str | None = None,
         as_of: datetime | None = None,
         time_window: Any | None = None,    # TimeWindow
+        *,
+        long_context: bool = False,
+        long_context_max_tokens: int = 200_000,
     ) -> list[RetrievalResult]:
         """Retrieve relevant memories for a query using 3-layer cascade.
 
@@ -959,7 +974,14 @@ class AgentMemory(_IdentityMixin, _QuotaMixin, _ProvenanceMixin):
         v4 + Phase 5.3 — bi-temporal:
           as_of       — point-in-time replay (returns past belief)
           time_window — event-time overlap pre-filter
-        Both pass through to the orchestrator and on to the lanes."""
+        Both pass through to the orchestrator and on to the lanes.
+
+        Long-context mode (``long_context=True``) skips Step 5 (MMR) and
+        swaps Step 6 from greedy fit-to-budget to a high-cap pack
+        (``long_context_max_tokens``, default 200_000). Use when the
+        downstream answerer is a 1M-context model (Claude Sonnet 4.6 /
+        Opus 4.x / Gemini 2 Pro) where diversity penalties hurt quality.
+        Default ``False`` preserves legacy behavior."""
         # v4: route through _resolve() so zero-config recall works in SOLO
         # mode. Recall doesn't autostart a session — read-only ops only need
         # user+project scope.
@@ -1002,6 +1024,19 @@ class AgentMemory(_IdentityMixin, _QuotaMixin, _ProvenanceMixin):
             recall_kwargs["as_of"] = as_of
         if time_window is not None:
             recall_kwargs["time_window"] = time_window
+        # Resolve long_context: explicit caller arg wins; otherwise fall
+        # back to the instance default (set by eval harnesses via
+        # ``set_default_long_context()``).
+        effective_long_context = (
+            long_context or getattr(self, "_default_long_context", False)
+        )
+        if effective_long_context:
+            recall_kwargs["long_context"] = True
+            recall_kwargs["long_context_max_tokens"] = (
+                long_context_max_tokens
+                if long_context
+                else getattr(self, "_default_long_context_max_tokens", 200_000)
+            )
         results = self._retrieval.recall(query, token_budget, **recall_kwargs)
         total_ms = round((time.monotonic() - t0) * 1000, 2)
 

--- a/attestor/retrieval/orchestrator/core.py
+++ b/attestor/retrieval/orchestrator/core.py
@@ -133,6 +133,9 @@ class RetrievalOrchestrator(
         namespace: str | None = None,
         as_of: Any | None = None,           # datetime; Phase 5.3
         time_window: Any | None = None,     # TimeWindow; Phase 5.3
+        *,
+        long_context: bool = False,
+        long_context_max_tokens: int = 200_000,
     ) -> list[RetrievalResult]:
         """Semantic-first recall with graph narrowing.
 
@@ -145,6 +148,13 @@ class RetrievalOrchestrator(
         Both kwargs are passed through to the vector + BM25 lanes; lanes
         that don't support them ignore them silently. Behavior unchanged
         when both are None.
+
+        Long-context mode (``long_context=True``) swaps Step 6 from the
+        standard greedy fit-to-budget to a high-cap pack
+        (``long_context_max_tokens``, default 200_000) and skips Step 5
+        (MMR). Designed for downstream 1M-context answerers (Claude
+        Sonnet 4.6 / Opus 4.x / Gemini 2 Pro). Default ``False`` preserves
+        legacy behavior exactly.
         """
         # Audit invariants A2 + A5 are enforced via two scopes opened
         # at the very top of the recall — recall_started_at_scope sets
@@ -193,6 +203,8 @@ class RetrievalOrchestrator(
                 bm25_hits_raw=bm25_hits_raw,
                 mq_used=mq_used, path=path,
                 token_budget=token_budget, t_total=t_total,
+                long_context=long_context,
+                long_context_max_tokens=long_context_max_tokens,
             )
 
     # ──────────────────────────────────────────────────────────────────
@@ -218,6 +230,9 @@ class RetrievalOrchestrator(
         namespace: str | None = None,
         as_of: Any | None = None,
         time_window: Any | None = None,
+        *,
+        long_context: bool = False,
+        long_context_max_tokens: int = 200_000,
     ) -> list[RetrievalResult]:
         """Async sibling of ``recall()``. Runs the vector lane and BM25
         lane concurrently via ``asyncio.gather`` + ``asyncio.to_thread``.
@@ -225,6 +240,9 @@ class RetrievalOrchestrator(
         Latency story (with vector ~80ms and BM25 ~50ms):
             sync:  ~130ms (vector → BM25 sequential)
             async:  ~80ms (vector ‖ BM25 under gather, max wins)
+
+        Supports the same long-context kwargs as :meth:`recall` — they
+        affect Steps 5 + 6 only (CPU-bound post-processing).
         """
         from attestor.recall_context import recall_started_at_scope_async
 
@@ -279,6 +297,8 @@ class RetrievalOrchestrator(
                     bm25_hits_raw=bm25_hits_raw,
                     mq_used=mq_used, path=path,
                     token_budget=token_budget, t_total=t_total,
+                    long_context=long_context,
+                    long_context_max_tokens=long_context_max_tokens,
                 )
 
     def recall_as_context(

--- a/attestor/retrieval/orchestrator/postprocess.py
+++ b/attestor/retrieval/orchestrator/postprocess.py
@@ -26,6 +26,73 @@ from attestor.retrieval.scorer import (
     temporal_boost,
 )
 from attestor.retrieval.trace import write as trace_write
+from attestor.utils.tokens import estimate_tokens
+
+# Default cap for long-context mode. Sized for 1M-context answerers
+# (Claude Sonnet 4.6 / Opus 4.x / Gemini 2 Pro) — 200_000 tokens
+# leaves ~800k for the system prompt + question + downstream reasoning.
+_DEFAULT_LONG_CONTEXT_MAX_TOKENS = 200_000
+
+
+def _long_context_pack(
+    candidates: list[RetrievalResult],
+    *,
+    max_tokens: int,
+) -> list[RetrievalResult]:
+    """Pack the top-scored candidates verbatim, capped by ``max_tokens``.
+
+    Sorts by score desc, accumulates until adding the next memory would
+    exceed the cap, drops it whole (never partial). Reuses the same
+    ``estimate_tokens`` helper that ``fit_to_budget`` uses, so cap-vs-
+    budget semantics stay aligned.
+
+    Designed for downstream answerers running on 1M-context models —
+    no MMR diversity penalty (near-duplicates that are genuinely relevant
+    survive). Pure CPU-bound; no LLM call.
+    """
+    if not candidates:
+        return []
+    sorted_results = sorted(candidates, key=lambda r: r.score, reverse=True)
+    selected: list[RetrievalResult] = []
+    tokens_used = 0
+    for r in sorted_results:
+        t = estimate_tokens(r.memory.content)
+        if tokens_used + t > max_tokens:
+            continue
+        selected.append(r)
+        tokens_used += t
+    return selected
+
+
+def _step6_pack(
+    candidates: list[RetrievalResult],
+    *,
+    token_budget: int,
+    long_context_mode: bool = False,
+    long_context_max_tokens: int = _DEFAULT_LONG_CONTEXT_MAX_TOKENS,
+) -> list[RetrievalResult]:
+    """Step 6 of the recall cascade — token-fit packing.
+
+    Two strategies:
+
+      Standard (``long_context_mode=False``)
+        Greedy fit-to-budget — optimized for short-context answerers
+        (gpt-4o, claude-haiku) where every token has measurable cost.
+
+      Long-context (``long_context_mode=True``)
+        Pack the top-scored candidates verbatim up to
+        ``long_context_max_tokens``. Designed for 1M-context answerers
+        where the diversity penalty actively HURTS (cuts genuinely-
+        relevant near-duplicates).
+
+    Default behavior (``long_context_mode=False``) is byte-identical
+    to the pre-feature pipeline.
+    """
+    if long_context_mode:
+        return _long_context_pack(
+            candidates, max_tokens=long_context_max_tokens,
+        )
+    return fit_to_budget(candidates, token_budget)
 
 
 class _OrchestratorPostProcessMixin:
@@ -116,6 +183,8 @@ class _OrchestratorPostProcessMixin:
         path: str,
         token_budget: int,
         t_total: float,
+        long_context: bool = False,
+        long_context_max_tokens: int = _DEFAULT_LONG_CONTEXT_MAX_TOKENS,
     ) -> list[RetrievalResult]:
         from attestor import trace as _tr
         results: list[RetrievalResult] = []
@@ -281,7 +350,11 @@ class _OrchestratorPostProcessMixin:
         results = entity_boost(results, question_entities or None)
 
         # ── Step 4: MMR diversity ──
-        if self.enable_mmr:
+        # Skipped when long_context=True — the downstream 1M-context
+        # answerer benefits more from raw top-K than from a diversity-
+        # trimmed subset (near-duplicates that are genuinely relevant
+        # survive). MMR + long-context are mutually exclusive by design.
+        if self.enable_mmr and not long_context:
             _pre_mmr_count = len(results)
             results = mmr_rerank(results, lambda_param=self.mmr_lambda)
             if self.mmr_top_n is not None and len(results) > self.mmr_top_n:
@@ -291,6 +364,9 @@ class _OrchestratorPostProcessMixin:
                           lambda_=self.mmr_lambda,
                           mmr_top_n=self.mmr_top_n,
                           in_count=_pre_mmr_count, out_count=len(results))
+        elif long_context and _tr.is_enabled():
+            _tr.event("recall.stage.mmr_skipped",
+                      reason="long_context_mode")
 
         # ── Step 5: Confidence decay ──
         results = confidence_decay_boost(
@@ -300,12 +376,21 @@ class _OrchestratorPostProcessMixin:
             gate=self.confidence_gate,
         )
 
-        # ── Step 6: Fit to budget ──
+        # ── Step 6: Fit to budget (or long-context pack) ──
         _pre_pack_count = len(results)
-        final = fit_to_budget(results, token_budget)
+        final = _step6_pack(
+            results,
+            token_budget=token_budget,
+            long_context_mode=long_context,
+            long_context_max_tokens=long_context_max_tokens,
+        )
         if _tr.is_enabled():
             _tr.event("recall.stage.pack",
+                      mode="long_context" if long_context else "greedy_fit",
                       token_budget=token_budget,
+                      long_context_max_tokens=(
+                          long_context_max_tokens if long_context else None
+                      ),
                       in_count=_pre_pack_count, out_count=len(final))
             _tr.event("recall.done",
                       query=query[:120],

--- a/configs/attestor.yaml
+++ b/configs/attestor.yaml
@@ -212,6 +212,16 @@ stack:
       2: 0.10
     graph_unreachable_penalty: -0.05
 
+    # Long-context fit mode (alternate Step 6). Callers opt in per
+    # recall via ``mem.recall(query, long_context=True)``; this YAML
+    # key is just the default cap when the caller doesn't pass an
+    # explicit ``long_context_max_tokens``. Sized for 1M-context
+    # answerers (Claude Sonnet 4.6 / Opus 4.x / Gemini 2 Pro) — leaves
+    # ~800k tokens for system prompt + question + downstream reasoning.
+    # When ``long_context=True``, MMR (Step 5) is skipped and Step 6
+    # packs the top-K reranked candidates verbatim up to this cap.
+    long_context_default_max_tokens: 200000
+
     # Multi-query lane. When enabled, the orchestrator rewrites the
     # question into N paraphrases via a single LLM call and RRF-merges
     # N+1 vector searches before the rest of the cascade.

--- a/evals/braintrust_longmemeval.py
+++ b/evals/braintrust_longmemeval.py
@@ -207,6 +207,7 @@ def run_live(
     contextual_embedding_override: dict[str, Any] | None = None,
     llm_entity_extraction_override: dict[str, Any] | None = None,
     reranker_override: dict[str, Any] | None = None,
+    long_context: bool = False,
     parallel: int = 1,
 ) -> None:
     """Execute a fresh bench run and upload as a Braintrust experiment.
@@ -280,7 +281,13 @@ def run_live(
             backend_config["backend_configs"]["postgres"]["skip_schema_init"] = True
 
         def mem_factory() -> AgentMemory:
-            return AgentMemory(store_path, config=backend_config)
+            mem = AgentMemory(store_path, config=backend_config)
+            if long_context:
+                # Flip the per-instance default; recall() resolves this
+                # when the explicit kwarg is False (the answerer code
+                # path doesn't pass long_context).
+                mem._default_long_context = True
+            return mem
 
         log_path = Path(f"logs/lme_{category}_{experiment_suffix}.json")
         log_path.parent.mkdir(parents=True, exist_ok=True)
@@ -470,6 +477,12 @@ def main() -> None:
     parser.add_argument("--reranker-provider", default=None,
                         choices=("bge", "cohere", "llm"),
                         help="Live mode override: enable reranker stage with this provider.")
+    parser.add_argument("--long-context", action="store_true",
+                        help=(
+                            "Live mode override: switch Step 6 to long-context "
+                            "fit (skip MMR + greedy-fit; pack top-K verbatim up "
+                            "to stack.retrieval.long_context_default_max_tokens)."
+                        ))
     parser.add_argument("--parallel", type=int, default=1,
                         help="Live mode: concurrent samples in run_async (default 1).")
     args = parser.parse_args()
@@ -526,6 +539,7 @@ def main() -> None:
         contextual_embedding_override=ce_override,
         llm_entity_extraction_override=le_override,
         reranker_override=rr_override,
+        long_context=args.long_context,
         parallel=args.parallel,
     )
 

--- a/evals/matrix.yaml
+++ b/evals/matrix.yaml
@@ -241,6 +241,81 @@ cells:
       cost_usd: 0.10, wall_min: 26,
       note: "Phase 9 GraphRAG lane; mostly local — null-result cell" }
 
+  # ── Long-context fit (alternate Step 6 — skip MMR + greedy-fit) ─────
+  # When ``long_context: true``, recall() skips Step 5 (MMR diversity)
+  # and Step 6 packs the top-K reranked candidates verbatim up to the
+  # configured cap (default 200_000 tokens). Designed for downstream
+  # 1M-context answerers (Claude Sonnet 4.6 / Opus 4.x / Gemini 2 Pro)
+  # where diversity penalties cut genuinely-relevant near-duplicates.
+  # Matched-pair vs GOLDEN per category to isolate the Step-6 swap.
+  - { category: temporal-reasoning,
+      label: "ablation:long_context=on",
+      samples: 10,
+      embedder: { provider: voyage, model: voyage-4 },
+      long_context: true,
+      cost_usd: 0.06, wall_min: 22,
+      note: "Step 6 swap — pack top-K verbatim (200k cap), MMR off" }
+
+  - { category: temporal-reasoning,
+      label: "ablation:long_context=on+reranker=bge",
+      samples: 10,
+      embedder: { provider: voyage, model: voyage-4 },
+      long_context: true,
+      reranker_provider: bge,
+      cost_usd: 0.06, wall_min: 24,
+      note: "long-context fit downstream of BGE rerank — no MMR diversity cut" }
+
+  - { category: multi-session,
+      label: "ablation:long_context=on",
+      samples: 10,
+      embedder: { provider: voyage, model: voyage-4 },
+      long_context: true,
+      cost_usd: 0.06, wall_min: 22,
+      note: "Step 6 swap — pack top-K verbatim (200k cap), MMR off" }
+
+  - { category: multi-session,
+      label: "ablation:long_context=on+reranker=bge",
+      samples: 10,
+      embedder: { provider: voyage, model: voyage-4 },
+      long_context: true,
+      reranker_provider: bge,
+      cost_usd: 0.06, wall_min: 24,
+      note: "long-context fit downstream of BGE rerank — no MMR diversity cut" }
+
+  - { category: knowledge-update,
+      label: "ablation:long_context=on",
+      samples: 10,
+      embedder: { provider: voyage, model: voyage-4 },
+      long_context: true,
+      cost_usd: 0.06, wall_min: 22,
+      note: "Step 6 swap — pack top-K verbatim (200k cap), MMR off" }
+
+  - { category: knowledge-update,
+      label: "ablation:long_context=on+reranker=bge",
+      samples: 10,
+      embedder: { provider: voyage, model: voyage-4 },
+      long_context: true,
+      reranker_provider: bge,
+      cost_usd: 0.06, wall_min: 24,
+      note: "long-context fit downstream of BGE rerank — no MMR diversity cut" }
+
+  - { category: single-session-user,
+      label: "ablation:long_context=on",
+      samples: 10,
+      embedder: { provider: voyage, model: voyage-4 },
+      long_context: true,
+      cost_usd: 0.06, wall_min: 22,
+      note: "Step 6 swap — pack top-K verbatim (200k cap), MMR off" }
+
+  - { category: single-session-user,
+      label: "ablation:long_context=on+reranker=bge",
+      samples: 10,
+      embedder: { provider: voyage, model: voyage-4 },
+      long_context: true,
+      reranker_provider: bge,
+      cost_usd: 0.06, wall_min: 24,
+      note: "long-context fit downstream of BGE rerank — no MMR diversity cut" }
+
   # Add more cells here as ablations are designed. Examples to seed:
   #
   # - { category: multi-session, label: "ablation:hyde=off", samples: 10,

--- a/evals/runner.py
+++ b/evals/runner.py
@@ -43,6 +43,7 @@ class Cell:
     contextual_embedding: bool = False
     llm_entity_extraction: bool = False
     reranker_provider: str | None = None
+    long_context: bool = False
     cost_usd: float = 0.0
     wall_min: int = 0
     note: str = ""
@@ -65,6 +66,8 @@ class Cell:
             args.append("--llm-entity-extraction")
         if self.reranker_provider:
             args.extend(["--reranker-provider", self.reranker_provider])
+        if self.long_context:
+            args.append("--long-context")
         return args
 
 
@@ -86,6 +89,7 @@ def load_matrix(path: Path) -> tuple[str, list[Cell]]:
             contextual_embedding=bool(raw.get("contextual_embedding", False)),
             llm_entity_extraction=bool(raw.get("llm_entity_extraction", False)),
             reranker_provider=raw.get("reranker_provider"),
+            long_context=bool(raw.get("long_context", False)),
             cost_usd=float(raw.get("cost_usd", 0.0)),
             wall_min=int(raw.get("wall_min", 0)),
             note=raw.get("note", ""),

--- a/skills/attestor-memory/SKILL.md
+++ b/skills/attestor-memory/SKILL.md
@@ -103,7 +103,7 @@ The skill exposes six primitives on `attestor.AgentMemory`. Every signature belo
 | Method | Purpose |
 | --- | --- |
 | `add(content, tags, category, entity, namespace, event_date, confidence, metadata, ...)` | Persist one fact. Auto-detects contradictions and supersedes the older one. Returns the stored `Memory`. |
-| `recall(query, budget, namespace, user_id, as_of, time_window)` | Six-step retrieval cascade (vector + BM25 + RRF + graph + MMR + token-budget pack). Returns `list[RetrievalResult]`. |
+| `recall(query, budget, namespace, user_id, as_of, time_window, *, long_context, long_context_max_tokens)` | Six-step retrieval cascade (vector + BM25 + RRF + graph + MMR + token-budget pack). Returns `list[RetrievalResult]`. Pass `long_context=True` to skip MMR + greedy-fit and pack the top-K candidates verbatim up to `long_context_max_tokens` (default 200_000) — designed for 1M-context downstream answerers (Claude Sonnet 4.6 / Opus 4.x / Gemini 2 Pro). |
 | `timeline(entity, namespace)` | Chronological replay of every memory about an entity (active + superseded). Returns `list[Memory]`. |
 | `current_facts(category, entity, namespace)` | Active, non-superseded memories only. The "what does the agent believe right now" view. |
 | `forget(memory_id)` / `forget_before(date)` | Archive a single memory by id, or every memory created before a date. Returns `bool` / `int`. |
@@ -218,7 +218,32 @@ for r in past_results:
 
 `as_of` resolves on event time (`valid_from` / `valid_until`), so the answer reflects what was true *then*, not what the agent learned later.
 
-### Example 4 — Multi-agent shared state with RBAC + namespace isolation
+### Example 4 — Long-context recall for 1M-context answerers
+
+```python
+from attestor import AgentMemory
+
+mem = AgentMemory("./agent-store")
+
+# Default: short-context optimized — MMR diversity + token-budget pack.
+short_ctx = mem.recall("project decisions Q3", budget=2000)
+
+# Long-context mode: skip MMR, pack top-K verbatim up to 200_000 tokens.
+# Use when the downstream answerer is Claude Sonnet 4.6 / Opus 4.x /
+# Gemini 2 Pro — diversity penalties cut genuinely-relevant duplicates.
+long_ctx = mem.recall("project decisions Q3", long_context=True)
+
+# Override the cap when needed (e.g., 500k for Gemini 2 Pro).
+big = mem.recall(
+    "project decisions Q3",
+    long_context=True,
+    long_context_max_tokens=500_000,
+)
+```
+
+Both modes coexist: short-context callers (gpt-4o, claude-haiku) keep MMR's diversity trim; long-context callers get the top-K verbatim. Attestor never calls the answerer itself — it just packs the memories.
+
+### Example 5 — Multi-agent shared state with RBAC + namespace isolation
 
 ```python
 from attestor import AgentContext, AgentMemory, AgentRole
@@ -245,7 +270,7 @@ print(orchestrator.agent_trail)         # full handoff chain for audit
 
 Roles enforced at the context layer (`attestor/context.py`): `ORCHESTRATOR` = full perms; `PLANNER` / `EXECUTOR` / `RESEARCHER` = read + write; `REVIEWER` / `MONITOR` = read-only. `read_only=True` is an independent kill switch that strips writes regardless of role.
 
-### Example 5 — Periodic reflection (distill many episodic memories into a few semantic ones)
+### Example 6 — Periodic reflection (distill many episodic memories into a few semantic ones)
 
 ```python
 from datetime import datetime, timedelta, timezone
@@ -276,7 +301,7 @@ for did in result.distilled_memory_ids:
 
 `dry_run=True` calls the LLM (so the cost estimate is accurate) but skips the writes — useful for canary deployments.
 
-### Example 6 — Global queries via Neo4j community detection (GraphRAG-style)
+### Example 7 — Global queries via Neo4j community detection (GraphRAG-style)
 
 Attestor's six-step recall is tuned for *local* questions ("what is my Wells Fargo pre-approval amount?"). For *global* questions that span many memories ("summarize my interactions with Wells Fargo across the last 6 months", "what are my recurring concerns this quarter?", "what trips have I taken over 8 months?") the right answer is a cluster-level synthesis, not a top-K passage list.
 
@@ -312,7 +337,7 @@ for r in results:
 
 Failure-isolated: if Neo4j is down, the LLM summarizer errors, or no candidate entities exist, the lane returns an empty result and `recall()` falls back to the local pipeline.
 
-### Example 7 — Audit + GDPR
+### Example 8 — Audit + GDPR
 
 ```python
 from attestor import AgentMemory

--- a/tests/test_long_context_fit.py
+++ b/tests/test_long_context_fit.py
@@ -1,0 +1,299 @@
+"""Tests for the long-context fit mode (alternate Step 6 packing).
+
+Long-context mode swaps the standard greedy ``fit_to_budget`` packing
+for a high-cap pack that returns the top-K reranked candidates verbatim
+(no MMR diversity penalty). Designed for downstream answerers running on
+1M+ context models (Claude Sonnet 4.6 / Opus 4.x / Gemini 2 Pro) where
+near-duplicate cuts actively hurt quality.
+
+Default behavior must be byte-identical to the pre-feature pipeline:
+``long_context=False`` is the contract; tests assert it explicitly.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from attestor.models import Memory, RetrievalResult
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Stubs (mirror the pattern in tests/test_hyde_orchestrator.py — no
+# Postgres / Pinecone / Neo4j touched).
+# ──────────────────────────────────────────────────────────────────────
+
+
+class _FakeStore:
+    def __init__(self) -> None:
+        self._mems: dict[str, Memory] = {}
+
+    def add_memory(self, memory_id: str, content: str = "x") -> None:
+        self._mems[memory_id] = Memory(id=memory_id, content=content)
+
+    def get(self, memory_id: str) -> Memory | None:
+        return self._mems.get(memory_id)
+
+
+class _FakeVectorStore:
+    def __init__(self, hits: list[dict[str, Any]]) -> None:
+        self._hits = hits
+
+    def search(
+        self,
+        query: str,
+        *,
+        limit: int = 50,
+        namespace: str | None = None,
+        **kwargs: Any,
+    ) -> list[dict[str, Any]]:
+        return list(self._hits)
+
+
+def _make_result(
+    content: str, score: float, memory_id: str | None = None
+) -> RetrievalResult:
+    mem = Memory(content=content, **({"id": memory_id} if memory_id else {}))
+    return RetrievalResult(memory=mem, score=score, match_source="vector")
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Direct unit tests on _step6_pack / _long_context_pack
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_default_mode_uses_greedy_fit() -> None:
+    """long_context=False → result is identical to fit_to_budget."""
+    from attestor.retrieval.orchestrator.postprocess import _step6_pack
+    from attestor.retrieval.scorer import fit_to_budget
+
+    results = [_make_result(f"memory {i} content here", 1.0 - i * 0.05)
+               for i in range(10)]
+    expected = fit_to_budget(results, token_budget=20)
+    actual = _step6_pack(
+        results,
+        token_budget=20,
+        long_context_mode=False,
+    )
+    assert [r.memory.id for r in actual] == [r.memory.id for r in expected]
+
+
+@pytest.mark.unit
+def test_long_context_pack_respects_max_tokens() -> None:
+    """Cumulative token count never exceeds long_context_max_tokens."""
+    from attestor.retrieval.orchestrator.postprocess import _step6_pack
+    from attestor.utils.tokens import estimate_tokens
+
+    # Each content is ~13 tokens (10 words * 1.3).
+    results = [
+        _make_result(" ".join([f"w{i}{j}" for j in range(10)]), 1.0 - i * 0.01)
+        for i in range(50)
+    ]
+    cap = 50  # tokens
+    packed = _step6_pack(
+        results,
+        token_budget=999_999,  # ignored in long-context mode
+        long_context_mode=True,
+        long_context_max_tokens=cap,
+    )
+    total = sum(estimate_tokens(r.memory.content) for r in packed)
+    assert total <= cap
+
+
+@pytest.mark.unit
+def test_long_context_pack_orders_by_score() -> None:
+    """Top-scored memories surface first when packing for long-context."""
+    from attestor.retrieval.orchestrator.postprocess import _step6_pack
+
+    results = [
+        _make_result("low score doc", 0.10, memory_id="low"),
+        _make_result("highest score doc", 0.99, memory_id="hi"),
+        _make_result("middle score doc", 0.50, memory_id="mid"),
+    ]
+    packed = _step6_pack(
+        results,
+        token_budget=100,
+        long_context_mode=True,
+        long_context_max_tokens=200_000,
+    )
+    assert [r.memory.id for r in packed] == ["hi", "mid", "low"]
+
+
+@pytest.mark.unit
+def test_long_context_returns_more_results_than_default() -> None:
+    """Same input — long-context mode includes ≥ memories than default."""
+    from attestor.retrieval.orchestrator.postprocess import _step6_pack
+
+    # 30 candidates, each ~13 tokens; default budget=50 fits maybe 3,
+    # long-context cap=200_000 fits all 30.
+    results = [
+        _make_result(" ".join([f"w{i}{j}" for j in range(10)]), 1.0 - i * 0.01,
+                     memory_id=f"m{i}")
+        for i in range(30)
+    ]
+    default = _step6_pack(
+        results, token_budget=50, long_context_mode=False,
+    )
+    long_ctx = _step6_pack(
+        results,
+        token_budget=50,
+        long_context_mode=True,
+        long_context_max_tokens=200_000,
+    )
+    assert len(long_ctx) >= len(default)
+    assert len(long_ctx) == 30
+
+
+@pytest.mark.unit
+def test_long_context_with_zero_candidates() -> None:
+    """Empty input → empty output (both modes)."""
+    from attestor.retrieval.orchestrator.postprocess import _step6_pack
+
+    assert _step6_pack([], token_budget=2000, long_context_mode=False) == []
+    assert _step6_pack(
+        [], token_budget=2000, long_context_mode=True,
+        long_context_max_tokens=200_000,
+    ) == []
+
+
+@pytest.mark.unit
+def test_long_context_token_count_uses_existing_helper() -> None:
+    """Long-context pack must call the same ``estimate_tokens`` helper
+    as ``fit_to_budget``; otherwise the cap-vs-budget semantics drift."""
+    from attestor.retrieval.orchestrator import postprocess as pp
+
+    results = [_make_result(f"doc {i}", 1.0 - i * 0.1) for i in range(5)]
+    with patch.object(pp, "estimate_tokens", wraps=pp.estimate_tokens) as spy:
+        pp._step6_pack(
+            results,
+            token_budget=2000,
+            long_context_mode=True,
+            long_context_max_tokens=200_000,
+        )
+        assert spy.call_count >= 1
+
+
+@pytest.mark.unit
+def test_token_overflow_truncates_last_candidate() -> None:
+    """When adding a candidate would exceed the cap, drop it whole —
+    never include a partial memory."""
+    from attestor.retrieval.orchestrator.postprocess import _step6_pack
+    from attestor.utils.tokens import estimate_tokens
+
+    # Each ~13 tokens.
+    big = " ".join([f"w{i}" for i in range(10)])
+    results = [
+        _make_result(big, 0.9, memory_id="a"),
+        _make_result(big, 0.8, memory_id="b"),
+        _make_result(big, 0.7, memory_id="c"),
+    ]
+    # cap=20 → only the first ~13-token doc fits; the second would overflow.
+    packed = _step6_pack(
+        results,
+        token_budget=999,
+        long_context_mode=True,
+        long_context_max_tokens=20,
+    )
+    total = sum(estimate_tokens(r.memory.content) for r in packed)
+    assert total <= 20
+    assert len(packed) == 1
+    assert packed[0].memory.id == "a"
+
+
+@pytest.mark.unit
+def test_long_context_default_cap_200k() -> None:
+    """When ``long_context_max_tokens`` is omitted, default = 200_000."""
+    import inspect
+
+    from attestor.retrieval.orchestrator.postprocess import _step6_pack
+
+    sig = inspect.signature(_step6_pack)
+    assert sig.parameters["long_context_max_tokens"].default == 200_000
+
+
+@pytest.mark.unit
+def test_long_context_max_tokens_override() -> None:
+    """Caller-supplied cap is honored over the default."""
+    from attestor.retrieval.orchestrator.postprocess import _step6_pack
+    from attestor.utils.tokens import estimate_tokens
+
+    results = [_make_result(" ".join([f"w{i}" for i in range(10)]),
+                            1.0 - i * 0.01, memory_id=f"m{i}")
+               for i in range(20)]
+    # Cap to ~26 tokens — only two ~13-token docs fit.
+    packed = _step6_pack(
+        results,
+        token_budget=999,
+        long_context_mode=True,
+        long_context_max_tokens=26,
+    )
+    total = sum(estimate_tokens(r.memory.content) for r in packed)
+    assert total <= 26
+    assert len(packed) == 2
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Orchestrator-level: long_context kwarg threading
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_long_context_mode_skips_mmr() -> None:
+    """When ``long_context=True``, the MMR rerank is NOT invoked."""
+    from attestor.retrieval.orchestrator import RetrievalOrchestrator
+    from attestor.retrieval import scorer as _scorer
+
+    store = _FakeStore()
+    for i in range(5):
+        store.add_memory(f"m{i}", content=f"unique content {i}")
+    vec = _FakeVectorStore([
+        {"memory_id": f"m{i}", "distance": 0.1 + i * 0.05}
+        for i in range(5)
+    ])
+    orch = RetrievalOrchestrator(store=store, vector_store=vec)
+
+    with patch.object(_scorer, "mmr_rerank", wraps=_scorer.mmr_rerank) as spy:
+        orch.recall("query", long_context=True)
+        spy.assert_not_called()
+
+
+@pytest.mark.unit
+def test_recall_kwarg_threads_through() -> None:
+    """``orch.recall(..., long_context=True)`` invokes _step6_pack with
+    long_context_mode=True."""
+    from attestor.retrieval.orchestrator import RetrievalOrchestrator
+    from attestor.retrieval.orchestrator import postprocess as pp
+
+    store = _FakeStore()
+    store.add_memory("m1")
+    vec = _FakeVectorStore([{"memory_id": "m1", "distance": 0.1}])
+    orch = RetrievalOrchestrator(store=store, vector_store=vec)
+
+    with patch.object(pp, "_step6_pack", wraps=pp._step6_pack) as spy:
+        orch.recall("q", long_context=True, long_context_max_tokens=12_345)
+        assert spy.call_count == 1
+        kwargs = spy.call_args.kwargs
+        assert kwargs.get("long_context_mode") is True
+        assert kwargs.get("long_context_max_tokens") == 12_345
+
+
+@pytest.mark.unit
+def test_recall_async_supports_long_context() -> None:
+    """The async path threads ``long_context`` through to Step 6."""
+    import asyncio
+
+    from attestor.retrieval.orchestrator import RetrievalOrchestrator
+    from attestor.retrieval.orchestrator import postprocess as pp
+
+    store = _FakeStore()
+    store.add_memory("m1")
+    vec = _FakeVectorStore([{"memory_id": "m1", "distance": 0.1}])
+    orch = RetrievalOrchestrator(store=store, vector_store=vec)
+
+    with patch.object(pp, "_step6_pack", wraps=pp._step6_pack) as spy:
+        asyncio.run(orch.recall_async("q", long_context=True))
+        assert spy.call_count == 1
+        assert spy.call_args.kwargs.get("long_context_mode") is True


### PR DESCRIPTION
## Summary

- Adds a **long-context fit mode** as an alternate Step 6 in the recall cascade — skips MMR (Step 5) and packs the top-K reranked candidates verbatim up to `long_context_max_tokens` (default 200_000). Designed for downstream answerers running on 1M-context models (Claude Sonnet 4.6 / Opus 4.x / Gemini 2 Pro), where MMR's diversity penalty actively HURTS quality.
- Default behavior (`long_context=False`) is byte-identical to the pre-feature pipeline; both modes coexist.
- Attestor still calls no LLM in the recall hot path — long-context mode just packs memories; the agent calls Claude/Gemini themselves.
- 12 new TDD-driven tests in `tests/test_long_context_fit.py`; zero regressions in scorer / supersession / temporal / reranker / hyde / multi_query / orchestrator suites (200 targeted tests pass; 1113 unit tests pass).

## Public surface

```python
mem.recall(
    query,
    budget=2000,
    namespace=None,
    user_id=None,
    as_of=None,
    time_window=None,
    *,
    long_context=False,                # NEW
    long_context_max_tokens=200_000,   # NEW
)
```

Same kwargs threaded through `RetrievalOrchestrator.recall()` + `recall_async()`.

## Why both modes coexist

- **Standard** (`long_context=False`): optimized for SHORT-context answerers (gpt-4o, claude-haiku) — MMR avoids feeding 5 near-duplicates, every token has measurable cost.
- **Long-context** (`long_context=True`): optimized for 1M-context answerers — diversity penalty actively cuts genuinely-relevant near-duplicates.

## Files touched

- `attestor/retrieval/orchestrator/postprocess.py` — `_step6_pack` + `_long_context_pack` + MMR-skip when `long_context=True`
- `attestor/retrieval/orchestrator/core.py` — kwargs threaded through sync + async recall
- `attestor/core/agent_memory.py` — kwargs on `AgentMemory.recall()` + per-instance `_default_long_context` for eval harnesses
- `attestor/config/{models,loader}.py` — `RetrievalCfg.long_context_default_max_tokens`
- `configs/attestor.yaml` — documents the new YAML key
- `evals/{matrix.yaml,runner.py,braintrust_longmemeval.py}` — 8 ablation cells (2 per LME-S category) + `--long-context` CLI flag
- `skills/attestor-memory/SKILL.md` — `long_context` in API table + Example 4
- `tests/test_long_context_fit.py` — 12 new TDD-driven tests

## Test plan

- [x] `test_default_mode_uses_greedy_fit` — pre-feature behavior preserved
- [x] `test_long_context_mode_skips_mmr` — MMR not invoked when `long_context=True`
- [x] `test_long_context_pack_respects_max_tokens` — cap honored
- [x] `test_long_context_pack_orders_by_score` — top-scored first
- [x] `test_long_context_returns_more_results_than_default`
- [x] `test_long_context_with_zero_candidates`
- [x] `test_long_context_token_count_uses_existing_helper`
- [x] `test_token_overflow_truncates_last_candidate` — drops whole, no partial
- [x] `test_long_context_default_cap_200k`
- [x] `test_long_context_max_tokens_override`
- [x] `test_recall_kwarg_threads_through` — sync `recall()` reaches Step 6 with mode set
- [x] `test_recall_async_supports_long_context` — async path threads the kwarg
- [x] Suite delta: 1113 unit tests pass; 200 targeted tests pass; zero regressions
- [ ] Live LME-S long-context cells (8 cells in `evals/matrix.yaml`) — user-driven smoke