### PR TITLE
feat(observability): audit dashboard + recall trace explorer

### DIFF
--- a/attestor/api.py
+++ b/attestor/api.py
@@ -212,6 +212,19 @@ try:
 except ImportError as e:  # pragma: no cover - UI is optional
     logger.warning("UI router unavailable: %s", e)
 
+# Attach the audit explorer at /audit/* + the static /audit.html dashboard.
+# Off by default — opt-in via `ATTESTOR_AUDIT_ENABLED=1` or
+# `audit.dashboard.enabled: true` in configs/attestor.yaml. Mounting only
+# when enabled keeps the surface smaller in single-user installs and lets
+# operators gate the audit trail behind explicit configuration.
+try:
+    from attestor.audit.routes import audit_routes, is_enabled as _audit_enabled
+
+    if _audit_enabled():
+        routes.extend(audit_routes())
+except ImportError as e:  # pragma: no cover - audit module is optional
+    logger.warning("Audit router unavailable: %s", e)
+
 
 def _build_middleware() -> list:
     """Return the Starlette middleware stack for the resolved mode.

--- a/attestor/audit/__init__.py
+++ b/attestor/audit/__init__.py
@@ -1,0 +1,35 @@
+"""Audit-trail explorer for Attestor recall traces.
+
+Reads the JSONL trace log written by ``attestor.trace`` (when
+``ATTESTOR_TRACE=1`` and ``ATTESTOR_TRACE_FILE`` are set), groups events
+by ``recall_id``, and surfaces summaries + details for the audit
+dashboard mounted at ``/audit/*`` on the Starlette ASGI app.
+
+The explorer is strictly read-only: it never writes to or rewrites the
+trace log. The JSONL log remains the source of truth — the explorer is
+a query-side index.
+"""
+
+from __future__ import annotations
+
+from attestor.audit.explorer import (
+    RecallDetail,
+    RecallSummary,
+    TraceExplorer,
+    get_recall,
+    list_recalls,
+    memory_access_timeline,
+    reset_cache,
+    user_activity,
+)
+
+__all__ = [
+    "RecallDetail",
+    "RecallSummary",
+    "TraceExplorer",
+    "get_recall",
+    "list_recalls",
+    "memory_access_timeline",
+    "reset_cache",
+    "user_activity",
+]

--- a/attestor/audit/explorer.py
+++ b/attestor/audit/explorer.py
@@ -1,0 +1,515 @@
+"""Read-only explorer for the Attestor JSONL trace log.
+
+The explorer indexes events by ``recall_id`` (set by
+``attestor.trace.recall_scope``) so each recall's full event tree can
+be served to the audit dashboard for inspection.
+
+Design constraints:
+    * Read-only — never mutate the JSONL log.
+    * Cheap on cold path — 100k events index in <500ms on a laptop.
+    * Backed by an in-memory cache keyed on ``(path, mtime, size)`` so
+      a second call against the same log is O(1).
+    * Tolerant of malformed lines — a corrupt JSONL line skips, never
+      crashes the pipeline.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+from collections import defaultdict
+from collections.abc import Iterable
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+from typing import Any
+
+# ──────────────────────────────────────────────────────────────────────
+# Public dataclasses
+# ──────────────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class RecallSummary:
+    """One row in the audit dashboard's recall table."""
+
+    recall_id: str
+    started_at: str
+    completed_at: str | None
+    user_id: str | None
+    namespace: str | None
+    query: str
+    elapsed_ms: float
+    result_count: int
+    lanes: tuple[str, ...]
+    cost_usd: float | None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "recall_id": self.recall_id,
+            "started_at": self.started_at,
+            "completed_at": self.completed_at,
+            "user_id": self.user_id,
+            "namespace": self.namespace,
+            "query": self.query,
+            "elapsed_ms": self.elapsed_ms,
+            "result_count": self.result_count,
+            "lanes": list(self.lanes),
+            "cost_usd": self.cost_usd,
+        }
+
+
+@dataclass(frozen=True)
+class RecallDetail:
+    """Full per-recall view: summary fields + the complete event tree.
+
+    We keep RecallDetail flat (not inheriting from RecallSummary) so the
+    dataclass stays a frozen value type — frozen-dataclass inheritance
+    with extra fields is a known foot-gun.
+    """
+
+    recall_id: str
+    started_at: str
+    completed_at: str | None
+    user_id: str | None
+    namespace: str | None
+    query: str
+    elapsed_ms: float
+    result_count: int
+    lanes: tuple[str, ...]
+    cost_usd: float | None
+    events: tuple[dict[str, Any], ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "recall_id": self.recall_id,
+            "started_at": self.started_at,
+            "completed_at": self.completed_at,
+            "user_id": self.user_id,
+            "namespace": self.namespace,
+            "query": self.query,
+            "elapsed_ms": self.elapsed_ms,
+            "result_count": self.result_count,
+            "lanes": list(self.lanes),
+            "cost_usd": self.cost_usd,
+            "events": list(self.events),
+        }
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Path resolution
+# ──────────────────────────────────────────────────────────────────────
+
+
+_DEFAULT_LOG_PATH = "~/.attestor/trace.jsonl"
+
+
+def default_log_path() -> Path:
+    """Resolve the default trace log path.
+
+    Resolution order:
+        1. ``ATTESTOR_TRACE_FILE`` env var.
+        2. ``~/.attestor/trace.jsonl`` (matches the docs in
+           ``attestor.trace``).
+    """
+    env = os.environ.get("ATTESTOR_TRACE_FILE")
+    if env:
+        return Path(env).expanduser()
+    return Path(_DEFAULT_LOG_PATH).expanduser()
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Internal index dataclass — built once per (path, mtime, size).
+# ──────────────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class _Index:
+    """In-memory index built from a JSONL trace log."""
+
+    # All events tagged with a recall_id, grouped + ordered by seq+ts.
+    events_by_recall: dict[str, list[dict[str, Any]]]
+    # recall_ids ordered newest-first by the recall.start ts.
+    ordered_recall_ids: tuple[str, ...]
+    # Per-recall summary cache.
+    summaries: dict[str, RecallSummary]
+    # memory_id → list of (recall_id, ts) pairs.
+    memory_to_recalls: dict[str, list[tuple[str, str]]]
+    # File fingerprint for cache invalidation.
+    fingerprint: tuple[str, float, int] = field(default=("", 0.0, 0))
+
+
+# ──────────────────────────────────────────────────────────────────────
+# TraceExplorer — primary class
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TraceExplorer:
+    """Read-only query interface for a JSONL trace log.
+
+    Construct once per log path; the index is lazily built on first
+    query and reused until the file's mtime/size changes.
+    """
+
+    def __init__(self, log_path: Path | str) -> None:
+        self.path = Path(log_path).expanduser()
+        self._lock = threading.Lock()
+        self._index: _Index | None = None
+
+    # ── Public surface ────────────────────────────────────────────
+
+    def list_recalls(
+        self,
+        *,
+        user_id: str | None = None,
+        namespace: str | None = None,
+        since: str | None = None,
+        limit: int = 100,
+    ) -> list[RecallSummary]:
+        idx = self._ensure_index()
+        out: list[RecallSummary] = []
+        for rid in idx.ordered_recall_ids:
+            summary = idx.summaries.get(rid)
+            if summary is None:
+                continue
+            if user_id is not None and summary.user_id != user_id:
+                continue
+            if namespace is not None and summary.namespace != namespace:
+                continue
+            if since is not None and summary.started_at < since:
+                continue
+            out.append(summary)
+            if len(out) >= limit:
+                break
+        return out
+
+    def get_recall(self, recall_id: str) -> RecallDetail | None:
+        idx = self._ensure_index()
+        events = idx.events_by_recall.get(recall_id)
+        if not events:
+            return None
+        summary = idx.summaries.get(recall_id)
+        if summary is None:
+            return None
+        return RecallDetail(
+            recall_id=summary.recall_id,
+            started_at=summary.started_at,
+            completed_at=summary.completed_at,
+            user_id=summary.user_id,
+            namespace=summary.namespace,
+            query=summary.query,
+            elapsed_ms=summary.elapsed_ms,
+            result_count=summary.result_count,
+            lanes=summary.lanes,
+            cost_usd=summary.cost_usd,
+            events=tuple(events),
+        )
+
+    def memory_access_timeline(self, memory_id: str) -> list[dict[str, Any]]:
+        idx = self._ensure_index()
+        rows = idx.memory_to_recalls.get(memory_id, [])
+        out: list[dict[str, Any]] = []
+        for recall_id, ts in rows:
+            summary = idx.summaries.get(recall_id)
+            if summary is None:
+                continue
+            out.append({
+                "recall_id": recall_id,
+                "ts": ts,
+                "query": summary.query,
+                "user_id": summary.user_id,
+                "namespace": summary.namespace,
+            })
+        out.sort(key=lambda r: r["ts"])
+        return out
+
+    def user_activity(
+        self,
+        user_id: str,
+        *,
+        since: str | None = None,
+    ) -> dict[str, Any]:
+        idx = self._ensure_index()
+        recall_count = 0
+        memories_accessed_total = 0
+        distinct_memories: set[str] = set()
+        lane_usage: dict[str, int] = defaultdict(int)
+
+        for rid in idx.ordered_recall_ids:
+            summary = idx.summaries.get(rid)
+            if summary is None or summary.user_id != user_id:
+                continue
+            if since is not None and summary.started_at < since:
+                continue
+            recall_count += 1
+            for lane in summary.lanes:
+                lane_usage[lane] += 1
+            # Collect distinct memory ids from the recall.complete event.
+            events = idx.events_by_recall.get(rid, [])
+            for ev in events:
+                if ev.get("event") in ("recall.complete", "recall.done"):
+                    for mid in _extract_result_ids(ev):
+                        distinct_memories.add(mid)
+                        memories_accessed_total += 1
+                    break
+
+        return {
+            "user_id": user_id,
+            "recall_count": recall_count,
+            "memories_accessed_total": memories_accessed_total,
+            "memories_accessed_distinct": len(distinct_memories),
+            "lane_usage": dict(lane_usage),
+        }
+
+    # ── Cache management ──────────────────────────────────────────
+
+    def reset_cache(self) -> None:
+        with self._lock:
+            self._index = None
+
+    def _ensure_index(self) -> _Index:
+        with self._lock:
+            fp = _file_fingerprint(self.path)
+            if self._index is None or self._index.fingerprint != fp:
+                self._index = _build_index(self.path, fp)
+            return self._index
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Internals — index construction + helpers
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _file_fingerprint(path: Path) -> tuple[str, float, int]:
+    try:
+        stat = path.stat()
+    except FileNotFoundError:
+        return (str(path), 0.0, 0)
+    return (str(path), stat.st_mtime, stat.st_size)
+
+
+def _build_index(path: Path, fingerprint: tuple[str, float, int]) -> _Index:
+    events_by_recall: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    if not path.exists():
+        return _Index(
+            events_by_recall={},
+            ordered_recall_ids=(),
+            summaries={},
+            memory_to_recalls={},
+            fingerprint=fingerprint,
+        )
+
+    with path.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                ev = json.loads(line)
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                # Tolerant of corrupt lines — never crash the audit path.
+                continue
+            rid = ev.get("recall_id")
+            if not rid:
+                continue
+            events_by_recall[rid].append(ev)
+
+    # Stable per-recall ordering by seq (then ts) so lane order is
+    # preserved even if the JSONL was concatenated out of order.
+    for events in events_by_recall.values():
+        events.sort(key=lambda e: (e.get("seq", 0), e.get("ts", "")))
+
+    summaries: dict[str, RecallSummary] = {}
+    memory_to_recalls: dict[str, list[tuple[str, str]]] = defaultdict(list)
+    for rid, events in events_by_recall.items():
+        summary = _summarize(rid, events)
+        if summary is None:
+            continue
+        summaries[rid] = summary
+        # Index returned memory ids for the access timeline.
+        for ev in events:
+            if ev.get("event") in ("recall.complete", "recall.done"):
+                ts = ev.get("ts") or summary.started_at
+                for mid in _extract_result_ids(ev):
+                    memory_to_recalls[mid].append((rid, ts))
+                break
+
+    # Newest-first ordering by start ts.
+    ordered = sorted(
+        summaries.keys(),
+        key=lambda r: summaries[r].started_at,
+        reverse=True,
+    )
+    return _Index(
+        events_by_recall=dict(events_by_recall),
+        ordered_recall_ids=tuple(ordered),
+        summaries=summaries,
+        memory_to_recalls=dict(memory_to_recalls),
+        fingerprint=fingerprint,
+    )
+
+
+_LANE_PREFIX = "recall.lane."
+_RERANKER_EVENT = "recall.stage.reranker"
+
+
+def _summarize(
+    recall_id: str,
+    events: list[dict[str, Any]],
+) -> RecallSummary | None:
+    if not events:
+        return None
+    start = next(
+        (e for e in events if e.get("event") == "recall.start"),
+        None,
+    )
+    complete = next(
+        (e for e in events if e.get("event") in ("recall.complete", "recall.done")),
+        None,
+    )
+    # If we have neither start nor complete, fall back to the first event.
+    anchor = start or events[0]
+
+    lanes: list[str] = []
+    seen_lanes: set[str] = set()
+    for ev in events:
+        name = ev.get("event", "")
+        lane = _lane_from_event(name)
+        if lane and lane not in seen_lanes:
+            seen_lanes.add(lane)
+            lanes.append(lane)
+
+    user_id = _first(events, "user_id")
+    namespace = _first(events, "namespace")
+    query = (start or {}).get("query") or _first(events, "query") or ""
+
+    started_at = (start or anchor).get("ts", "")
+    completed_at = complete.get("ts") if complete else None
+    elapsed_ms = float(complete.get("elapsed_ms", 0.0)) if complete else 0.0
+    result_count = int(complete.get("result_count", 0)) if complete else 0
+    cost_usd_raw = (complete or {}).get("cost_usd")
+    cost_usd = float(cost_usd_raw) if cost_usd_raw is not None else None
+
+    return RecallSummary(
+        recall_id=recall_id,
+        started_at=started_at,
+        completed_at=completed_at,
+        user_id=user_id,
+        namespace=namespace,
+        query=query,
+        elapsed_ms=elapsed_ms,
+        result_count=result_count,
+        lanes=tuple(lanes),
+        cost_usd=cost_usd,
+    )
+
+
+def _lane_from_event(name: str) -> str | None:
+    """Extract a lane label from an event name.
+
+    Recognized lanes:
+        - ``recall.lane.<lane>``      → ``<lane>`` (vector / bm25 / graph / reranker)
+        - ``recall.stage.reranker``   → ``reranker``
+    """
+    if name.startswith(_LANE_PREFIX):
+        return name[len(_LANE_PREFIX):]
+    if name == _RERANKER_EVENT:
+        return "reranker"
+    return None
+
+
+def _first(events: Iterable[dict[str, Any]], key: str) -> Any:
+    for ev in events:
+        val = ev.get(key)
+        if val is not None:
+            return val
+    return None
+
+
+def _extract_result_ids(complete_event: dict[str, Any]) -> list[str]:
+    """Pull memory ids from a recall.complete (or recall.done) event.
+
+    Two payload shapes are supported because the codebase emits both:
+        * ``result_ids: ["m-1", "m-2"]`` — flat list (Phase 3 audit format).
+        * ``final_ids: [{"id": "m-1", ...}, ...]`` — rich format used by
+          ``orchestrator/postprocess.py``.
+    """
+    raw = complete_event.get("result_ids")
+    if isinstance(raw, list):
+        return [str(x) for x in raw if isinstance(x, (str, int))]
+    rich = complete_event.get("final_ids")
+    if isinstance(rich, list):
+        out: list[str] = []
+        for entry in rich:
+            if isinstance(entry, dict) and entry.get("id") is not None:
+                out.append(str(entry["id"]))
+            elif isinstance(entry, str):
+                out.append(entry)
+        return out
+    return []
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Module-level convenience surface (uses default log path).
+# ──────────────────────────────────────────────────────────────────────
+
+
+_default_explorer: TraceExplorer | None = None
+_default_lock = threading.Lock()
+
+
+def _resolve_default() -> TraceExplorer:
+    global _default_explorer
+    with _default_lock:
+        path = default_log_path()
+        # Re-resolve when the configured path changes.
+        if _default_explorer is None or _default_explorer.path != path:
+            _default_explorer = TraceExplorer(path)
+        return _default_explorer
+
+
+def reset_cache() -> None:
+    """Drop the module-level explorer cache. Used by tests + on config reload."""
+    global _default_explorer
+    with _default_lock:
+        _default_explorer = None
+
+
+def list_recalls(
+    *,
+    user_id: str | None = None,
+    namespace: str | None = None,
+    since: str | None = None,
+    limit: int = 100,
+) -> list[RecallSummary]:
+    return _resolve_default().list_recalls(
+        user_id=user_id, namespace=namespace, since=since, limit=limit,
+    )
+
+
+def get_recall(recall_id: str) -> RecallDetail | None:
+    return _resolve_default().get_recall(recall_id)
+
+
+def memory_access_timeline(memory_id: str) -> list[dict[str, Any]]:
+    return _resolve_default().memory_access_timeline(memory_id)
+
+
+def user_activity(user_id: str, *, since: str | None = None) -> dict[str, Any]:
+    return _resolve_default().user_activity(user_id, since=since)
+
+
+# ``replace`` re-exported so external callers can derive variants of a
+# RecallSummary without having to import ``dataclasses.replace`` directly.
+__all__ = [
+    "RecallDetail",
+    "RecallSummary",
+    "TraceExplorer",
+    "default_log_path",
+    "get_recall",
+    "list_recalls",
+    "memory_access_timeline",
+    "replace",
+    "reset_cache",
+    "user_activity",
+]

--- a/attestor/audit/routes.py
+++ b/attestor/audit/routes.py
@@ -1,0 +1,177 @@
+"""Starlette route handlers for the /audit/* surface.
+
+Kept separate from ``attestor.audit.explorer`` so the explorer stays
+import-light (no Starlette dependency for callers that only want the
+in-process query API).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+from starlette.requests import Request
+from starlette.responses import FileResponse, JSONResponse
+from starlette.routing import Route
+
+from attestor.audit.explorer import (
+    TraceExplorer,
+    default_log_path,
+)
+
+logger = logging.getLogger("attestor.audit")
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Toggle — endpoints OFF by default unless ATTESTOR_AUDIT_ENABLED=1
+# (or audit.dashboard.enabled=true in YAML).
+# ──────────────────────────────────────────────────────────────────────
+
+
+def is_enabled() -> bool:
+    if os.environ.get("ATTESTOR_AUDIT_ENABLED", "").lower() in ("1", "true", "yes"):
+        return True
+    # Best-effort: read configs/attestor.yaml without forcing a hard import.
+    cfg = _load_audit_block()
+    return bool(cfg.get("dashboard", {}).get("enabled", False))
+
+
+def _load_audit_block() -> dict[str, Any]:
+    """Load just the ``audit:`` block from configs/attestor.yaml.
+
+    Done with a tolerant try/except so a missing PyYAML or missing config
+    file degrades to ``{}`` rather than crashing the API at import time.
+    """
+    try:
+        import yaml  # type: ignore[import-untyped]
+    except ImportError:
+        return {}
+    cfg_path = os.environ.get(
+        "ATTESTOR_CONFIG",
+        str(Path(__file__).resolve().parents[2] / "configs" / "attestor.yaml"),
+    )
+    try:
+        with open(cfg_path, encoding="utf-8") as fh:
+            data = yaml.safe_load(fh) or {}
+    except (OSError, yaml.YAMLError):
+        return {}
+    block = data.get("audit") or {}
+    if not isinstance(block, dict):
+        return {}
+    return block
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Lazy explorer — re-resolves on each request so the path can change at
+# runtime (e.g. tests monkeypatching ATTESTOR_TRACE_FILE).
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _get_explorer() -> TraceExplorer:
+    """Build/return a TraceExplorer pinned to the configured log path.
+
+    Resolution order:
+        1. ``ATTESTOR_TRACE_FILE`` env (matches the writer in attestor.trace).
+        2. ``audit.trace_log_path`` in configs/attestor.yaml.
+        3. ``~/.attestor/trace.jsonl`` default.
+    """
+    env = os.environ.get("ATTESTOR_TRACE_FILE")
+    if env:
+        return TraceExplorer(Path(env).expanduser())
+
+    block = _load_audit_block()
+    configured = block.get("trace_log_path")
+    if configured:
+        return TraceExplorer(Path(configured).expanduser())
+
+    return TraceExplorer(default_log_path())
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Handlers
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _ok(data: Any) -> JSONResponse:
+    return JSONResponse({"ok": True, "data": data})
+
+
+def _err(msg: str, status: int = 400) -> JSONResponse:
+    return JSONResponse({"ok": False, "error": msg}, status_code=status)
+
+
+async def list_recalls_handler(request: Request) -> JSONResponse:
+    qp = request.query_params
+    try:
+        limit = int(qp.get("limit", "100"))
+    except ValueError:
+        return _err("limit must be an integer")
+    limit = max(1, min(limit, 1000))
+    explorer = _get_explorer()
+    summaries = explorer.list_recalls(
+        user_id=qp.get("user_id") or None,
+        namespace=qp.get("namespace") or None,
+        since=qp.get("since") or None,
+        limit=limit,
+    )
+    return _ok([s.to_dict() for s in summaries])
+
+
+async def recall_detail_handler(request: Request) -> JSONResponse:
+    rid = request.path_params["recall_id"]
+    explorer = _get_explorer()
+    detail = explorer.get_recall(rid)
+    if detail is None:
+        return _err("recall not found", status=404)
+    return _ok(detail.to_dict())
+
+
+async def memory_access_handler(request: Request) -> JSONResponse:
+    mid = request.path_params["memory_id"]
+    explorer = _get_explorer()
+    return _ok(explorer.memory_access_timeline(mid))
+
+
+async def user_activity_handler(request: Request) -> JSONResponse:
+    uid = request.path_params["user_id"]
+    since = request.query_params.get("since") or None
+    explorer = _get_explorer()
+    return _ok(explorer.user_activity(uid, since=since))
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Static dashboard handler — Starlette's StaticFiles would mount a
+# directory, but we want a single canonical path /audit.html that maps
+# to the bundled file. A FileResponse keeps the routing explicit.
+# ──────────────────────────────────────────────────────────────────────
+
+
+_DASHBOARD_PATH = Path(__file__).resolve().parents[1] / "ui" / "static" / "audit.html"
+
+
+async def dashboard_html_handler(request: Request) -> FileResponse | JSONResponse:
+    if not _DASHBOARD_PATH.exists():
+        return _err("dashboard asset missing", status=500)
+    return FileResponse(
+        _DASHBOARD_PATH,
+        media_type="text/html; charset=utf-8",
+        headers={"cache-control": "no-store"},
+    )
+
+
+def audit_routes() -> list[Route]:
+    """Return the audit + dashboard routes for mounting on the API app."""
+    return [
+        Route("/audit/recalls", list_recalls_handler, methods=["GET"]),
+        Route("/audit/recall/{recall_id}", recall_detail_handler, methods=["GET"]),
+        Route("/audit/memory/{memory_id}/access",
+              memory_access_handler, methods=["GET"]),
+        Route("/audit/user/{user_id}/activity",
+              user_activity_handler, methods=["GET"]),
+        Route("/audit.html", dashboard_html_handler, methods=["GET"]),
+    ]
+
+
+__all__ = ["audit_routes", "is_enabled"]

--- a/attestor/ui/static/audit.html
+++ b/attestor/ui/static/audit.html
@@ -1,0 +1,161 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Attestor — Audit &amp; Recall Trace Explorer</title>
+  <meta name="description" content="Forensic recall-trace explorer: every recall an Attestor agent ever did, with lane breakdown, scoring, and result provenance." />
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>
+    body{font-family:ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;}
+    .mono{font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace;}
+    .lane-pill{display:inline-block;padding:1px 8px;border-radius:9999px;font-size:11px;font-weight:600;letter-spacing:.02em;text-transform:uppercase;}
+    .lane-vector{background:#dbeafe;color:#1e3a8a;}
+    .lane-bm25{background:#dcfce7;color:#166534;}
+    .lane-graph{background:#fae8ff;color:#86198f;}
+    .lane-reranker{background:#fef3c7;color:#854d0e;}
+    .lane-mmr{background:#f1f5f9;color:#334155;}
+    .lane-other{background:#f1f5f9;color:#475569;}
+    tr.row:hover{background:#f8fafc;cursor:pointer;}
+    .modal-bg{background:rgba(15,23,42,.55);backdrop-filter:blur(2px);}
+    pre.evjson{font-size:11px;line-height:1.5;}
+  </style>
+</head>
+<body class="bg-slate-50 text-slate-900">
+  <header class="border-b border-slate-200 bg-white">
+    <div class="mx-auto max-w-7xl px-6 py-4 flex items-center justify-between">
+      <div>
+        <h1 class="text-xl font-semibold tracking-tight">Attestor — Audit Explorer</h1>
+        <p class="text-sm text-slate-500">Recall trace forensics. Read-only. Source: <span id="src-path" class="mono">trace.jsonl</span></p>
+      </div>
+      <div class="text-xs text-slate-400">
+        <span id="status-pill" class="inline-flex items-center gap-1">
+          <span class="h-2 w-2 rounded-full bg-emerald-500"></span>
+          live
+        </span>
+      </div>
+    </div>
+  </header>
+
+  <section class="mx-auto max-w-7xl px-6 py-6">
+    <!-- Filters -->
+    <form id="filters" class="grid grid-cols-1 md:grid-cols-5 gap-3 bg-white border border-slate-200 rounded-lg p-4 shadow-sm">
+      <div>
+        <label class="block text-xs font-medium text-slate-600">User</label>
+        <input id="f-user" type="text" placeholder="any user"
+               class="mt-1 w-full rounded-md border-slate-300 text-sm shadow-sm focus:border-slate-500 focus:ring-slate-500" />
+      </div>
+      <div>
+        <label class="block text-xs font-medium text-slate-600">Namespace</label>
+        <input id="f-ns" type="text" placeholder="any namespace"
+               class="mt-1 w-full rounded-md border-slate-300 text-sm shadow-sm focus:border-slate-500 focus:ring-slate-500" />
+      </div>
+      <div>
+        <label class="block text-xs font-medium text-slate-600">Since (ISO 8601)</label>
+        <input id="f-since" type="text" placeholder="2026-05-01T00:00:00Z"
+               class="mt-1 w-full rounded-md border-slate-300 text-sm shadow-sm focus:border-slate-500 focus:ring-slate-500" />
+      </div>
+      <div>
+        <label class="block text-xs font-medium text-slate-600">Limit</label>
+        <input id="f-limit" type="number" value="100" min="1" max="1000"
+               class="mt-1 w-full rounded-md border-slate-300 text-sm shadow-sm focus:border-slate-500 focus:ring-slate-500" />
+      </div>
+      <div class="flex items-end gap-2">
+        <button type="submit" class="px-3 py-2 rounded-md bg-slate-900 text-white text-sm font-medium hover:bg-slate-700">Refresh</button>
+        <button type="button" id="reset-btn" class="px-3 py-2 rounded-md bg-white border border-slate-300 text-sm font-medium text-slate-700 hover:bg-slate-100">Clear</button>
+      </div>
+    </form>
+
+    <!-- Stats strip -->
+    <div id="stats" class="mt-4 grid grid-cols-2 md:grid-cols-4 gap-3">
+      <div class="bg-white border border-slate-200 rounded-lg p-3"><div class="text-xs text-slate-500">Recalls shown</div><div id="s-count" class="text-2xl font-semibold tracking-tight">—</div></div>
+      <div class="bg-white border border-slate-200 rounded-lg p-3"><div class="text-xs text-slate-500">Avg latency (ms)</div><div id="s-latency" class="text-2xl font-semibold tracking-tight">—</div></div>
+      <div class="bg-white border border-slate-200 rounded-lg p-3"><div class="text-xs text-slate-500">Total cost (USD)</div><div id="s-cost" class="text-2xl font-semibold tracking-tight">—</div></div>
+      <div class="bg-white border border-slate-200 rounded-lg p-3"><div class="text-xs text-slate-500">Distinct users</div><div id="s-users" class="text-2xl font-semibold tracking-tight">—</div></div>
+    </div>
+
+    <!-- Recalls table -->
+    <div class="mt-4 bg-white border border-slate-200 rounded-lg overflow-hidden shadow-sm">
+      <table class="min-w-full divide-y divide-slate-200">
+        <thead class="bg-slate-50">
+          <tr class="text-xs uppercase tracking-wider text-slate-500">
+            <th class="px-4 py-3 text-left">Started</th>
+            <th class="px-4 py-3 text-left">User</th>
+            <th class="px-4 py-3 text-left">Namespace</th>
+            <th class="px-4 py-3 text-left">Query</th>
+            <th class="px-4 py-3 text-left">Lanes</th>
+            <th class="px-4 py-3 text-right">Results</th>
+            <th class="px-4 py-3 text-right">Latency</th>
+            <th class="px-4 py-3 text-right">Cost</th>
+          </tr>
+        </thead>
+        <tbody id="tbody" class="divide-y divide-slate-200 text-sm"></tbody>
+      </table>
+      <div id="empty-state" class="hidden text-center py-12 text-slate-500 text-sm">
+        No recalls match the current filters.
+      </div>
+    </div>
+
+    <p class="mt-3 text-xs text-slate-400">
+      Endpoints: <span class="mono">GET /audit/recalls</span>,
+      <span class="mono">GET /audit/recall/{id}</span>,
+      <span class="mono">GET /audit/memory/{id}/access</span>,
+      <span class="mono">GET /audit/user/{id}/activity</span>.
+    </p>
+  </section>
+
+  <!-- Recall detail modal -->
+  <div id="modal" class="hidden fixed inset-0 modal-bg z-40 flex items-start justify-center p-6 overflow-y-auto">
+    <div class="bg-white rounded-xl shadow-2xl w-full max-w-5xl my-8 border border-slate-200">
+      <header class="flex items-center justify-between px-6 py-4 border-b border-slate-200">
+        <div>
+          <h2 class="text-lg font-semibold tracking-tight">Recall <span id="m-rid" class="mono text-slate-500"></span></h2>
+          <p id="m-query" class="text-sm text-slate-600 mt-1"></p>
+        </div>
+        <button id="modal-close" class="rounded-md p-1.5 hover:bg-slate-100" aria-label="Close">
+          <svg viewBox="0 0 20 20" fill="currentColor" class="h-5 w-5 text-slate-500"><path fill-rule="evenodd" d="M4.28 4.22a.75.75 0 011.06 0L10 8.94l4.66-4.72a.75.75 0 011.07 1.05L11.06 10l4.67 4.72a.75.75 0 11-1.06 1.06L10 11.06l-4.66 4.72a.75.75 0 11-1.07-1.06L8.94 10 4.28 5.28a.75.75 0 010-1.06z" clip-rule="evenodd"/></svg>
+        </button>
+      </header>
+
+      <div class="grid grid-cols-2 md:grid-cols-4 gap-3 p-6 border-b border-slate-200 bg-slate-50">
+        <div><div class="text-xs text-slate-500">User</div><div id="m-user" class="mono text-sm">—</div></div>
+        <div><div class="text-xs text-slate-500">Namespace</div><div id="m-ns" class="mono text-sm">—</div></div>
+        <div><div class="text-xs text-slate-500">Latency</div><div id="m-latency" class="mono text-sm">—</div></div>
+        <div><div class="text-xs text-slate-500">Cost</div><div id="m-cost" class="mono text-sm">—</div></div>
+      </div>
+
+      <div class="p-6 space-y-6">
+        <div>
+          <h3 class="text-sm font-semibold text-slate-700 uppercase tracking-wider">Lane Activity</h3>
+          <div id="m-lanes" class="mt-2 flex flex-wrap gap-2"></div>
+        </div>
+
+        <div>
+          <h3 class="text-sm font-semibold text-slate-700 uppercase tracking-wider">Returned Memories</h3>
+          <ul id="m-results" class="mt-2 divide-y divide-slate-200 border border-slate-200 rounded-md"></ul>
+        </div>
+
+        <div>
+          <h3 class="text-sm font-semibold text-slate-700 uppercase tracking-wider">Event Trace</h3>
+          <div id="m-events" class="mt-2 space-y-2"></div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Memory drill-down modal -->
+  <div id="mem-modal" class="hidden fixed inset-0 modal-bg z-50 flex items-start justify-center p-6 overflow-y-auto">
+    <div class="bg-white rounded-xl shadow-2xl w-full max-w-3xl my-8 border border-slate-200">
+      <header class="flex items-center justify-between px-6 py-4 border-b border-slate-200">
+        <h2 class="text-lg font-semibold tracking-tight">Memory access timeline — <span id="mm-id" class="mono text-slate-500"></span></h2>
+        <button id="mem-close" class="rounded-md p-1.5 hover:bg-slate-100" aria-label="Close">
+          <svg viewBox="0 0 20 20" fill="currentColor" class="h-5 w-5 text-slate-500"><path fill-rule="evenodd" d="M4.28 4.22a.75.75 0 011.06 0L10 8.94l4.66-4.72a.75.75 0 011.07 1.05L11.06 10l4.67 4.72a.75.75 0 11-1.06 1.06L10 11.06l-4.66 4.72a.75.75 0 11-1.07-1.06L8.94 10 4.28 5.28a.75.75 0 010-1.06z" clip-rule="evenodd"/></svg>
+        </button>
+      </header>
+      <ul id="mm-rows" class="divide-y divide-slate-200"></ul>
+    </div>
+  </div>
+
+  <script src="/ui/static/audit.js"></script>
+</body>
+</html>

--- a/attestor/ui/static/audit.js
+++ b/attestor/ui/static/audit.js
@@ -1,0 +1,299 @@
+// Attestor — audit dashboard front-end.
+// Plain ES modules, no build step. Talks to /audit/* JSON endpoints.
+
+(function () {
+  "use strict";
+
+  // ── DOM refs ──────────────────────────────────────────────────────────
+  const $ = (sel) => document.querySelector(sel);
+  const tbody = $("#tbody");
+  const empty = $("#empty-state");
+  const filtersForm = $("#filters");
+  const userInput = $("#f-user");
+  const nsInput = $("#f-ns");
+  const sinceInput = $("#f-since");
+  const limitInput = $("#f-limit");
+  const resetBtn = $("#reset-btn");
+
+  const modal = $("#modal");
+  const modalClose = $("#modal-close");
+  const memModal = $("#mem-modal");
+  const memClose = $("#mem-close");
+
+  // ── Helpers ───────────────────────────────────────────────────────────
+  function fmtMs(v) {
+    if (v == null) return "—";
+    const n = Number(v);
+    if (!Number.isFinite(n)) return "—";
+    if (n < 1) return n.toFixed(2) + " ms";
+    return n.toFixed(1) + " ms";
+  }
+
+  function fmtCost(v) {
+    if (v == null) return "—";
+    const n = Number(v);
+    if (!Number.isFinite(n)) return "—";
+    if (n === 0) return "$0.00";
+    if (n < 0.001) return "$" + n.toExponential(2);
+    return "$" + n.toFixed(4);
+  }
+
+  function fmtTime(iso) {
+    if (!iso) return "—";
+    try {
+      const d = new Date(iso);
+      if (Number.isNaN(d.getTime())) return iso;
+      return d.toISOString().replace("T", " ").replace("Z", "");
+    } catch (e) {
+      return iso;
+    }
+  }
+
+  function escapeHTML(s) {
+    if (s == null) return "";
+    return String(s)
+      .replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;")
+      .replaceAll('"', "&quot;")
+      .replaceAll("'", "&#039;");
+  }
+
+  function lanePill(lane) {
+    const cls = `lane-pill lane-${escapeHTML(lane)}` ||
+      "lane-pill lane-other";
+    const known = ["vector", "bm25", "graph", "reranker", "mmr"];
+    const finalCls = known.includes(lane)
+      ? `lane-pill lane-${lane}`
+      : "lane-pill lane-other";
+    return `<span class="${finalCls}">${escapeHTML(lane)}</span>`;
+  }
+
+  // ── Data layer ────────────────────────────────────────────────────────
+  async function fetchJSON(url) {
+    const res = await fetch(url, { headers: { "accept": "application/json" } });
+    if (!res.ok) {
+      throw new Error(`${res.status} ${res.statusText} on ${url}`);
+    }
+    const body = await res.json();
+    if (body && body.ok === false) {
+      throw new Error(body.error || "request failed");
+    }
+    return body.data;
+  }
+
+  function buildListURL() {
+    const params = new URLSearchParams();
+    const u = userInput.value.trim();
+    const ns = nsInput.value.trim();
+    const since = sinceInput.value.trim();
+    const limit = limitInput.value.trim();
+    if (u) params.set("user_id", u);
+    if (ns) params.set("namespace", ns);
+    if (since) params.set("since", since);
+    if (limit) params.set("limit", limit);
+    const qs = params.toString();
+    return "/audit/recalls" + (qs ? "?" + qs : "");
+  }
+
+  // ── Render ────────────────────────────────────────────────────────────
+  function renderRows(rows) {
+    tbody.innerHTML = "";
+    empty.classList.toggle("hidden", rows.length > 0);
+
+    if (rows.length === 0) {
+      $("#s-count").textContent = "0";
+      $("#s-latency").textContent = "—";
+      $("#s-cost").textContent = "—";
+      $("#s-users").textContent = "0";
+      return;
+    }
+
+    let totalLatency = 0;
+    let totalCost = 0;
+    const users = new Set();
+
+    const frag = document.createDocumentFragment();
+    for (const r of rows) {
+      totalLatency += Number(r.elapsed_ms || 0);
+      totalCost += Number(r.cost_usd || 0);
+      if (r.user_id) users.add(r.user_id);
+
+      const tr = document.createElement("tr");
+      tr.className = "row";
+      tr.dataset.recallId = r.recall_id;
+      tr.innerHTML = `
+        <td class="px-4 py-3 mono text-xs text-slate-600">${escapeHTML(fmtTime(r.started_at))}</td>
+        <td class="px-4 py-3 text-sm">${escapeHTML(r.user_id || "—")}</td>
+        <td class="px-4 py-3 text-sm">${escapeHTML(r.namespace || "—")}</td>
+        <td class="px-4 py-3 text-sm max-w-md truncate" title="${escapeHTML(r.query)}">${escapeHTML(r.query || "—")}</td>
+        <td class="px-4 py-3 text-sm">${(r.lanes || []).map(lanePill).join(" ")}</td>
+        <td class="px-4 py-3 text-sm text-right mono">${r.result_count}</td>
+        <td class="px-4 py-3 text-sm text-right mono">${escapeHTML(fmtMs(r.elapsed_ms))}</td>
+        <td class="px-4 py-3 text-sm text-right mono">${escapeHTML(fmtCost(r.cost_usd))}</td>
+      `;
+      tr.addEventListener("click", () => openRecallDetail(r.recall_id));
+      frag.appendChild(tr);
+    }
+    tbody.appendChild(frag);
+
+    $("#s-count").textContent = String(rows.length);
+    $("#s-latency").textContent = (totalLatency / rows.length).toFixed(1);
+    $("#s-cost").textContent = totalCost.toFixed(4);
+    $("#s-users").textContent = String(users.size);
+  }
+
+  async function refresh() {
+    try {
+      const data = await fetchJSON(buildListURL());
+      renderRows(data);
+    } catch (err) {
+      tbody.innerHTML = "";
+      empty.classList.remove("hidden");
+      empty.textContent = `Error: ${err.message}`;
+    }
+  }
+
+  // ── Detail modal ──────────────────────────────────────────────────────
+  async function openRecallDetail(rid) {
+    try {
+      const detail = await fetchJSON(`/audit/recall/${encodeURIComponent(rid)}`);
+      $("#m-rid").textContent = detail.recall_id;
+      $("#m-query").textContent = detail.query;
+      $("#m-user").textContent = detail.user_id || "—";
+      $("#m-ns").textContent = detail.namespace || "—";
+      $("#m-latency").textContent = fmtMs(detail.elapsed_ms);
+      $("#m-cost").textContent = fmtCost(detail.cost_usd);
+
+      const lanesEl = $("#m-lanes");
+      lanesEl.innerHTML = (detail.lanes || []).map(lanePill).join(" ") || "—";
+
+      const resultsEl = $("#m-results");
+      const completeEv = (detail.events || []).find(
+        (e) => e.event === "recall.complete" || e.event === "recall.done",
+      ) || {};
+      const ids = completeEv.result_ids || (completeEv.final_ids || []).map(
+        (x) => (typeof x === "string" ? x : x.id),
+      );
+      const finalEntries = completeEv.final_ids || ids.map((id) => ({ id }));
+      resultsEl.innerHTML = "";
+      if (finalEntries.length === 0) {
+        resultsEl.innerHTML = '<li class="px-3 py-2 text-sm text-slate-500">No memories returned.</li>';
+      } else {
+        for (const entry of finalEntries) {
+          const id = entry.id || entry;
+          const score = entry.score != null ? entry.score : null;
+          const source = entry.source || entry.match_source || "—";
+          const preview = entry.preview || "";
+          const li = document.createElement("li");
+          li.className = "px-3 py-2 text-sm flex items-center justify-between hover:bg-slate-50 cursor-pointer";
+          li.innerHTML = `
+            <div class="min-w-0">
+              <div class="mono text-xs text-slate-500">${escapeHTML(id)}</div>
+              <div class="text-slate-700 truncate" title="${escapeHTML(preview)}">${escapeHTML(preview || "(no preview)")}</div>
+            </div>
+            <div class="ml-3 flex items-center gap-3 text-xs text-slate-500">
+              <span class="mono">${score != null ? Number(score).toFixed(4) : "—"}</span>
+              <span>${escapeHTML(source)}</span>
+            </div>`;
+          li.addEventListener("click", (ev) => {
+            ev.stopPropagation();
+            openMemoryAccess(id);
+          });
+          resultsEl.appendChild(li);
+        }
+      }
+
+      const eventsEl = $("#m-events");
+      eventsEl.innerHTML = "";
+      for (const ev of detail.events || []) {
+        const block = document.createElement("div");
+        block.className = "border border-slate-200 rounded-md overflow-hidden";
+        const head = document.createElement("button");
+        head.type = "button";
+        head.className = "w-full text-left px-3 py-2 bg-slate-50 hover:bg-slate-100 flex items-center justify-between";
+        head.innerHTML = `
+          <div class="flex items-center gap-3">
+            <span class="mono text-xs text-slate-500">#${ev.seq ?? "—"}</span>
+            <span class="font-medium text-slate-800">${escapeHTML(ev.event || "(unknown)")}</span>
+          </div>
+          <span class="mono text-xs text-slate-400">${escapeHTML(fmtTime(ev.ts))}</span>`;
+        const body = document.createElement("pre");
+        body.className = "evjson hidden whitespace-pre-wrap p-3 bg-white text-slate-700 mono";
+        body.textContent = JSON.stringify(ev, null, 2);
+        head.addEventListener("click", () => body.classList.toggle("hidden"));
+        block.appendChild(head);
+        block.appendChild(body);
+        eventsEl.appendChild(block);
+      }
+
+      modal.classList.remove("hidden");
+    } catch (err) {
+      alert("Failed to load recall: " + err.message);
+    }
+  }
+
+  function closeModal() {
+    modal.classList.add("hidden");
+  }
+
+  async function openMemoryAccess(memoryId) {
+    try {
+      const rows = await fetchJSON(`/audit/memory/${encodeURIComponent(memoryId)}/access`);
+      $("#mm-id").textContent = memoryId;
+      const ul = $("#mm-rows");
+      ul.innerHTML = "";
+      if (!rows.length) {
+        ul.innerHTML = '<li class="px-6 py-4 text-sm text-slate-500">No access events recorded.</li>';
+      } else {
+        for (const r of rows) {
+          const li = document.createElement("li");
+          li.className = "px-6 py-3 text-sm";
+          li.innerHTML = `
+            <div class="flex items-center justify-between">
+              <span class="mono text-xs text-slate-500">${escapeHTML(fmtTime(r.ts))}</span>
+              <span class="text-xs text-slate-400">${escapeHTML(r.recall_id)}</span>
+            </div>
+            <div class="mt-1 text-slate-700">${escapeHTML(r.query || "—")}</div>
+            <div class="mt-1 text-xs text-slate-500">user=${escapeHTML(r.user_id || "—")} · ns=${escapeHTML(r.namespace || "—")}</div>`;
+          ul.appendChild(li);
+        }
+      }
+      memModal.classList.remove("hidden");
+    } catch (err) {
+      alert("Failed to load memory access: " + err.message);
+    }
+  }
+
+  function closeMemModal() {
+    memModal.classList.add("hidden");
+  }
+
+  // ── Wire it up ────────────────────────────────────────────────────────
+  filtersForm.addEventListener("submit", (e) => {
+    e.preventDefault();
+    refresh();
+  });
+
+  resetBtn.addEventListener("click", () => {
+    userInput.value = "";
+    nsInput.value = "";
+    sinceInput.value = "";
+    limitInput.value = "100";
+    refresh();
+  });
+
+  modalClose.addEventListener("click", closeModal);
+  memClose.addEventListener("click", closeMemModal);
+  modal.addEventListener("click", (e) => { if (e.target === modal) closeModal(); });
+  memModal.addEventListener("click", (e) => { if (e.target === memModal) closeMemModal(); });
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape") {
+      if (!memModal.classList.contains("hidden")) closeMemModal();
+      else if (!modal.classList.contains("hidden")) closeModal();
+    }
+  });
+
+  // Initial paint.
+  refresh();
+})();

--- a/configs/attestor.yaml
+++ b/configs/attestor.yaml
@@ -432,6 +432,25 @@ stack:
     model: null             # null → stack.models.distill
     dry_run: false          # true → call LLM, skip writes (cost preview only)
 
+# ─── Audit dashboard + recall trace explorer ───────────────────────────
+# The audit explorer reads the JSONL trace log written by `attestor.trace`
+# (toggle via ATTESTOR_TRACE=1) and surfaces it through `/audit/*` REST
+# endpoints + a static `/audit.html` dashboard. Off by default — flip
+# `dashboard.enabled` (or set ATTESTOR_AUDIT_ENABLED=1 in the env) to
+# expose the routes. In HOSTED / SHARED modes the same JWT bearer-token
+# middleware that gates `/recall` also gates `/audit/*`.
+#
+# Endpoints:
+#   GET /audit/recalls?user_id=&namespace=&since=&limit=  → list summaries
+#   GET /audit/recall/{recall_id}                          → full event tree
+#   GET /audit/memory/{memory_id}/access                   → access timeline
+#   GET /audit/user/{user_id}/activity?since=              → aggregate stats
+#   GET /audit.html                                        → static dashboard
+audit:
+  dashboard:
+    enabled: false                  # opt-in; flip true to mount /audit/*
+  trace_log_path: ~/.attestor/trace.jsonl   # default ATTESTOR_TRACE_FILE
+
 # ─── Container image (for cloud deploys) ────────────────────────────────
 # The published image is currently the *introspection-only* MCP stub
 # (Glama listing). For Path B cloud deploys we build a separate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,10 @@ include = [
     # Shipping it inside the wheel means `pip install attestor` is enough
     # for any 2026 agent harness to pick the skill up.
     { path = "skills/*/SKILL.md", format = ["sdist", "wheel"] },
