### PR TITLE
fix(lme): _strip_reasoning kept only first line — broke list answers

### DIFF
--- a/attestor/longmemeval/fixtures.py
+++ b/attestor/longmemeval/fixtures.py
@@ -751,11 +751,23 @@ def _extract_retrieved_session_ids(results: list) -> tuple[str, ...]:
     return tuple(out)
 
 
+_LIST_LEAD_RE = __import__("re").compile(
+    r"^\s*(?:\d+[\.\)]|[-*•]|first[,:]?|then|finally|lastly)",
+    __import__("re").IGNORECASE,
+)
+
+
 def _strip_reasoning(raw: str) -> tuple[str, str]:
     """Split an answerer response into (reasoning, final_answer).
 
     Supports the <reasoning>...</reasoning> then final-answer contract.
     If no tags are present, treats the whole string as the final answer.
+
+    Multi-line list answers (numbered, bulleted, or "First, … Then, …
+    Lastly, …" prose) are preserved in full — pre-fix the heuristic
+    truncated to the first non-empty line, dropping every list item
+    after item 1 and silently breaking the LIST COMPLETENESS contract
+    (RC6) for ordering questions.
     """
     if not raw:
         return "", ""
@@ -764,10 +776,22 @@ def _strip_reasoning(raw: str) -> tuple[str, str]:
         return "", raw.strip()
     reasoning = m.group(1).strip()
     after = raw[m.end():].strip()
-    # Some models wrap the final answer in ticks / extra prose — take the
-    # first non-empty line after the reasoning block.
-    for line in after.splitlines():
-        line = line.strip().strip("`").strip()
-        if line:
-            return reasoning, line
-    return reasoning, after
+    if not after:
+        return reasoning, ""
+
+    # Pull the first non-empty line — used to detect list-shaped output.
+    first_nonempty = next(
+        (ln for ln in after.splitlines() if ln.strip()),
+        "",
+    )
+
+    # If the answer starts a list (numbered, bulleted, or ordering
+    # adverb like "First,") return everything — let the judge see all
+    # the items.
+    if _LIST_LEAD_RE.match(first_nonempty):
+        return reasoning, after
+
+    # Single-line answer: strip surrounding backticks/whitespace, drop
+    # trailing prose ("extra elaboration") that some models append.
+    line = first_nonempty.strip().strip("`").strip()
+    return reasoning, line or after

--- a/tests/test_longmemeval.py
+++ b/tests/test_longmemeval.py
@@ -554,6 +554,41 @@ def test_strip_reasoning_multiline_reasoning() -> None:
     assert final == "final"
 
 
+# ── Regression: numbered/bulleted/ordering answers must NOT be truncated ──
+# Pre-fix the heuristic took only the first non-empty line, dropping every
+# list item past item 1 and breaking the LIST COMPLETENESS contract.
+
+@pytest.mark.unit
+def test_strip_reasoning_preserves_numbered_list() -> None:
+    raw = (
+        "<reasoning>three events ordered</reasoning>\n"
+        "1. Helped friend prepare nursery — Feb 5\n"
+        "2. Helped cousin baby shower — Feb 12\n"
+        "3. Ordered phone case — Feb 18"
+    )
+    reasoning, final = _strip_reasoning(raw)
+    assert reasoning == "three events ordered"
+    assert "1." in final and "2." in final and "3." in final
+
+
+@pytest.mark.unit
+def test_strip_reasoning_preserves_first_then_lastly_prose() -> None:
+    raw = (
+        "<reasoning>r</reasoning>\n"
+        "First, A. Then, B. Lastly, C."
+    )
+    reasoning, final = _strip_reasoning(raw)
+    assert reasoning == "r"
+    assert "Lastly, C" in final
+
+
+@pytest.mark.unit
+def test_strip_reasoning_preserves_bullets() -> None:
+    raw = "<reasoning>r</reasoning>\n- one\n- two\n- three"
+    _, final = _strip_reasoning(raw)
+    assert final.count("- ") == 3
+
+
 @pytest.mark.unit
 def test_answer_prompt_includes_arithmetic_guidance() -> None:
     # Guard against a future edit that silently removes the CoT / date-math section.


### PR DESCRIPTION
Root cause for the temporal smoke single failure (gpt4_f49edff3 ordering Q). Answerer produced all 3 items; parser truncated to line 1. Detect list-shaped output (numbered / bulleted / 'First,Then,Lastly' prose) and preserve full block; backward-compat single-line trim retained. +3 regression tests, 1,485 total passing.