### PR TITLE
fix: KU smoke 66.7% → 100% — MMR cap + LME runner YAML config

### DIFF
--- a/attestor/retrieval/orchestrator/postprocess.py
+++ b/attestor/retrieval/orchestrator/postprocess.py
@@ -362,7 +362,22 @@ class _OrchestratorPostProcessMixin:
         # survive). MMR + long-context are mutually exclusive by design.
         if self.enable_mmr and not long_context:
             _pre_mmr_count = len(results)
-            results = mmr_rerank(results, lambda_param=self.mmr_lambda)
+            # Pass max_results to MMR so the diversity loop keeps enough
+            # candidates for the downstream budget packer. Pre-fix MMR
+            # used its hardcoded default of 10, silently dropping every
+            # candidate past rank 10 — including answer-bearing turns
+            # in the same session as the top hit (knowledge-update
+            # questions reliably hit this: 3+ turns about the same
+            # topic in one session, MMR de-dupes them as redundant and
+            # the answer ends up dropped). vector_top_k is the right
+            # ceiling — MMR already orders by score, the budget packer
+            # will trim further.
+            mmr_max = self.mmr_top_n if self.mmr_top_n is not None else self.vector_top_k
+            results = mmr_rerank(
+                results,
+                lambda_param=self.mmr_lambda,
+                max_results=mmr_max,
+            )
             if self.mmr_top_n is not None and len(results) > self.mmr_top_n:
                 results = results[: self.mmr_top_n]
             if _tr.is_enabled():