+    # Web UI assets — read-only dashboard, recall explorer, audit dashboard.
+    # FileResponse serves them directly so they MUST be in the wheel.
+    { path = "attestor/ui/static/*", format = ["sdist", "wheel"] },
+    { path = "attestor/ui/templates/*.html", format = ["sdist", "wheel"] },
 ]
 
 [tool.poetry.group.dev.dependencies]

--- a/skills/attestor-memory/SKILL.md
+++ b/skills/attestor-memory/SKILL.md
@@ -405,7 +405,15 @@ Attestor is built for regulated workloads:
 
 - **Bi-temporal storage.** Every memory has both event time (`valid_from` / `valid_until`) and transaction time (`t_created` / `t_expired`). Nothing is deleted on contradiction — the older fact is marked `superseded` and stays queryable forever via `timeline()` and `recall(as_of=...)`.
 - **Provenance signing.** Opt-in Ed25519 signature on every memory (`signing` block in config). `mem.verify_memory(memory_id)` re-checks the signature against the canonical payload.
-- **Audit trail via traces.** OpenTelemetry-style spans on every ingest / recall / supersede call (`attestor/trace.py`). Toggle with `ATTESTOR_TRACE=1`.
+- **Audit trail via traces.** OpenTelemetry-style spans on every ingest / recall / supersede call (`attestor/trace.py`). Toggle with `ATTESTOR_TRACE=1`; point at a JSONL log via `ATTESTOR_TRACE_FILE`.
+- **Audit dashboard.** Set `audit.dashboard.enabled: true` in `configs/attestor.yaml` (or `ATTESTOR_AUDIT_ENABLED=1` in the env) to mount the recall trace explorer:
+  - `GET /audit/recalls?user_id=&namespace=&since=&limit=` — recall summaries (newest first).
+  - `GET /audit/recall/{recall_id}` — full event tree for one recall (lanes, scores, returned ids).
+  - `GET /audit/memory/{memory_id}/access` — every recall that surfaced a given memory.
+  - `GET /audit/user/{user_id}/activity` — recall count, distinct memories, per-lane usage.
+  - `GET /audit.html` — single-page static dashboard (Tailwind CDN, vanilla JS) for visual inspection.
+
+  In HOSTED / SHARED modes the existing `JWTAuthMiddleware` gates the audit surface alongside `/recall` — same bearer-token contract. The dashboard is read-only; it never mutates the JSONL log.
 - **Tenancy.** Postgres row-level security scoped by `user_id`; namespaces are first-class; Neo4j namespace enforcement is partial (graph entity nodes are still global as of v4.0.0 — see CLAUDE.md).
 - **GDPR-compatible erasure.** `purge_user()` issues a CASCADE delete and writes an audit row; export via `export_user()` produces a JSON-portable dump.
 - **No LLM in the critical path.** The recall cascade is fully deterministic — same query, same ranking — which is what regulators want when they audit a recommendation.

