### PR TITLE
chore(yaml): swap gpt-5.5 → gpt-5.4 across all roles

### DIFF
--- a/configs/attestor.yaml
+++ b/configs/attestor.yaml
@@ -75,7 +75,7 @@ stack:
   # Where chat-completion calls land. Multi-provider mode: route by
   # model prefix (split on the first `/`).
   #
-  #   model: openai/gpt-5.5                → openai provider (direct)
+  #   model: openai/gpt-5.4                → openai provider (direct)
   #   model: openrouter/anthropic/claude-… → openrouter provider
   #                                          (suffix becomes the OR model id)
   #   model: anthropic/claude-sonnet-4-6   → anthropic provider (org proxy)
@@ -124,15 +124,15 @@ stack:
   # ─── Models (per-role assignment) ────────────────────────────────────
   models:
     # Answerer — synthesises the final reply from retrieved context.
-    answerer: openrouter/openai/gpt-5.5
+    answerer: openrouter/openai/gpt-5.4
 
     # Judge — single-judge accuracy verdict.
-    judge: openrouter/openai/gpt-5.5
+    judge: openrouter/openai/gpt-5.4
 
     # Extraction / distillation — runs once per turn during ingest to
     # pull explicit facts out of the conversation.
-    extraction: openrouter/openai/gpt-5.5
-    distill:    openrouter/openai/gpt-5.5
+    extraction: openrouter/openai/gpt-5.4
+    distill:    openrouter/openai/gpt-5.4
 
     # Verifier — second-pass cross-check after Judge. Anthropic
     # complements OpenAI for cross-model validation.
@@ -145,7 +145,7 @@ stack:
     # Generic CLI default — used when an ad-hoc command (e.g.
     # `attestor locomo`) is invoked without an explicit `--model` flag
     # and no specific role applies.
-    benchmark_default: openrouter/openai/gpt-5.5
+    benchmark_default: openrouter/openai/gpt-5.4
 
     # ─── Reasoning effort (gpt-5.x reasoning-model param) ──────────────
     # Higher effort = more internal CoT tokens spent before the visible
@@ -439,7 +439,7 @@ stack:
   # invoke ad-hoc via `mem.consolidate(user_id="<id>")`.
   #
   # Cost: ONE LLM call per pass (target ~10 source memories →
-  # 3 distilled). With models.distill = openai/gpt-5.5, expect roughly
+  # 3 distilled). With models.distill = openai/gpt-5.4, expect roughly
   # $0.05–$0.10 per pass — a back-of-envelope estimate is returned via
   # ReflectionResult.cost_estimate_usd.
   consolidation:


### PR DESCRIPTION
## Summary
- Swap `openrouter/openai/gpt-5.5` → `openrouter/openai/gpt-5.4` for **answerer, judge, extraction, distill, benchmark_default**
- 50% cost reduction (input $5→$2.50/M, output $30→$15/M)
- Keeps reasoning-model behavior (honors `reasoning_effort`)
- Keeps 1.05M context window
- 5 config values + 2 doc comments updated; verifier (anthropic) and planner (anthropic) unchanged

## Test plan
- [ ] Verify YAML loads (`attestor doctor`)
- [ ] Smoke a single LME-S sample to confirm answerer call routes to gpt-5.4
