### PR TITLE
chore: LOW nits + observability facade (follow-up to #160)

### DIFF
--- a/attestor/cli/commands/memory.py
+++ b/attestor/cli/commands/memory.py
@@ -189,13 +189,19 @@ def _cmd_stats(args: argparse.Namespace) -> None:
                 print(f"  {cat}: {count}")
 
 
+# Effective "no limit" for `attestor export` to stdout. The store
+# isn't expected to grow past low-millions, so 1M is a safe ceiling
+# that matches "fetch everything" without a true unbounded scan.
+_EXPORT_ALL_LIMIT = 1_000_000
+
+
 def _cmd_export(args: argparse.Namespace) -> None:
     with AgentMemory(args.path) as mem:
         if args.output:
             mem.export_json(args.output)
             print(f"Exported to {args.output}")
         else:
-            memories = mem.search(limit=1_000_000)
+            memories = mem.search(limit=_EXPORT_ALL_LIMIT)
             print(json.dumps([m.to_dict() for m in memories], indent=2))
 
 

--- a/attestor/cli/commands/server.py
+++ b/attestor/cli/commands/server.py
@@ -98,7 +98,8 @@ def _cmd_ui(args: argparse.Namespace) -> None:
     print(f"→ http://{args.host}:{args.port}/ui/memories", file=sys.stderr)
 
     if args.open:
-        import webbrowser, threading
+        import threading
+        import webbrowser
         url = f"http://{args.host}:{args.port}/ui/memories"
         threading.Timer(1.0, lambda: webbrowser.open(url)).start()
 

--- a/attestor/compliance/pii.py
+++ b/attestor/compliance/pii.py
@@ -34,7 +34,7 @@ from __future__ import annotations
 import logging
 import re
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any
 
 logger = logging.getLogger("attestor.compliance.pii")

--- a/attestor/locomo/runner.py
+++ b/attestor/locomo/runner.py
@@ -85,6 +85,8 @@ CATEGORY_NAMES = {
 
 def _guess_entity_type(name: str) -> str:
     """Guess entity type from name for graph storage."""
+    if not name:
+        return "concept"
     name_lower = name.lower()
 
     location_words = {"city", "country", "town", "state", "island", "lake",
@@ -97,7 +99,7 @@ def _guess_entity_type(name: str) -> str:
     if any(w in name_lower for w in org_words):
         return "organization"
 
-    if name and name[0].isupper():
+    if name[0].isupper():
         return "entity"
 
     return "concept"
@@ -127,7 +129,7 @@ def download_locomo(dest_path: str) -> str:
 
 def load_locomo(file_path: str) -> list[dict[str, Any]]:
     """Load and parse the LOCOMO dataset."""
-    with open(file_path) as f:
+    with open(file_path, encoding="utf-8") as f:
         data = json.load(f)
 
     conversations = []

--- a/attestor/longmemeval/runner.py
+++ b/attestor/longmemeval/runner.py
@@ -17,6 +17,7 @@ import itertools
 import json
 import logging
 import sys
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -449,8 +450,6 @@ def answer_question(
         ``AnswerResult`` with final answer + retrieval counts + latency +
         optional reasoning trace + verification flag.
     """
-    import time
-
     ns = namespace_for(sample)
     t0 = time.monotonic()
     results = mem.recall(sample.question, budget=budget, namespace=ns) or []

--- a/attestor/mab/retrieval.py
+++ b/attestor/mab/retrieval.py
@@ -408,8 +408,12 @@ def answer_question(
     prompt_template = MAB_EXACT_PROMPT if use_exact else MAB_ANSWER_PROMPT
     prompt = prompt_template.format(context=context, question=question)
 
-    # Retry with exponential backoff on rate limits
+    # Retry with exponential backoff on rate limits.
+    # Total wall-clock cap = 2+4+8+16+32 = 62s. Caller waits at most
+    # ~62s + the final 33rd-second attempt before we give up.
     import time as _time
+    _MAX_RETRY_WALL_S = 62.0
+    _retry_started = _time.monotonic()
     for attempt in range(5):
         try:
             response = traced_create(
@@ -422,6 +426,8 @@ def answer_question(
             break
         except Exception as e:
             if "rate" in str(e).lower() or "429" in str(e):
+                if (_time.monotonic() - _retry_started) >= _MAX_RETRY_WALL_S:
+                    raise
                 wait = 2 ** attempt
                 _time.sleep(wait)
             else:

--- a/attestor/observability/__init__.py
+++ b/attestor/observability/__init__.py
@@ -1,0 +1,65 @@
+"""Unified observability facade — recall trace + OTel + LLM cost trace.
+
+Three modules previously formed the observability surface:
+
+  - ``attestor.trace``      JSONL recall-trace events + nested scopes
+  - ``attestor.otel``       OpenTelemetry spans (request-scoped)
+  - ``attestor.llm_trace``  Per-LLM-call cost + latency capture
+
+They each have distinct responsibilities, but callers regularly need a
+mix of all three (e.g. "open a recall scope, emit an OTel span event,
+log the embedded LLM call"). The previous setup forced every call site
+to import three separate modules. This facade re-exports the canonical
+names from one place; the underlying modules stay where they are so
+existing imports keep working.
+
+Use ``from attestor.observability import event, recall_scope, ...`` in
+new code; the older ``from attestor import trace as _tr; _tr.event(...)``
+form remains supported.
+"""
+
+from __future__ import annotations
+
+# Recall-trace JSONL surface.
+from attestor.trace import (
+    event,
+    event_scope,
+    is_enabled,
+    recall_scope,
+    reset_for_test,
+)
+
+# OpenTelemetry-mirror surface.
+from attestor import otel as _otel
+otel_add_event = _otel.add_event
+otel_current_span_id = _otel.current_span_id
+otel_is_enabled = _otel.is_enabled
+otel_start_span = _otel.start_span
+
+# LLM cost / latency surface.
+from attestor.config import chat_kwargs_for_role
+from attestor.llm_trace import (
+    emit_chat_trace,
+    get_client_for_model,
+    make_async_client,
+    make_client,
+    traced_create,
+)
+
+__all__ = [
+    "chat_kwargs_for_role",
+    "emit_chat_trace",
+    "event",
+    "event_scope",
+    "get_client_for_model",
+    "is_enabled",
+    "make_async_client",
+    "make_client",
+    "otel_add_event",
+    "otel_current_span_id",
+    "otel_is_enabled",
+    "otel_start_span",
+    "recall_scope",
+    "reset_for_test",
+    "traced_create",
+]

--- a/attestor/quotas.py
+++ b/attestor/quotas.py
@@ -24,9 +24,16 @@ import logging
 from dataclasses import dataclass
 from typing import Any
 
-import psycopg2.extras
-
 logger = logging.getLogger("attestor.quotas")
+
+
+def _psycopg2_extras() -> Any:
+    """Lazy import: psycopg2 is optional (Postgres-only). Importing
+    at module level breaks ``from attestor.quotas import QuotaExceeded``
+    in environments where psycopg2 isn't installed (docs build, tests
+    that don't need the DB layer)."""
+    import psycopg2.extras
+    return psycopg2.extras
 
 
 class QuotaExceeded(Exception):
@@ -90,7 +97,7 @@ class QuotaRepo:
 
     def get(self, user_id: str) -> UserQuota | None:
         with self._conn.cursor(
-            cursor_factory=psycopg2.extras.RealDictCursor,
+            cursor_factory=_psycopg2_extras().RealDictCursor,
         ) as cur:
             cur.execute(
                 "SELECT * FROM user_quotas WHERE user_id = %s", (user_id,),
@@ -109,7 +116,7 @@ class QuotaRepo:
     ) -> UserQuota:
         """Update one or more limits. Counters are NOT touched."""
         with self._conn.cursor(
-            cursor_factory=psycopg2.extras.RealDictCursor,
+            cursor_factory=_psycopg2_extras().RealDictCursor,
         ) as cur:
             cur.execute(
                 """

--- a/attestor/retrieval/global_query.py
+++ b/attestor/retrieval/global_query.py
@@ -365,7 +365,18 @@ def run_global_query(
     caller can fall through to the local pipeline if it wants to.
     """
     t0 = time.monotonic()
-    model = llm_model or "anthropic/claude-haiku-4.5"
+    # Resolve from YAML when caller didn't override. The hardcoded
+    # fallback contradicts the canonical-stack invariant ("YAML is the
+    # only lever") but is retained as a last-resort default so the
+    # module still imports cleanly in test envs without YAML.
+    if llm_model is None:
+        try:
+            from attestor.config import get_stack
+            model = get_stack().models.planner
+        except Exception:  # noqa: BLE001
+            model = "anthropic/claude-haiku-4.5"
+    else:
+        model = llm_model
     summary_fn: _Summarizer = summarizer or _default_summarizer
 
     def _result(

--- a/attestor/ui/routes.py
+++ b/attestor/ui/routes.py
@@ -445,7 +445,8 @@ def build_routes(templates: Jinja2Templates) -> list[Route]:
             ns = d.get("namespace") or "default"
             ns_data.setdefault(ns, []).append(d)
 
-        today = datetime.utcnow().date()
+        from datetime import timezone as _tz
+        today = datetime.now(tz=_tz.utc).date()
         namespaces = []
         for ns_name, mems in sorted(ns_data.items()):
             mems.sort(key=lambda m: m.get("created_at") or "", reverse=True)


### PR DESCRIPTION
## Summary

Fourth PR in the FAANG-review series. Closes meaningful LOW-tier findings + adds the observability facade for the 3-tracing-modules deferred item.

- 10 files modified (1 new: `attestor/observability/`)
- **+112 / -14** LOC
- **1,480 tests passing, 0 regressions**

## Cumulative review impact (4 PRs)

| PR | Tier | Findings | Status |
|---|---|---|---|
| #158 | CRITICAL + HIGH | 23 + 47 | merged `98b45c2` |
| #159 | MEDIUM batch 1 | 14 | merged `13a0247` |
| #160 | MEDIUM rest | 25 | merged `36fe42a` |
| **this** | LOW + facade | 10 nits + 1 deferred | pending |
| **Total** | — | **120 findings** | — |

## Changes

### LOW nits
- `mab.retrieval.answer_question`: explicit 62s wall-clock cap on retry loop.
- `ui.routes.agents_json`: `datetime.utcnow` → `datetime.now(tz=UTC)` (3.12 deprecation).
- `locomo.runner.load_locomo`: `open(..., encoding="utf-8")`.
- `locomo.runner._guess_entity_type`: empty-string guard.
- `compliance.pii`: drop unused `dataclasses.field` import.
- `cli.commands.server`: PEP8 one-import-per-line for `webbrowser`+`threading`.
- `cli.commands.memory`: name the `1_000_000` export limit (`_EXPORT_ALL_LIMIT`).
- `longmemeval.runner`: hoist `import time` to module level.
- `quotas`: lazy `psycopg2.extras` import (module imports in psycopg2-less envs).
- `retrieval.global_query`: resolve model from `get_stack().models.planner` instead of hardcoded literal.

### Observability facade (deferred item from #158)
- New `attestor.observability` package re-exports:
  - Recall-trace JSONL: `event`, `event_scope`, `is_enabled`, `recall_scope`, `reset_for_test`
  - OpenTelemetry mirror: `otel_*` namespaced helpers
  - LLM cost surface: `traced_create`, `make_client`, `get_client_for_model`, `chat_kwargs_for_role`, etc.
- Underlying modules (`trace.py` / `otel.py` / `llm_trace.py`) unchanged — existing imports keep working. No breaking change.
- New code uses one import line; old code untouched.

## Skipped intentionally

- 50+ pure-cosmetic LOW nits (variable rename, comment-only)
- 4 deferred refactors still pending design call:
  - `agent_memory.py` 1902-line split
  - `agents_json` / `memory_detail` DB-side aggregation
  - Async HyDE under `recall_async`
  - `audit/routes.py` per-endpoint auth

## Test plan

- [x] `pytest tests/ -q` — 1,480 passed, 165 skipped, 0 failed
- [x] Smoke: `python -c "from attestor.observability import event, recall_scope, traced_create"` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)