--- a/evals/longmemeval/runner.py
+++ b/evals/longmemeval/runner.py
@@ -183,6 +183,40 @@ def run(
 # ── CLI ───────────────────────────────────────────────────────────────────
 
 
+def _build_mem_factory(*, warm_schema: bool = True) -> Callable[[], Any]:
+    """Build a zero-arg factory that returns ``AgentMemory`` instances
+    wired with the canonical YAML stack (PG + Pinecone + Neo4j).
+
+    Pre-fix: the factory called ``AgentMemory(tempfile.mkdtemp(...))``
+    with no config kwarg, so AgentMemory fell through to a passwordless
+    Postgres default and the smoke run died with
+    ``fe_sendauth: no password supplied``. The bug was a silent skip of
+    ``configs/attestor.yaml`` for the ``python -m evals.longmemeval``
+    entry point. ``evals/braintrust_longmemeval.py`` was already correct.
+
+    ``warm_schema=True`` runs one schema-init pass with a throw-away
+    AgentMemory before parallel workers spin up, so they don't race on
+    CREATE TABLE catalog locks. Tests pass ``warm_schema=False`` to
+    avoid the live DB call.
+    """
+    import tempfile
+    from attestor.config import build_backend_config, get_stack
+    from attestor.core import AgentMemory
+
+    backend_config = build_backend_config(get_stack())
+    if warm_schema:
+        backend_config["backend_configs"]["postgres"]["skip_schema_init"] = False
+        AgentMemory(tempfile.mkdtemp(prefix="lme_warmup_"), config=backend_config)
+    backend_config["backend_configs"]["postgres"]["skip_schema_init"] = True
+
+    def _factory() -> AgentMemory:
+        return AgentMemory(
+            tempfile.mkdtemp(prefix="lme_"), config=backend_config,
+        )
+
+    return _factory
+
+
 def main(argv: Optional[list[str]] = None) -> int:
     """`python -m evals.longmemeval` entry point.
 
@@ -208,14 +242,7 @@ def main(argv: Optional[list[str]] = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    # The mem_factory builder is intentionally split out — operators wire
-    # their own (Postgres URL, Neo4j URL, embedding model). Default uses
-    # the SOLO config from the user's environment.
-    from attestor.core import AgentMemory
-    import tempfile
-
-    def _factory() -> AgentMemory:
-        return AgentMemory(tempfile.mkdtemp(prefix="lme_"))
+    _factory = _build_mem_factory()
 
     summary = run(
         mem_factory=_factory,

--- a/tests/test_ruflo_features.py
+++ b/tests/test_ruflo_features.py
@@ -298,3 +298,39 @@ class TestRetrievalConfig:
         assert cfg.confidence_gate == 0.0
         assert cfg.confidence_decay_rate == 0.001
         assert cfg.confidence_boost_rate == 0.03
+
+
+# ── Regression: MMR cap must respect the orchestrator's vector_top_k ──
+# Pre-fix the orchestrator called ``mmr_rerank(results, lambda_param=...)``
+# with no ``max_results`` kwarg, so MMR fell back to its hardcoded default
+# of 10. Knowledge-update LME questions reliably tripped this: 3+ turns
+# from the same session would all match the query, MMR demoted them as
+# redundant, and the answer-bearing turn (rank 11+) got dropped.
+class TestMmrRespectsOrchestratorCap:
+    """Verify mmr_rerank surfaces enough candidates when called with a
+    higher ``max_results`` cap from the orchestrator's vector_top_k."""
+
+    def _mk(self, idx: int, score: float) -> "RetrievalResult":
+        from attestor.models import Memory, RetrievalResult
+        return RetrievalResult(
+            memory=Memory(id=str(idx), content=f"distinct content number {idx}"),
+            score=score,
+            match_source="vector",
+        )
+
+    def test_default_caps_at_10(self) -> None:
+        """Default behaviour — no max_results — caps at 10."""
+        from attestor.retrieval.scorer import mmr_rerank
+        results = [self._mk(i, 1.0 - i * 0.01) for i in range(30)]
+        out = mmr_rerank(results)
+        assert len(out) == 10, "default cap regression"
+
+    def test_custom_max_results_keeps_more(self) -> None:
+        """Passing max_results=30 must surface up to 30 candidates."""
+        from attestor.retrieval.scorer import mmr_rerank
+        results = [self._mk(i, 1.0 - i * 0.01) for i in range(30)]
+        out = mmr_rerank(results, max_results=30)
+        assert len(out) == 30, (
+            "the LME knowledge-update fix relies on this — bumping "
+            "max_results must let downstream candidates survive MMR"
+        )


### PR DESCRIPTION
## Summary

Two bugs that together blocked the LME knowledge-update smoke. Verified end-to-end on local: **3-sample KU smoke went from 66.7% → 100%**, 100% inter-judge agreement (gpt-5.5 + claude-sonnet-4-6).

## Bug 1 — MMR drops answer-bearing turns from the same session

**File:** `attestor/retrieval/orchestrator/postprocess.py:365`

\`\`\`python
# Before
results = mmr_rerank(results, lambda_param=self.mmr_lambda)
# → MMR's hardcoded default ``max_results=10`` silently dropped
#   every candidate past rank 10. The downstream ``mmr_top_n`` trim
#   could only reduce, never expand.

# After
mmr_max = self.mmr_top_n if self.mmr_top_n is not None else self.vector_top_k
results = mmr_rerank(results, lambda_param=self.mmr_lambda, max_results=mmr_max)
\`\`\`

**Why it bites knowledge-update specifically:** these questions have an updated value mentioned in a session that contains 3+ turns about the same topic (user asks → follow-up → assistant response repeating the value). Vector retrieval scored them all similarly; MMR's diversity penalty marked them as redundant and demoted the answer-bearing turn past rank 10.

**Reproducer:** sample `6a1eabeb` ("What was my personal best time in the charity 5K run?"). Top-1 hit was the right session but the wrong turn (no "25:50"). The two turns containing "25:50" were at ranks 25+ and got dropped. Answerer abstained.

## Bug 2 — LME runner skipped `configs/attestor.yaml`

**File:** `evals/longmemeval/runner.py:217`

\`\`\`python
# Before
def _factory() -> AgentMemory:
    return AgentMemory(tempfile.mkdtemp(prefix="lme_"))
# → AgentMemory falls through to a passwordless Postgres default
#   → fe_sendauth: no password supplied

# After
_factory = _build_mem_factory()  # loads YAML, warms schema, parallel-safe
\`\`\`

`evals/braintrust_longmemeval.py` was already correct; the bare `python -m evals.longmemeval` entry was the only callsite silently skipping YAML. Extracted `_build_mem_factory()` so future entries share the pattern.

## Tests added

`tests/test_ruflo_features.py::TestMmrRespectsOrchestratorCap`
- **default_caps_at_10** — locks the legacy `mmr_rerank()` default (so callers that omit `max_results` still get the historic shape)
- **custom_max_results_keeps_more** — locks the new contract; bumping the cap surfaces more candidates

## Verification

| Check | Before | After |
|---|---|---|
| KU 3-sample accuracy (gpt-5.5 judge) | 66.7% | **100%** |
| KU 3-sample accuracy (claude-sonnet-4-6 judge) | 66.7% | **100%** |
| Inter-judge agreement | 100% | 100% |
| Sample `6a1eabeb` answer | "I don't know." | **"25:50"** ✅ |
| Unit tests (`pytest tests/`) | 1,480 | **1,482** (added 2) |

## Test plan

- [x] `pytest tests/ -q` — 1,482 passed, 165 skipped, 0 failed
- [x] End-to-end KU smoke at 3 samples — 100%
- [ ] User to verify on a larger cohort if desired (next memory-tier checkpoint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)