--- a/tests/test_audit_explorer.py
+++ b/tests/test_audit_explorer.py
@@ -1,0 +1,498 @@
+"""Unit + integration tests for the audit trace explorer.
+
+These tests are TDD-first: they exercise the not-yet-written
+``attestor.audit.explorer`` module and the ``/audit/*`` REST surface
+mounted on the existing Starlette ASGI app. They MUST fail before the
+implementation lands.
+
+The explorer is a read-only consumer of the JSONL trace log written by
+``attestor.trace`` (see ``ATTESTOR_TRACE_FILE``). It groups events by
+``recall_id`` (set by ``recall_scope()``) and surfaces summaries +
+details for the audit dashboard.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Trace log fixtures
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _write_jsonl(path: Path, events: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as fh:
+        for ev in events:
+            fh.write(json.dumps(ev) + "\n")
+
+
+def _make_recall_events(
+    recall_id: str,
+    *,
+    user_id: str | None = None,
+    namespace: str = "default",
+    query: str = "what was the meeting about?",
+    lanes: tuple[str, ...] = ("vector", "bm25"),
+    result_ids: tuple[str, ...] = ("m-1", "m-2"),
+    started_at: str = "2026-05-01T12:00:00.000+00:00",
+    completed_at: str = "2026-05-01T12:00:00.150+00:00",
+    cost_usd: float = 0.00012,
+    elapsed_ms: float | None = None,
+) -> list[dict[str, Any]]:
+    # Derive elapsed_ms from timestamps when not explicitly provided so
+    # callers don't have to keep the two in sync by hand.
+    if elapsed_ms is None:
+        try:
+            from datetime import datetime
+            t0 = datetime.fromisoformat(started_at)
+            t1 = datetime.fromisoformat(completed_at)
+            elapsed_ms = (t1 - t0).total_seconds() * 1000.0
+        except ValueError:
+            elapsed_ms = 0.0
+    base: dict[str, Any] = {
+        "recall_id": recall_id,
+        "namespace": namespace,
+    }
+    if user_id is not None:
+        base["user_id"] = user_id
+
+    events: list[dict[str, Any]] = [
+        {**base, "ts": started_at, "event": "recall.start", "seq": 1,
+         "query": query, "token_budget": 2000},
+    ]
+    seq = 2
+    for lane in lanes:
+        events.append({
+            **base, "ts": started_at, "event": f"recall.lane.{lane}",
+            "seq": seq, "candidates": 10, "latency_ms": 12.5,
+        })
+        seq += 1
+    events.append({
+        **base, "ts": completed_at, "event": "recall.complete",
+        "seq": seq,
+        "elapsed_ms": elapsed_ms, "cost_usd": cost_usd,
+        "result_count": len(result_ids),
+        "result_ids": list(result_ids),
+    })
+    return events
+
+
+@pytest.fixture
+def trace_log(tmp_path: Path) -> Path:
+    """A populated JSONL trace log with three recalls."""
+    log = tmp_path / "trace.jsonl"
+    events: list[dict[str, Any]] = []
+    events += _make_recall_events(
+        "rec-001", user_id="alice", namespace="ns-a",
+        query="when did we ship v4?",
+        lanes=("vector", "bm25", "graph"),
+        result_ids=("m-10", "m-11"),
+        started_at="2026-05-01T08:00:00.000+00:00",
+        completed_at="2026-05-01T08:00:00.120+00:00",
+    )
+    events += _make_recall_events(
+        "rec-002", user_id="bob", namespace="ns-b",
+        query="what's the deploy plan?",
+        lanes=("vector",),
+        result_ids=("m-20",),
+        started_at="2026-05-01T09:30:00.000+00:00",
+        completed_at="2026-05-01T09:30:00.090+00:00",
+    )
+    events += _make_recall_events(
+        "rec-003", user_id="alice", namespace="ns-a",
+        query="follow-up on v4 release",
+        lanes=("vector", "bm25", "reranker"),
+        result_ids=("m-10", "m-30", "m-31"),
+        started_at="2026-05-01T11:15:00.000+00:00",
+        completed_at="2026-05-01T11:15:00.205+00:00",
+    )
+    _write_jsonl(log, events)
+    return log
+
+
+@pytest.fixture
+def empty_trace_log(tmp_path: Path) -> Path:
+    log = tmp_path / "trace.jsonl"
+    log.parent.mkdir(parents=True, exist_ok=True)
+    log.touch()
+    return log
+
+
+@pytest.fixture
+def explorer(trace_log: Path):
+    from attestor.audit import explorer as mod
+
+    return mod.TraceExplorer(trace_log)
+
+
+@pytest.fixture
+def empty_explorer(empty_trace_log: Path):
+    from attestor.audit import explorer as mod
+
+    return mod.TraceExplorer(empty_trace_log)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Module-level smoke
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_module_exports_public_symbols():
+    mod = importlib.import_module("attestor.audit.explorer")
+    for sym in ("RecallSummary", "RecallDetail", "TraceExplorer",
+                "list_recalls", "get_recall",
+                "memory_access_timeline", "user_activity"):
+        assert hasattr(mod, sym), f"missing {sym}"
+
+
+# ──────────────────────────────────────────────────────────────────────
+# list_recalls
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_list_recalls_empty_log(empty_explorer):
+    out = empty_explorer.list_recalls()
+    assert out == []
+
+
+@pytest.mark.unit
+def test_list_recalls_groups_by_recall_id(explorer):
+    out = explorer.list_recalls()
+    assert {r.recall_id for r in out} == {"rec-001", "rec-002", "rec-003"}
+    # Newest-first ordering.
+    assert out[0].recall_id == "rec-003"
+    assert out[-1].recall_id == "rec-001"
+
+
+@pytest.mark.unit
+def test_list_recalls_summary_shape(explorer):
+    out = explorer.list_recalls()
+    summary = next(r for r in out if r.recall_id == "rec-001")
+    assert summary.user_id == "alice"
+    assert summary.namespace == "ns-a"
+    assert summary.query == "when did we ship v4?"
+    assert summary.result_count == 2
+    assert summary.elapsed_ms == 120.0
+    # Lanes are deduped + tuple-typed.
+    assert set(summary.lanes) == {"vector", "bm25", "graph"}
+    assert isinstance(summary.lanes, tuple)
+
+
+@pytest.mark.unit
+def test_list_recalls_filters_by_user(explorer):
+    out = explorer.list_recalls(user_id="alice")
+    assert {r.recall_id for r in out} == {"rec-001", "rec-003"}
+
+
+@pytest.mark.unit
+def test_list_recalls_filters_by_namespace(explorer):
+    out = explorer.list_recalls(namespace="ns-b")
+    assert [r.recall_id for r in out] == ["rec-002"]
+
+
+@pytest.mark.unit
+def test_list_recalls_filters_by_since(explorer):
+    out = explorer.list_recalls(since="2026-05-01T10:00:00+00:00")
+    # Only rec-003 starts after 10:00.
+    assert [r.recall_id for r in out] == ["rec-003"]
+
+
+@pytest.mark.unit
+def test_list_recalls_limit_honored(explorer):
+    out = explorer.list_recalls(limit=2)
+    assert len(out) == 2
+    # Newest-first → rec-003, rec-002.
+    assert [r.recall_id for r in out] == ["rec-003", "rec-002"]
+
+
+# ──────────────────────────────────────────────────────────────────────
+# get_recall
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_get_recall_returns_detail(explorer):
+    detail = explorer.get_recall("rec-001")
+    assert detail is not None
+    assert detail.recall_id == "rec-001"
+    assert detail.query == "when did we ship v4?"
+    # Detail extends summary AND carries the full event tree.
+    assert len(detail.events) == 5  # start + 3 lanes + complete
+    assert detail.events[0]["event"] == "recall.start"
+    assert detail.events[-1]["event"] == "recall.complete"
+    # Events are tuple (frozen) — not list.
+    assert isinstance(detail.events, tuple)
+
+
+@pytest.mark.unit
+def test_get_recall_missing_id_returns_none(explorer):
+    assert explorer.get_recall("does-not-exist") is None
+
+
+# ──────────────────────────────────────────────────────────────────────
+# memory_access_timeline
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_memory_access_timeline(explorer):
+    # m-10 was returned by rec-001 AND rec-003.
+    tl = explorer.memory_access_timeline("m-10")
+    assert len(tl) == 2
+    recall_ids = {row["recall_id"] for row in tl}
+    assert recall_ids == {"rec-001", "rec-003"}
+    # Rows are sorted ascending by ts (oldest first).
+    assert tl[0]["ts"] <= tl[1]["ts"]
+    # Each row has the query and the recall context.
+    for row in tl:
+        assert "query" in row
+        assert "user_id" in row
+        assert "namespace" in row
+
+
+@pytest.mark.unit
+def test_memory_access_timeline_unseen_id(explorer):
+    assert explorer.memory_access_timeline("never-recalled") == []
+
+
+# ──────────────────────────────────────────────────────────────────────
+# user_activity
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_user_activity_aggregates(explorer):
+    stats = explorer.user_activity("alice")
+    assert stats["user_id"] == "alice"
+    assert stats["recall_count"] == 2
+    # Memories accessed across both recalls (m-10 dedup'd? no — total accesses).
+    assert stats["memories_accessed_total"] == 5  # 2 + 3
+    # Distinct memory ids across user's recalls = m-10, m-11, m-30, m-31.
+    assert stats["memories_accessed_distinct"] == 4
+    # Lane-usage histogram.
+    histo = stats["lane_usage"]
+    assert histo["vector"] == 2
+    assert histo["bm25"] == 2
+    assert histo["graph"] == 1
+    assert histo["reranker"] == 1
+
+
+@pytest.mark.unit
+def test_user_activity_since_filter(explorer):
+    stats = explorer.user_activity("alice", since="2026-05-01T10:00:00+00:00")
+    assert stats["recall_count"] == 1
+
+
+@pytest.mark.unit
+def test_user_activity_unknown_user(explorer):
+    stats = explorer.user_activity("nobody")
+    assert stats["recall_count"] == 0
+    assert stats["memories_accessed_total"] == 0
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Module-level convenience functions (point at default log path)
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_module_functions_use_env_path(monkeypatch, trace_log):
+    monkeypatch.setenv("ATTESTOR_TRACE_FILE", str(trace_log))
+    # Force a re-read in the explorer cache.
+    from attestor.audit import explorer as mod
+    mod.reset_cache()
+
+    out = mod.list_recalls()
+    assert {r.recall_id for r in out} == {"rec-001", "rec-002", "rec-003"}
+
+    detail = mod.get_recall("rec-002")
+    assert detail is not None
+    assert detail.user_id == "bob"
+
+    tl = mod.memory_access_timeline("m-20")
+    assert len(tl) == 1
+
+    stats = mod.user_activity("bob")
+    assert stats["recall_count"] == 1
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Indexing perf — must handle 100k events under 500ms on first call,
+# and subsequent calls hit the cache.
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_index_performance_100k_events(tmp_path):
+    log = tmp_path / "big.jsonl"
+    events: list[dict[str, Any]] = []
+    # ~17k recalls * 6 events each ≈ 100k events.
+    for i in range(17_000):
+        events += _make_recall_events(
+            f"rec-{i:05d}", user_id=f"user-{i % 50}", namespace="ns",
+            lanes=("vector", "bm25", "graph", "reranker"),
+            result_ids=(f"m-{i}-1", f"m-{i}-2", f"m-{i}-3"),
+        )
+    _write_jsonl(log, events)
+    assert sum(1 for _ in log.open()) >= 100_000
+
+    from attestor.audit import explorer as mod
+    exp = mod.TraceExplorer(log)
+    t0 = time.monotonic()
+    summaries = exp.list_recalls(limit=10)
+    elapsed = time.monotonic() - t0
+    # 500ms budget for the cold path.
+    assert elapsed < 0.5, f"index too slow: {elapsed:.3f}s"
+    assert len(summaries) == 10
+
+
+# ──────────────────────────────────────────────────────────────────────
+# REST endpoints — wired into existing api.py
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def api_client(monkeypatch, trace_log):
+    """Starlette TestClient with audit endpoints active and SOLO mode (no auth)."""
+    monkeypatch.setenv("ATTESTOR_TRACE_FILE", str(trace_log))
+    monkeypatch.setenv("ATTESTOR_AUDIT_ENABLED", "1")
+    monkeypatch.delenv("ATTESTOR_MODE", raising=False)
+    # Reset the audit cache so the new file is read.
+    from attestor.audit import explorer as mod
+    mod.reset_cache()
+
+    # Reload api.py to rebuild routes with audit toggled on.
+    import attestor.api as api_mod
+    importlib.reload(api_mod)
+
+    from starlette.testclient import TestClient
+    return TestClient(api_mod.app)
+
+
+@pytest.mark.unit
+def test_endpoint_list_recalls_returns_json(api_client):
+    r = api_client.get("/audit/recalls")
+    assert r.status_code == 200
+    assert r.headers["content-type"].startswith("application/json")
+    body = r.json()
+    assert body["ok"] is True
+    assert isinstance(body["data"], list)
+    assert len(body["data"]) == 3
+
+
+@pytest.mark.unit
+def test_endpoint_list_recalls_filter(api_client):
+    r = api_client.get("/audit/recalls", params={"user_id": "alice"})
+    assert r.status_code == 200
+    body = r.json()
+    assert {item["recall_id"] for item in body["data"]} == {"rec-001", "rec-003"}
+
+
+@pytest.mark.unit
+def test_endpoint_recall_detail(api_client):
+    r = api_client.get("/audit/recall/rec-001")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["ok"] is True
+    assert body["data"]["recall_id"] == "rec-001"
+    assert len(body["data"]["events"]) == 5
+
+
+@pytest.mark.unit
+def test_endpoint_recall_detail_404(api_client):
+    r = api_client.get("/audit/recall/does-not-exist")
+    assert r.status_code == 404
+    assert r.json()["ok"] is False
+
+
+@pytest.mark.unit
+def test_endpoint_memory_access(api_client):
+    r = api_client.get("/audit/memory/m-10/access")
+    assert r.status_code == 200
+    body = r.json()
+    assert len(body["data"]) == 2
+
+
+@pytest.mark.unit
+def test_endpoint_user_activity(api_client):
+    r = api_client.get("/audit/user/alice/activity")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["data"]["recall_count"] == 2
+
+
+@pytest.mark.unit
+def test_endpoint_disabled_when_audit_off(monkeypatch, trace_log):
+    monkeypatch.setenv("ATTESTOR_TRACE_FILE", str(trace_log))
+    monkeypatch.delenv("ATTESTOR_AUDIT_ENABLED", raising=False)
+    monkeypatch.delenv("ATTESTOR_MODE", raising=False)
+
+    import attestor.api as api_mod
+    importlib.reload(api_mod)
+    from starlette.testclient import TestClient
+    client = TestClient(api_mod.app)
+    r = client.get("/audit/recalls")
+    # With audit disabled the route does not exist — Starlette returns 404.
+    assert r.status_code == 404
+
+
+@pytest.mark.unit
+def test_endpoint_auth_required_in_hosted_mode(monkeypatch, trace_log):
+    """In HOSTED mode, /audit/* requires a bearer token like /recall does."""
+    monkeypatch.setenv("ATTESTOR_TRACE_FILE", str(trace_log))
+    monkeypatch.setenv("ATTESTOR_AUDIT_ENABLED", "1")
+    monkeypatch.setenv("ATTESTOR_MODE", "hosted")
+    # Public key set so the middleware doesn't 500 with "auth not configured".
+    monkeypatch.setenv("ATTESTOR_JWT_PUBLIC_KEY", "dummy-key-for-route-check")
+
+    import attestor.api as api_mod
+    importlib.reload(api_mod)
+    from starlette.testclient import TestClient
+    client = TestClient(api_mod.app)
+    r = client.get("/audit/recalls")
+    # No bearer header → 401.
+    assert r.status_code == 401
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Static dashboard
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_dashboard_html_served(api_client):
+    r = api_client.get("/audit.html")
+    assert r.status_code == 200
+    assert r.headers["content-type"].startswith("text/html")
+    assert "Attestor" in r.text
+    assert "Audit" in r.text
+
+
+@pytest.mark.unit
+def test_dashboard_calls_endpoints(api_client):
+    """The dashboard's JS must reference the documented endpoints."""
+    r = api_client.get("/audit.html")
+    assert r.status_code == 200
+    body = r.text
+    # We expect fetch('/audit/...') calls in the inline JS or referenced JS file.
+    js_path = "/audit/recalls"
+    if js_path not in body:
+        # If the dashboard separates its JS into a file, the link tag must
+        # reference it AND the file itself must call /audit/recalls.
+        assert "audit.js" in body
+        r2 = api_client.get("/ui/static/audit.js")
+        assert r2.status_code == 200
+        assert "/audit/recalls" in r2.text
+    else:
+        assert "/audit/recall/" in body
+        assert "/audit/user/" in body


### PR DESCRIPTION
## Summary
- New ``attestor/audit/explorer.py`` indexes the JSONL trace log written by ``attestor.trace`` and surfaces ``list_recalls`` / ``get_recall`` / ``memory_access_timeline`` / ``user_activity`` as frozen-dataclass results.
- New ``/audit/*`` REST surface mounted on the existing Starlette ASGI app, gated by ``ATTESTOR_AUDIT_ENABLED`` / ``audit.dashboard.enabled``. In HOSTED / SHARED modes the same ``JWTAuthMiddleware`` that gates ``/recall`` also gates ``/audit/*``.
- New ``attestor/ui/static/audit.html`` + ``audit.js`` — single-page dashboard, Tailwind via CDN, no build step. Recalls table with filter bar, click-through detail modal (lane pills, returned memories with score+source, collapsible event tree), and memory drill-down modal (``/audit/memory/{id}/access``).

## Files touched
- NEW: ``attestor/audit/{__init__,explorer,routes}.py``
- NEW: ``attestor/ui/static/audit.html`` + ``audit.js``
- NEW: ``tests/test_audit_explorer.py`` (27 tests)
- MODIFIED: ``attestor/api.py`` (mount audit routes when enabled)
- MODIFIED: ``configs/attestor.yaml`` (add ``audit:`` block)
- MODIFIED: ``skills/attestor-memory/SKILL.md`` (document endpoints + dashboard)
- MODIFIED: ``pyproject.toml`` (explicit wheel/sdist include for ``ui/static/*`` + ``ui/templates/*.html``)

## Performance
100k events indexed in ~325 ms cold (~314 k events/sec) on an M-series laptop; warm path is O(1) via a ``(path, mtime, size)`` cache key. The ``test_index_performance_100k_events`` test enforces a 500 ms cold bound.

## Auth + safety
- Read-only: explorer never mutates the JSONL log; trace remains the source of truth.
- Off by default — opt-in via env or YAML.
- HOSTED/SHARED mode requires bearer token (test ``test_endpoint_auth_required_in_hosted_mode``).
- Existing trace-event secret-redaction is unchanged; explorer surfaces only what was already on disk.

## Test plan
- [x] ``pytest tests/test_audit_explorer.py`` — 27 passed (RED first, GREEN after implementation).
- [x] Full suite ``pytest -m 'not live'`` — 1263 passed, 126 skipped, 0 regressions.
- [x] ``ruff check attestor/audit/`` — clean (only TC002/TC003 stylistic warnings consistent with existing code).
- [x] End-to-end ``TestClient`` smoke: ``GET /audit/recalls``, ``/audit/recall/{id}``, ``/audit/memory/{id}/access``, ``/audit/user/{id}/activity``, ``/audit.html`` all return 200 with expected payload shapes.
- [ ] Manual browser visit on a deployment with ``ATTESTOR_TRACE=1`` + a populated JSONL log (filter, click row, drill into a memory).

## Notes for follow-up
- Trace event format unchanged. The explorer reads two emitter shapes for the completion event (``recall.complete`` with flat ``result_ids`` and ``recall.done`` with rich ``final_ids: [{id, score, source, preview}, ...]``). Long-term, we should pick one canonical shape — flagging in this PR but not changing the writer.
- ``cost_usd`` is read off the completion event; not all emitters set it today. Adding cost tagging across multi_query / hyde / reranker is a follow-up.