### PR TITLE
chore: 14 MEDIUM findings from Python FAANG review (follow-up to #158)

### DIFF
--- a/attestor/bench_config.py
+++ b/attestor/bench_config.py
@@ -22,6 +22,7 @@ mode the user pushed back against in the prior session.
 
 from __future__ import annotations
 
+import logging
 import os
 import threading
 from dataclasses import dataclass, field
@@ -31,6 +32,8 @@ from typing import Any
 import yaml
 
 from attestor.config import StackConfig
+
+logger = logging.getLogger(__name__)
 
 # ──────────────────────────────────────────────────────────────────────
 # Errors
@@ -272,19 +275,24 @@ def reset_bench() -> None:
 
 
 def print_bench_banner(cfg: BenchCfg, *, run_label: str) -> None:
-    """Print [stack] and [bench] blocks side-by-side at startup."""
+    """Print [stack] and [bench] blocks side-by-side at startup.
+
+    Routes through ``logger.info`` so downstream consumers (CI log
+    capture, structured-log shippers) see the banner with a level and
+    timestamp instead of a raw stdout write.
+    """
     s = cfg.stack
     pg = s.postgres.url.split("@", 1)[-1] if "@" in s.postgres.url else s.postgres.url
-    print(f"[{run_label}]")
-    print(
-        f"  [stack]   embedder={s.embedder.model} ({s.embedder.dimensions}d) "
-        f"· answerer={s.models.answerer} · judge={s.models.judge} "
-        f"· pg={pg} · neo4j={s.neo4j.url}",
+    logger.info("[%s]", run_label)
+    logger.info(
+        "  [stack]   embedder=%s (%dd) · answerer=%s · judge=%s · pg=%s · neo4j=%s",
+        s.embedder.model, s.embedder.dimensions, s.models.answerer,
+        s.models.judge, pg, s.neo4j.url,
     )
-    print(
-        f"  [bench]   variant={cfg.lme.variant} "
-        f"· category={cfg.lme.category or 'ALL'} "
-        f"· sample_limit={cfg.lme.sample_limit or 'full'} "
-        f"· parallel={s.parallel} · budget={s.budget} "
-        f"· output_dir={cfg.lme.output_dir}",
+    logger.info(
+        "  [bench]   variant=%s · category=%s · sample_limit=%s "
+        "· parallel=%d · budget=%d · output_dir=%s",
+        cfg.lme.variant, cfg.lme.category or "ALL",
+        cfg.lme.sample_limit or "full",
+        s.parallel, s.budget, cfg.lme.output_dir,
     )

--- a/attestor/cli/main.py
+++ b/attestor/cli/main.py
@@ -10,6 +10,7 @@ byte-identical.
 from __future__ import annotations
 
 import argparse
+import sys
 
 from attestor.cli._common import _add_backend_args, _suppress_noisy_output
 from attestor.cli.commands.bench import (
@@ -383,8 +384,11 @@ def main(argv=None):
     args = parser.parse_args(argv)
 
     if not args.command:
+        # No subcommand → print help and exit 1 so CI / scripts that
+        # check ``$?`` see "bad usage" rather than "success". The
+        # previous fall-through returned 0 silently.
         parser.print_help()
-        return
+        sys.exit(1)
 
     # Dispatch
     handlers = {

--- a/attestor/config/loader.py
+++ b/attestor/config/loader.py
@@ -62,7 +62,7 @@ def _parse_yaml(cfg_path: Path, *, strict: bool) -> StackConfig:
 
     pg = stack_blk.get("postgres") or {}
     neo = stack_blk.get("neo4j") or {}
-    pcn = stack_blk.get("pinecone")  # None when unset → vector role falls back to pgvector
+    pcn = stack_blk.get("pinecone")  # None when unset → vector role lives on the postgres pgvector column (no separate Pinecone backend registered)
     emb = stack_blk.get("embedder") or {}
     models = stack_blk.get("models") or {}
     llm_blk = stack_blk.get("llm") or {}

--- a/attestor/doctor_v4.py
+++ b/attestor/doctor_v4.py
@@ -254,7 +254,16 @@ def run_v4_doctor(conn: Any) -> V4DoctorReport:
                 name=name, status="skip",
                 detail=f"check raised {type(exc).__name__}: {exc}",
             ))
+    # Any non-ok result (including "skip" — inconclusive) means the
+    # report can't certify health. Operators running on a low-privilege
+    # connection see "skip" entries and know to investigate rather
+    # than assume the schema is validated.
     healthy = all(r.status == "ok" for r in results)
+    if any(r.status == "skip" for r in results):
+        logger.warning(
+            "v4 doctor: %d check(s) returned 'skip' (inconclusive)",
+            sum(1 for r in results if r.status == "skip"),
+        )
     return V4DoctorReport(healthy=healthy, checks=tuple(results))
 
 

--- a/attestor/extraction/llm_entity_extractor.py
+++ b/attestor/extraction/llm_entity_extractor.py
@@ -234,11 +234,26 @@ def _resolve_client(model: str, api_key: str | None) -> tuple[Any, str]:
 # future concern; the prompt is cheap enough that we don't need it
 # for the LME-S benches motivating this PR.
 
-_CACHE: dict[str, tuple[list[ExtractedEntity], list[ExtractedRelation]]] = {}
+# Cap the cache to bound memory in long-lived service processes.
+# OrderedDict.popitem(last=False) drops the oldest entry on overflow,
+# giving FIFO eviction with O(1) lookup. Bench runs touch O(few-thousand)
+# unique chunks; production traffic hits this much harder so the cap
+# matters there.
+from collections import OrderedDict
+
+_CACHE_MAX_SIZE = int(__import__("os").environ.get("ATTESTOR_ENTITY_CACHE_MAX", "2048"))
+_CACHE: OrderedDict[str, tuple[list[ExtractedEntity], list[ExtractedRelation]]] = OrderedDict()
 
 
 def _content_hash(content: str) -> str:
     return hashlib.sha256(content.strip().encode()).hexdigest()
+
+
+def _cache_put(key: str, value: tuple[list[ExtractedEntity], list[ExtractedRelation]]) -> None:
+    """Insert into the LRU-ish cache with FIFO eviction at the cap."""
+    _CACHE[key] = value
+    while len(_CACHE) > _CACHE_MAX_SIZE:
+        _CACHE.popitem(last=False)
 
 
 def _reset_cache() -> None:
@@ -412,7 +427,7 @@ def extract_with_llm(
     # Cache the result (even when empty — repeated calls on the same
     # content shouldn't keep retrying a model that produced empty
     # output for legitimate reasons).
-    _CACHE[chash] = (entities, relations)
+    _cache_put(chash, (entities, relations))
     return entities, relations
 
 

--- a/attestor/longmemeval_consistency.py
+++ b/attestor/longmemeval_consistency.py
@@ -66,7 +66,7 @@ class ConsistencyResult:
     in which case ``voter`` is reported as ``"majority"``.
     """
 
-    samples: list[str]                       # all K raw answers (post-strip)
+    samples: tuple[str, ...]                 # all K raw answers (post-strip)
     chosen: str                              # the elected final answer
     voter: str                               # "majority" | "judge_pick"
     vote_breakdown: dict[str, int] = field(default_factory=dict)
@@ -290,7 +290,7 @@ def answer_with_self_consistency(
         )
 
     if k <= 0:
-        return ConsistencyResult(samples=[], chosen="", voter=voter, vote_breakdown={})
+        return ConsistencyResult(samples=(), chosen="", voter=voter, vote_breakdown={})
 
     samples: list[str] = []
     for i in range(k):
@@ -315,7 +315,7 @@ def answer_with_self_consistency(
     )
 
     if not samples:
-        return ConsistencyResult(samples=[], chosen="", voter=voter, vote_breakdown={})
+        return ConsistencyResult(samples=(), chosen="", voter=voter, vote_breakdown={})
 
     if voter == "judge_pick" and judge_model:
         try:
@@ -331,7 +331,7 @@ def answer_with_self_consistency(
                 voter="judge_pick", chosen=chosen, breakdown=breakdown,
             )
             return ConsistencyResult(
-                samples=samples, chosen=chosen,
+                samples=tuple(samples), chosen=chosen,
                 voter="judge_pick", vote_breakdown=breakdown,
             )
         except Exception as exc:  # noqa: BLE001 — fall back to majority
@@ -344,7 +344,7 @@ def answer_with_self_consistency(
         voter="majority", chosen=chosen, breakdown=breakdown,
     )
     return ConsistencyResult(
-        samples=samples, chosen=chosen,
+        samples=tuple(samples), chosen=chosen,
         voter="majority", vote_breakdown=breakdown,
     )
 
@@ -463,7 +463,7 @@ async def answer_with_self_consistency_async(
         )
 
     if k <= 0:
-        return ConsistencyResult(samples=[], chosen="", voter=voter, vote_breakdown={})
+        return ConsistencyResult(samples=(), chosen="", voter=voter, vote_breakdown={})
 
     # K samples in parallel, BUT bounded by ``concurrency``. Unbounded
     # K-fanout (e.g. K=20) would spike provider rate limits and cause
@@ -498,7 +498,7 @@ async def answer_with_self_consistency_async(
     )
 
     if not samples:
-        return ConsistencyResult(samples=[], chosen="", voter=voter, vote_breakdown={})
+        return ConsistencyResult(samples=(), chosen="", voter=voter, vote_breakdown={})
 
     if voter == "judge_pick" and judge_model:
         try:
@@ -518,7 +518,7 @@ async def answer_with_self_consistency_async(
                 voter="judge_pick", chosen=chosen, breakdown=breakdown,
             )
             return ConsistencyResult(
-                samples=samples, chosen=chosen,
+                samples=tuple(samples), chosen=chosen,
                 voter="judge_pick", vote_breakdown=breakdown,
             )
         except Exception as exc:  # noqa: BLE001
@@ -531,6 +531,6 @@ async def answer_with_self_consistency_async(
         voter="majority", chosen=chosen, breakdown=breakdown,
     )
     return ConsistencyResult(
-        samples=samples, chosen=chosen,
+        samples=tuple(samples), chosen=chosen,
         voter="majority", vote_breakdown=breakdown,
     )

--- a/attestor/mab/__init__.py
+++ b/attestor/mab/__init__.py
@@ -84,14 +84,4 @@ __all__ = [
     "print_mab",
     # Embedding upgrade helper
     "_upgrade_embeddings_for_benchmark",
-    # Internal helpers (kept public for tests + downstream callers)
-    "_EXACT_MATCH_SOURCES",
-    "_extract_answer",
-    "_flatten_answers",
-    "_get_budget_for_source",
-    "_is_exact_source",
-    "_extract_entities_from_context",
-    "_merge_splits",
-    "_merge_splits_overlap",
-    "_rerank_results",
 ]

--- a/attestor/mode.py
+++ b/attestor/mode.py
@@ -53,8 +53,13 @@ def detect_mode(env: dict | None = None) -> AttestorMode:
             return AttestorMode(explicit.lower())
         except ValueError:
             # Invalid override — fall through to SOLO rather than crash.
-            # An invalid env var shouldn't take down a fresh install.
-            pass
+            # An invalid env var shouldn't take down a fresh install,
+            # but the operator should see that their explicit setting
+            # was ignored.
+            import logging
+            logging.getLogger(__name__).warning(
+                "Invalid ATTESTOR_MODE=%r; falling back to SOLO", explicit,
+            )
 
     if src.get("ATTESTOR_AUTH_PROVIDER"):
         return AttestorMode.HOSTED

--- a/attestor/store/connection.py
+++ b/attestor/store/connection.py
@@ -383,7 +383,10 @@ class CloudConnection:
     mode: str = "cloud"
     url: str = "postgresql://localhost:5432"
     database: str = "attestor"
-    port: int = 8529
+    # Default to the Postgres port — was 8529 (ArangoDB), removed
+    # 2026-05-02. Pinecone has no port and Neo4j is 7687, neither of
+    # which makes sense as a generic CloudConnection default.
+    port: int = 5432
     auth: AuthConfig = field(default_factory=AuthConfig)
     tls: TLSConfig = field(default_factory=TLSConfig)
     extra: dict[str, Any] = field(default_factory=dict)

--- a/attestor/store/embeddings.py
+++ b/attestor/store/embeddings.py
@@ -331,8 +331,9 @@ def _try_voyage() -> EmbeddingProvider | None:
 def _try_pinecone_inference() -> EmbeddingProvider | None:
     """Try Pinecone Inference (cloud-only — Local Docker doesn't serve it).
 
-    Activated by ATTESTOR_PREFER_EMBEDDER=pinecone OR by configure_embedder
-    setting PINECONE_EMBEDDING_MODEL when stack.embedder.provider="pinecone".
+    Activated when ``stack.embedder.provider == "pinecone"`` in
+    ``configs/attestor.yaml``. The earlier ``ATTESTOR_PREFER_EMBEDDER``
+    env var was removed 2026-05-01 — YAML is the only switch.
     Configurable via:
         PINECONE_API_KEY                   required (cloud key from app.pinecone.io)
         PINECONE_EMBEDDING_MODEL           default ``llama-text-embed-v2``

--- a/attestor/store/pinecone_backend.py
+++ b/attestor/store/pinecone_backend.py
@@ -358,7 +358,6 @@ class PineconeBackend:
     def close(self) -> None:
         """Pinecone SDK has no explicit close — connection is
         implicit per-request. Provided for Protocol compliance."""
-        return None
 
     # ── helpers for hermetic test runs ────────────────────────────
 

--- a/attestor/ui/routes.py
+++ b/attestor/ui/routes.py
@@ -302,7 +302,11 @@ def build_routes(templates: Jinja2Templates) -> list[Route]:
             return JSONResponse({"error": "query is required"}, status_code=400)
 
         namespace = body.get("namespace") or None
-        budget = int(body.get("budget", 2000))
+        # Cap on token budget — an unbounded value can request the
+        # retrieval pipeline to pack arbitrarily many memories,
+        # exhausting RAM and Postgres connection time. 100k tokens is
+        # well past the largest legitimate long-context budget.
+        budget = min(int(body.get("budget", 2000)), 100_000)
 
         retrieval = getattr(mem, "_retrieval", None)
         if retrieval is None:
@@ -332,6 +336,22 @@ def build_routes(templates: Jinja2Templates) -> list[Route]:
         date_from = request.query_params.get("from") or None
         date_to = request.query_params.get("to") or None
         as_of = request.query_params.get("as_of") or None
+
+        # Reject malformed dates up-front. The legacy lexicographic
+        # string compares (`created[:10] < date_from`) silently produced
+        # wrong results when a caller passed e.g. "not-a-date" instead
+        # of erroring at the boundary.
+        from datetime import date as _date
+        for label, val in (("from", date_from), ("to", date_to), ("as_of", as_of)):
+            if val is None:
+                continue
+            try:
+                _date.fromisoformat(val[:10])
+            except ValueError:
+                return JSONResponse(
+                    {"error": f"invalid date for '{label}': {val!r}"},
+                    status_code=400,
+                )
 
         try:
             search_status = status if status and status != "all" else None

--- a/tests/async_retrieval/test_self_consistency_async.py
+++ b/tests/async_retrieval/test_self_consistency_async.py
@@ -195,7 +195,7 @@ async def test_self_consistency_async_handles_all_failures():
         k=5, temperature=0.7,
     )
 
-    assert result.samples == []
+    assert result.samples == ()
     assert result.chosen == ""
 
 
@@ -213,6 +213,6 @@ async def test_self_consistency_async_k_zero_returns_empty():
         k=0, temperature=0.7,
     )
 
-    assert result.samples == []
+    assert result.samples == ()
     assert result.chosen == ""
     client.chat.completions.create.assert_not_called()

--- a/tests/test_self_consistency.py
+++ b/tests/test_self_consistency.py
@@ -163,7 +163,7 @@ def test_k_zero_returns_empty_string() -> None:
         temperature=0.7,
     )
     assert result.chosen == ""
-    assert result.samples == []
+    assert result.samples == ()
     # No LLM calls should fire when k=0.
     client.chat.completions.create.assert_not_called()
 
@@ -317,7 +317,7 @@ def test_judge_pick_invalid_index_falls_back_to_majority() -> None:
 def test_consistency_result_is_frozen_dataclass() -> None:
     """ConsistencyResult is immutable per coding-style.md."""
     result = ConsistencyResult(
-        samples=["a", "b"], chosen="a", voter="majority", vote_breakdown={"a": 2},
+        samples=("a", "b"), chosen="a", voter="majority", vote_breakdown={"a": 2},
     )
     with pytest.raises((AttributeError, Exception)):  # frozen dataclass error
         result.chosen = "x"  # type: ignore[misc]


### PR DESCRIPTION
## Summary

Follow-up to PR #158 (CRITICAL + HIGH). Addresses 14 of 56 MEDIUM-tier findings — the highest-value subset across stale references, type discipline, bounds, and CLI exit codes.

- 14 files modified, 2 test files updated
- **+100 / -46** LOC
- **1,480 tests passing, 0 regressions**

## Changes

### Stale comments / dead refs
- `CloudConnection.port`: `8529` (ArangoDB, removed) → `5432` (Postgres).
- `embeddings._try_pinecone_inference`: drop `ATTESTOR_PREFER_EMBEDDER` reference (env var was removed 2026-05-01).
- `pinecone_backend.close`: drop explicit `return None`.
- `mab/__init__.__all__`: drop 9 leading-underscore implementation symbols (tests still import them by name; only star-import surface is narrowed).
- `bench_config.print_bench_banner`: `print()` → `logger.info()`.
- `config.loader`: pgvector-fallback comment updated to current reality.

### Type / idiom polish + bounds
- `ConsistencyResult.samples`: `list[str]` → `tuple[str, ...]` for true immutability.
- `llm_entity_extractor._CACHE`: `dict` → `OrderedDict` with FIFO cap via `ATTESTOR_ENTITY_CACHE_MAX` (default 2048). Closes a slow memory leak in long-lived service processes.
- `ui.routes.recall_json`: clamp `body["budget"]` to 100k tokens.
- `ui.routes.timeline_json`: 400 on malformed `from`/`to`/`as_of` instead of silent wrong-results from lexicographic string compares.

### CLI exit codes + UX
- `cli.main.main()`: no subcommand → print help + `sys.exit(1)` (was silent `return 0`).
- `mode.detect_mode`: log WARNING when `ATTESTOR_MODE` is invalid.
- `doctor_v4.run_v4_doctor`: log WARNING when any check returns `skip`.

## Test plan

- [x] `pytest tests/ -q` — 1,480 passed, 165 skipped, 0 failed
- [ ] Verify `attestor` (no subcommand) now exits with code 1
- [ ] Verify `ATTESTOR_MODE=invalid attestor doctor` logs the warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)