### PR TITLE
fix: missing @dataclass on MemoryLayersCfg (post-merge regression)

### DIFF
--- a/attestor/config/models.py
+++ b/attestor/config/models.py
@@ -696,6 +696,7 @@ class ConsolidationCfg:
     dry_run: bool = False
 
 
+@dataclass(frozen=True)
 class MemoryLayersCfg:
     """Hierarchical memory layer config (2026 best-practice).
 


### PR DESCRIPTION
Conflict-resolution merge of #155 dropped the @dataclass(frozen=True) decorator from MemoryLayersCfg. Restore it. Verified locally: get_stack() now boots.