### PR TITLE
feat(claude-code): native plugin + per-project memory isolation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "attestor",
+  "description": "Self-hosted memory layer for Claude Code with hard per-project isolation.",
+  "owner": {
+    "name": "bolnet",
+    "url": "https://github.com/bolnet"
+  },
+  "plugins": [
+    {
+      "name": "attestor",
+      "source": "./",
+      "description": "Self-hosted memory layer for Claude Code with hard per-project isolation (Postgres RLS + Pinecone + Neo4j).",
+      "version": "4.0.0",
+      "author": {
+        "name": "Surendra Singh",
+        "url": "https://github.com/bolnet/attestor"
+      },
+      "homepage": "https://github.com/bolnet/attestor",
+      "repository": "https://github.com/bolnet/attestor",
+      "license": "MIT",
+      "keywords": ["memory", "mcp", "claude-code"],
+      "category": "workflow"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "attestor",
+  "version": "4.0.0",
+  "description": "The memory layer for agent teams. Deterministic retrieval, hard per-project isolation, zero LLM in the critical path.",
+  "author": {
+    "name": "Surendra Singh",
+    "url": "https://github.com/bolnet/attestor"
+  },
+  "homepage": "https://github.com/bolnet/attestor",
+  "repository": "https://github.com/bolnet/attestor",
+  "license": "MIT",
+  "keywords": [
+    "memory",
+    "mcp",
+    "agents",
+    "rag",
+    "postgres",
+    "pinecone",
+    "neo4j",
+    "claude-code"
+  ],
+  "skills": ["./skills/"],
+  "commands": ["./commands/"]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -18,7 +18,5 @@
     "pinecone",
     "neo4j",
     "claude-code"
-  ],
-  "skills": ["./skills/"],
-  "commands": ["./commands/"]
+  ]
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "attestor": {
+      "command": "attestor",
+      "args": ["mcp"]
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ semantic-first (vector → BM25 → RRF → graph → MMR → fit) as of 2026-04
 a separate tag-match utility lives at `attestor/retrieval/tag_matcher.py`
 but is consumed by the entity extractor, not the recall pipeline.
 
-**Multi-agent primitives:** 6 RBAC roles (ORCHESTRATOR, PLANNER, EXECUTOR, RESEARCHER, REVIEWER, MONITOR) — **enforced at the AgentContext layer** via `ROLE_PERMISSIONS` in `attestor/context.py`. Matrix: ORCHESTRATOR = READ+WRITE+FORGET; PLANNER/EXECUTOR/RESEARCHER = READ+WRITE; REVIEWER/MONITOR = READ only. `read_only=True` is an independent kill switch that strips WRITE+FORGET regardless of role. Direct `AgentMemory.add()` calls (without an AgentContext) bypass the matrix — RBAC is a context-layer guarantee, not a backend one. Namespace isolation is row-level on Postgres but **not yet enforced on Neo4j** (graph entity nodes are global across namespaces). Provenance tracking, write quotas, and per-agent token budgets are wired.
+**Multi-agent primitives:** 6 RBAC roles (ORCHESTRATOR, PLANNER, EXECUTOR, RESEARCHER, REVIEWER, MONITOR) — **enforced at the AgentContext layer** via `ROLE_PERMISSIONS` in `attestor/context.py`. Matrix: ORCHESTRATOR = READ+WRITE+FORGET; PLANNER/EXECUTOR/RESEARCHER = READ+WRITE; REVIEWER/MONITOR = READ only. `read_only=True` is an independent kill switch that strips WRITE+FORGET regardless of role. Direct `AgentMemory.add()` calls (without an AgentContext) bypass the matrix — RBAC is a context-layer guarantee, not a backend one. Namespace isolation is enforced across all three roles: row-level + RLS on Postgres (policies keyed to `attestor.current_user_id`), per-namespace on Pinecone, and a `namespace` property with a composite `(key, namespace)` constraint plus namespace-scoped BFS on Neo4j (`store/neo4j_backend.py`). One known caveat: the Neo4j PageRank GDS projection (`neo4j_backend.py:pagerank`) is **not** namespace-scoped — it computes entity importance over the global graph. This is a ranking *signal* only (it reorders results that are already namespace-filtered); it does not surface another project's memories. The Claude Code plugin keys each project (git root, else cwd) to its own RLS tenant (`external_id=cc-project:<sha256(root)>`, hashed so it fits `VARCHAR(256)` and avoids path-separator issues; the human path is kept in user metadata) via `attestor/_project.py` + `attestor/hooks/_tenant.py`, so memory never bleeds across projects. Provenance tracking, write quotas, and per-agent token budgets are wired.
 
 **Temporal:** Contradiction detection auto-supersedes older facts; nothing is deleted. Every fact has a validity window; `recall(as_of=...)` replays the past.
 
@@ -108,19 +108,15 @@ Same API across all three. Only configuration changes.
 
 ## Install for Claude Code
 
-Single instruction users can give Claude Code: **`install attestor`** (or run `/install-attestor`).
+**The one instruction:** a user tells Claude Code **"install attestor to claude code"** (or runs `/install-attestor`) and Claude does the rest — installs the package, wires the MCP server + hooks, sets up the backends, and verifies. The full guide, **including the copy-paste install prompt for a cold session**, is **[`docs/INSTALL.md`](docs/INSTALL.md)** (start at *Chapter 00 — Install via Claude Code*).
 
-This triggers `commands/install-attestor.md` which interviews the user on:
-1. Scope — global (`~/.claude/.mcp.json`) vs project (`.mcp.json`)
-2. Postgres connection (local Docker, Neon, RDS, etc.)
-3. Pinecone connection (Local Docker via `localhost:5080`, or Cloud via `*.pinecone.io` host + API key)
-4. Neo4j connection (local Docker, AuraDB, etc.)
-5. Backend override (default postgres+pinecone+neo4j, or pgvector / arangodb / aws / azure / gcp)
-6. Embedding provider — Pinecone Inference (default), Voyage, OpenAI, or local Ollama
-7. Hooks — whether to wire session-start / post-tool-use / stop
-8. Namespace + default token budget
+Three install paths (all detailed in `docs/INSTALL.md`):
 
-Then it installs `attestor` via pipx/pip, writes the MCP config, optionally writes `settings.json` hooks, and runs `attestor doctor` to verify.
+1. **Plugin (recommended).** `/plugin marketplace add bolnet/attestor` then `/plugin install attestor`. The plugin manifest (`.claude-plugin/plugin.json`) auto-wires the MCP server (`.mcp.json`) and the SessionStart / PostToolUse / Stop hooks (`hooks/hooks.json`) by convention. Still requires `pipx install attestor` (so the `attestor` binary is on PATH) plus reachable backends.
+2. **Guided wizard.** `/install-attestor` runs `commands/install-attestor.md`, an interactive interview — scope (global `~/.claude` vs project), Postgres / Pinecone / Neo4j connections, embedding provider (Pinecone Inference default, or Voyage / OpenAI / Ollama), hook wiring — then installs `attestor`, merges the MCP + hook config, and runs `attestor doctor`.
+3. **Copy-paste prompt.** For a cold Claude Code session with nothing installed, paste the detailed install prompt from `docs/INSTALL.md` and Claude executes the whole flow.
+
+**Per-project isolation is automatic.** Each working directory (git root, else cwd) is its own hard-isolated memory tenant (`attestor/_project.py` + `attestor/hooks/_tenant.py`) — no namespace to configure, and memory never bleeds across projects. Other MCP clients (Cursor, etc.) and runtimes (library / sidecar / shared service) are covered in `docs/INSTALL.md`.
 
 ## Health Check
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 pip install attestor
 ```
 
-> **Using Claude Code?** Paste this repo's link and say *"install attestor"* — Claude scans your machine, brings up the backends, installs the package, and wires the MCP server + hooks for you. See **[Install for Claude Code](#install-for-claude-code)**.
+> **Using Claude Code?** Paste this repo's link and say *"install attestor"* — Claude follows the repo's install guide to scan your machine, bring up the backends, install the package, and wire the MCP server + hooks (it asks you for credentials when it needs them). See **[Install for Claude Code](#install-for-claude-code)**.
 >
 > ```
 > https://github.com/bolnet/attestor  — install attestor to claude code
@@ -819,13 +819,13 @@ Wire them up via the installer (next section) or by hand in `~/.claude/settings.
 https://github.com/bolnet/attestor  — install attestor to claude code
 ```
 
-Claude Code reads this repo's install guide ([`docs/INSTALL.md`](docs/INSTALL.md) → *Chapter 00*), then **scans your machine first, looks up current docs via Context7, and installs** — it brings up the three backend containers, installs the `attestor` package, wires the MCP server + hooks, and verifies. It assumes you start with nothing installed.
+Claude Code reads this repo's install guide ([`docs/INSTALL.md` → Chapter 00](docs/INSTALL.md#chapter-00--install-via-claude-code-recommended)), then **scans your machine first, looks up current docs via Context7, and installs** — it brings up the three backend containers, installs the `attestor` package, wires the MCP server + hooks, and verifies. It assumes you start with nothing installed.
 
 Three ways in (full detail in [`docs/INSTALL.md`](docs/INSTALL.md)):
 
-1. **Plugin (recommended)** — `/plugin marketplace add bolnet/attestor` then `/plugin install attestor`. Auto-wires the MCP server (`.mcp.json`) and the SessionStart / PostToolUse / Stop hooks (`hooks/hooks.json`) by convention. Requires `pipx install attestor` (so the `attestor` binary is on PATH) plus reachable backends.
+1. **Plugin (recommended)** — `/plugin marketplace add bolnet/attestor` then `/plugin install attestor`. On **Claude Code v2.1+** the MCP server (`.mcp.json`) and the SessionStart / PostToolUse / Stop hooks (`hooks/hooks.json`) are auto-loaded by convention; on older versions, use the wizard (below) to wire them. Either way you still need `pipx install attestor` (so the `attestor` binary is on PATH) plus reachable backends.
 2. **Guided wizard** — `/install-attestor` runs an interactive interview (scope, Postgres / Pinecone / Neo4j connections, embedding provider, hook wiring), installs `attestor`, merges the config, and runs `attestor doctor`.
-3. **Copy-paste prompt** — for a cold session, paste the detailed install prompt from [`docs/INSTALL.md` Chapter 00](docs/INSTALL.md).
+3. **Copy-paste prompt** — for a cold session, paste the detailed install prompt from [`docs/INSTALL.md` Chapter 00](docs/INSTALL.md#chapter-00--install-via-claude-code-recommended).
 
 **Memory is isolated per project automatically** — each working directory (git root, else cwd) is its own hard-isolated tenant, so projects never share memory. No namespace to configure.
 
@@ -836,6 +836,8 @@ The backends come up as three clearly-named Docker instances, one per storage ro
 | `attestor-postgres` | Postgres 16 + pgvector | Document — source of truth |
 | `attestor-pinecone` | Pinecone Local | Vector — embeddings |
 | `attestor-neo4j` | Neo4j 5 + GDS | Graph — PageRank / BFS |
+
+> These are the names the Chapter 00 cold-start installer uses (public images). The legacy `attestor/infra/local/docker-compose.yml` dev stack uses different names (`attestor-pg-local`, `attestor-neo4j-local`, Pinecone started separately) — see [`docs/INSTALL.md`](docs/INSTALL.md) Chapter 01.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@
 pip install attestor
 ```
 
+> **Using Claude Code?** Paste this repo's link and say *"install attestor"* — Claude scans your machine, brings up the backends, installs the package, and wires the MCP server + hooks for you. See **[Install for Claude Code](#install-for-claude-code)**.
+>
+> ```
+> https://github.com/bolnet/attestor  — install attestor to claude code
+> ```
+
 | | |
 |---|---|
 | **Version** | `4.0.0` (stable; greenfield rebuild — no v3 migration path) |
@@ -807,23 +813,29 @@ Wire them up via the installer (next section) or by hand in `~/.claude/settings.
 
 ## Install for Claude Code
 
-Single instruction users can give Claude Code:
+**The one instruction.** Open Claude Code, paste this repo's URL, and say **"install attestor"**:
 
 ```
-install attestor
+https://github.com/bolnet/attestor  — install attestor to claude code
 ```
 
-(Or run `/install-attestor`.) The installer interviews you on:
+Claude Code reads this repo's install guide ([`docs/INSTALL.md`](docs/INSTALL.md) → *Chapter 00*), then **scans your machine first, looks up current docs via Context7, and installs** — it brings up the three backend containers, installs the `attestor` package, wires the MCP server + hooks, and verifies. It assumes you start with nothing installed.
 
-1. **Scope** — global (`~/.claude/.mcp.json`) vs project (`.mcp.json`)
-2. **Postgres connection** — local Docker, Neon, RDS, etc.
-3. **Neo4j connection** — local Docker, AuraDB, etc.
-4. **Backend override** — default `postgres+neo4j`, or `arangodb` / `aws` / `azure` / `gcp`
-5. **Embedding provider** — local Ollama (default), OpenAI, or cloud-native
-6. **Hooks** — whether to wire `session-start` / `post-tool-use` / `stop`
-7. **Namespace + default token budget**
+Three ways in (full detail in [`docs/INSTALL.md`](docs/INSTALL.md)):
 
-Then it installs `attestor` via pipx, writes the MCP config, optionally writes `settings.json` hooks, and runs `attestor doctor` to verify.
+1. **Plugin (recommended)** — `/plugin marketplace add bolnet/attestor` then `/plugin install attestor`. Auto-wires the MCP server (`.mcp.json`) and the SessionStart / PostToolUse / Stop hooks (`hooks/hooks.json`) by convention. Requires `pipx install attestor` (so the `attestor` binary is on PATH) plus reachable backends.
+2. **Guided wizard** — `/install-attestor` runs an interactive interview (scope, Postgres / Pinecone / Neo4j connections, embedding provider, hook wiring), installs `attestor`, merges the config, and runs `attestor doctor`.
+3. **Copy-paste prompt** — for a cold session, paste the detailed install prompt from [`docs/INSTALL.md` Chapter 00](docs/INSTALL.md).
+
+**Memory is isolated per project automatically** — each working directory (git root, else cwd) is its own hard-isolated tenant, so projects never share memory. No namespace to configure.
+
+The backends come up as three clearly-named Docker instances, one per storage role:
+
+| Container | Type | Storage role |
+|---|---|---|
+| `attestor-postgres` | Postgres 16 + pgvector | Document — source of truth |
+| `attestor-pinecone` | Pinecone Local | Vector — embeddings |
+| `attestor-neo4j` | Neo4j 5 + GDS | Graph — PageRank / BFS |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -82,8 +82,21 @@ The image's default entrypoint is `attestor mcp` (MCP server over stdio). For fu
 
 ```bash
 attestor setup local                                       # writes attestor/infra/local/docker-compose.yml
-docker compose -f attestor/infra/local/docker-compose.yml up -d
+
+# Vector role: Pinecone Local is a SEPARATE container (not in the compose file) — start it first.
+docker run -d --name pinecone-local -e PORT=5080 -e PINECONE_HOST=localhost \
+  -p 5080-5090:5080-5090 --platform linux/amd64 \
+  ghcr.io/pinecone-io/pinecone-local:latest
+
+# Compose loads its env file from the compose file's own directory, so pass the
+# repo-root .env explicitly (it holds PINECONE_API_KEY / VOYAGE_API_KEY / etc).
+docker compose --env-file .env -f attestor/infra/local/docker-compose.yml up -d --build
 ```
+
+> **New here? Read [docs/LOCAL_DOCKER_SETUP.md](docs/LOCAL_DOCKER_SETUP.md)** for the full step-by-step
+> container walkthrough, the exact verify command, and a Troubleshooting section covering the common
+> first-run gotchas (missing `--env-file`, Pinecone Local not running, and the host-vs-container
+> `localhost:5080` nuance).
 
 The default stack ships **three containers** (one per storage role):
 

--- a/attestor/_project.py
+++ b/attestor/_project.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: 2026 Surendra Singh <66422685+bolnet@users.noreply.github.com>
+# SPDX-License-Identifier: MIT
+"""Resolve a Claude Code working directory to a stable project identity.
+
+A *project* is the unit of memory isolation: the git repository root if the
+working directory is inside one, otherwise the working directory itself. Two
+unrelated directories always resolve to different identities, so memory never
+bleeds across projects.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+# external_id of the RLS tenant that owns a project's memory. Distinct from the
+# SOLO singleton ("local") so per-project tenants never collide with it.
+_PROJECT_EXTERNAL_PREFIX = "cc-project:"
+
+# Defense-in-depth namespace stamped on Pinecone vectors and Neo4j nodes (and
+# the Postgres doc-store ``_namespace`` metadata shim).
+_PROJECT_NAMESPACE_PREFIX = "project:"
+
+
+def _digest(root: str) -> str:
+    """Stable 64-char hex digest of a project root.
+
+    Hashing keeps the derived identifiers fixed-length and charset-safe:
+    ``users.external_id`` is ``VARCHAR(256)`` (a deep absolute path could
+    overflow it, silently dropping the RLS tenant), and a Pinecone namespace
+    must avoid path separators. The human-readable root is preserved in the
+    user's metadata/display_name by ``resolve_tenant`` for debugging.
+    """
+    return hashlib.sha256(root.encode("utf-8")).hexdigest()
+
+
+def resolve_project_root(cwd: str | Path) -> str:
+    """Return the project root for ``cwd``.
+
+    Git repository root if ``cwd`` is inside one (so subdirectories of a repo
+    share memory); otherwise the resolved absolute ``cwd``. If ``cwd`` is a
+    file, its parent directory is used.
+    """
+    start = Path(cwd).expanduser().resolve()
+    if start.is_file():
+        start = start.parent
+    for candidate in (start, *start.parents):
+        if (candidate / ".git").exists():
+            return str(candidate)
+    return str(start)
+
+
+def project_external_id(root: str) -> str:
+    """RLS tenant external_id for a project root (fixed-length, charset-safe)."""
+    return f"{_PROJECT_EXTERNAL_PREFIX}{_digest(root)}"
+
+
+def project_namespace(root: str) -> str:
+    """Vector/graph namespace for a project root (fixed-length, charset-safe)."""
+    return f"{_PROJECT_NAMESPACE_PREFIX}{_digest(root)}"

--- a/attestor/hooks/_tenant.py
+++ b/attestor/hooks/_tenant.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: 2026 Surendra Singh <66422685+bolnet@users.noreply.github.com>
+# SPDX-License-Identifier: MIT
+"""Map a Claude Code working directory to the tenant that owns its memory.
+
+This is the single chokepoint that enforces per-project isolation in the hook
+path. Every hook recall/add routes its ``cwd`` through here.
+
+On a v4 Postgres store this returns a real ``user_id`` so the Row-Level
+Security policy (keyed to ``attestor.current_user_id``) filters to exactly one
+project. On a v3 / non-Postgres / degraded store ``ensure_user`` is
+unavailable; we fall back to ``user_id=None`` and rely on the ``namespace`` to
+isolate the Pinecone vector lane, the Neo4j graph lane, and the Postgres
+doc-store ``_namespace`` metadata shim. Either way, memory never bleeds across
+projects.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from attestor._project import (
+    project_external_id,
+    project_namespace,
+    resolve_project_root,
+)
+
+
+def resolve_tenant(mem: Any, cwd: str) -> tuple[str | None, str]:
+    """Return ``(user_id, namespace)`` for the project containing ``cwd``.
+
+    Idempotently ensures an RLS user keyed to the project root when the store
+    supports it. ``ensure_user`` is a cheap lookup after first creation. Any
+    failure (v3 store, Postgres down) degrades to ``user_id=None`` with the
+    namespace still set — never raises, so hooks never crash the host.
+    """
+    root = resolve_project_root(cwd)
+    namespace = project_namespace(root)
+
+    ensure_user = getattr(mem, "ensure_user", None)
+    if ensure_user is None:
+        return None, namespace
+    try:
+        # external_id is a hash; carry the human path in display_name/metadata
+        # so the tenant is debuggable in the users table.
+        user = ensure_user(
+            external_id=project_external_id(root),
+            display_name=root,
+            metadata={"project_root": root, "source": "claude-code"},
+        )
+        return user.id, namespace
+    except Exception:  # noqa: BLE001 -- degrade to namespace-only isolation
+        return None, namespace

--- a/attestor/hooks/post_tool_use.py
+++ b/attestor/hooks/post_tool_use.py
@@ -11,6 +11,7 @@ import re
 from typing import Any
 
 from attestor.hooks._base import run_hook
+from attestor.hooks._tenant import resolve_tenant
 
 # Same wall-clock deadline contract as the SessionStart hook. PostToolUse
 # fires on every Write/Edit/Bash so a stalled DB on this path blocks every
@@ -41,6 +42,7 @@ _SECRET_PATTERNS = (
     (re.compile(r"\bsk-ant-[A-Za-z0-9_-]{20,}"),    "<REDACTED:anthropic>"),
     (re.compile(r"\bsk-[A-Za-z0-9_-]{32,}"),        "<REDACTED:openai>"),
     (re.compile(r"\bpa-[A-Za-z0-9_-]{30,}"),        "<REDACTED:voyage>"),
+    (re.compile(r"\bpcsk_[A-Za-z0-9_-]{20,}"),      "<REDACTED:pinecone>"),
     (re.compile(r"\bghp_[A-Za-z0-9]{30,}"),         "<REDACTED:github>"),
     (re.compile(r"\bgithub_pat_[A-Za-z0-9_]{30,}"), "<REDACTED:github>"),
     (re.compile(r"\bAKIA[A-Z0-9]{16}\b"),           "<REDACTED:aws>"),
@@ -143,7 +145,15 @@ def handle(payload: dict[str, Any]) -> dict[str, Any]:
             def _do_add() -> None:
                 mem = AgentMemory(store_path)
                 try:
-                    mem.add(content, tags=tags, category=category)
+                    user_id, namespace = resolve_tenant(mem, cwd)
+                    mem.add(
+                        content,
+                        tags=tags,
+                        category=category,
+                        user_id=user_id,
+                        namespace=namespace,
+                        scope="project",
+                    )
                 finally:
                     mem.close()
 

--- a/attestor/hooks/session_start.py
+++ b/attestor/hooks/session_start.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from attestor import _branding as brand
 from attestor.hooks._base import run_hook
+from attestor.hooks._tenant import resolve_tenant
 
 _EMPTY_RESPONSE: dict[str, Any] = {"additionalContext": ""}
 
@@ -26,8 +27,12 @@ _SESSION_QUERY = "session context project overview recent decisions"
 _HOOK_TIMEOUT_S = float(os.environ.get("ATTESTOR_HOOK_TIMEOUT_S", "5.0"))
 
 
-def _do_recall() -> dict[str, Any]:
-    """The actual recall + pagerank pass — runs inside the timeout shim."""
+def _do_recall(cwd: str) -> dict[str, Any]:
+    """The actual recall + pagerank pass — runs inside the timeout shim.
+
+    Scopes the recall to the project that owns ``cwd`` so a session never
+    surfaces another project's memories.
+    """
     from attestor._paths import resolve_store_path
     from attestor.core import AgentMemory
     from attestor.retrieval.scorer import pagerank_boost
@@ -35,7 +40,13 @@ def _do_recall() -> dict[str, Any]:
     store_path = resolve_store_path()
     mem = AgentMemory(store_path)
     try:
-        results = mem.recall(_SESSION_QUERY, budget=_SESSION_BUDGET)
+        user_id, namespace = resolve_tenant(mem, cwd)
+        results = mem.recall(
+            _SESSION_QUERY,
+            budget=_SESSION_BUDGET,
+            user_id=user_id,
+            namespace=namespace,
+        )
 
         pr_scores = mem.pagerank()
         if pr_scores and results:
@@ -67,7 +78,7 @@ def handle(payload: dict[str, Any]) -> dict[str, Any]:
         # for now, but the host session is unblocked. Pre-fix this hook
         # could hang the user's terminal forever on a stalled DB.
         with concurrent.futures.ThreadPoolExecutor(max_workers=1) as ex:
-            fut = ex.submit(_do_recall)
+            fut = ex.submit(_do_recall, cwd)
             try:
                 return fut.result(timeout=_HOOK_TIMEOUT_S)
             except concurrent.futures.TimeoutError:

--- a/attestor/hooks/stop.py
+++ b/attestor/hooks/stop.py
@@ -8,6 +8,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from attestor.hooks._base import run_hook
+from attestor.hooks._tenant import resolve_tenant
 
 _EMPTY_RESPONSE: dict[str, Any] = {}
 
@@ -34,11 +35,20 @@ def handle(payload: dict[str, Any]) -> dict[str, Any]:
 
         mem = AgentMemory(store_path)
         try:
+            user_id, namespace = resolve_tenant(mem, cwd)
+
+            # The captures from PostToolUse were written under this project's
+            # RLS user. A fresh AgentMemory sets RLS to the SOLO user at init,
+            # so we must switch RLS to the project user BEFORE the read or the
+            # time-window query would see another tenant's rows (or none).
+            if user_id is not None and getattr(mem._store, "_v4", False):
+                mem._resolve(user_id=user_id, autostart=False)
+
             # Query memories from the last hour (this session's captures)
             one_hour_ago = (
                 datetime.now(timezone.utc) - timedelta(hours=1)
             ).isoformat()
-            recent = mem.search(after=one_hour_ago, limit=50)
+            recent = mem.search(after=one_hour_ago, limit=50, namespace=namespace)
 
             if not recent:
                 return _EMPTY_RESPONSE
@@ -46,7 +56,14 @@ def handle(payload: dict[str, Any]) -> dict[str, Any]:
             # Build rule-based summary
             summary = _build_summary(recent)
             if summary:
-                mem.add(summary, tags=["session-summary"], category="session")
+                mem.add(
+                    summary,
+                    tags=["session-summary"],
+                    category="session",
+                    user_id=user_id,
+                    namespace=namespace,
+                    scope="project",
+                )
 
             return _EMPTY_RESPONSE
         finally:

--- a/attestor/infra/local/api.Dockerfile
+++ b/attestor/infra/local/api.Dockerfile
@@ -29,8 +29,15 @@ WORKDIR /app
 
 COPY pyproject.toml README.md ./
 COPY attestor/ attestor/
+# configs/attestor.yaml is the ONLY source of truth for the stack (embedder,
+# vector, models) — the loader hard-fails without it (fallback constants were
+# removed), so it must be baked into the image.
+COPY configs/ configs/
 
-# Install only what the HTTP + Postgres + Pinecone + Neo4j paths need.
+# Install what the HTTP + Postgres + Pinecone + Neo4j paths need, INCLUDING
+# the canonical default stack's embedder (Voyage) and vector store (Pinecone)
+# clients — without these the container cannot honor configs/attestor.yaml's
+# default (voyage-4 + Pinecone) and `_ensure_embedding_fn()` fails at startup.
 RUN pip install --no-cache-dir --upgrade pip \
     && pip install --no-cache-dir \
         "starlette>=0.27.0" \
@@ -38,6 +45,8 @@ RUN pip install --no-cache-dir --upgrade pip \
         "psycopg2-binary>=2.9.0" \
         "neo4j>=5.0.0" \
         "openai>=1.0.0" \
+        "voyageai>=0.3.0" \
+        "pinecone>=5.0.0" \
         "tomlkit>=0.12.0" \
     && pip install --no-cache-dir --no-deps .
 

--- a/attestor/infra/local/docker-compose.yml
+++ b/attestor/infra/local/docker-compose.yml
@@ -85,10 +85,15 @@ services:
       NEO4J_URI: bolt://neo4j:7687
       NEO4J_USERNAME: neo4j
       NEO4J_PASSWORD: ${NEO4J_PASSWORD:-attestor}
-      # Secrets — read from .env. Embedder choice and dim live in
-      # configs/attestor.yaml (canonical default: voyage-4 @ 1024-D); the
-      # api container reads them from there via attestor.config.get_stack().
+      # Secrets — substituted from the env file Compose loads (pass the
+      # repo-root .env explicitly: `docker compose --env-file .env -f …`).
+      # Embedder/vector choice live in configs/attestor.yaml (default:
+      # voyage-4 embedder + Pinecone vector); the container reads them via
+      # attestor.config.get_stack(), so BOTH keys must be present:
+      #   VOYAGE_API_KEY   → embedder (voyage-4)
+      #   PINECONE_API_KEY → vector store (Pinecone cloud)
       VOYAGE_API_KEY: ${VOYAGE_API_KEY:-}
+      PINECONE_API_KEY: ${PINECONE_API_KEY:-}
       OPENROUTER_API_KEY: ${OPENROUTER_API_KEY:-}
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}

--- a/attestor/mcp/server.py
+++ b/attestor/mcp/server.py
@@ -10,11 +10,28 @@ import sys
 from typing import Any
 
 from attestor import _branding as _brand
+from attestor._project import (
+    project_external_id,
+    project_namespace,
+    resolve_project_root,
+)
 from attestor.core import AgentMemory
 
 _URI_SCHEME: str = _brand.MCP_URI_SCHEME
 _ENTITY_PREFIX: str = f"{_URI_SCHEME}://entity/"
 _MEMORY_PREFIX: str = f"{_URI_SCHEME}://memory/"
+
+
+def _default_tenant_for_cwd() -> tuple[str, str]:
+    """Return ``(external_id, namespace)`` for the server's launch directory.
+
+    Claude Code launches the MCP server with cwd = the workspace root, so the
+    project the user is working in is ``os.getcwd()`` at server start. Pure —
+    no DB call; the server resolves the external_id to a real user_id lazily on
+    first tool use.
+    """
+    root = resolve_project_root(os.getcwd())
+    return project_external_id(root), project_namespace(root)
 
 
 def _build_handlers(mem: AgentMemory) -> dict:
@@ -384,6 +401,12 @@ def create_server(memory_path: str):
             ),
         ]
 
+    # Per-server project tenant, resolved lazily on first tool call. Claude
+    # Code launches one MCP server per workspace, so the launch cwd identifies
+    # the project. All tools default to this tenant so memory never bleeds
+    # across projects; an explicit ``namespace`` arg still overrides.
+    _tenant: dict[str, Any] = {"resolved": False, "user_id": None, "namespace": None}
+
     @server.call_tool()
     async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
         if mem is None:
@@ -392,8 +415,28 @@ def create_server(memory_path: str):
                          "Provide working Postgres + Neo4j connections (ATTESTOR_PATH or config.toml) and unset "
                          "ATTESTOR_MCP_TOLERATE_INIT_FAILURE to enable tool execution.",
             }))]
+
+        # Resolve the project tenant once (DB lookup), then pin RLS to it on
+        # every call so read-only tools (search/timeline/get) are scoped too.
+        if not _tenant["resolved"]:
+            ext_id, _tenant["namespace"] = _default_tenant_for_cwd()
+            try:
+                _tenant["user_id"] = mem.ensure_user(external_id=ext_id).id
+            except Exception:  # noqa: BLE001 -- v3 / degraded: namespace-only
+                _tenant["user_id"] = None
+            _tenant["resolved"] = True
+        if _tenant["user_id"] and getattr(mem._store, "_v4", False):
+            try:
+                mem._resolve(user_id=_tenant["user_id"], autostart=False)
+            except Exception:  # noqa: BLE001 -- never fail a tool on RLS pin
+                pass
+
         try:
-            result = _handle_tool(mem, name, arguments)
+            result = _handle_tool(
+                mem, name, arguments,
+                default_user_id=_tenant["user_id"],
+                default_namespace=_tenant["namespace"],
+            )
             return [TextContent(type="text", text=json.dumps(result, indent=2))]
         except (ValueError, KeyError, TypeError) as e:
             # User-input failures: surface the message so the MCP client
@@ -439,16 +482,28 @@ def create_server(memory_path: str):
     return server
 
 
-def _handle_tool(mem: AgentMemory, name: str, args: dict) -> dict:
+def _handle_tool(
+    mem: AgentMemory,
+    name: str,
+    args: dict,
+    default_user_id: str | None = None,
+    default_namespace: str | None = None,
+) -> dict:
+    # Project tenant defaults: an explicit ``namespace`` arg always wins so a
+    # caller can intentionally reach a shared/user scope; otherwise the
+    # per-project namespace + RLS user keep memory isolated to this project.
+    _ns = args.get("namespace") or default_namespace
     if name == "memory_add":
         memory = mem.add(
             content=args["content"],
             tags=args.get("tags", []),
             category=args.get("category", "general"),
             entity=args.get("entity"),
-            namespace=args.get("namespace", "default"),
+            namespace=_ns or "default",
             event_date=args.get("event_date"),
             confidence=args.get("confidence", 1.0),
+            user_id=args.get("user_id") or default_user_id,
+            scope=args.get("scope", "project"),
         )
         return {"id": memory.id, "content": memory.content, "status": "stored"}
 
@@ -471,7 +526,8 @@ def _handle_tool(mem: AgentMemory, name: str, args: dict) -> dict:
         results = mem.recall(
             args["query"],
             budget=args.get("budget", 2000),
-            namespace=args.get("namespace"),
+            namespace=_ns,
+            user_id=args.get("user_id") or default_user_id,
         )
         return {
             "count": len(results),
@@ -494,7 +550,7 @@ def _handle_tool(mem: AgentMemory, name: str, args: dict) -> dict:
             query=args.get("query"),
             category=args.get("category"),
             entity=args.get("entity"),
-            namespace=args.get("namespace"),
+            namespace=_ns,
             status=args.get("status", "active"),
             after=args.get("after"),
             before=args.get("before"),
@@ -520,7 +576,7 @@ def _handle_tool(mem: AgentMemory, name: str, args: dict) -> dict:
         return {"success": success, "memory_id": args["memory_id"]}
 
     elif name == "memory_timeline":
-        memories = mem.timeline(args["entity"], namespace=args.get("namespace"))
+        memories = mem.timeline(args["entity"], namespace=_ns)
         return {
             "entity": args["entity"],
             "count": len(memories),

--- a/commands/install-attestor.md
+++ b/commands/install-attestor.md
@@ -10,6 +10,8 @@ You are installing **Attestor** (PyPI: `attestor`, import: `attestor`) — a mem
 
 This command is **interactive**. The wizard is the single source of truth for every install input — scope, paths, backends, credentials, secrets, hook wiring, verification. **Do NOT silently apply defaults when state already exists. Do NOT collect secrets out-of-band. If the install needs a value, the wizard asks for it.**
 
+> **Plugin mode:** When Attestor is installed as a Claude Code plugin (`/plugin install attestor`), the MCP server (`.mcp.json`) and the session-start / post-tool-use / stop hooks (`hooks/hooks.json`) are **auto-wired by the plugin** — Claude Code v2.1+ loads them by convention. In that case this wizard only needs to: (a) `pip`/`pipx install attestor` so the `attestor` binary is on PATH, (b) collect backend connection details (Postgres + Pinecone + Neo4j; local Docker or cloud), (c) collect the embedding provider, and (d) run `attestor doctor`. **Skip the `settings.json` MCP + hook writing steps in plugin mode** — they only apply to manual, non-plugin installs and would duplicate the plugin's wiring. Memory is automatically isolated per project: each working directory (git root, else cwd) becomes its own RLS tenant, so projects never share memory.
+
 Rules:
 - Ask **one** question at a time via `AskUserQuestion` — never batch.
 - Ask Q0 (pre-existing state) questions first — only ask the ones whose preconditions were detected in Step 1.

--- a/docs/CLAUDE_LOCAL_SETUP_PROMPT.md
+++ b/docs/CLAUDE_LOCAL_SETUP_PROMPT.md
@@ -1,0 +1,95 @@
+# Claude prompt — stand up Attestor locally with containers
+
+Copy everything in the fenced block below and paste it to Claude (Claude Code)
+from the **root of the Attestor repo**. It is a self-contained, imperative,
+step-by-step prompt that drives an agent to bring up the full local stack and
+verify all four health checks.
+
+> Before running: make sure Docker is running and a repo-root `.env` exists with
+> `PINECONE_API_KEY`, `VOYAGE_API_KEY`, `NEO4J_PASSWORD`, and
+> `OPENROUTER_API_KEY`. The agent must **never** print, commit, or echo these
+> values.
+
+---
+
+```text
+You are setting up Attestor to run locally with Docker containers. Work from the
+repository root. The default stack is: Postgres (document) + Pinecone (vector,
+via the Pinecone Local emulator) + Neo4j (graph), with the Voyage voyage-4
+embedder. Do all of the following, in order, and report results after each step.
+
+SAFETY RULES (follow strictly):
+- Never print, echo, log, or commit secret values. The required keys live in the
+  repo-root .env (PINECONE_API_KEY, VOYAGE_API_KEY, NEO4J_PASSWORD,
+  OPENROUTER_API_KEY). .env is gitignored — leave it untouched.
+- Do NOT edit configs/attestor.yaml.
+- Reference keys only via ${VAR} interpolation or by extracting a single value
+  from .env at the moment you export it — and only check presence, never value.
+
+STEP 1 — Preconditions.
+- Confirm Docker is running: `docker info` (just check it succeeds).
+- Confirm the repo-root .env exists and lists the 4 required keys by NAME only:
+  `grep -oE '^(PINECONE_API_KEY|VOYAGE_API_KEY|NEO4J_PASSWORD|OPENROUTER_API_KEY)=' .env | sort -u`
+  Report which of the four are present. If any are missing, STOP and tell the user.
+
+STEP 2 — Start Pinecone Local (the vector emulator; it is a SEPARATE container,
+not in the compose file). If a container named `pinecone-local` is already
+running, reuse it. Otherwise start it:
+  docker run -d --name pinecone-local -e PORT=5080 -e PINECONE_HOST=localhost \
+    -p 5080-5090:5080-5090 --platform linux/amd64 \
+    ghcr.io/pinecone-io/pinecone-local:latest
+  Verify with: `docker ps --filter name=pinecone-local`
+
+STEP 3 — Bring up the compose stack (Postgres + Neo4j + API). Pass the repo-root
+.env explicitly with --env-file (Compose otherwise reads its env file from the
+compose file's own directory and misses the repo-root .env), and build:
+  docker compose --env-file .env -f attestor/infra/local/docker-compose.yml up -d --build
+  Then show status: `docker compose --env-file .env -f attestor/infra/local/docker-compose.yml ps`
+  Confirm the key reached the container (presence only, no value):
+  `docker exec attestor-api-local sh -c '[ -n "$PINECONE_API_KEY" ] && echo SET || echo EMPTY'`
+
+STEP 4 — Verify the FULLY-GREEN path with a host-run API. The containerized API
+at :8080 cannot reach Pinecone Local (its config pins host=localhost:5080, which
+inside the container is the container itself, not the host) — so its Vector
+Store will read "Not initialized". The verified all-green path is the host-run
+API. Export ONLY the four required keys (do not `source` the whole .env — a stray
+NEO4J_URI/POSTGRES_URL in it would hijack backend resolution), and unset those
+overrides:
+  export PINECONE_API_KEY=$(grep -E '^PINECONE_API_KEY=' .env | cut -d= -f2-)
+  export VOYAGE_API_KEY=$(grep -E '^VOYAGE_API_KEY=' .env | cut -d= -f2-)
+  export OPENROUTER_API_KEY=$(grep -E '^OPENROUTER_API_KEY=' .env | cut -d= -f2-)
+  export NEO4J_PASSWORD=attestor
+  unset NEO4J_URI POSTGRES_URL ARANGO_URL
+  # Use a Python environment that has voyageai + pinecone installed (e.g. the
+  # project virtualenv at .venv). If `attestor` isn't on PATH, run the module:
+  attestor api --port 8090     # or: .venv/bin/python -m attestor.cli api --port 8090
+Then check health (retry a few times; first hit may race on cold init):
+  curl -s http://127.0.0.1:8090/health | python3 -m json.tool
+Confirm "healthy": true with all four checks "ok": Document Store (Postgres),
+Vector Store (Pinecone), Graph Store (Neo4j), and Retrieval Pipeline (3/3 layers:
+tag_match + graph_expansion + vector_similarity).
+
+STEP 5 — Report.
+- Which of the four health checks are green, and via which path (host-run API at
+  :8090 vs containerized API at :8080).
+- Note the expected, documented nuance: the containerized :8080 API shows Vector
+  Store "Not initialized" because localhost:5080 inside the container is not the
+  host; this is by design and not a failure of the setup.
+
+TROUBLESHOOTING (apply if a step fails):
+- ModuleNotFoundError voyageai/pinecone at startup → rebuild the image with
+  --build (the local Dockerfile installs voyageai>=0.3.0 + pinecone>=5.0.0); for
+  the host-run API, use an env that has those libs (e.g. .venv).
+- "... missing in configs/attestor.yaml" → the image must COPY configs/ (the
+  local Dockerfile does this); rebuild with --build.
+- Services can't read keys → you forgot `--env-file .env`.
+- Vector Store "connection refused localhost:5080" → pinecone-local isn't running
+  (Step 2).
+- Host API KeyError 'document' or only the Neo4j check passes → a stray NEO4J_URI
+  /POSTGRES_URL is set; export only the 4 keys and unset those (Step 4).
+```
+
+---
+
+For the full human-readable walkthrough and a deeper Troubleshooting section, see
+[LOCAL_DOCKER_SETUP.md](LOCAL_DOCKER_SETUP.md).

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -6,9 +6,87 @@ A step-by-step guide to installing and verifying Attestor across different topol
 
 | # | Topology | Backend |
 |---|----------|---------|
+| [00](#chapter-00--install-via-claude-code-recommended) | **Install via Claude Code** (one prompt · cold start) | Postgres + Pinecone + Neo4j |
 | [01](#chapter-01--local-stack-with-docker-compose) | Local stack (Docker Compose) | Postgres + pgvector, Neo4j + GDS |
 | [02](#chapter-02--sidecar-rest-api) | Sidecar REST API | Same stack, exposed over HTTP |
 | [03](#chapter-03--cloud-managed) | Cloud managed | Managed Postgres + Neo4j / Arango / AWS / Azure / GCP |
+
+---
+
+## Chapter 00 — Install via Claude Code (recommended)
+
+**The one instruction.** Tell Claude Code **"install attestor to claude code"** (or run `/install-attestor`, or paste the prompt below). Claude **scans your machine first, looks up the current docs for every tool via Context7, then installs** — it brings up the three backend containers, installs the `attestor` package, wires the MCP server + hooks, and verifies. It assumes you start with **nothing installed**.
+
+> Chapters 01–03 describe the lower-level / older pgvector topologies. Chapter 00 reflects the current **canonical stack: Postgres (document) + Pinecone (vector) + Neo4j (graph)**.
+
+### The three backends — one clearly-named Docker instance per storage role
+
+Each storage role is its own container, all `attestor-`prefixed and labeled by type:
+
+| Container | Type | Storage role | Image | Ports |
+|-----------|------|--------------|-------|-------|
+| `attestor-postgres` | **Postgres 16 + pgvector** | **Document** — source of truth (content, tags, entity, ts, provenance, confidence) | `pgvector/pgvector:pg16` | `5432` |
+| `attestor-pinecone` | **Pinecone Local** | **Vector** — dense embeddings, per-namespace cosine search | `ghcr.io/pinecone-io/pinecone-local:latest` | `5080-5090` |
+| `attestor-neo4j` | **Neo4j 5 + GDS** | **Graph** — entity nodes + typed edges, PageRank / BFS | `neo4j:5.24-community` | `7474`, `7687` |
+
+### The install prompt — paste into a fresh Claude Code session
+
+```text
+Install Attestor as my agent-memory layer and wire it natively into Claude Code.
+Assume a COLD machine — I may have nothing installed. Work in this order and ask
+me only when you hit a real decision or need a secret.
+
+PHASE 1 — SCAN (install nothing yet)
+Detect and show me a table of present vs missing:
+- OS + arch; Python (need >=3.10); pip / pipx; Docker + Docker Compose (running?).
+- Existing Attestor: `attestor --version`, ~/.attestor, an MCP entry in
+  ~/.claude or ./.mcp.json, attestor hooks in settings.json.
+- Running backend containers (`docker ps`) and listeners on 5432 / 5080 / 7687.
+Then tell me what you'll INSTALL, REUSE, and SKIP before doing anything.
+
+PHASE 2 — LOOK UP CURRENT DOCS WITH CONTEXT7 (before every install step)
+Before you install or run ANY tool, fetch its current docs via the Context7 MCP
+(resolve-library-id -> query-docs): pipx, pgvector, Pinecone Local, Neo4j GDS,
+the `attestor` PyPI package, and the Claude Code plugin / MCP / hooks format.
+Use the commands and versions Context7 returns — not ones from memory. If
+Context7 is unavailable, tell me and pause.
+
+PHASE 3 — BACKENDS: three clearly-named Docker instances (attestor- prefix), one per role
+Start exactly these and confirm each reports healthy:
+- attestor-postgres  Postgres 16 + pgvector   DOCUMENT store   :5432         pgvector/pgvector:pg16
+- attestor-pinecone  Pinecone Local           VECTOR store     :5080-5090    ghcr.io/pinecone-io/pinecone-local:latest
+- attestor-neo4j     Neo4j 5 + GDS            GRAPH store      :7474/:7687   neo4j:5.24-community (NEO4J_PLUGINS=["graph-data-science"])
+Use a single password (default `attestor`) and put every secret in a gitignored
+.env — never hardcode. Persist data in named volumes.
+
+PHASE 4 — INSTALL THE ATTESTOR PACKAGE
+`pipx install attestor` (fallback `pip install --user attestor`). Confirm
+`attestor --version`. The `attestor` binary must be on PATH — the plugin's hooks
+and MCP server call it directly.
+
+PHASE 5 — WIRE INTO CLAUDE CODE (prefer the plugin)
+Ask my scope: global (~/.claude) or this project only. Then:
+- Plugin (recommended): `/plugin marketplace add bolnet/attestor` then
+  `/plugin install attestor` — this auto-wires the MCP server (.mcp.json) and the
+  SessionStart / PostToolUse / Stop hooks by convention.
+- If I decline the plugin: merge the attestor MCP server into .mcp.json and the
+  three hooks into settings.json yourself, without clobbering existing entries.
+Ask my embedding provider (Pinecone Inference default, else Voyage / OpenAI /
+Ollama) and store its API key in .env.
+
+PHASE 6 — VERIFY
+Run `attestor doctor <store-path>` (expect Document / Vector / Graph / Retrieval
+all healthy) and call the `memory_health` MCP tool. Then prove per-project
+isolation: add a memory here, and confirm a different project directory does NOT
+see it. Show me the results.
+
+NOTES
+- Memory is automatically isolated per project — each git-root (else cwd) is its
+  own tenant. There is no namespace to configure.
+- If any phase fails, STOP and tell me exactly what failed. Do not continue silently.
+```
+
+After it finishes you can use the `memory_*` tools immediately, and every project you open gets its own hard-isolated memory automatically.
 
 ---
 

--- a/docs/LOCAL_DOCKER_SETUP.md
+++ b/docs/LOCAL_DOCKER_SETUP.md
@@ -1,0 +1,260 @@
+# Running Attestor locally with containers
+
+A step-by-step guide to stand up the full default Attestor stack
+(**Postgres** document store + **Pinecone** vector store + **Neo4j** graph
+store) on your own machine using Docker, and verify that all four health
+checks go green.
+
+This guide reflects the **out-of-the-box default stack** declared in
+`configs/attestor.yaml`: the **Voyage `voyage-4`** embedder (1024-D) and the
+**Pinecone** vector role, backed by **Pinecone Local** (the `:5080` emulator).
+
+---
+
+## Prerequisites
+
+1. **Docker** (Desktop or Engine) with Compose v2 (`docker compose`, not the
+   legacy `docker-compose`). The Pinecone Local image is `linux/amd64`; on
+   Apple Silicon it runs under emulation automatically (`--platform
+   linux/amd64`, shown below).
+2. **A repo-root `.env`** with the four keys the default stack needs:
+
+   ```dotenv
+   PINECONE_API_KEY=...      # Pinecone (vector role + cloud fallback)
+   VOYAGE_API_KEY=...        # Voyage voyage-4 embedder
+   NEO4J_PASSWORD=...        # Neo4j graph store (compose default: "attestor")
+   OPENROUTER_API_KEY=...    # LLM calls (extraction / answerer)
+   ```
+
+   `.env` is **gitignored** (`.gitignore` lists `.env` and `.env.*`) — never
+   commit it. The compose file and Dockerfile reference these only via
+   `${VAR}` interpolation, so no secret is ever baked into an image.
+
+> **Note on the `PINECONE_API_KEY` value.** For **Pinecone Local** the key is
+> ignored by the emulator (any non-empty value works). For Pinecone **Cloud**
+> it must be a real key from app.pinecone.io.
+
+---
+
+## Step 1 — Start Pinecone Local (the vector emulator)
+
+Pinecone Local is the default vector store, but it is **not** part of the
+compose file — it runs as its own container. Start it first:
+
+```bash
+docker run -d --name pinecone-local \
+  -e PORT=5080 -e PINECONE_HOST=localhost \
+  -p 5080-5090:5080-5090 \
+  --platform linux/amd64 \
+  ghcr.io/pinecone-io/pinecone-local:latest
+```
+
+(This is the canonical command documented in
+`attestor/store/pinecone_backend.py`.) If a `pinecone-local` container is
+already running, reuse it — no need to start a second one.
+
+Verify it is up:
+
+```bash
+docker ps --filter name=pinecone-local
+# Expect: Up ... 0.0.0.0:5080-5090->5080-5090/tcp
+```
+
+---
+
+## Step 2 — Bring up the compose stack (Postgres + Neo4j + API)
+
+From the **repo root**, build and start the three-service stack. Pass the
+repo-root `.env` explicitly with `--env-file` (see Troubleshooting #3 for why
+this is required):
+
+```bash
+docker compose --env-file .env \
+  -f attestor/infra/local/docker-compose.yml \
+  up -d --build
+```
+
+This builds the `attestor/api` image (which now bundles the Voyage + Pinecone
+client libraries and bakes in `configs/`) and starts:
+
+| Container             | Role     | Port(s)      |
+| --------------------- | -------- | ------------ |
+| `attestor-pg-local`   | Document | `5432`       |
+| `attestor-neo4j-local`| Graph    | `7474`, `7687` |
+| `attestor-api-local`  | REST API | `8080`       |
+
+Watch them become healthy:
+
+```bash
+docker compose --env-file .env -f attestor/infra/local/docker-compose.yml ps
+```
+
+---
+
+## Step 3 — Verify (the recommended, fully-green path)
+
+There are two ways to reach the API. **Use the host-run API for a clean,
+fully-green verification** — it can reach Pinecone Local at `localhost:5080`,
+whereas the containerized API cannot (see the important note below).
+
+### Recommended: host-run API → all 4 checks green
+
+Run the API on the host (it talks to the containers via their published
+ports). Export **only the four required keys** — do **not** `source` your whole
+`.env`, which may contain unrelated vars (e.g. a stray `NEO4J_URI` /
+`POSTGRES_URL`) that hijack the API's backend resolution (Troubleshooting #5):
+
+```bash
+export PINECONE_API_KEY=$(grep -E '^PINECONE_API_KEY=' .env | cut -d= -f2-)
+export VOYAGE_API_KEY=$(grep -E '^VOYAGE_API_KEY=' .env | cut -d= -f2-)
+export OPENROUTER_API_KEY=$(grep -E '^OPENROUTER_API_KEY=' .env | cut -d= -f2-)
+export NEO4J_PASSWORD=attestor
+unset NEO4J_URI POSTGRES_URL ARANGO_URL    # avoid env-based backend override
+
+attestor api --port 8090
+```
+
+Then, in another shell, check health:
+
+```bash
+curl -s http://127.0.0.1:8090/health | python3 -m json.tool
+```
+
+or use the doctor CLI (point it at your data dir):
+
+```bash
+attestor doctor ~/.attestor
+```
+
+You should see **all four checks OK**:
+
+```
+Overall: ALL HEALTHY
+
+  [OK] PostgresBackend  (... memories)
+  [OK] PineconeBackend  (... vectors)
+  [OK] Neo4jBackend     (... nodes, ... edges)
+  [OK] Retrieval Pipeline (3/3 layers)
+```
+
+The four checks correspond to: **Document Store** (Postgres), **Vector Store**
+(Pinecone), **Graph Store** (Neo4j), and the **Retrieval Pipeline** (3/3 layers
+= `tag_match` + `graph_expansion` + `vector_similarity`).
+
+### Containerized API at `:8080`
+
+The compose API is also reachable:
+
+```bash
+curl -s http://127.0.0.1:8080/health | python3 -m json.tool
+```
+
+It will report **Document Store, Graph Store, and Retrieval Pipeline green**,
+but **Vector Store "Not initialized"** — see the important nuance below.
+
+---
+
+## Important: why the *containerized* API's Vector Store stays "Not initialized"
+
+`configs/attestor.yaml` pins the Pinecone host to `pinecone.host:
+http://localhost:5080`. Inside the `attestor-api` container, `localhost` is the
+**container itself**, not the host machine — so the containerized API cannot
+reach the host's `pinecone-local` container that way, and its Vector Store
+check reports `Not initialized`. Retrieval still works in a **degraded** mode
+on the remaining two layers (`tag_match` + `graph_expansion`, 2/3).
+
+Attestor reads the Pinecone host **only** from `configs/attestor.yaml`
+(`build_backend_config` does `host = pcn.get("host")`); there is **no
+environment-variable override** for the Pinecone host in the loader. Making the
+*fully-containerized* path reach Pinecone would therefore require editing
+`configs/attestor.yaml` to a Docker-network-reachable host (e.g. a
+`pinecone-local` service name) — which is intentionally **out of scope** here.
+
+**The verified fully-green path is the host-run API in Step 3.** Use that to
+confirm your install, and use the containerized `:8080` API for the three
+non-vector roles.
+
+---
+
+## Troubleshooting — first-run gotchas
+
+These are the issues a brand-new user hits, in the order they tend to surface.
+
+### 1. `ModuleNotFoundError: No module named 'voyageai'` (or `pinecone`) at API startup
+
+The base image historically installed only the Postgres + Neo4j + OpenAI
+clients, but the **default** stack is **Voyage embedder + Pinecone vector**. The
+local API Dockerfile (`attestor/infra/local/api.Dockerfile`) now pip-installs
+`voyageai>=0.3.0` and `pinecone>=5.0.0` so the image can honor the default
+`configs/attestor.yaml` out of the box. If you see this error, rebuild with
+`--build`.
+
+> Running the API **on the host** (Step 3)? Use an environment that has these
+> libs installed (e.g. a project virtualenv: `pip install voyageai pinecone`),
+> otherwise the Voyage embedder fails with *"embedder provider 'voyage' failed
+> to initialize"*.
+
+### 2. Config loader hard-fails: `... missing in configs/attestor.yaml`
+
+`configs/attestor.yaml` is the **only source of truth** for the stack (embedder,
+vector, models) — the loader raises rather than falling back to constants. The
+local API Dockerfile now does `COPY configs/ configs/` so the YAML is baked into
+the image. Without it the container can't start. Rebuild with `--build`.
+
+### 3. Health checks fail / services can't read their keys → **pass `--env-file .env`**
+
+Docker Compose reads its env file from **the compose file's own directory**, not
+your current working directory. Since the keys live in the **repo-root** `.env`
+but the compose file is at `attestor/infra/local/docker-compose.yml`, the
+`.env` is **not** picked up automatically. Always pass it explicitly:
+
+```bash
+docker compose --env-file .env -f attestor/infra/local/docker-compose.yml up -d --build
+```
+
+Confirm a key reached the container (presence only, never print the value):
+
+```bash
+docker exec attestor-api-local sh -c '[ -n "$PINECONE_API_KEY" ] && echo SET || echo EMPTY'
+```
+
+### 4. Vector Store: "Not initialized (localhost:5080 connection refused)"
+
+The `pinecone-local` container isn't running. Start it (Step 1). Pinecone Local
+is the default vector store but is **not** part of the compose file, so a fresh
+machine won't have it until you run the `docker run … pinecone-local` command.
+Without it, retrieval runs degraded on `tag_match` + `graph_expansion` only
+(2/3 layers).
+
+### 5. Host-run API shows `KeyError: 'document'` or only the Neo4j check
+
+The host API's config resolver checks **explicit env vars first**
+(`POSTGRES_URL`, `NEO4J_URI`, `ARANGO_URL`) before the YAML. If your `.env`
+contains a stray `NEO4J_URI` (or `POSTGRES_URL`) meant for other tooling and you
+`source` the whole file, the API short-circuits to an env-only backend set and
+drops the document/vector roles. Export **only** the four required keys and
+`unset NEO4J_URI POSTGRES_URL ARANGO_URL` before starting the host API (see
+Step 3).
+
+---
+
+## Quick reference
+
+```bash
+# 1. Vector emulator (separate container; reuse if already running)
+docker run -d --name pinecone-local -e PORT=5080 -e PINECONE_HOST=localhost \
+  -p 5080-5090:5080-5090 --platform linux/amd64 \
+  ghcr.io/pinecone-io/pinecone-local:latest
+
+# 2. Compose stack (note --env-file .env and --build)
+docker compose --env-file .env -f attestor/infra/local/docker-compose.yml up -d --build
+
+# 3. Verify (host-run API → all 4 green)
+export PINECONE_API_KEY=$(grep -E '^PINECONE_API_KEY=' .env | cut -d= -f2-)
+export VOYAGE_API_KEY=$(grep -E '^VOYAGE_API_KEY=' .env | cut -d= -f2-)
+export OPENROUTER_API_KEY=$(grep -E '^OPENROUTER_API_KEY=' .env | cut -d= -f2-)
+export NEO4J_PASSWORD=attestor
+unset NEO4J_URI POSTGRES_URL ARANGO_URL
+attestor api --port 8090
+curl -s http://127.0.0.1:8090/health | python3 -m json.tool
+```

--- a/docs/context-clock-benchmark.html
+++ b/docs/context-clock-benchmark.html
@@ -1,0 +1,629 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>context-clock — full methodology & per-turn results</title>
+<style>
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+:root{
+  --ink:#0f0e0c;--ink2:#3a3630;--ink3:#7a766e;
+  --paper:#faf8f4;--paper2:#f3f0ea;--paper3:#e8e3d8;--rule:#d4cfc3;
+  --g:#1a3a26;--g2:#2a5c3a;--g3:#cfe8d4;--g4:#f0f7f2;
+  --r:#7a1a1a;--r2:#f7ecec;--amber:#b07a00;
+  --navy:#0d1f3c;
+  --mono:'SF Mono','Fira Code','Cascadia Code',ui-monospace,monospace;
+  --serif:Georgia,'Times New Roman',serif;
+  --sans:-apple-system,BlinkMacSystemFont,'Segoe UI',system-ui,sans-serif;
+  --maxw:1080px;
+}
+html{scroll-behavior:smooth}
+body{background:var(--paper3);color:var(--ink);font-family:var(--sans);font-size:16px;line-height:1.7;-webkit-font-smoothing:antialiased}
+.wrap{max-width:var(--maxw);margin:0 auto;padding:0 24px}
+a{color:inherit}
+.mono{font-family:var(--mono)}
+
+/* nav */
+nav{position:sticky;top:0;z-index:50;background:rgba(250,248,244,0.9);backdrop-filter:blur(8px);border-bottom:0.5px solid var(--rule)}
+.nav-in{max-width:var(--maxw);margin:0 auto;padding:14px 24px;display:flex;align-items:center;justify-content:space-between}
+.brand{font-family:var(--mono);font-size:14px;font-weight:600;letter-spacing:-0.01em;color:var(--ink);text-decoration:none}
+.brand b{color:var(--g2)}
+.nav-links{display:flex;gap:22px;align-items:center}
+.nav-links a{font-size:13px;color:var(--ink2);text-decoration:none;font-family:var(--mono)}
+.nav-links a:hover{color:var(--g2)}
+.btn{display:inline-block;text-decoration:none;font-weight:600;border-radius:6px;white-space:nowrap;transition:transform .12s ease}
+.btn:hover{transform:translateY(-1px)}
+.btn-g{background:var(--g);color:var(--g4);padding:9px 18px;font-size:13px}
+.btn-ghost{background:transparent;border:0.5px solid var(--rule);color:var(--ink2);padding:9px 16px;font-size:13px;font-family:var(--mono)}
+@media(max-width:680px){.nav-links a:not(.btn){display:none}}
+
+/* hero */
+.hero{padding:64px 0 40px}
+.kicker{font-family:var(--mono);font-size:12px;letter-spacing:0.12em;text-transform:uppercase;color:var(--g2);margin-bottom:20px;display:flex;align-items:center;gap:10px}
+.kicker::before{content:'';width:34px;height:1px;background:var(--g2)}
+h1{font-family:var(--serif);font-weight:700;font-size:clamp(34px,6vw,60px);line-height:1.04;letter-spacing:-0.025em;max-width:17ch}
+h1 .ital{font-style:italic;color:var(--g2)}
+.lede{font-size:clamp(17px,2.2vw,20px);color:var(--ink2);margin-top:24px;max-width:62ch;line-height:1.55}
+.lede strong{color:var(--ink)}
+.hero-cta{display:flex;gap:14px;flex-wrap:wrap;margin-top:32px;align-items:center}
+.btn-lg{padding:13px 26px;font-size:15px}
+.term{margin-top:30px;background:var(--ink);color:#a8e6c0;font-family:var(--mono);font-size:13px;padding:16px 18px;border-radius:8px;line-height:1.9;max-width:600px;overflow-x:auto}
+.term .pr{color:rgba(168,230,192,0.45)}
+.term .cm{color:rgba(168,230,192,0.4);font-style:italic}
+
+/* stat row */
+.statrow{display:grid;grid-template-columns:repeat(4,1fr);gap:1px;background:var(--rule);border:0.5px solid var(--rule);border-radius:10px;overflow:hidden;margin:48px 0 8px}
+.statrow .ss{background:var(--paper);padding:22px 16px;text-align:center}
+.ss-num{font-family:var(--serif);font-size:clamp(26px,3.4vw,36px);font-weight:700;line-height:1}
+.ss-num.g{color:var(--g2)}.ss-num.r{color:var(--r)}.ss-num.a{color:var(--amber)}
+.ss-lbl{font-size:11.5px;color:var(--ink3);margin-top:7px;line-height:1.4}
+@media(max-width:680px){.statrow{grid-template-columns:repeat(2,1fr)}}
+
+/* sections */
+section{padding:60px 0;border-top:0.5px solid var(--rule)}
+.sec-label{font-family:var(--mono);font-size:12px;letter-spacing:0.1em;text-transform:uppercase;color:var(--ink3);margin-bottom:14px}
+h2{font-family:var(--serif);font-weight:700;font-size:clamp(26px,3.6vw,38px);line-height:1.12;letter-spacing:-0.02em;max-width:20ch}
+h2 .ital{font-style:italic;color:var(--g2)}
+.sec-lede{font-size:17px;color:var(--ink2);margin-top:16px;max-width:64ch}
+.sec-lede code{font-family:var(--mono);font-size:13px;background:var(--paper3);padding:1px 5px;border-radius:3px}
+
+/* two-mode cards */
+.modes{display:grid;grid-template-columns:1fr 1fr;gap:18px;margin-top:32px}
+.mode{border-radius:10px;padding:24px;border:0.5px solid var(--rule)}
+.mode.bad{background:var(--r2)}
+.mode.bad2{background:var(--navy);color:#dfe7f4;border-color:var(--navy)}
+.mode h3{font-family:var(--serif);font-size:21px;font-weight:700;margin-bottom:8px}
+.mode.bad h3{color:var(--r)}
+.mode.bad2 h3{color:#fff}
+.mode p{font-size:14px;line-height:1.6}
+.mode.bad p{color:var(--ink2)}
+.mode.bad2 p{color:#c3cfe2}
+.mode .big{font-family:var(--serif);font-size:30px;font-weight:700;margin:14px 0 4px}
+.mode.bad .big{color:var(--r)}.mode.bad2 .big{color:#ff9b8a}
+@media(max-width:680px){.modes{grid-template-columns:1fr}}
+
+/* chart */
+.chartwrap{margin-top:34px;background:var(--paper);border:0.5px solid var(--rule);border-radius:12px;padding:24px}
+.chart-hud{display:flex;gap:28px;flex-wrap:wrap;align-items:baseline;margin-bottom:8px}
+.hud-item .n{font-family:var(--serif);font-size:24px;font-weight:700}
+.hud-item .n.r{color:var(--r)}.hud-item .n.g{color:var(--g2)}.hud-item .n.k{color:var(--ink)}
+.hud-item .l{font-family:var(--mono);font-size:10px;text-transform:uppercase;letter-spacing:0.06em;color:var(--ink3)}
+svg .draw{stroke-dasharray:2400;stroke-dashoffset:2400;animation:draw 2.2s ease forwards}
+svg .draw.mem{animation-delay:.3s}
+@keyframes draw{to{stroke-dashoffset:0}}
+.chart-leg{display:flex;gap:20px;flex-wrap:wrap;margin-top:12px;font-size:12.5px;color:var(--ink2);font-family:var(--mono)}
+.chart-leg b{font-weight:600}
+.swatch{display:inline-block;width:18px;height:3px;border-radius:2px;vertical-align:middle;margin-right:7px}
+
+/* staircase */
+.rot-box{background:var(--paper);border:0.5px solid var(--rule);border-radius:12px;padding:22px;margin-top:24px}
+.rot-title{font-family:var(--mono);font-size:11px;letter-spacing:0.08em;text-transform:uppercase;color:var(--ink3);margin-bottom:16px}
+.rrow{display:flex;align-items:center;gap:12px;margin-bottom:9px}
+.rlbl{font-family:var(--mono);font-size:12px;color:var(--ink3);min-width:78px}
+.rbw{flex:1;height:14px;background:var(--paper3);border-radius:3px;overflow:hidden}
+.rb{height:100%;width:0;border-radius:3px;transition:width 1.1s cubic-bezier(.2,.7,.2,1)}
+.rpct{font-family:var(--mono);font-size:12px;min-width:38px;text-align:right;font-weight:600}
+
+/* model table */
+.mtab{margin-top:30px;border:0.5px solid var(--rule);border-radius:12px;overflow:hidden;background:var(--paper)}
+.mtab-head,.mtab-row{display:grid;grid-template-columns:1.6fr 0.8fr 1.4fr;gap:8px;padding:13px 20px;align-items:center}
+.mtab-head{background:var(--paper3);font-family:var(--mono);font-size:10.5px;letter-spacing:0.07em;text-transform:uppercase;color:var(--ink3)}
+.mtab-row{border-top:0.5px solid var(--rule)}
+.mtab-row .nm{font-family:var(--mono);font-size:13.5px}
+.mtab-row .mult{font-family:var(--serif);font-size:19px;font-weight:700;color:var(--g2)}
+.mtab-row .cost{font-family:var(--mono);font-size:12.5px;color:var(--ink3)}
+.mtab-row.hl{background:var(--g4)}
+.open{display:inline-block;background:var(--g3);color:var(--g);font-family:var(--mono);font-size:9px;padding:1px 5px;border-radius:3px;margin-left:6px;vertical-align:middle}
+
+/* run steps */
+.code-line{background:var(--ink);color:#a8e6c0;font-family:var(--mono);font-size:13px;padding:18px 20px;border-radius:10px;margin-top:24px;line-height:2;overflow-x:auto}
+.code-line .cm{color:rgba(168,230,192,0.4);font-style:italic}
+.code-line .kw{color:#7ee8ff}
+.code-line .pr{color:rgba(168,230,192,0.45)}
+
+/* fix CTA band */
+.band{background:var(--navy);color:#dfe7f4;border-radius:14px;padding:40px;margin-top:8px;display:flex;justify-content:space-between;align-items:center;gap:24px;flex-wrap:wrap}
+.band h3{font-family:var(--serif);font-size:26px;font-weight:700;color:#fff;line-height:1.2;max-width:24ch}
+.band p{font-size:14px;color:#b7c4da;margin-top:8px;max-width:48ch}
+.btn-navy{background:#fff;color:var(--navy);padding:13px 24px;font-size:14px}
+
+/* footer */
+footer{border-top:0.5px solid var(--rule);padding:38px 0 60px;margin-top:20px}
+.foot-in{display:flex;justify-content:space-between;gap:20px;flex-wrap:wrap;align-items:center}
+.foot-links{display:flex;gap:18px;flex-wrap:wrap}
+.foot-links a{font-family:var(--mono);font-size:13px;color:var(--ink2);text-decoration:none}
+.foot-links a:hover{color:var(--g2)}
+.foot-note{font-family:var(--mono);font-size:11px;color:var(--ink3)}
+.tag{font-family:var(--mono);font-size:10px;letter-spacing:0.06em;background:var(--g3);color:var(--g);padding:3px 9px;border-radius:3px}
+
+/* reveal + animated components (shared with landing) */
+.reveal{opacity:0;transform:translateY(16px);transition:opacity .6s ease,transform .6s ease}
+.reveal.in{opacity:1;transform:none}
+.bignums{display:grid;grid-template-columns:repeat(4,1fr);gap:16px;margin-top:30px}
+.bignums>div{text-align:center;padding:22px 10px;background:var(--paper);border:0.5px solid var(--rule);border-radius:10px}
+.bignums .cu{font-family:var(--serif);font-size:clamp(30px,4vw,44px);font-weight:700;color:var(--g2);line-height:1;display:block}
+.bignums small{display:block;margin-top:8px;font-size:11.5px;color:var(--ink3);line-height:1.4}
+@media(max-width:680px){.bignums{grid-template-columns:repeat(2,1fr)}}
+.detail-grid{display:grid;grid-template-columns:1fr 1fr;gap:18px;margin-top:24px}
+.dcard{background:var(--paper);border:0.5px solid var(--rule);border-radius:12px;padding:24px}
+.dcard h4{font-family:var(--serif);font-size:17px;font-weight:700;margin-bottom:16px}
+.dcard p{font-size:13px;color:var(--ink3);margin-top:14px;line-height:1.5}
+@media(max-width:680px){.detail-grid{grid-template-columns:1fr}}
+
+/* per-call / cost bars */
+.cbar{display:flex;align-items:center;gap:12px;margin-bottom:12px}
+.cbar-lbl{font-family:var(--mono);font-size:11px;color:var(--ink3);min-width:118px}
+.cbar-track{flex:1;height:18px;background:var(--paper3);border-radius:4px;overflow:hidden}
+.cbar-fill{height:100%;width:0;border-radius:4px;transition:width 1.3s cubic-bezier(.2,.7,.2,1)}
+.cbar-val{font-family:var(--serif);font-size:15px;font-weight:700;min-width:62px;text-align:right}
+
+/* reduction curve */
+.rcurve{display:flex;flex-direction:column;gap:11px}
+.rc{display:flex;align-items:center;gap:12px}
+.rc>span{font-family:var(--mono);font-size:11px;color:var(--ink3);min-width:34px}
+.rc-track{flex:1;height:16px;background:var(--paper3);border-radius:4px;overflow:hidden}
+.rc-fill{height:100%;width:0;border-radius:4px;background:linear-gradient(90deg,#cfe8d4,#2a5c3a);transition:width 1.1s cubic-bezier(.2,.7,.2,1)}
+.rc>b{font-family:var(--serif);font-size:15px;color:var(--g2);min-width:56px;text-align:right}
+
+/* input-x model bars */
+.mbar{display:flex;align-items:center;gap:12px;margin-bottom:11px}
+.mbar-lbl{font-family:var(--mono);font-size:12px;color:var(--ink2);min-width:150px}
+.mbar-lbl .open{margin-left:5px}
+.mbar-track{flex:1;height:16px;background:var(--paper3);border-radius:4px;overflow:hidden}
+.mbar-fill{height:100%;width:0;border-radius:4px;background:linear-gradient(90deg,#cfe8d4,#2a5c3a);transition:width 1.2s cubic-bezier(.2,.7,.2,1)}
+.mbar-val{font-family:var(--serif);font-size:16px;font-weight:700;color:var(--g2);min-width:52px;text-align:right}
+
+/* method block */
+.method{margin-top:24px;background:var(--paper2);border:0.5px solid var(--rule);border-radius:12px;padding:24px}
+.method ul{list-style:none;margin:10px 0 4px}
+.method li{font-size:13.5px;color:var(--ink2);padding-left:20px;position:relative;margin-bottom:10px;line-height:1.55}
+.method li::before{content:'·';position:absolute;left:4px;color:var(--g2);font-weight:700}
+.method code{font-family:var(--mono);font-size:12px;background:var(--paper3);padding:1px 5px;border-radius:3px}
+.method li b{color:var(--ink)}
+
+/* per-turn data table */
+.ptab{margin-top:26px;border:0.5px solid var(--rule);border-radius:12px;overflow:hidden;background:var(--paper)}
+.ptab-head,.ptab-row{display:grid;grid-template-columns:0.7fr 1.4fr 1.4fr 0.9fr;gap:8px;padding:13px 20px;align-items:center}
+.ptab-head{background:var(--paper3);font-family:var(--mono);font-size:10.5px;letter-spacing:0.07em;text-transform:uppercase;color:var(--ink3)}
+.ptab-row{border-top:0.5px solid var(--rule);font-family:var(--mono);font-size:13px}
+.ptab-row .tn{color:var(--ink3)}
+.ptab-row .raw{color:var(--r)}
+.ptab-row .mem{color:var(--g2)}
+.ptab-row .red{font-family:var(--serif);font-size:16px;font-weight:700;color:var(--ink)}
+.ptab-row.last{background:var(--g4)}
+.ptab-row.last .red{color:var(--g2)}
+@media(max-width:680px){
+  .ptab-head,.ptab-row{grid-template-columns:0.6fr 1.3fr 1.3fr 0.8fr;font-size:11px;padding:11px 12px}
+}
+
+/* footnote / caveats two-column */
+.fineprint{margin-top:24px;display:grid;grid-template-columns:1fr 1fr;gap:16px}
+.fp{background:var(--paper);border:0.5px solid var(--rule);border-radius:12px;padding:22px}
+.fp h4{font-family:var(--serif);font-size:16px;font-weight:700;margin-bottom:8px}
+.fp p{font-size:13px;color:var(--ink3);line-height:1.55}
+.fp code{font-family:var(--mono);font-size:11.5px;background:var(--paper3);padding:1px 5px;border-radius:3px}
+@media(max-width:680px){.fineprint{grid-template-columns:1fr}}
+
+.callout{margin-top:20px;background:var(--navy);color:#dfe7f4;border-radius:12px;padding:22px 24px}
+.callout b{color:#ff9b8a;font-family:var(--serif);font-size:18px}
+.callout span{color:#9fb6da}
+
+@media(prefers-reduced-motion:reduce){
+  .reveal{opacity:1;transform:none;transition:none}
+  svg .draw{animation:none;stroke-dashoffset:0}
+  .cbar-fill,.rc-fill,.mbar-fill,.rb{transition:none}
+}
+</style>
+</head>
+<body>
+
+<nav>
+  <div class="nav-in">
+    <a href="#top" class="brand">context-<b>clock</b></a>
+    <div class="nav-links">
+      <a href="#setup">Setup</a>
+      <a href="#chart">The chart</a>
+      <a href="#models">6 models</a>
+      <a href="#perturn">Per-turn</a>
+      <a href="https://github.com/bolnet/context-clock" class="btn btn-g">Fork on GitHub →</a>
+    </div>
+  </div>
+</nav>
+
+<div id="top" class="wrap">
+
+  <!-- HERO -->
+  <header class="hero">
+    <div class="kicker">Benchmark · Full methodology &amp; results</div>
+    <h1>How much does it cost to <span class="ital">remember</span>? We measured it.</h1>
+    <p class="lede">A deterministic benchmark of the context-rot arc across <strong>6 models</strong>. Under full-context replay, cumulative input tokens grow <strong>O(n²)</strong>; with retrieval, they grow <strong>O(n)</strong>. By turn 100 that's <strong>~21× fewer input tokens</strong> — at <strong>100% recall</strong>. This is the full picture: the workload, the two failure modes, the per-turn data, and exactly how to reproduce every number.</p>
+    <div class="hero-cta">
+      <a href="https://github.com/bolnet/context-clock" class="btn btn-g btn-lg">Fork the benchmark →</a>
+      <a href="#perturn" class="btn btn-ghost btn-lg">Jump to per-turn data ↓</a>
+    </div>
+    <div class="term">
+<span class="cm"># reproduce the whole arc locally — no API keys</span><br>
+<span class="pr">$</span> git clone github.com/bolnet/context-clock<br>
+<span class="pr">$</span> python -m context_clock.run --until-rotted --turns 100<br>
+<span class="pr">$</span> python -m context_clock.run --memory --turns 100
+    </div>
+
+    <div class="statrow">
+      <div class="ss"><div class="ss-num g"><span class="cu" data-to="6">0</span></div><div class="ss-lbl">models · open + closed</div></div>
+      <div class="ss"><div class="ss-num g"><span class="cu" data-to="100">0</span></div><div class="ss-lbl">turns per session</div></div>
+      <div class="ss"><div class="ss-num g"><span class="cu" data-to="21">0</span>×</div><div class="ss-lbl">fewer input tokens at turn 100</div></div>
+      <div class="ss"><div class="ss-num g"><span class="cu" data-to="100" data-suffix="%">0</span></div><div class="ss-lbl">recall held, both configs</div></div>
+    </div>
+  </header>
+
+  <!-- SETUP -->
+  <section id="setup">
+    <div class="sec-label reveal">The setup · the workload</div>
+    <h2 class="reveal">An inject-and-probe <span class="ital">needle in a haystack</span>.</h2>
+    <p class="sec-lede reveal">Every turn plants one unique code inside a short memo — a needle like <code>k9f3a2</code>. Then a probe asks for a specific memo's code, and grading is done at the answer level: an <strong>exact string match</strong>, nothing fuzzy. Same workload, run two ways.</p>
+
+    <div class="detail-grid">
+      <div class="dcard reveal">
+        <h4>The two configs</h4>
+        <div class="cbar"><span class="cbar-lbl">raw · re-send all</span><div class="cbar-track"><div class="cbar-fill grow" data-w="100" style="background:#7a1a1a"></div></div><span class="cbar-val" style="color:#7a1a1a">O(n²)</span></div>
+        <div class="cbar"><span class="cbar-lbl">memory · top-1</span><div class="cbar-track"><div class="cbar-fill grow" data-w="14" style="background:#2a5c3a"></div></div><span class="cbar-val" style="color:#2a5c3a">O(n)</span></div>
+        <p><b>raw</b> re-sends the entire transcript each turn. <b>memory</b> retrieves only the single most relevant memo (top-1). Both must still answer the probe correctly.</p>
+      </div>
+      <div class="dcard reveal">
+        <h4>Run parameters · held fixed</h4>
+        <div class="method" style="margin-top:0;background:transparent;border:0;padding:0">
+          <ul>
+            <li><b>Native context window</b> — models run at full capacity.</li>
+            <li><b>temperature 0</b> — deterministic, repeatable.</li>
+            <li><b>cadence 1</b> — one inject + one probe every turn.</li>
+            <li><b>100 turns</b> — long enough for the curves to separate.</li>
+            <li>Grading: <b>answer-level exact string</b> on the planted code.</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- TWO FAILURE MODES -->
+  <section id="failures">
+    <div class="sec-label reveal">Two ways to run out of road</div>
+    <h2 class="reveal">Grow it and you pay <span class="ital">quadratically</span>. Cap it and it forgets.</h2>
+    <p class="sec-lede reveal">There's no free lunch with raw context. context-clock reproduces each failure mode deterministically before measuring the way out.</p>
+    <div class="modes">
+      <div class="mode bad reveal">
+        <h3>Grow it → O(n²)</h3>
+        <p>Re-read the whole transcript every turn and input tokens pile up as n²/2. By turn 100 a single gpt-5.4 raw session has read <strong>1,326,734 cumulative input tokens</strong> — for one conversation.</p>
+        <div class="big">1,326,734</div>
+        <p>cumulative input tokens · gpt-5.4 · 100 turns · no memory</p>
+      </div>
+      <div class="mode bad2 reveal">
+        <h3>Cap it → rot</h3>
+        <p>Cap the window to bound cost and the oldest turns truncate. Recall decays in a staircase — and it's <strong>identical from a 3B model to a 671B one</strong>. Truncation is mechanical, not a function of model size.</p>
+        <div class="big">100% → 0%</div>
+        <p>recall, by turn 10 · capped window · every model</p>
+      </div>
+    </div>
+
+    <div class="rot-box reveal">
+      <div class="rot-title">The cap-and-rot staircase · identical 3B → 671B</div>
+      <div class="rrow"><span class="rlbl">turns 1–7</span><div class="rbw"><div class="rb grow" data-w="100" style="background:#2a5c3a"></div></div><span class="rpct" style="color:#2a5c3a">100%</span></div>
+      <div class="rrow"><span class="rlbl">turn 8</span><div class="rbw"><div class="rb grow" data-w="67" style="background:#b07a00"></div></div><span class="rpct" style="color:#b07a00">67%</span></div>
+      <div class="rrow"><span class="rlbl">turn 9</span><div class="rbw"><div class="rb grow" data-w="33" style="background:#b03a2e"></div></div><span class="rpct" style="color:#b03a2e">33%</span></div>
+      <div class="rrow"><span class="rlbl">turn 10+</span><div class="rbw"><div class="rb grow" data-w="2" style="background:#b03a2e"></div></div><span class="rpct" style="color:#b03a2e">0%</span></div>
+    </div>
+  </section>
+
+  <!-- HERO CHART -->
+  <section id="chart">
+    <div class="sec-label reveal">The proof · linear vs quadratic</div>
+    <h2 class="reveal">A parabola becomes a <span class="ital">straight line</span>.</h2>
+    <p class="sec-lede reveal">Same workload, run two ways, both holding 100% recall: re-send everything (raw) vs retrieve only what's needed (memory). Cumulative <strong>input</strong> tokens — the part memory actually controls. gpt-5.4, native window.</p>
+
+    <div class="chartwrap reveal">
+      <div class="chart-hud">
+        <div class="hud-item"><div class="n k">t100</div><div class="l">turn</div></div>
+        <div class="hud-item"><div class="n r">1.33M</div><div class="l">raw input tokens</div></div>
+        <div class="hud-item"><div class="n g">61.8K</div><div class="l">memory input tokens</div></div>
+        <div class="hud-item"><div class="n k">21.5×</div><div class="l">fewer input tokens</div></div>
+      </div>
+      <svg viewBox="0 0 760 320" width="100%" role="img" aria-label="Cumulative input tokens: raw grows quadratically to 1.33M, memory stays flat near 61.8K">
+        <!-- gridlines -->
+        <line x1="70" y1="290" x2="730" y2="290" stroke="#d4cfc3" stroke-width="1"/>
+        <line x1="70" y1="160" x2="730" y2="160" stroke="#e8e3d8" stroke-width="1" stroke-dasharray="3 4"/>
+        <line x1="70" y1="40" x2="730" y2="40" stroke="#e8e3d8" stroke-width="1" stroke-dasharray="3 4"/>
+        <!-- y labels -->
+        <text x="62" y="294" text-anchor="end" font-family="SF Mono,monospace" font-size="10" fill="#7a766e">0</text>
+        <text x="62" y="164" text-anchor="end" font-family="SF Mono,monospace" font-size="10" fill="#7a766e">700K</text>
+        <text x="62" y="44" text-anchor="end" font-family="SF Mono,monospace" font-size="10" fill="#7a766e">1.4M</text>
+        <!-- x labels -->
+        <text x="70" y="308" text-anchor="middle" font-family="SF Mono,monospace" font-size="10" fill="#7a766e">t1</text>
+        <text x="400" y="308" text-anchor="middle" font-family="SF Mono,monospace" font-size="10" fill="#7a766e">t50</text>
+        <text x="730" y="308" text-anchor="middle" font-family="SF Mono,monospace" font-size="10" fill="#7a766e">t100</text>
+        <!-- animated curve — JS grows it turn-by-turn (quadratic); pulses every 10 turns -->
+        <path class="c-rawfill" d="" fill="#7a1a1a" fill-opacity="0.07"/>
+        <path class="c-raw" d="" fill="none" stroke="#7a1a1a" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+        <path class="c-mem" d="" fill="none" stroke="#2a5c3a" stroke-width="3" stroke-linecap="round"/>
+        <g class="c-pulses"></g>
+        <circle class="c-memdot" cx="70" cy="290" r="4.5" fill="#2a5c3a"/>
+        <circle class="c-rawdot" cx="70" cy="290" r="5" fill="#7a1a1a"/>
+        <text class="c-turn" x="70" y="278" text-anchor="middle" font-family="SF Mono,monospace" font-size="11" font-weight="600" fill="#7a1a1a" opacity="0">t0</text>
+        <text class="c-lbl" x="715" y="34" text-anchor="end" font-family="Georgia,serif" font-size="14" font-weight="700" fill="#7a1a1a" opacity="0">21.5×</text>
+      </svg>
+      <div class="chart-leg">
+        <span><span class="swatch" style="background:#7a1a1a"></span><b>raw</b> — re-send all (quadratic → 1.33M)</span>
+        <span><span class="swatch" style="background:#2a5c3a"></span><b>memory</b> — retrieve top-1 (linear → 61.8K)</span>
+        <span style="color:#7a766e">gpt-5.4 · native window · 100% recall both sides</span>
+      </div>
+    </div>
+  </section>
+
+  <!-- PER-CALL CONTEXT -->
+  <section id="percall">
+    <div class="sec-label reveal">Per-call context · what the model reads each turn</div>
+    <h2 class="reveal">It's the <span class="ital">per-call read</span> that diverges.</h2>
+    <p class="sec-lede reveal">The cumulative curve is just the running sum of what each turn reads. Raw's per-call input climbs toward the window; memory's stays flat near ~209 tokens the entire session.</p>
+
+    <div class="detail-grid">
+      <div class="dcard reveal">
+        <h4>raw · input tokens read on a single call</h4>
+        <div class="cbar"><span class="cbar-lbl">turn 1</span><div class="cbar-track"><div class="cbar-fill grow" data-w="1.5" style="background:#7a1a1a"></div></div><span class="cbar-val" style="color:#7a1a1a">132</span></div>
+        <div class="cbar"><span class="cbar-lbl">turn 24</span><div class="cbar-track"><div class="cbar-fill grow" data-w="24" style="background:#7a1a1a"></div></div><span class="cbar-val" style="color:#7a1a1a">2,122</span></div>
+        <div class="cbar"><span class="cbar-lbl">turn 50</span><div class="cbar-track"><div class="cbar-fill grow" data-w="50" style="background:#7a1a1a"></div></div><span class="cbar-val" style="color:#7a1a1a">4,380</span></div>
+        <div class="cbar"><span class="cbar-lbl">turn 100</span><div class="cbar-track"><div class="cbar-fill grow" data-w="100" style="background:#7a1a1a"></div></div><span class="cbar-val" style="color:#7a1a1a">8,709</span></div>
+        <p>Each turn re-reads the whole transcript, so the per-call read grows linearly — and the cumulative sum grows quadratically.</p>
+      </div>
+      <div class="dcard reveal">
+        <h4>memory · input tokens read on a single call</h4>
+        <div class="cbar"><span class="cbar-lbl">turn 1</span><div class="cbar-track"><div class="cbar-fill grow" data-w="2.4" style="background:#2a5c3a"></div></div><span class="cbar-val" style="color:#2a5c3a">~209</span></div>
+        <div class="cbar"><span class="cbar-lbl">turn 24</span><div class="cbar-track"><div class="cbar-fill grow" data-w="2.4" style="background:#2a5c3a"></div></div><span class="cbar-val" style="color:#2a5c3a">~209</span></div>
+        <div class="cbar"><span class="cbar-lbl">turn 50</span><div class="cbar-track"><div class="cbar-fill grow" data-w="2.4" style="background:#2a5c3a"></div></div><span class="cbar-val" style="color:#2a5c3a">~209</span></div>
+        <div class="cbar"><span class="cbar-lbl">turn 100</span><div class="cbar-track"><div class="cbar-fill grow" data-w="2.4" style="background:#2a5c3a"></div></div><span class="cbar-val" style="color:#2a5c3a">~209</span></div>
+        <p>Retrieve top-1 and the per-call read is flat — prompt + one memo + probe — from turn 1 to turn 100.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- 6-MODEL RESULTS -->
+  <section id="models">
+    <div class="sec-label reveal">6-model study · input × at turn 100 · all 100% recall</div>
+    <h2 class="reveal">Input × is workload geometry — <span class="ital">model-independent</span>.</h2>
+    <p class="sec-lede reveal">Six models — open and closed, 3B-class to frontier — all trace the identical reduction curve. The number is set by the shape of the workload, not the model under it.</p>
+
+    <div class="mtab reveal">
+      <div class="mtab-head"><span>model</span><span>input ×</span><span>recall</span></div>
+      <div class="mtab-row"><span class="nm">gpt-5.4</span><span class="mult">21.5×</span><span class="cost">100%</span></div>
+      <div class="mtab-row"><span class="nm">gpt-5.4-mini</span><span class="mult">21.5×</span><span class="cost">100%</span></div>
+      <div class="mtab-row"><span class="nm">claude-sonnet-4</span><span class="mult">22.1×</span><span class="cost">100%</span></div>
+      <div class="mtab-row hl"><span class="nm">claude-opus-4</span><span class="mult">22.2×</span><span class="cost">100%</span></div>
+      <div class="mtab-row"><span class="nm">kimi-k2.6 <span class="open">open</span></span><span class="mult">21.0×</span><span class="cost">100%</span></div>
+      <div class="mtab-row"><span class="nm">deepseek-v3.2 <span class="open">open</span></span><span class="mult">22.5×</span><span class="cost">100%</span></div>
+    </div>
+
+    <div class="dcard reveal" style="margin-top:18px">
+      <h4>Input-token reduction at turn 100 · per model</h4>
+      <div class="mbar"><span class="mbar-lbl">gpt-5.4</span><div class="mbar-track"><div class="mbar-fill grow" data-w="95.6"></div></div><span class="mbar-val">21.5×</span></div>
+      <div class="mbar"><span class="mbar-lbl">gpt-5.4-mini</span><div class="mbar-track"><div class="mbar-fill grow" data-w="95.6"></div></div><span class="mbar-val">21.5×</span></div>
+      <div class="mbar"><span class="mbar-lbl">claude-sonnet-4</span><div class="mbar-track"><div class="mbar-fill grow" data-w="98.2"></div></div><span class="mbar-val">22.1×</span></div>
+      <div class="mbar"><span class="mbar-lbl">claude-opus-4</span><div class="mbar-track"><div class="mbar-fill grow" data-w="98.7"></div></div><span class="mbar-val">22.2×</span></div>
+      <div class="mbar"><span class="mbar-lbl">kimi-k2.6 <span class="open">open</span></span><div class="mbar-track"><div class="mbar-fill grow" data-w="93.3"></div></div><span class="mbar-val">21.0×</span></div>
+      <div class="mbar"><span class="mbar-lbl">deepseek-v3.2 <span class="open">open</span></span><div class="mbar-track"><div class="mbar-fill grow" data-w="100"></div></div><span class="mbar-val">22.5×</span></div>
+    </div>
+
+    <div class="dcard reveal" style="margin-top:18px">
+      <h4>The reduction curve is identical across all 6 models</h4>
+      <div class="rcurve">
+        <div class="rc"><span>t24</span><div class="rc-track"><div class="rc-fill grow" data-w="26"></div></div><b>5.6×</b></div>
+        <div class="rc"><span>t50</span><div class="rc-track"><div class="rc-fill grow" data-w="51"></div></div><b>11.0×</b></div>
+        <div class="rc"><span>t75</span><div class="rc-track"><div class="rc-fill grow" data-w="75"></div></div><b>16.2×</b></div>
+        <div class="rc"><span>t100</span><div class="rc-track"><div class="rc-fill grow" data-w="100"></div></div><b>~21–22.5×</b></div>
+      </div>
+      <p>5.6× (t24) → 11.0× (t50) → 16.2× (t75) → ~21–22.5× (t100). A straight line against a parabola → the ratio is unbounded, and it doesn't care which model you put under it.</p>
+    </div>
+  </section>
+
+  <!-- COST (footnote framing) -->
+  <section id="cost">
+    <div class="sec-label reveal">Cost · a footnote, not the headline</div>
+    <h2 class="reveal">Why we lead with <span class="ital">input tokens</span>, not dollars.</h2>
+    <p class="sec-lede reveal">Cost <em>does</em> drop — but the multiple is distorted by two things that have nothing to do with the workload: provider <strong>prompt caching</strong> and answer <strong>verbosity</strong>. Tokens are the universal, model-independent number; cost is downstream of billing quirks.</p>
+
+    <div class="mtab reveal">
+      <div class="mtab-head"><span>model</span><span>cost ×</span><span>billed @ t100 · raw → mem</span></div>
+      <div class="mtab-row"><span class="nm">gpt-5.4</span><span class="mult">3.0×</span><span class="cost">$0.5701 → $0.1902</span></div>
+      <div class="mtab-row"><span class="nm">gpt-5.4-mini</span><span class="mult">3.8×</span><span class="cost">$0.2191 → $0.0571</span></div>
+      <div class="mtab-row"><span class="nm">claude-sonnet-4</span><span class="mult">19.5×</span><span class="cost">$4.8304 → $0.2482</span></div>
+      <div class="mtab-row hl"><span class="nm">claude-opus-4</span><span class="mult">19.5×</span><span class="cost">$24.1521 → $1.2392</span></div>
+      <div class="mtab-row"><span class="nm">kimi-k2.6 <span class="open">open</span></span><span class="mult">2.5×</span><span class="cost">$0.4263 → $0.1677</span></div>
+      <div class="mtab-row"><span class="nm">deepseek-v3.2 <span class="open">open</span></span><span class="mult">17.4×</span><span class="cost">$0.1617 → $0.0093</span></div>
+    </div>
+
+    <div class="detail-grid">
+      <div class="dcard reveal">
+        <h4>Prompt caching flattens the closed-source spread</h4>
+        <p style="margin-top:0">OpenAI auto-caches the repeated raw prefix, so the raw side is already cheap → cost only drops ~3–4×. Anthropic and DeepSeek don't cache here, so the raw side is billed in full → ~17–19.5× cost reduction. The token count doesn't change; only the bill does.</p>
+      </div>
+      <div class="dcard reveal">
+        <h4>Verbosity distorts the open-source spread</h4>
+        <p style="margin-top:0">kimi-k2.6 is chatty — its answer-side output tokens dominate, which memory doesn't touch — so its cost ratio compresses to 2.5× even though its input × is 21.0×. Same workload geometry, different output behavior.</p>
+      </div>
+    </div>
+
+    <div class="callout reveal">
+      <b>claude-opus-4: $24.15 raw → $1.24 memory</b> &nbsp;<span>— for a single 100-turn session. Input tokens are the cause; the bill is just one of its shadows.</span>
+    </div>
+  </section>
+
+  <!-- PER-TURN DATA TABLE (deepest detail) -->
+  <section id="perturn">
+    <div class="sec-label reveal">Per-turn data · gpt-5.4 · cumulative input tokens</div>
+    <h2 class="reveal">The numbers, turn by <span class="ital">turn</span>.</h2>
+    <p class="sec-lede reveal">Cumulative input tokens for gpt-5.4, both configs, with the running reduction. Memory adds a constant ~647 input tokens per turn (linear); raw's per-turn add grows every turn (quadratic).</p>
+
+    <div class="ptab reveal">
+      <div class="ptab-head"><span>turn</span><span>raw · cum. input</span><span>memory · cum. input</span><span>reduction</span></div>
+      <div class="ptab-row"><span class="tn">t1</span><span class="raw">132</span><span class="mem">125</span><span class="red">1.1×</span></div>
+      <div class="ptab-row"><span class="tn">t24</span><span class="raw">80,897</span><span class="mem">14,405</span><span class="red">5.6×</span></div>
+      <div class="ptab-row"><span class="tn">t50</span><span class="raw">338,147</span><span class="mem">30,706</span><span class="red">11.0×</span></div>
+      <div class="ptab-row"><span class="tn">t75</span><span class="raw">751,406</span><span class="mem">46,268</span><span class="red">16.2×</span></div>
+      <div class="ptab-row last"><span class="tn">t100</span><span class="raw">1,326,734</span><span class="mem">61,818</span><span class="red">21.5×</span></div>
+    </div>
+    <p class="sec-lede reveal" style="font-size:14px;color:var(--ink3);margin-top:18px">Read the two middle columns as functions of n: the memory column is a straight line (+~647/turn); the raw column is a parabola (its per-turn increment itself grows every turn). The reduction is their ratio — which is why it keeps climbing with no ceiling.</p>
+  </section>
+
+  <!-- REPRODUCE IT -->
+  <section id="reproduce">
+    <div class="sec-label reveal">Reproduce it · 100% local</div>
+    <h2 class="reveal">Every number here is <span class="ital">re-runnable</span>.</h2>
+    <p class="sec-lede reveal">Fork it, run the rot stress test, run the fix, then point the same harness at any model via OpenRouter. Locally it runs on Ollama with no API keys.</p>
+    <div class="code-line reveal">
+<span class="cm"># clone</span><br>
+<span class="pr">$</span> git clone github.com/bolnet/context-clock<br><br>
+<span class="cm"># 1 · grow until recall dies — the O(n²) failure mode</span><br>
+<span class="pr">$</span> python -m context_clock.run <span class="kw">--until-rotted</span> --turns 100<br><br>
+<span class="cm"># 2 · the fix — retrieved memory, flat context, 100% recall</span><br>
+<span class="pr">$</span> python -m context_clock.run <span class="kw">--memory</span> --turns 100<br><br>
+<span class="cm"># 3 · any model, same harness — real billed cost from usage.cost</span><br>
+<span class="pr">$</span> python -m context_clock.run <span class="kw">--provider</span> openrouter <span class="kw">--model</span> openai/gpt-5.4
+    </div>
+    <div class="statrow" style="margin-top:30px">
+      <div class="ss"><div class="ss-num g"><span class="cu" data-to="99">0</span></div><div class="ss-lbl">tests — reproduce every number here</div></div>
+      <div class="ss"><div class="ss-num g">Ollama</div><div class="ss-lbl">runs locally · no API keys needed</div></div>
+      <div class="ss"><div class="ss-num g">usage.cost</div><div class="ss-lbl">real billed cost from OpenRouter</div></div>
+      <div class="ss"><div class="ss-num a">MIT</div><div class="ss-lbl">open source · no lock-in · fork freely</div></div>
+    </div>
+  </section>
+
+  <!-- CAVEATS / FINE PRINT (deepest detail) -->
+  <section id="caveats">
+    <div class="sec-label reveal">Honest scope · the fine print</div>
+    <h2 class="reveal">What this benchmark <span class="ital">does and doesn't</span> claim.</h2>
+    <p class="sec-lede reveal">The arc is real and it reproduces; the scope is deliberately narrow. Here's exactly where the edges are.</p>
+
+    <div class="fineprint">
+      <div class="fp reveal">
+        <h4>Single-fact NIAH, top-1</h4>
+        <p>One unique code per memo, retrieved top-1, no distractors. This isolates "does the system still have the fact?" — it is <b>not</b> a claim about hard multi-hop or conflicting-fact retrieval.</p>
+      </div>
+      <div class="fp reveal">
+        <h4>Native window throughout</h4>
+        <p>Models run at full context capacity. Capping is shown <b>only</b> to reproduce the cap-and-rot failure mode — the headline 21× numbers are all at native window.</p>
+      </div>
+      <div class="fp reveal">
+        <h4>The recall budget must be tight</h4>
+        <p>memory's win depends on a small retrieval budget. A fat budget — retrieving many memos per turn — drags the memory curve back toward quadratic. top-1 is doing real work here.</p>
+      </div>
+      <div class="fp reveal">
+        <h4>Input vs total tokens</h4>
+        <p>memory cuts the <b>input</b> tokens (what the model reads). Output — the model's answer — is unchanged across configs. The headline number is specifically about input.</p>
+      </div>
+      <div class="fp reveal">
+        <h4>Qwen3-Max excluded</h4>
+        <p>Dropped for provider rate-limiting during the run, not for disagreeing. The remaining <b>6 models already agree</b> on the identical curve, so the conclusion stands.</p>
+      </div>
+      <div class="fp reveal">
+        <h4>Cost is downstream</h4>
+        <p>Reported cost is real billed <code>usage.cost</code>, but it's distorted by caching and verbosity. That's why the report leads with input tokens, the universal number.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- CTA BAND -->
+  <section>
+    <div class="sec-label reveal">From measurement to fix</div>
+    <div class="band reveal">
+      <div>
+        <h3>context-clock measures it; Attestor fixes it.</h3>
+        <p>This benchmark proves the problem; <b style="color:#fff">Attestor</b> is the open-source memory layer that delivers it — flat ~200 tokens per call, ~21× fewer input tokens, 100% recall, two API calls.</p>
+      </div>
+      <a href="https://attestor.dev" class="btn btn-navy">Get the fix → attestor.dev</a>
+    </div>
+    <p class="sec-lede reveal" style="font-size:14px;color:var(--ink3);margin-top:20px">
+      ← <a href="context-clock-landing.html" style="color:var(--g2);text-decoration:none;font-family:var(--mono);font-size:13px">Back to the landing page</a>
+      &nbsp;·&nbsp;
+      <a href="https://github.com/bolnet/context-clock" style="color:var(--g2);text-decoration:none;font-family:var(--mono);font-size:13px">github.com/bolnet/context-clock →</a>
+    </p>
+  </section>
+
+</div>
+
+<footer>
+  <div class="wrap foot-in">
+    <div class="foot-links">
+      <a href="https://github.com/bolnet/context-clock">github.com/bolnet/context-clock</a>
+      <a href="https://attestor.dev">attestor.dev</a>
+      <a href="context-clock-landing.html">← landing</a>
+    </div>
+    <span class="foot-note"><span class="tag">FREE · MIT · NO LOCK-IN</span> &nbsp; context-clock — the agent token benchmark</span>
+  </div>
+</footer>
+
+<script>
+(function(){
+  function cu(el){var to=+el.dataset.to,suf=el.dataset.suffix||'',st=null,d=1200;
+    function f(t){if(!st)st=t;var p=Math.min(1,(t-st)/d);el.textContent=Math.round(to*(1-Math.pow(1-p,3)))+suf;if(p<1)requestAnimationFrame(f)}requestAnimationFrame(f)}
+  var io=new IntersectionObserver(function(es){es.forEach(function(e){if(!e.isIntersecting)return;var t=e.target;
+    t.classList.add('in');
+    if(t.classList.contains('grow'))t.style.width=t.dataset.w+'%';
+    if(t.classList.contains('cu'))cu(t);
+    io.unobserve(t);})},{threshold:.25});
+  document.querySelectorAll('.reveal,.grow,.cu').forEach(function(el){io.observe(el)});
+})();
+</script>
+
+<script>
+/* Parabola growth — cumulative-input chart grows turn-by-turn (linear in turns,
+   y follows t²): creeps early, accelerates late. Dot + turn label ride the curve;
+   pulse ring every 10 turns. Triggers on scroll; click chart to replay. */
+(function(){
+  var reduce = window.matchMedia && matchMedia('(prefers-reduced-motion: reduce)').matches;
+  function fmt(n){return n>=1e6?(n/1e6).toFixed(2)+'M':n>=1e3?Math.round(n/1e3)+'K':Math.round(n);}
+  function run(svg){
+    var rl=svg.querySelector('.c-raw'),rf=svg.querySelector('.c-rawfill'),ml=svg.querySelector('.c-mem'),
+        rd=svg.querySelector('.c-rawdot'),md=svg.querySelector('.c-memdot'),lb=svg.querySelector('.c-lbl'),
+        tn=svg.querySelector('.c-turn'),pg=svg.querySelector('.c-pulses');
+    if(!rl)return;
+    var X0=70,X1=730,Y0=290,RT=42,MT=279,N=100,DUR=reduce?0:4200,RAWMAX=1326734,MEMMAX=61818;
+    var hud=(svg.parentNode&&svg.parentNode.querySelector)?svg.parentNode.querySelector('.chart-hud'):null,
+        ns=hud?hud.querySelectorAll('.hud-item .n'):[];
+    function x(t){return X0+(X1-X0)*t;} function ry(t){return Y0-(Y0-RT)*t*t;} function my(t){return Y0-(Y0-MT)*t;}
+    function pulse(cx,cy){
+      if(reduce||!pg)return;
+      var c=document.createElementNS('http://www.w3.org/2000/svg','circle');
+      c.setAttribute('cx',cx);c.setAttribute('cy',cy);c.setAttribute('fill','none');
+      c.setAttribute('stroke','#7a1a1a');c.setAttribute('stroke-width','2');pg.appendChild(c);
+      var s=null;(function pf(t){if(!s)s=t;var q=Math.min(1,(t-s)/640);
+        c.setAttribute('r',(6+q*24).toFixed(1));c.setAttribute('opacity',(0.7*(1-q)).toFixed(2));
+        if(q<1)requestAnimationFrame(pf);else if(c.parentNode)pg.removeChild(c);})(performance.now());
+      rd.setAttribute('r','8');setTimeout(function(){rd.setAttribute('r','5');},170);
+    }
+    while(pg&&pg.firstChild)pg.removeChild(pg.firstChild);
+    var lastMile=0,start=null;
+    (function frame(ts){if(!start)start=ts;var p=DUR?Math.min(1,(ts-start)/DUR):1;
+      var d='M'+X0+' '+Y0;
+      for(var i=1;i<=N;i++){var t=p*i/N;d+=' L'+x(t).toFixed(1)+' '+ry(t).toFixed(1);}
+      rl.setAttribute('d',d); rf.setAttribute('d',d+' L'+x(p).toFixed(1)+' '+Y0+' Z');
+      ml.setAttribute('d','M'+X0+' '+Y0+' L'+x(p).toFixed(1)+' '+my(p).toFixed(1));
+      rd.setAttribute('cx',x(p));rd.setAttribute('cy',ry(p));md.setAttribute('cx',x(p));md.setAttribute('cy',my(p));
+      var turn=Math.round(p*100);
+      if(tn){tn.setAttribute('opacity',(p>0.02&&p<0.99)?'1':'0');tn.setAttribute('x',x(p));tn.setAttribute('y',(ry(p)-12).toFixed(1));tn.textContent='t'+turn;}
+      if(ns.length>=3){ns[0].textContent='t'+turn;ns[1].textContent=fmt(RAWMAX*p*p);ns[2].textContent=fmt(MEMMAX*p);}
+      var mile=Math.floor(turn/10);
+      if(mile>lastMile&&turn>0&&turn<100){lastMile=mile;pulse(x(p),ry(p));}
+      if(lb)lb.setAttribute('opacity',(p>0.85?(p-0.85)/0.15:0).toFixed(2));
+      if(p<1)requestAnimationFrame(frame);
+      else{if(ns.length>=3){ns[0].textContent='t100';ns[1].textContent='1.33M';ns[2].textContent='61.8K';}
+           if(tn)tn.setAttribute('opacity','0');pulse(x(1),ry(1));}
+    })(performance.now());
+  }
+  document.querySelectorAll('svg').forEach(function(svg){
+    if(!svg.querySelector('.c-raw'))return;
+    var fired=false;
+    new IntersectionObserver(function(es){es.forEach(function(e){if(e.isIntersecting&&!fired){fired=true;run(svg);}});},{threshold:.35}).observe(svg);
+    var wrap=svg.closest('.chartwrap')||svg.parentNode;
+    if(wrap){wrap.style.cursor='pointer';wrap.setAttribute('title','click to replay');wrap.addEventListener('click',function(){run(svg);});}
+  });
+})();
+</script>
+
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,3199 +1,500 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
 <head>
-<meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Attestor — Auditable memory for agent teams</title>
-<meta name="description" content="What did the agent know, and when did it know it? Auditable, deterministic, bitemporal memory for multi-agent systems. Namespace isolation, RBAC, provenance, ranked retrieval. Self-hosted, no LLM in the critical path.">
-<meta name="theme-color" content="#0C0B09">
-<meta property="og:title" content="Attestor — What did the agent know, and when did it know it?">
-<meta property="og:description" content="Auditable, deterministic, bitemporal memory for agent teams. Namespace isolation, RBAC, provenance, ranked retrieval. Self-hosted, no LLM in the critical path.">
-<meta property="og:type" content="website">
-<meta property="og:url" content="https://attestor.dev/">
-<meta property="og:image" content="https://attestor.dev/og-image.png">
-<meta property="og:image:width" content="1200">
-<meta property="og:image:height" content="630">
-<meta property="og:image:alt" content="Attestor — What did the agent know, and when did it know it? Open-source memory infrastructure for multi-agent AI.">
-<meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:image" content="https://attestor.dev/og-image.png">
-<meta name="twitter:image:alt" content="Attestor — What did the agent know, and when did it know it? Open-source memory infrastructure for multi-agent AI.">
-<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' font-family='serif' fill='%23E86A3B'>M</text></svg>">
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300..900;1,9..144,300..900&family=IBM+Plex+Sans:wght@300;400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Attestor — tokenmaxing memory for agents · 21× fewer input tokens</title>
 <style>
-/* ═══════════════════════════════════════════════════
-   SYSTEMS JOURNAL — ATTESTOR
-   Typography: Fraunces (display) · IBM Plex Sans (body) · JetBrains Mono (code)
-   ═══════════════════════════════════════════════════ */
-
-*, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
-
-:root {
-  --ink:           #0C0B09;
-  --ink-raise:     #141210;
-  --ink-surface:   #1A1713;
-  --paper:         #EDE8DC;
-  --paper-dim:     #C8C1B2;
-  --muted:         #8B857A;
-  --faint:         #55504A;
-  --rule:          rgba(237,232,220,0.09);
-  --rule-strong:   rgba(237,232,220,0.22);
-  --accent:        #E86A3B;   /* terracotta */
-  --accent-warm:   #D4A574;   /* aged brass */
-  --accent-cool:   #7FA99B;   /* oxidized teal */
-
-  --ff-display: 'Fraunces', 'Times New Roman', serif;
-  --ff-body:    'IBM Plex Sans', -apple-system, sans-serif;
-  --ff-mono:    'JetBrains Mono', ui-monospace, monospace;
-
-  --max-w: 1120px;
-  --gutter: 32px;
-  --section-gap: 140px;
-}
-
-html { scroll-behavior: smooth; }
-
-body {
-  font-family: var(--ff-body);
-  background: var(--ink);
-  color: var(--paper);
-  font-size: 16px;
-  line-height: 1.65;
-  font-weight: 300;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  overflow-x: hidden;
-  position: relative;
-}
-
-/* Paper grain overlay */
-body::before {
-  content: '';
-  position: fixed;
-  inset: 0;
-  pointer-events: none;
-  z-index: 200;
-  opacity: 0.04;
-  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='3'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
-  mix-blend-mode: overlay;
-}
-
-/* Subtle warm vignette at edges */
-body::after {
-  content: '';
-  position: fixed;
-  inset: 0;
-  pointer-events: none;
-  z-index: 1;
-  background: radial-gradient(ellipse 80% 60% at 50% 0%, rgba(232,106,59,0.06), transparent 60%);
-}
-
-a {
-  color: var(--accent);
-  text-decoration: none;
-  transition: color 0.2s;
-}
-a:hover { color: var(--accent-warm); }
-
-::selection { background: var(--accent); color: var(--ink); }
-
-.container {
-  max-width: var(--max-w);
-  margin: 0 auto;
-  padding: 0 var(--gutter);
-  position: relative;
-  z-index: 2;
-}
-
-/* ═══════════════════════════════════════════════════
-   TYPE SYSTEM
-   ═══════════════════════════════════════════════════ */
-
-.eyebrow {
-  font-family: var(--ff-mono);
-  font-size: 11px;
-  font-weight: 500;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  color: var(--accent);
-  display: inline-flex;
-  align-items: center;
-  gap: 14px;
-  margin-bottom: 28px;
-}
-.eyebrow::before {
-  content: '';
-  width: 28px;
-  height: 1px;
-  background: var(--accent);
-}
-
-.section-head {
-  font-family: var(--ff-display);
-  font-variation-settings: 'opsz' 144, 'wght' 380;
-  font-size: clamp(36px, 5.4vw, 68px);
-  line-height: 1.02;
-  letter-spacing: -0.02em;
-  color: var(--paper);
-  margin-bottom: 24px;
-  max-width: 20ch;
-}
-.section-head em {
-  font-style: italic;
-  font-variation-settings: 'opsz' 144, 'wght' 320;
-  color: var(--accent);
-}
-.section-head strong {
-  font-weight: inherit;
-  font-variation-settings: 'opsz' 144, 'wght' 600;
-}
-
-.standfirst {
-  font-family: var(--ff-display);
-  font-variation-settings: 'opsz' 18, 'wght' 400;
-  font-size: clamp(18px, 2vw, 22px);
-  line-height: 1.5;
-  color: var(--paper-dim);
-  max-width: 62ch;
-  letter-spacing: -0.005em;
-}
-
-.rule {
-  height: 1px;
-  background: var(--rule-strong);
-  border: none;
-}
-
-.rule-cross {
-  text-align: center;
-  color: var(--faint);
-  font-family: var(--ff-mono);
-  font-size: 10px;
-  letter-spacing: 0.3em;
-  margin: 48px 0;
-}
-.rule-cross::before, .rule-cross::after {
-  content: '';
-  display: inline-block;
-  width: 80px;
-  height: 1px;
-  background: var(--rule-strong);
-  vertical-align: middle;
-  margin: 0 14px;
-}
-
-/* ═══════════════════════════════════════════════════
-   MASTHEAD STRIP
-   ═══════════════════════════════════════════════════ */
-
-.masthead-strip {
-  border-bottom: 1px solid var(--rule);
-  padding: 12px 0;
-  position: relative;
-  z-index: 10;
-  background: var(--ink);
-}
-.masthead-strip .container {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 20px;
-  font-family: var(--ff-mono);
-  font-size: 10px;
-  font-weight: 500;
-  letter-spacing: 0.2em;
-  text-transform: uppercase;
-  color: var(--muted);
-  flex-wrap: wrap;
-}
-.masthead-strip .lead { color: var(--paper); }
-.masthead-strip .dot {
-  display: inline-block;
-  width: 5px;
-  height: 5px;
-  border-radius: 50%;
-  background: var(--accent);
-  vertical-align: middle;
-  margin-right: 8px;
-  animation: pulse 2.4s ease-in-out infinite;
-}
-@keyframes pulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.4; }
-}
-
-/* ═══════════════════════════════════════════════════
-   NAV
-   ═══════════════════════════════════════════════════ */
-
-nav {
-  position: sticky;
-  top: 0;
-  z-index: 50;
-  background: rgba(12, 11, 9, 0.88);
-  backdrop-filter: blur(18px);
-  -webkit-backdrop-filter: blur(18px);
-  border-bottom: 1px solid var(--rule);
-  padding: 18px 0;
-  transition: padding 0.3s;
-}
-nav.scrolled { padding: 12px 0; }
-
-.nav-inner {
-  max-width: var(--max-w);
-  margin: 0 auto;
-  padding: 0 var(--gutter);
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 24px;
-}
-
-.nav-logo {
-  font-family: var(--ff-display);
-  font-variation-settings: 'opsz' 144, 'wght' 500;
-  font-size: 26px;
-  letter-spacing: -0.02em;
-  color: var(--paper);
-  line-height: 1;
-  display: inline-flex;
-  align-items: baseline;
-  gap: 8px;
-}
-.nav-logo::after {
-  content: '';
-  display: inline-block;
-  width: 7px;
-  height: 7px;
-  background: var(--accent);
-  border-radius: 50%;
-  transform: translateY(-2px);
-}
-
-.nav-links {
-  display: flex;
-  align-items: center;
-  gap: 32px;
-  list-style: none;
-}
-.nav-links a {
-  font-family: var(--ff-mono);
-  font-size: 11px;
-  font-weight: 500;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  color: var(--muted);
-  position: relative;
-  padding: 4px 0;
-  transition: color 0.2s;
-}
-.nav-links a:hover { color: var(--paper); }
-.nav-links a::before {
-  content: attr(data-num);
-  color: var(--faint);
-  margin-right: 6px;
-}
-
-.nav-ctas {
-  display: flex;
-  gap: 10px;
-  align-items: center;
-}
-
-.btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  padding: 10px 18px;
-  font-family: var(--ff-mono);
-  font-size: 11px;
-  font-weight: 500;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  cursor: pointer;
-  border: none;
-  text-decoration: none;
-  transition: all 0.2s;
-  line-height: 1;
-}
-.btn-primary {
-  background: var(--accent);
-  color: var(--ink);
-}
-.btn-primary:hover { background: var(--paper); color: var(--ink); }
-.btn-ghost {
-  background: transparent;
-  color: var(--paper);
-  border: 1px solid var(--rule-strong);
-}
-.btn-ghost:hover { border-color: var(--accent); color: var(--accent); }
-
-.nav-mobile-toggle {
-  display: none;
-  background: none;
-  border: none;
-  color: var(--paper);
-  font-size: 22px;
-  cursor: pointer;
-}
-
-/* ═══════════════════════════════════════════════════
-   HERO
-   ═══════════════════════════════════════════════════ */
-
-#hero {
-  padding: 110px 0 80px;
-  position: relative;
-  overflow: hidden;
-}
-
-.hero-dateline {
-  display: flex;
-  gap: 32px;
-  font-family: var(--ff-mono);
-  font-size: 11px;
-  font-weight: 500;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  color: var(--muted);
-  margin-bottom: 56px;
-  padding-bottom: 16px;
-  border-bottom: 1px solid var(--rule);
-  flex-wrap: wrap;
-}
-.hero-dateline span { color: var(--muted); }
-.hero-dateline .accent { color: var(--accent); }
-.hero-dateline .filing { color: var(--paper); }
-
-.hero-headline {
-  font-family: var(--ff-display);
-  font-variation-settings: 'opsz' 144, 'wght' 340;
-  font-size: clamp(52px, 9vw, 124px);
-  line-height: 0.94;
-  letter-spacing: -0.035em;
-  color: var(--paper);
-  margin-bottom: 48px;
-  max-width: 16ch;
-}
-.hero-headline em {
-  font-style: italic;
-  font-variation-settings: 'opsz' 144, 'wght' 300;
-  color: var(--accent);
-  display: inline-block;
-}
-.hero-headline .soft {
-  color: var(--paper-dim);
-  font-variation-settings: 'opsz' 144, 'wght' 320;
-}
-
-.hero-grid {
-  display: grid;
-  grid-template-columns: 1.3fr 1fr;
-  gap: 72px;
-  margin-bottom: 64px;
-  align-items: start;
-}
-
-.hero-sub {
-  font-family: var(--ff-display);
-  font-variation-settings: 'opsz' 18, 'wght' 400;
-  font-size: 22px;
-  line-height: 1.45;
-  color: var(--paper);
-  margin-bottom: 28px;
-  letter-spacing: -0.005em;
-}
-.hero-sub-detail {
-  font-size: 15px;
-  color: var(--muted);
-  line-height: 1.7;
-  max-width: 48ch;
-  margin-bottom: 32px;
-}
-
-.hero-install {
-  display: inline-flex;
-  align-items: center;
-  gap: 14px;
-  background: var(--ink-raise);
-  border: 1px solid var(--rule-strong);
-  padding: 16px 20px;
-  font-family: var(--ff-mono);
-  font-size: 13px;
-  color: var(--paper);
-  cursor: pointer;
-  transition: border-color 0.2s;
-  max-width: 100%;
-  overflow-x: auto;
-  position: relative;
-}
-.hero-install::before {
-  content: '$';
-  color: var(--accent);
-  font-weight: 500;
-}
-.hero-install:hover { border-color: var(--accent); }
-.hero-install.copied { border-color: var(--accent); }
-.hero-install .copy-icon {
-  color: var(--muted);
-  font-size: 13px;
-  flex-shrink: 0;
-  margin-left: auto;
-  padding-left: 14px;
-}
-
-.hero-install-note {
-  display: block;
-  margin-top: 14px;
-  font-family: var(--ff-mono);
-  font-size: 11px;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  color: var(--muted);
-}
-
-/* Spec sheet right column */
-.hero-spec {
-  border-top: 1px solid var(--rule-strong);
-  padding-top: 0;
-}
-.hero-spec-title {
-  font-family: var(--ff-mono);
-  font-size: 10px;
-  font-weight: 500;
-  letter-spacing: 0.22em;
-  text-transform: uppercase;
-  color: var(--accent);
-  padding: 14px 0;
-  border-bottom: 1px solid var(--rule);
-  margin-bottom: 0;
-}
-.hero-spec-row {
-  display: grid;
-  grid-template-columns: 1fr auto;
-  padding: 14px 0;
-  border-bottom: 1px solid var(--rule);
-  align-items: baseline;
-  gap: 14px;
-}
-.hero-spec-row:last-child { border-bottom: none; }
-.hero-spec-label {
-  font-family: var(--ff-mono);
-  font-size: 10px;
-  font-weight: 500;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  color: var(--muted);
-}
-.hero-spec-value {
-  font-family: var(--ff-display);
-  font-variation-settings: 'opsz' 36, 'wght' 500;
-  font-size: 20px;
-  color: var(--paper);
-  letter-spacing: -0.01em;
-  font-variant-numeric: tabular-nums;
-}
-.hero-spec-value .unit {
-  font-family: var(--ff-mono);
-  font-size: 11px;
-  color: var(--muted);
-  font-variation-settings: normal;
-  letter-spacing: 0.1em;
-  margin-left: 4px;
-  font-weight: 500;
-}
-
-/* Ticker */
-.ticker {
-  border-top: 1px solid var(--rule);
-  border-bottom: 1px solid var(--rule);
-  background: var(--ink);
-  padding: 18px 0;
-  overflow: hidden;
-  position: relative;
-  z-index: 2;
-}
-.ticker::before, .ticker::after {
-  content: '';
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  width: 120px;
-  z-index: 3;
-  pointer-events: none;
-}
-.ticker::before { left: 0; background: linear-gradient(90deg, var(--ink), transparent); }
-.ticker::after { right: 0; background: linear-gradient(-90deg, var(--ink), transparent); }
-.ticker-track {
-  display: flex;
-  white-space: nowrap;
-  animation: scroll-ticker 62s linear infinite;
-  font-family: var(--ff-mono);
-  font-size: 12px;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  color: var(--muted);
-  gap: 0;
-}
-.ticker-track span {
-  padding: 0 32px;
-  border-right: 1px solid var(--rule);
-  flex-shrink: 0;
-}
-.ticker-track span b {
-  color: var(--accent);
-  font-weight: 500;
-  margin-right: 8px;
-}
-@keyframes scroll-ticker {
-  from { transform: translateX(0); }
-  to { transform: translateX(-50%); }
-}
-
-/* ═══════════════════════════════════════════════════
-   SECTIONS (common)
-   ═══════════════════════════════════════════════════ */
-
-section {
-  padding: var(--section-gap) 0;
-  position: relative;
-  z-index: 2;
-}
-
-.section-filing {
-  display: flex;
-  gap: 24px;
-  align-items: baseline;
-  padding-bottom: 14px;
-  margin-bottom: 40px;
-  border-bottom: 1px solid var(--rule);
-  font-family: var(--ff-mono);
-  font-size: 11px;
-  font-weight: 500;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  color: var(--muted);
-  flex-wrap: wrap;
-}
-.section-filing .section-num {
-  font-family: var(--ff-display);
-  font-variation-settings: 'opsz' 36, 'wght' 500;
-  font-size: 18px;
-  letter-spacing: 0;
-  text-transform: none;
-  color: var(--accent);
-}
-.section-filing .section-name {
-  color: var(--paper);
-}
-
-.reveal {
-  opacity: 0;
-  transform: translateY(18px);
-  transition: opacity 0.8s cubic-bezier(0.2, 0.6, 0.2, 1), transform 0.8s cubic-bezier(0.2, 0.6, 0.2, 1);
-}
-.reveal.visible {
-  opacity: 1;
-  transform: translateY(0);
-}
-
-/* ═══════════════════════════════════════════════════
-   § 01 · THE PROBLEM
-   ═══════════════════════════════════════════════════ */
-
-#problem {
-  background: var(--ink-raise);
-  border-top: 1px solid var(--rule);
-  border-bottom: 1px solid var(--rule);
-}
-
-.pullquote {
-  font-family: var(--ff-display);
-  font-style: italic;
-  font-variation-settings: 'opsz' 144, 'wght' 360;
-  font-size: clamp(26px, 3.6vw, 42px);
-  line-height: 1.25;
-  color: var(--paper);
-  max-width: 22ch;
-  margin: 56px 0;
-  letter-spacing: -0.015em;
-  position: relative;
-}
-.pullquote::before {
-  content: '"';
-  position: absolute;
-  left: -0.5em;
-  top: -0.3em;
-  font-size: 2.4em;
-  color: var(--accent);
-  font-style: normal;
-  line-height: 1;
-  font-variation-settings: 'opsz' 144, 'wght' 500;
-}
-.pullquote-attr {
-  display: block;
-  font-family: var(--ff-mono);
-  font-size: 11px;
-  font-style: normal;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  color: var(--muted);
-  margin-top: 24px;
-}
-.pullquote-attr::before {
-  content: '— ';
-}
-
-.versus {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  border-top: 1px solid var(--rule-strong);
-  border-bottom: 1px solid var(--rule-strong);
-  margin: 56px 0;
-}
-.versus-col {
-  padding: 32px 28px 32px 0;
-}
-.versus-col + .versus-col {
-  padding-left: 40px;
-  padding-right: 0;
-  border-left: 1px solid var(--rule);
-}
-.versus-label {
-  font-family: var(--ff-mono);
-  font-size: 10px;
-  font-weight: 500;
-  letter-spacing: 0.22em;
-  text-transform: uppercase;
-  margin-bottom: 24px;
-  display: flex;
-  align-items: center;
-  gap: 10px;
-}
-.versus-bad .versus-label { color: var(--paper-dim); }
-.versus-good .versus-label { color: var(--accent); }
-.versus-label::before {
-  content: '';
-  display: inline-block;
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-}
-.versus-bad .versus-label::before { background: var(--faint); }
-.versus-good .versus-label::before { background: var(--accent); }
-
-.versus-item {
-  display: flex;
-  gap: 16px;
-  align-items: flex-start;
-  padding: 14px 0;
-  border-bottom: 1px dashed var(--rule);
-  font-size: 14.5px;
-  line-height: 1.55;
-  color: var(--paper-dim);
-}
-.versus-item:last-child { border-bottom: none; }
-.versus-item .marker {
-  font-family: var(--ff-mono);
-  font-size: 11px;
-  font-weight: 500;
-  color: var(--faint);
-  min-width: 22px;
-}
-.versus-good .versus-item .marker { color: var(--accent); }
-
-/* Token chart — reframed */
-.token-plate {
-  margin-top: 56px;
-  padding: 40px;
-  background: var(--ink);
-  border: 1px solid var(--rule-strong);
-}
-.plate-title {
-  display: flex;
-  justify-content: space-between;
-  align-items: baseline;
-  margin-bottom: 32px;
-  padding-bottom: 14px;
-  border-bottom: 1px solid var(--rule);
-  gap: 20px;
-  flex-wrap: wrap;
-}
-.plate-title h4 {
-  font-family: var(--ff-display);
-  font-variation-settings: 'opsz' 36, 'wght' 460;
-  font-size: 20px;
-  color: var(--paper);
-  letter-spacing: -0.01em;
-}
-.plate-title .plate-meta {
-  font-family: var(--ff-mono);
-  font-size: 10px;
-  letter-spacing: 0.2em;
-  text-transform: uppercase;
-  color: var(--muted);
-}
-.chart-row {
-  display: grid;
-  grid-template-columns: 80px 1fr;
-  align-items: center;
-  gap: 18px;
-  margin-bottom: 18px;
-}
-.chart-row:last-child { margin-bottom: 0; }
-.chart-label {
-  font-family: var(--ff-mono);
-  font-size: 11px;
-  letter-spacing: 0.15em;
-  text-transform: uppercase;
-  color: var(--muted);
-}
-.chart-bars {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-.chart-bar {
-  height: 22px;
-  display: flex;
-  align-items: center;
-  padding-left: 10px;
-  font-family: var(--ff-mono);
-  font-size: 11px;
-  font-weight: 500;
-  color: var(--ink);
-  transition: width 1.3s cubic-bezier(0.2, 0.7, 0.2, 1);
-}
-.bar-memory { background: var(--accent-warm); }
-.bar-attestor { background: var(--accent); }
-
-.chart-legend {
-  display: flex;
-  gap: 24px;
-  margin-top: 20px;
-  padding-top: 16px;
-  border-top: 1px solid var(--rule);
-  font-family: var(--ff-mono);
-  font-size: 11px;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  color: var(--muted);
-}
-.legend-dot {
-  display: inline-block;
-  width: 10px;
-  height: 10px;
-  margin-right: 8px;
-  vertical-align: middle;
-}
-
-.bottom-line {
-  font-family: var(--ff-display);
-  font-style: italic;
-  font-variation-settings: 'opsz' 24, 'wght' 400;
-  font-size: 20px;
-  color: var(--paper-dim);
-  margin-top: 40px;
-  line-height: 1.5;
-  max-width: 64ch;
-}
-
-/* ═══════════════════════════════════════════════════
-   § 02 · MULTI-AGENT
-   ═══════════════════════════════════════════════════ */
-
-.capabilities {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 1px;
-  background: var(--rule-strong);
-  border: 1px solid var(--rule-strong);
-  margin-top: 56px;
-}
-.capability {
-  background: var(--ink);
-  padding: 40px 36px;
-  transition: background 0.3s;
-  position: relative;
-}
-.capability:hover { background: var(--ink-raise); }
-.capability-num {
-  font-family: var(--ff-mono);
-  font-size: 11px;
-  font-weight: 500;
-  letter-spacing: 0.18em;
-  color: var(--accent);
-  margin-bottom: 20px;
-  display: block;
-}
-.capability h3 {
-  font-family: var(--ff-display);
-  font-variation-settings: 'opsz' 36, 'wght' 460;
-  font-size: 26px;
-  color: var(--paper);
-  margin-bottom: 14px;
-  letter-spacing: -0.015em;
-  line-height: 1.1;
-}
-.capability p {
-  font-size: 14.5px;
-  line-height: 1.7;
-  color: var(--paper-dim);
-}
-.capability code {
-  font-family: var(--ff-mono);
-  font-size: 12.5px;
-  background: var(--ink-surface);
-  color: var(--accent);
-  padding: 2px 7px;
-  border: 1px solid var(--rule);
-}
-
-/* ═══════════════════════════════════════════════════
-   § 03 · BENCHMARKS
-   ═══════════════════════════════════════════════════ */
-
-#compare {
-  background: var(--ink-raise);
-  border-top: 1px solid var(--rule);
-  border-bottom: 1px solid var(--rule);
-}
-
-.table-heading {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  margin-top: 48px;
-  padding-bottom: 14px;
-  border-bottom: 1px solid var(--rule-strong);
-  gap: 20px;
-  flex-wrap: wrap;
-}
-.table-heading h3 {
-  font-family: var(--ff-display);
-  font-variation-settings: 'opsz' 36, 'wght' 460;
-  font-size: 24px;
-  color: var(--paper);
-  letter-spacing: -0.01em;
-}
-.table-heading .table-meta {
-  font-family: var(--ff-mono);
-  font-size: 10px;
-  letter-spacing: 0.22em;
-  text-transform: uppercase;
-  color: var(--muted);
-}
-
-.datatable-wrap {
-  overflow-x: auto;
-  margin-top: 0;
-  margin-bottom: 20px;
-}
-.datatable {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: 14px;
-  font-variant-numeric: tabular-nums;
-}
-.datatable th,
-.datatable td {
-  padding: 14px 18px 14px 0;
-  text-align: left;
-  border-bottom: 1px solid var(--rule);
-  white-space: nowrap;
-}
-.datatable th {
-  font-family: var(--ff-mono);
-  font-size: 10px;
-  font-weight: 500;
-  color: var(--muted);
-  text-transform: uppercase;
-  letter-spacing: 0.16em;
-  padding-top: 18px;
-  padding-bottom: 14px;
-}
-.datatable td { color: var(--paper-dim); }
-.datatable td:first-child {
-  color: var(--paper);
-  font-weight: 400;
-  font-family: var(--ff-display);
-  font-variation-settings: 'opsz' 18, 'wght' 460;
-  font-size: 15px;
-  letter-spacing: -0.005em;
-}
-.datatable tr.row-hl td { color: var(--paper); }
-.datatable tr.row-hl td:first-child { color: var(--accent); }
-.datatable tr.row-hl td.num { color: var(--accent); font-weight: 500; }
-.datatable tr:last-child td { border-bottom: none; }
-.datatable .num {
-  font-family: var(--ff-mono);
-  font-weight: 500;
-  color: var(--paper);
-}
-
-.comp-footnote {
-  font-size: 13px;
-  color: var(--muted);
-  margin-top: 20px;
-  line-height: 1.6;
-  font-style: italic;
-  font-family: var(--ff-display);
-  font-variation-settings: 'opsz' 14, 'wght' 400;
-}
-.comp-footnote code {
-  font-family: var(--ff-mono);
-  font-style: normal;
-  font-size: 12px;
-  background: var(--ink);
-  color: var(--accent);
-  padding: 2px 7px;
-  border: 1px solid var(--rule);
-}
-
-/* ═══════════════════════════════════════════════════
-   § 04 · PIPELINE
-   ═══════════════════════════════════════════════════ */
-
-.pipeline {
-  margin-top: 56px;
-  border-top: 1px solid var(--rule-strong);
-}
-.pipeline-step {
-  display: grid;
-  grid-template-columns: 80px 1fr 240px;
-  align-items: baseline;
-  padding: 34px 0;
-  border-bottom: 1px solid var(--rule);
-  gap: 32px;
-  transition: background 0.3s;
-  position: relative;
-}
-.pipeline-step:hover {
-  background: linear-gradient(90deg, transparent, rgba(232,106,59,0.04), transparent);
-}
-.step-index {
-  font-family: var(--ff-display);
-  font-variation-settings: 'opsz' 144, 'wght' 320;
-  font-size: 58px;
-  line-height: 0.9;
-  color: var(--accent);
-  letter-spacing: -0.04em;
-  font-variant-numeric: tabular-nums;
-}
-.step-body h3 {
-  font-family: var(--ff-display);
-  font-variation-settings: 'opsz' 36, 'wght' 460;
-  font-size: 26px;
-  color: var(--paper);
-  letter-spacing: -0.015em;
-  margin-bottom: 6px;
-}
-.step-body p {
-  font-size: 14.5px;
-  line-height: 1.7;
-  color: var(--paper-dim);
-  max-width: 52ch;
-}
-.step-engine {
-  font-family: var(--ff-mono);
-  font-size: 11px;
-  font-weight: 500;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
-  color: var(--muted);
-  text-align: right;
-  padding-top: 10px;
-}
-.step-engine b {
-  display: block;
-  color: var(--accent);
-  font-weight: 500;
-  margin-bottom: 4px;
-}
-
-/* ═══════════════════════════════════════════════════
-   § 05 · DEPLOY MATRIX
-   ═══════════════════════════════════════════════════ */
-
-.matrix {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 1px;
-  background: var(--rule-strong);
-  border: 1px solid var(--rule-strong);
-  margin-top: 56px;
-}
-.matrix-cell {
-  background: var(--ink);
-  padding: 36px 32px;
-  transition: background 0.3s;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  min-height: 200px;
-}
-.matrix-cell:hover { background: var(--ink-raise); }
-.matrix-tag {
-  font-family: var(--ff-mono);
-  font-size: 10px;
-  font-weight: 500;
-  letter-spacing: 0.2em;
-  text-transform: uppercase;
-  color: var(--accent);
-}
-.matrix-cell h3 {
-  font-family: var(--ff-display);
-  font-variation-settings: 'opsz' 36, 'wght' 480;
-  font-size: 24px;
-  color: var(--paper);
-  letter-spacing: -0.015em;
-  line-height: 1;
-}
-.matrix-cell p {
-  font-size: 14px;
-  line-height: 1.65;
-  color: var(--paper-dim);
-  margin-top: auto;
-}
-.matrix-spec {
-  font-family: var(--ff-mono);
-  font-size: 11px;
-  color: var(--muted);
-  letter-spacing: 0.08em;
-  padding-top: 14px;
-  margin-top: 14px;
-  border-top: 1px solid var(--rule);
-}
-
-/* ═══════════════════════════════════════════════════
-   § 06 · QUICKSTART
-   ═══════════════════════════════════════════════════ */
-
-#quickstart {
-  background: var(--ink-raise);
-  border-top: 1px solid var(--rule);
-  border-bottom: 1px solid var(--rule);
-}
-
-.tabs {
-  display: flex;
-  gap: 0;
-  margin-top: 48px;
-  border-bottom: 1px solid var(--rule-strong);
-}
-.tab-btn {
-  padding: 14px 28px 14px 0;
-  margin-right: 28px;
-  font-family: var(--ff-mono);
-  font-size: 11px;
-  font-weight: 500;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  background: none;
-  border: none;
-  color: var(--muted);
-  cursor: pointer;
-  border-bottom: 2px solid transparent;
-  transition: all 0.2s;
-  margin-bottom: -1px;
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
-}
-.tab-btn .tab-num {
-  font-family: var(--ff-display);
-  font-variation-settings: 'opsz' 18, 'wght' 500;
-  font-size: 13px;
-  color: var(--faint);
-  letter-spacing: 0;
-}
-.tab-btn.active {
-  color: var(--accent);
-  border-bottom-color: var(--accent);
-}
-.tab-btn.active .tab-num { color: var(--accent); }
-.tab-btn:hover:not(.active) { color: var(--paper); }
-
-.tab-panel {
-  display: none;
-  padding: 32px 0;
-}
-.tab-panel.active { display: block; }
-
-.code-block {
-  background: var(--ink);
-  border: 1px solid var(--rule-strong);
-  padding: 28px 32px;
-  font-family: var(--ff-mono);
-  font-size: 13px;
-  line-height: 1.9;
-  color: var(--paper-dim);
-  overflow-x: auto;
-  position: relative;
-  white-space: pre;
-}
-.code-block::before {
-  content: attr(data-lang);
-  position: absolute;
-  top: 0;
-  left: 32px;
-  font-size: 9px;
-  letter-spacing: 0.3em;
-  color: var(--accent);
-  background: var(--ink);
-  padding: 0 8px;
-  transform: translateY(-50%);
-  text-transform: uppercase;
-  font-weight: 500;
-}
-.code-block .comment { color: var(--faint); }
-.code-block .cmd { color: var(--paper); }
-.code-block .string { color: var(--accent-warm); }
-.code-block .keyword { color: var(--accent); }
-.code-block .fn { color: var(--accent-cool); }
-
-.code-copy-btn {
-  position: absolute;
-  top: 12px;
-  right: 12px;
-  background: var(--ink-raise);
-  border: 1px solid var(--rule-strong);
-  color: var(--muted);
-  font-size: 10px;
-  letter-spacing: 0.15em;
-  text-transform: uppercase;
-  padding: 6px 12px;
-  cursor: pointer;
-  font-family: var(--ff-mono);
-  font-weight: 500;
-  transition: all 0.2s;
-}
-.code-copy-btn:hover { border-color: var(--accent); color: var(--accent); }
-
-/* ═══════════════════════════════════════════════════
-   § 07 · PRINCIPLES
-   ═══════════════════════════════════════════════════ */
-
-.manifesto {
-  margin-top: 56px;
-  max-width: 68ch;
-}
-.manifesto-line {
-  font-family: var(--ff-display);
-  font-variation-settings: 'opsz' 144, 'wght' 360;
-  font-size: clamp(22px, 2.6vw, 30px);
-  line-height: 1.4;
-  color: var(--paper);
-  padding: 28px 0 28px 60px;
-  border-bottom: 1px solid var(--rule);
-  letter-spacing: -0.015em;
-  position: relative;
-  transition: color 0.3s;
-}
-.manifesto-line:hover { color: var(--accent); }
-.manifesto-line::before {
-  content: attr(data-num);
-  position: absolute;
-  left: 0;
-  top: 36px;
-  font-family: var(--ff-mono);
-  font-size: 11px;
-  font-weight: 500;
-  letter-spacing: 0.15em;
-  color: var(--faint);
-  font-variation-settings: normal;
-}
-.manifesto-line em {
-  font-style: italic;
-  font-variation-settings: 'opsz' 144, 'wght' 320;
-  color: var(--accent);
-}
-
-/* ═══════════════════════════════════════════════════
-   CLOSING
-   ═══════════════════════════════════════════════════ */
-
-#closing {
-  padding: 160px 0 120px;
-  border-top: 1px solid var(--rule);
-  position: relative;
-  overflow: hidden;
-  text-align: left;
-}
-#closing::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: radial-gradient(circle at 85% 15%, rgba(232,106,59,0.12), transparent 55%);
-  pointer-events: none;
-}
-.closing-head {
-  font-family: var(--ff-display);
-  font-variation-settings: 'opsz' 144, 'wght' 340;
-  font-size: clamp(44px, 7vw, 92px);
-  line-height: 1;
-  letter-spacing: -0.03em;
-  color: var(--paper);
-  margin-bottom: 40px;
-  max-width: 20ch;
-}
-.closing-head em {
-  font-style: italic;
-  font-variation-settings: 'opsz' 144, 'wght' 300;
-  color: var(--accent);
-}
-
-.closing-row {
-  display: flex;
-  gap: 16px;
-  align-items: center;
-  flex-wrap: wrap;
-  margin-bottom: 40px;
-}
-.closing-install {
-  display: inline-flex;
-  align-items: center;
-  gap: 14px;
-  background: var(--ink-raise);
-  border: 1px solid var(--rule-strong);
-  padding: 16px 22px;
-  font-family: var(--ff-mono);
-  font-size: 13px;
-  color: var(--paper);
-  cursor: pointer;
-  transition: border-color 0.2s;
-}
-.closing-install::before {
-  content: '$';
-  color: var(--accent);
-  font-weight: 500;
-}
-.closing-install:hover { border-color: var(--accent); }
-
-.closing-byline {
-  font-family: var(--ff-display);
-  font-variation-settings: 'opsz' 18, 'wght' 400;
-  font-size: 17px;
-  line-height: 1.6;
-  color: var(--paper-dim);
-  max-width: 56ch;
-  font-style: italic;
-}
-.closing-byline a {
-  color: var(--accent);
-  border-bottom: 1px solid currentColor;
-  padding-bottom: 1px;
-}
-
-/* ═══════════════════════════════════════════════════
-   COLOPHON (FOOTER)
-   ═══════════════════════════════════════════════════ */
-
-footer.colophon {
-  border-top: 1px solid var(--rule-strong);
-  padding: 80px 0 60px;
-  background: var(--ink);
-  position: relative;
-  z-index: 3;
-}
-.colophon-grid {
-  display: grid;
-  grid-template-columns: 2fr 1fr 1fr 1fr;
-  gap: 48px;
-  margin-bottom: 56px;
-}
-.col-label {
-  font-family: var(--ff-mono);
-  font-size: 10px;
-  font-weight: 500;
-  letter-spacing: 0.22em;
-  text-transform: uppercase;
-  color: var(--accent);
-  margin-bottom: 20px;
-  padding-bottom: 10px;
-  border-bottom: 1px solid var(--rule);
-}
-.colophon-body {
-  font-family: var(--ff-display);
-  font-variation-settings: 'opsz' 14, 'wght' 400;
-  font-size: 14.5px;
-  line-height: 1.7;
-  color: var(--paper-dim);
-  max-width: 52ch;
-}
-.colophon-body em {
-  font-style: italic;
-  color: var(--paper);
-}
-.colophon-list {
-  list-style: none;
-  font-size: 13.5px;
-  line-height: 2;
-  color: var(--paper-dim);
-}
-.colophon-list a { color: var(--paper-dim); }
-.colophon-list a:hover { color: var(--accent); }
-
-.colophon-mark {
-  border-top: 1px solid var(--rule);
-  padding-top: 24px;
-  display: flex;
-  justify-content: space-between;
-  align-items: baseline;
-  gap: 20px;
-  flex-wrap: wrap;
-  font-family: var(--ff-mono);
-  font-size: 10px;
-  letter-spacing: 0.2em;
-  text-transform: uppercase;
-  color: var(--muted);
-}
-.colophon-mark .left {
-  font-family: var(--ff-display);
-  font-variation-settings: 'opsz' 144, 'wght' 500;
-  font-size: 32px;
-  color: var(--paper);
-  letter-spacing: -0.02em;
-  text-transform: none;
-  line-height: 1;
-}
-.colophon-mark .left b {
-  color: var(--accent);
-  font-weight: inherit;
-}
-
-/* ═══════════════════════════════════════════════════
-   RESPONSIVE
-   ═══════════════════════════════════════════════════ */
-
-@media (max-width: 960px) {
-  :root { --section-gap: 100px; }
-  .hero-grid { grid-template-columns: 1fr; gap: 48px; }
-  .versus { grid-template-columns: 1fr; border-bottom: none; }
-  .versus-col + .versus-col {
-    border-left: none;
-    border-top: 1px solid var(--rule);
-    padding-left: 0;
-    padding-top: 32px;
-  }
-  .capabilities { grid-template-columns: 1fr; }
-  .matrix { grid-template-columns: 1fr 1fr; }
-  .pipeline-step {
-    grid-template-columns: 60px 1fr;
-    gap: 20px;
-  }
-  .step-index { font-size: 44px; }
-  .step-engine {
-    grid-column: 2;
-    text-align: left;
-    padding-top: 4px;
-  }
-  .colophon-grid { grid-template-columns: 1fr 1fr; gap: 40px 32px; }
-  .nav-links { display: none; }
-  .nav-mobile-toggle { display: block; }
-  nav.mobile-open .nav-links {
-    display: flex;
-    flex-direction: column;
-    position: absolute;
-    top: 60px;
-    left: 0;
-    right: 0;
-    background: rgba(12, 11, 9, 0.96);
-    backdrop-filter: blur(18px);
-    padding: 28px var(--gutter);
-    border-bottom: 1px solid var(--rule-strong);
-    align-items: flex-start;
-    gap: 20px;
-  }
-}
-
-@media (max-width: 640px) {
-  :root { --section-gap: 80px; --gutter: 22px; }
-  #hero { padding: 70px 0 60px; }
-  .hero-dateline { font-size: 10px; gap: 18px; margin-bottom: 40px; }
-  .hero-headline { font-size: 44px; letter-spacing: -0.03em; }
-  .hero-sub { font-size: 18px; }
-  .section-head { font-size: 34px; }
-  .matrix { grid-template-columns: 1fr; }
-  .capability { padding: 28px 22px; }
-  .token-plate { padding: 24px; }
-  .chart-row { grid-template-columns: 60px 1fr; gap: 12px; }
-  .pullquote { font-size: 22px; margin: 36px 0; }
-  .pullquote::before { font-size: 2em; left: -0.3em; }
-  .closing-head { font-size: 40px; }
-  .colophon-grid { grid-template-columns: 1fr; }
-  .tab-btn { padding: 12px 16px 12px 0; margin-right: 14px; font-size: 10px; }
-  .datatable th, .datatable td { padding: 10px 12px 10px 0; font-size: 12px; }
-  .nav-ctas .btn-ghost { display: none; }
-  .manifesto-line { padding-left: 44px; font-size: 20px; }
-  .hero-install, .closing-install { font-size: 12px; padding: 14px 16px; }
-}
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+:root{
+  --ink:#0f0e0c;--ink2:#3a3630;--ink3:#7a766e;
+  --paper:#faf8f4;--paper2:#f3f0ea;--paper3:#e8e3d8;--rule:#d4cfc3;
+  --g:#1a3a26;--g2:#2a5c3a;--g3:#cfe8d4;--g4:#f0f7f2;
+  --r:#7a1a1a;--r2:#f7ecec;--amber:#b07a00;
+  --navy:#0d1f3c;--navy2:#1a3460;--navy3:#d4dff0;--navy4:#f0f4fb;
+  --mono:'SF Mono','Fira Code','Cascadia Code',ui-monospace,monospace;
+  --serif:Georgia,'Times New Roman',serif;
+  --sans:-apple-system,BlinkMacSystemFont,'Segoe UI',system-ui,sans-serif;
+  --maxw:1080px;
+}
+html{scroll-behavior:smooth}
+body{background:var(--paper3);color:var(--ink);font-family:var(--sans);font-size:16px;line-height:1.7;-webkit-font-smoothing:antialiased}
+.wrap{max-width:var(--maxw);margin:0 auto;padding:0 24px}
+a{color:inherit}.mono{font-family:var(--mono)}
+
+nav{position:sticky;top:0;z-index:50;background:rgba(250,248,244,0.9);backdrop-filter:blur(8px);border-bottom:0.5px solid var(--rule)}
+.nav-in{max-width:var(--maxw);margin:0 auto;padding:14px 24px;display:flex;align-items:center;justify-content:space-between}
+.brand{font-family:var(--mono);font-size:14px;font-weight:600;color:var(--navy);text-decoration:none}
+.brand b{color:var(--g2)}
+.nav-links{display:flex;gap:22px;align-items:center}
+.nav-links a{font-size:13px;color:var(--ink2);text-decoration:none;font-family:var(--mono)}
+.nav-links a:hover{color:var(--navy2)}
+.btn{display:inline-block;text-decoration:none;font-weight:600;border-radius:6px;white-space:nowrap;transition:transform .12s ease}
+.btn:hover{transform:translateY(-1px)}
+.btn-n{background:var(--navy);color:#fff;padding:9px 18px;font-size:13px}
+.btn-g{background:var(--g);color:var(--g4);padding:9px 18px;font-size:13px}
+.btn-ghost{background:transparent;border:0.5px solid var(--rule);color:var(--ink2);padding:9px 16px;font-size:13px;font-family:var(--mono)}
+@media(max-width:680px){.nav-links a:not(.btn){display:none}}
+
+.hero{padding:64px 0 40px}
+.kicker{font-family:var(--mono);font-size:12px;letter-spacing:0.12em;text-transform:uppercase;color:var(--navy2);margin-bottom:20px;display:flex;align-items:center;gap:10px}
+.kicker::before{content:'';width:34px;height:1px;background:var(--navy2)}
+h1{font-family:var(--serif);font-weight:700;font-size:clamp(34px,6vw,60px);line-height:1.04;letter-spacing:-0.025em;max-width:15ch;color:var(--navy)}
+h1 .ital{font-style:italic;color:var(--g2)}
+.lede{font-size:clamp(17px,2.2vw,20px);color:var(--ink2);margin-top:24px;max-width:58ch;line-height:1.55}
+.lede strong{color:var(--ink)}
+.hero-cta{display:flex;gap:14px;flex-wrap:wrap;margin-top:32px;align-items:center}
+.btn-lg{padding:13px 26px;font-size:15px}
+.code-line{background:var(--ink);color:#a8e6c0;font-family:var(--mono);font-size:13px;padding:18px 20px;border-radius:10px;line-height:2;overflow-x:auto}
+.code-line.hero-code{margin-top:30px;max-width:600px}
+.code-line .cm{color:rgba(168,230,192,0.4);font-style:italic}
+.code-line .kw{color:#7ee8ff}
+.code-line .fn{color:#ffd479}
+
+.statrow{display:grid;grid-template-columns:repeat(4,1fr);gap:1px;background:var(--rule);border:0.5px solid var(--rule);border-radius:10px;overflow:hidden;margin:48px 0 8px}
+.statrow .ss{background:var(--paper);padding:22px 16px;text-align:center}
+.ss-num{font-family:var(--serif);font-size:clamp(26px,3.4vw,36px);font-weight:700;line-height:1}
+.ss-num.g{color:var(--g2)}.ss-num.r{color:var(--r)}.ss-num.n{color:var(--navy)}
+.ss-lbl{font-size:11.5px;color:var(--ink3);margin-top:7px;line-height:1.4}
+@media(max-width:680px){.statrow{grid-template-columns:repeat(2,1fr)}}
+
+section{padding:60px 0;border-top:0.5px solid var(--rule)}
+.sec-label{font-family:var(--mono);font-size:12px;letter-spacing:0.1em;text-transform:uppercase;color:var(--ink3);margin-bottom:14px}
+h2{font-family:var(--serif);font-weight:700;font-size:clamp(26px,3.6vw,38px);line-height:1.12;letter-spacing:-0.02em;max-width:20ch;color:var(--navy)}
+h2 .ital{font-style:italic;color:var(--g2)}
+.sec-lede{font-size:17px;color:var(--ink2);margin-top:16px;max-width:62ch}
+
+/* chart */
+.chartwrap{margin-top:34px;background:var(--paper);border:0.5px solid var(--rule);border-radius:12px;padding:24px}
+.chart-hud{display:flex;gap:28px;flex-wrap:wrap;align-items:baseline;margin-bottom:8px}
+.hud-item .n{font-family:var(--serif);font-size:24px;font-weight:700}
+.hud-item .n.r{color:var(--r)}.hud-item .n.g{color:var(--g2)}.hud-item .n.k{color:var(--ink)}
+.hud-item .l{font-family:var(--mono);font-size:10px;text-transform:uppercase;letter-spacing:0.06em;color:var(--ink3)}
+svg .draw{stroke-dasharray:2400;stroke-dashoffset:2400;animation:draw 2.2s ease forwards}
+svg .draw.mem{animation-delay:.3s}
+@keyframes draw{to{stroke-dashoffset:0}}
+.chart-leg{display:flex;gap:20px;flex-wrap:wrap;margin-top:12px;font-size:12.5px;color:var(--ink2);font-family:var(--mono)}
+.swatch{display:inline-block;width:18px;height:3px;border-radius:2px;vertical-align:middle;margin-right:7px}
+
+/* cost vs */
+.cost-vs{display:grid;grid-template-columns:1fr auto 1fr;gap:16px;align-items:center;margin-top:26px;padding:26px;background:var(--paper);border-radius:12px;border:0.5px solid var(--rule)}
+.cv-side{text-align:center}
+.cv-num{font-family:var(--serif);font-size:clamp(30px,5vw,46px);font-weight:700;line-height:1;margin-bottom:6px}
+.cv-bad{color:var(--r)}.cv-good{color:var(--g2)}
+.cv-lbl{font-size:12px;color:var(--ink3);line-height:1.4}
+.cv-arrow{font-family:var(--serif);font-size:28px;color:var(--ink3)}
+
+/* model table */
+.mtab{margin-top:30px;border:0.5px solid var(--rule);border-radius:12px;overflow:hidden;background:var(--paper)}
+.mtab-head,.mtab-row{display:grid;grid-template-columns:1.6fr 1fr 1.2fr;gap:8px;padding:13px 20px;align-items:center}
+.mtab-head{background:var(--paper3);font-family:var(--mono);font-size:10.5px;letter-spacing:0.07em;text-transform:uppercase;color:var(--ink3)}
+.mtab-row{border-top:0.5px solid var(--rule)}
+.mtab-row .nm{font-family:var(--mono);font-size:13.5px}
+.mtab-row .mult{font-family:var(--serif);font-size:19px;font-weight:700;color:var(--g2)}
+.mtab-row .cost{font-family:var(--mono);font-size:12.5px;color:var(--ink3)}
+.mtab-row.hl{background:var(--navy4)}
+.open{display:inline-block;background:var(--g3);color:var(--g);font-family:var(--mono);font-size:9px;padding:1px 5px;border-radius:3px;margin-left:6px;vertical-align:middle}
+
+/* audience tabs */
+.tabs{display:flex;gap:8px;margin-top:30px;flex-wrap:wrap}
+.tab{font-family:var(--mono);font-size:13px;padding:10px 18px;border-radius:8px;border:0.5px solid var(--rule);background:var(--paper);color:var(--ink2);cursor:pointer;transition:all .15s}
+.tab[aria-selected="true"]{background:var(--navy);color:#fff;border-color:var(--navy)}
+.tab .dot{display:inline-block;width:6px;height:6px;border-radius:50%;background:currentColor;opacity:.6;margin-right:7px;vertical-align:middle}
+.panel{display:none;margin-top:22px;background:var(--paper);border:0.5px solid var(--rule);border-radius:12px;padding:28px}
+.panel[data-active="true"]{display:block;animation:fade .35s ease}
+@keyframes fade{from{opacity:0;transform:translateY(6px)}to{opacity:1;transform:none}}
+.panel h3{font-family:var(--serif);font-size:23px;font-weight:700;color:var(--navy);line-height:1.2;margin-bottom:12px;max-width:26ch}
+.panel .hook{font-size:15px;font-weight:500;color:var(--ink);padding:14px 16px;border-left:3px solid var(--navy2);background:var(--navy4);margin-bottom:16px;line-height:1.5}
+.panel p{font-size:14.5px;color:var(--ink2);margin-bottom:12px;line-height:1.6}
+.panel p strong{color:var(--ink)}
+.panel ul{list-style:none;margin:4px 0 14px}
+.panel ul li{font-size:14px;color:var(--ink2);padding-left:18px;position:relative;margin-bottom:6px}
+.panel ul li::before{content:'→';position:absolute;left:0;color:var(--g2)}
+.panel .pcta{margin-top:8px;display:flex;gap:12px;flex-wrap:wrap}
+.minicode{background:var(--ink);color:#a8e6c0;font-family:var(--mono);font-size:12.5px;padding:14px 16px;border-radius:8px;margin:6px 0 14px;line-height:1.9}
+.minicode .cm{color:rgba(168,230,192,0.4);font-style:italic}.minicode .kw{color:#7ee8ff}.minicode .fn{color:#ffd479}
+
+/* arch compare */
+.alt-compare{display:grid;grid-template-columns:1fr 1fr;gap:16px;margin-top:30px}
+.alt-col{border-radius:12px;padding:24px;border:0.5px solid var(--rule)}
+.alt-col.bad{background:var(--r2)}
+.alt-col.good{background:var(--g4);border-color:var(--g3)}
+.alt-col h4{font-size:15px;font-weight:700;margin-bottom:12px;font-family:var(--mono)}
+.alt-col.bad h4{color:var(--r)}.alt-col.good h4{color:var(--g2)}
+.alt-col ul{list-style:none}
+.alt-col ul li{font-size:13.5px;color:var(--ink2);padding-left:20px;position:relative;margin-bottom:8px;line-height:1.5}
+.alt-col.bad ul li::before{content:'✕';position:absolute;left:0;color:var(--r);font-size:12px}
+.alt-col.good ul li::before{content:'✓';position:absolute;left:0;color:var(--g2);font-size:12px}
+@media(max-width:680px){.alt-compare{grid-template-columns:1fr}}
+
+.band{background:var(--navy);color:#dfe7f4;border-radius:14px;padding:44px;margin-top:60px;text-align:center}
+.band h3{font-family:var(--serif);font-size:clamp(26px,4vw,38px);font-weight:700;color:#fff;line-height:1.15;max-width:24ch;margin:0 auto 14px}
+.band p{font-size:15px;color:#b7c4da;max-width:48ch;margin:0 auto 26px}
+.band-cta{display:flex;gap:14px;justify-content:center;flex-wrap:wrap}
+.btn-white{background:#fff;color:var(--navy);padding:14px 28px;font-size:15px}
+.btn-outline{background:transparent;border:1px solid rgba(255,255,255,0.3);color:#fff;padding:14px 24px;font-size:14px;font-family:var(--mono)}
+
+footer{border-top:0.5px solid var(--rule);padding:38px 0 60px}
+.foot-in{display:flex;justify-content:space-between;gap:20px;flex-wrap:wrap;align-items:center}
+.foot-links{display:flex;gap:18px;flex-wrap:wrap}
+.foot-links a{font-family:var(--mono);font-size:13px;color:var(--ink2);text-decoration:none}
+.foot-links a:hover{color:var(--navy2)}
+.foot-note{font-family:var(--mono);font-size:11px;color:var(--ink3)}
+.tag{font-family:var(--mono);font-size:10px;letter-spacing:0.06em;background:var(--navy3);color:var(--navy);padding:3px 9px;border-radius:3px}
 </style>
 </head>
 <body>
 
-<!-- ═══════════════════════════════════════════════════
-     MASTHEAD STRIP
-     ═══════════════════════════════════════════════════ -->
-<div class="masthead-strip">
-  <div class="container">
-    <span class="lead"><span class="dot"></span>ATTESTOR &mdash; A MEMORY JOURNAL FOR AGENTIC SYSTEMS</span>
-    <span>VOL. 02 &middot; REV. 0.1</span>
-    <span>EST. 2026 &middot; NEW YORK</span>
-    <span>MIT</span>
-  </div>
-</div>
-
-<!-- ═══════════════════════════════════════════════════
-     NAV
-     ═══════════════════════════════════════════════════ -->
-<nav id="nav">
-  <div class="nav-inner">
-    <a href="#" class="nav-logo">Attestor</a>
-    <ul class="nav-links">
-      <li><a href="#problem" data-num="01">Problem</a></li>
-      <li><a href="#multiagent" data-num="02">Multi-Agent</a></li>
-      <li><a href="#how" data-num="03">Pipeline</a></li>
-      <li><a href="#platforms" data-num="04">Deploy</a></li>
-      <li><a href="#quickstart" data-num="05">Quickstart</a></li>
-      <li><a href="#principles" data-num="06">Principles</a></li>
-    </ul>
-    <div class="nav-ctas">
-      <a href="https://pypi.org/project/attestor/" class="btn btn-ghost" target="_blank" rel="noopener">PyPI</a>
-      <a href="https://github.com/bolnet/attestor" class="btn btn-primary" target="_blank" rel="noopener">GitHub &rarr;</a>
+<nav>
+  <div class="nav-in">
+    <a href="#top" class="brand">attestor<b>.dev</b></a>
+    <div class="nav-links">
+      <a href="#proof">The numbers</a>
+      <a href="#who">Who it's for</a>
+      <a href="#how">How it works</a>
+      <a href="inside_attestor.html" class="btn btn-n">Get started →</a>
     </div>
-    <button class="nav-mobile-toggle" onclick="document.getElementById('nav').classList.toggle('mobile-open')" aria-label="Toggle menu">&#9776;</button>
   </div>
 </nav>
 
-<!-- ═══════════════════════════════════════════════════
-     HERO
-     ═══════════════════════════════════════════════════ -->
-<section id="hero">
-  <div class="container">
-    <div class="hero-dateline">
-      <span class="filing">&sect; 00 &middot; Masthead</span>
-      <span>Filed under Infrastructure</span>
-      <span>By <a href="https://www.linkedin.com/in/singhsurendra/" target="_blank" rel="noopener" style="color:inherit;text-decoration:underline;text-decoration-thickness:1px;text-underline-offset:3px;">Surendra Singh</a></span>
-      <span class="accent">&mdash; For publication &mdash;</span>
+<div id="top" class="wrap">
+
+  <!-- HERO -->
+  <header class="hero">
+    <div class="kicker">Open-source memory for agents · tokenmaxing · MIT</div>
+    <h1>Cut your agent's token burn <span class="ital">21×</span>. Two API calls.</h1>
+    <p class="lede">Full-context replay re-reads the whole conversation every turn — input tokens that grow <strong>O(n²)</strong> and a bill that compounds with every session. Attestor retrieves only what's needed: <strong>flat ~200 tokens per call, 21× fewer input tokens by turn 100, 100% recall</strong> — measured across six models, open and closed.</p>
+    <div class="hero-cta">
+      <a href="inside_attestor.html" class="btn btn-n btn-lg">Get started →</a>
+      <a href="https://github.com/bolnet/context-clock" class="btn btn-ghost btn-lg">See the benchmark →</a>
+    </div>
+    <div class="code-line hero-code">
+<span class="cm"># when new information arrives</span><br>
+<span class="kw">await</span> attestor.<span class="fn">add</span>(namespace, content)<br><br>
+<span class="cm"># before each model call — returns ~200 flat tokens</span><br>
+facts = <span class="kw">await</span> attestor.<span class="fn">recall</span>(namespace, query)<br><br>
+<span class="cm"># working context is now flat. session caps come off.</span>
     </div>
 
-    <h1 class="hero-headline">
-      What did the agent know, <em>and when did it know it?</em>
-    </h1>
+    <div class="statrow">
+      <div class="ss"><div class="ss-num g">21×</div><div class="ss-lbl">fewer input tokens @ 100 turns</div></div>
+      <div class="ss"><div class="ss-num n">~200</div><div class="ss-lbl">tokens / call, flat — turn 1 to 100</div></div>
+      <div class="ss"><div class="ss-num g">100%</div><div class="ss-lbl">recall held the whole session</div></div>
+      <div class="ss"><div class="ss-num n">O(n)</div><div class="ss-lbl">linear, not O(n²) — by architecture</div></div>
+    </div>
+  </header>
 
-    <div class="hero-grid">
-      <div>
-        <p class="hero-sub">Auditable memory for agent teams. <em>Deterministic.</em> <em>Bitemporal.</em> Self&#8209;hosted, with no LLM in the critical path.</p>
-        <p class="hero-sub-detail">One tier your whole pipeline shares &mdash; planner writes, executor reads, reviewer sees both. Namespaces, RBAC, provenance, temporal correctness, ranked retrieval, token budgets &mdash; built in, not bolted on. Python library, REST API, or containerized service. No SaaS middleman. No per&#8209;seat fees. No vendor lock&#8209;in. It&rsquo;s yours.</p>
+  <!-- PROOF -->
+  <section id="proof">
+    <div class="sec-label">The token math · linear vs quadratic</div>
+    <h2>Same answer. <span class="ital">21× fewer</span> input tokens to get it.</h2>
+    <p class="sec-lede">Re-sending the transcript makes input tokens a parabola; retrieving the one fact you need makes them a straight line. Both hold 100% recall — the only thing that changes is how much the model has to read.</p>
 
-        <div class="hero-install" onclick="copyToClipboard(this, 'poetry add attestor')" title="Click to copy">
-          <span>poetry add attestor</span>
-          <span class="copy-icon">&#x2398;</span>
-        </div>
-        <div class="hero-cta-row" style="display:flex;gap:12px;flex-wrap:wrap;margin-top:12px;">
-          <a href="https://github.com/bolnet/attestor" class="btn btn-primary" target="_blank" rel="noopener">Architecture &amp; deploy guide &rarr;</a>
-          <a href="https://github.com/bolnet/attestor/stargazers" target="_blank" rel="noopener"><img src="https://img.shields.io/github/stars/bolnet/attestor?style=for-the-badge&amp;label=GitHub&amp;color=111" alt="GitHub stars"></a>
-          <a href="https://pypi.org/project/attestor/" target="_blank" rel="noopener" title="Live monthly installs from PyPI"><img src="https://img.shields.io/pypi/dm/attestor?style=for-the-badge&amp;label=Installs%2Fmo&amp;color=C15F3C&amp;labelColor=1A1614" alt="PyPI monthly downloads" style="box-shadow:0 0 0 2px var(--accent);border-radius:4px;"></a>
-          <span style="display:inline-flex;align-items:center;font-family:var(--ff-mono);font-size:10px;letter-spacing:0.2em;color:var(--muted);text-transform:uppercase;">&larr;&nbsp;live from pypi</span>
-        </div>
-        <span class="hero-install-note">MIT &middot; Python 3.10&ndash;3.14 &middot; Production deploy in one command</span>
+    <div class="chartwrap">
+      <div class="chart-hud">
+        <div class="hud-item"><div class="n k">t100</div><div class="l">turn</div></div>
+        <div class="hud-item"><div class="n r">1.33M</div><div class="l">replay input tokens</div></div>
+        <div class="hud-item"><div class="n g">61.8K</div><div class="l">attestor input tokens</div></div>
+        <div class="hud-item"><div class="n k">21.5×</div><div class="l">fewer</div></div>
       </div>
-
-      <aside class="hero-spec">
-        <div class="hero-spec-title">&sect; Spec Sheet</div>
-        <div class="hero-spec-row">
-          <span class="hero-spec-label">Storage Roles</span>
-          <span class="hero-spec-value">Doc &middot; Vector &middot; Graph</span>
-        </div>
-        <div class="hero-spec-row">
-          <span class="hero-spec-label">Interfaces</span>
-          <span class="hero-spec-value">Python &middot; REST &middot; MCP</span>
-        </div>
-        <div class="hero-spec-row">
-          <span class="hero-spec-label">Pipeline Steps</span>
-          <span class="hero-spec-value">6</span>
-        </div>
-        <div class="hero-spec-row">
-          <span class="hero-spec-label">RBAC Roles</span>
-          <span class="hero-spec-value">6</span>
-        </div>
-        <div class="hero-spec-row">
-          <span class="hero-spec-label">Cloud Targets</span>
-          <span class="hero-spec-value">AWS &middot; Azure &middot; GCP</span>
-        </div>
-        <div class="hero-spec-row">
-          <span class="hero-spec-label">License</span>
-          <span class="hero-spec-value">MIT</span>
-        </div>
-      </aside>
-    </div>
-  </div>
-
-  <div class="ticker">
-    <div class="ticker-track">
-      <span><b>MULTI-AGENT</b>NAMESPACE</span>
-      <span><b>ACCESS</b>RBAC</span>
-      <span><b>TRACE</b>PROVENANCE</span>
-      <span><b>CONTEXT</b>TOKEN BUDGETS</span>
-      <span><b>PIPELINE</b>SEMANTIC-FIRST</span>
-      <span><b>PYTHON</b>3.10 &mdash; 3.14</span>
-      <span><b>STACK</b>Postgres &middot; pgvector &middot; Neo4j</span>
-      <span><b>CLOUD</b>PostgreSQL &middot; ArangoDB &middot; Cosmos &middot; AlloyDB</span>
-      <span><b>DEPLOY</b>AWS &middot; Azure &middot; GCP</span>
-      <span><b>RETRIEVAL</b>Vector &middot; BM25 &middot; RRF &middot; MMR</span>
-      <span><b>LICENSE</b>MIT</span>
-      <!-- duplicate -->
-      <span><b>MULTI-AGENT</b>NAMESPACE</span>
-      <span><b>ACCESS</b>RBAC</span>
-      <span><b>TRACE</b>PROVENANCE</span>
-      <span><b>CONTEXT</b>TOKEN BUDGETS</span>
-      <span><b>PIPELINE</b>SEMANTIC-FIRST</span>
-      <span><b>PYTHON</b>3.10 &mdash; 3.14</span>
-      <span><b>STACK</b>Postgres &middot; pgvector &middot; Neo4j</span>
-      <span><b>CLOUD</b>PostgreSQL &middot; ArangoDB &middot; Cosmos &middot; AlloyDB</span>
-      <span><b>DEPLOY</b>AWS &middot; Azure &middot; GCP</span>
-      <span><b>RETRIEVAL</b>Vector &middot; BM25 &middot; RRF &middot; MMR</span>
-      <span><b>LICENSE</b>MIT</span>
-    </div>
-  </div>
-</section>
-
-<!-- ═══════════════════════════════════════════════════
-     REVEAL · "IT REMEMBERS"
-     ═══════════════════════════════════════════════════ -->
-<section id="reveal" style="padding:96px 0 48px;border-top:1px solid var(--rule);">
-  <div class="container">
-    <figure class="reveal" style="margin:0 auto;max-width:1040px;text-align:center;">
-      <img src="constellation.svg" alt="Six stars out of eight hundred light up — Attestor recalls exactly what this moment needs" style="display:block;width:100%;height:auto;">
-      <figcaption style="margin-top:28px;font-family:var(--ff-display);font-variation-settings:'opsz' 144,'wght' 380;font-size:clamp(28px,4vw,46px);line-height:1.1;letter-spacing:-0.02em;color:var(--paper);"><em style="font-variation-settings:'opsz' 144,'wght' 320;color:var(--accent);">Attestor doesn&rsquo;t search.</em> It remembers.</figcaption>
-      <p style="margin:20px auto 0;max-width:60ch;font-family:var(--ff-display);font-variation-settings:'opsz' 18,'wght' 400;font-size:18px;line-height:1.6;color:var(--paper-dim);">Eight hundred memories in the store. Six light up. Not the six it <em>searched</em> &mdash; the six this moment <em>needs</em>. Your planner&rsquo;s decision from Monday. The researcher&rsquo;s finding from Wednesday. The reviewer&rsquo;s objection from yesterday. Ranked, deduped, fit to budget. <b>Zero LLM calls in the critical path.</b></p>
-    </figure>
-  </div>
-</section>
-
-<!-- ═══════════════════════════════════════════════════
-     SOLUTION AT A GLANCE · TIMELINE
-     ═══════════════════════════════════════════════════ -->
-<section id="timeline-reveal" style="padding:48px 0 96px;">
-  <div class="container">
-    <div class="section-filing reveal">
-      <span class="section-num">&sect; 00.1</span>
-      <span class="section-name">&mdash; The solution, in one picture</span>
-      <span>Memory accumulates &middot; load primes</span>
-    </div>
-    <div class="reveal">
-      <h2 class="section-head">Memory accumulates. <em>Load primes.</em></h2>
-      <p class="standfirst">Four writes across Mon&ndash;Thu land as persisted memories. Friday morning a fresh Portfolio Planner wakes up to a new task, calls <code style="font-family:var(--ff-mono);font-size:15px;color:var(--accent);background:var(--ink-raise);padding:2px 8px;border:1px solid var(--rule);">mem.load_context()</code>, and Attestor ranks + dedupes + budget-fits all four back into the context window. The agent resumes with full continuity &mdash; earnings signal, risk cap, prior stance, compliance precedent.</p>
-    </div>
-    <figure class="reveal" style="margin:40px auto 16px;max-width:1040px;background:#f4efe3;border:1px solid var(--rule-strong);border-radius:6px;padding:24px;">
-      <img src="timeline.svg" alt="Write · Write · Write · Write ... Read — memories accumulate across sessions, load_context primes the next task" style="display:block;width:100%;height:auto;">
-      <figcaption style="font-family:var(--ff-mono);font-size:11px;text-transform:uppercase;letter-spacing:0.16em;color:#3a3530;text-align:center;margin-top:14px;">Fig. 0.1 &mdash; Not RAG over documents. The agents&rsquo; <em>own history</em>, replayed into a fresh context.</figcaption>
-    </figure>
-  </div>
-</section>
-
-<!-- ═══════════════════════════════════════════════════
-     § 01 · THE PROBLEM  (Act I — cold open)
-     ═══════════════════════════════════════════════════ -->
-<section id="problem">
-  <div class="container">
-    <div class="section-filing reveal">
-      <span class="section-num">&sect; 01</span>
-      <span class="section-name">&mdash; The Problem</span>
-      <span>Why agent prototypes don't survive production</span>
-    </div>
-
-    <div class="reveal">
-      <h2 class="section-head">Every agent starts the day with <em>amnesia.</em></h2>
-      <p class="standfirst">Single agents rediscover the same facts every run. Multi-agent pipelines are worse &mdash; the planner&rsquo;s decisions never reach the executor, the researcher&rsquo;s findings never reach the reviewer. So teams do the only thing they can: stuff giant prompts between agents. Burn tokens. Hope nothing important fell off the edge. That&rsquo;s not an architecture. That&rsquo;s a workaround.</p>
-    </div>
-
-    <blockquote class="pullquote reveal">
-      We had a planner, a coder, a reviewer, a deployer &mdash; four agents in a pipeline. None of them knew what the others learned. We were passing giant prompts between them and burning tokens on stale information.
-      <span class="pullquote-attr">Overheard &middot; Engineering Lead, Fortune 100 Bank</span>
-    </blockquote>
-
-    <div class="versus reveal">
-      <div class="versus-col versus-bad">
-        <div class="versus-label">Without Attestor</div>
-        <div class="versus-item"><span class="marker">01</span><span>Each agent starts blind &mdash; no knowledge of what others learned</span></div>
-        <div class="versus-item"><span class="marker">02</span><span>Giant prompts passed between agents burn context tokens</span></div>
-        <div class="versus-item"><span class="marker">03</span><span>No access control &mdash; any agent can overwrite any state</span></div>
-        <div class="versus-item"><span class="marker">04</span><span>Contradicting facts from different agents go undetected</span></div>
-        <div class="versus-item"><span class="marker">05</span><span>Session ends, everything learned is gone forever</span></div>
-      </div>
-      <div class="versus-col versus-good">
-        <div class="versus-label">With Attestor</div>
-        <div class="versus-item"><span class="marker">01</span><span>Shared memory &mdash; planner writes, coder reads, reviewer sees both</span></div>
-        <div class="versus-item"><span class="marker">02</span><span>Token-budget recall &mdash; each agent pulls only what fits</span></div>
-        <div class="versus-item"><span class="marker">03</span><span>Six RBAC roles, namespace isolation, write quotas per agent</span></div>
-        <div class="versus-item"><span class="marker">04</span><span>Contradictions auto-resolved &mdash; newer facts supersede older ones</span></div>
-        <div class="versus-item"><span class="marker">05</span><span>Persistent across sessions, pipelines, and agent restarts</span></div>
+      <svg viewBox="0 0 760 320" width="100%" role="img" aria-label="Cumulative input tokens: replay grows quadratically, Attestor stays flat">
+        <line x1="70" y1="290" x2="730" y2="290" stroke="#d4cfc3" stroke-width="1"/>
+        <line x1="70" y1="160" x2="730" y2="160" stroke="#e8e3d8" stroke-width="1" stroke-dasharray="3 4"/>
+        <line x1="70" y1="40" x2="730" y2="40" stroke="#e8e3d8" stroke-width="1" stroke-dasharray="3 4"/>
+        <text x="62" y="294" text-anchor="end" font-family="SF Mono,monospace" font-size="10" fill="#7a766e">0</text>
+        <text x="62" y="164" text-anchor="end" font-family="SF Mono,monospace" font-size="10" fill="#7a766e">700K</text>
+        <text x="62" y="44" text-anchor="end" font-family="SF Mono,monospace" font-size="10" fill="#7a766e">1.4M</text>
+        <text x="70" y="308" text-anchor="middle" font-family="SF Mono,monospace" font-size="10" fill="#7a766e">t1</text>
+        <text x="400" y="308" text-anchor="middle" font-family="SF Mono,monospace" font-size="10" fill="#7a766e">t50</text>
+        <text x="730" y="308" text-anchor="middle" font-family="SF Mono,monospace" font-size="10" fill="#7a766e">t100</text>
+        <path class="c-rawfill" d="" fill="#7a1a1a" fill-opacity="0.07"/>
+        <path class="c-raw" d="" fill="none" stroke="#7a1a1a" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+        <path class="c-mem" d="" fill="none" stroke="#2a5c3a" stroke-width="3" stroke-linecap="round"/>
+        <g class="c-pulses"></g>
+        <circle class="c-memdot" cx="70" cy="290" r="4.5" fill="#2a5c3a"/>
+        <circle class="c-rawdot" cx="70" cy="290" r="5" fill="#7a1a1a"/>
+        <text class="c-turn" x="70" y="278" text-anchor="middle" font-family="SF Mono,monospace" font-size="11" font-weight="600" fill="#7a1a1a" opacity="0">t0</text>
+        <text class="c-lbl" x="715" y="34" text-anchor="end" font-family="Georgia,serif" font-size="14" font-weight="700" fill="#7a1a1a" opacity="0">21.5×</text>
+      </svg>
+      <div class="chart-leg">
+        <span><span class="swatch" style="background:#7a1a1a"></span><b>replay</b> — re-send all (→ 1.33M)</span>
+        <span><span class="swatch" style="background:#2a5c3a"></span><b>attestor</b> — retrieve (→ 61.8K)</span>
+        <span style="color:#7a766e">gpt-5.4 · 100% recall both sides</span>
       </div>
     </div>
 
-    <div class="token-plate reveal" id="tokenChart">
-      <div class="plate-title">
-        <h4>Token cost per agent as memories grow</h4>
-        <span class="plate-meta">Fig. 01.1 &middot; Lower is better</span>
-      </div>
-      <div class="chart-row">
-        <div class="chart-label">Month 1</div>
-        <div class="chart-bars">
-          <div class="chart-bar bar-memory" data-width="13.3" style="width: 0%">2K</div>
-          <div class="chart-bar bar-attestor" data-width="13.3" style="width: 0%">2K</div>
-        </div>
-      </div>
-      <div class="chart-row">
-        <div class="chart-label">Month 3</div>
-        <div class="chart-bars">
-          <div class="chart-bar bar-memory" data-width="53.3" style="width: 0%">8K</div>
-          <div class="chart-bar bar-attestor" data-width="13.3" style="width: 0%">2K</div>
-        </div>
-      </div>
-      <div class="chart-row">
-        <div class="chart-label">Month 6</div>
-        <div class="chart-bars">
-          <div class="chart-bar bar-memory" data-width="100" style="width: 0%">15K</div>
-          <div class="chart-bar bar-attestor" data-width="13.3" style="width: 0%">2K</div>
-        </div>
-      </div>
-      <div class="chart-legend">
-        <span><span class="legend-dot" style="background:var(--accent-warm)"></span>Prompt-passing</span>
-        <span><span class="legend-dot" style="background:var(--accent)"></span>Attestor</span>
-      </div>
+    <div class="cost-vs">
+      <div class="cv-side"><div class="cv-num cv-bad">$24.15</div><div class="cv-lbl">Claude Opus 4 · one 100-turn session<br>full-context replay</div></div>
+      <div class="cv-arrow">→</div>
+      <div class="cv-side"><div class="cv-num cv-good">$1.24</div><div class="cv-lbl">Claude Opus 4 · same session<br>with Attestor</div></div>
     </div>
 
-    <p class="bottom-line reveal">More agents, more sessions, more memories &mdash; retrieval gets <em>better</em> while context cost stays flat.</p>
-  </div>
-</section>
+    <div class="mtab">
+      <div class="mtab-head"><span>6-model study · input-token reduction @ turn 100 · 100% recall</span><span>input ×</span><span>cost (raw → mem)</span></div>
+      <div class="mtab-row"><span class="nm">gpt-5.4</span><span class="mult">21.5×</span><span class="cost">$0.57 → $0.19</span></div>
+      <div class="mtab-row"><span class="nm">gpt-5.4-mini</span><span class="mult">21.5×</span><span class="cost">$0.22 → $0.06</span></div>
+      <div class="mtab-row hl"><span class="nm">claude-opus-4</span><span class="mult">22.2×</span><span class="cost">$24.15 → $1.24</span></div>
+      <div class="mtab-row"><span class="nm">claude-sonnet-4</span><span class="mult">22.1×</span><span class="cost">$4.83 → $0.25</span></div>
+      <div class="mtab-row"><span class="nm">kimi-k2.6 <span class="open">open</span></span><span class="mult">21.0×</span><span class="cost">$0.43 → $0.17</span></div>
+      <div class="mtab-row"><span class="nm">deepseek-v3.2 <span class="open">open</span></span><span class="mult">22.5×</span><span class="cost">$0.16 → $0.009</span></div>
+    </div>
+    <p class="sec-lede" style="margin-top:18px;font-size:14px;color:var(--ink3)">Input × is model-independent — it's workload geometry. Every model: 5.6× (t24) → 11× (t50) → ~21–22.5× (t100). Verify it yourself with <a href="https://github.com/bolnet/context-clock" style="color:var(--g2)">context-clock</a>.</p>
+  </section>
 
-<!-- ═══════════════════════════════════════════════════
-     § 02 · MULTI-AGENT
-     ═══════════════════════════════════════════════════ -->
-<section id="multiagent">
-  <div class="container">
-    <div class="section-filing reveal">
-      <span class="section-num">&sect; 02</span>
-      <span class="section-name">&mdash; Built for teams, not chatbots</span>
-      <span>Orchestrator &middot; Planner &middot; Executor &middot; Reviewer</span>
+  <!-- WHO -->
+  <section id="who">
+    <div class="sec-label">Who it's for</div>
+    <h2>One architecture. <span class="ital">Three rooms.</span></h2>
+    <p class="sec-lede">The token curve is the same problem whether you're underwriting it, operating it, or building it. Pick your seat.</p>
+
+    <div class="tabs" role="tablist">
+      <button class="tab" role="tab" aria-selected="true" data-tab="pe"><span class="dot"></span>PE · VC · Founders</button>
+      <button class="tab" role="tab" aria-selected="false" data-tab="ent"><span class="dot"></span>Enterprise · Platform</button>
+      <button class="tab" role="tab" aria-selected="false" data-tab="dev"><span class="dot"></span>Developers · AI Eng</button>
     </div>
 
-    <div class="reveal">
-      <h2 class="section-head">Not a chatbot plugin. <em>Infrastructure</em> for agent teams.</h2>
-      <p class="standfirst">Every recall and write is scoped to an <code style="font-family:var(--ff-mono);font-size:15px;color:var(--accent);background:var(--ink-raise);padding:2px 8px;border:1px solid var(--rule);">AgentContext</code> &mdash; identity, role, namespace, parent trail, token budget, write quota, visibility. Contexts are immutable. Spawning a sub-agent returns a new context with inherited provenance. Planner writes. Executor reads. Reviewer sees both. <em>Every call authorised before it touches storage.</em></p>
+    <!-- PE -->
+    <div class="panel" data-active="true" id="pe">
+      <h3>The diligence question: is cost per session linear or quadratic?</h3>
+      <div class="hook">Full-context replay is O(n²). Your most engaged users become your most expensive liabilities — and the curve compounds with every session they run.</div>
+      <p>Token governance is now a CFO-level line item. Salesforce reported <strong>20 trillion tokens</strong> consumed in a quarter; teams burn annual AI budgets in months. A product whose cost grows quadratically with engagement has a margin problem hiding in plain sight.</p>
+      <ul>
+        <li>One Claude Opus 4 session, 100 turns: <strong>$24.15 → $1.24</strong> with Attestor.</li>
+        <li>The fix is <strong>architectural, not a model swap</strong> — it survives the next model.</li>
+        <li>Both tools are open-source: the benchmark <em>is</em> the diligence, and it's free.</li>
+      </ul>
+      <div class="pcta"><a href="inside_attestor.html" class="btn btn-n">Review the benchmark →</a><a href="https://github.com/bolnet/context-clock" class="btn btn-ghost">Audit a pipeline: context-clock</a></div>
     </div>
 
-    <figure class="reveal" style="margin:48px auto 24px;max-width:880px;background:#f4efe3;border:1px solid var(--rule-strong);border-radius:6px;padding:28px;">
-      <img src="architecture.svg" alt="Attestor high-level architecture" style="display:block;width:100%;height:auto;"/>
-      <figcaption style="font-family:var(--ff-mono);font-size:12px;text-transform:uppercase;letter-spacing:0.12em;color:#3a3530;text-align:center;margin-top:16px;">Fig. 1 &mdash; Agents talk to Attestor through Python, REST, or MCP. Storage is pluggable.</figcaption>
-    </figure>
-
-    <div class="capabilities reveal">
-      <div class="capability">
-        <span class="capability-num">01 / 06</span>
-        <h3>Namespace isolation</h3>
-        <p>Every agent, project, or tenant gets its own namespace. Planner writes, coder reads, reviewer sees both. Isolated by default, shared when you configure it.</p>
-      </div>
-      <div class="capability">
-        <span class="capability-num">02 / 06</span>
-        <h3>Six RBAC roles</h3>
-        <p>Orchestrator, Planner, Executor, Researcher, Reviewer, Monitor. Read-only observers to full admins. Control who can read, write, or supersede in each namespace.</p>
-      </div>
-      <div class="capability">
-        <span class="capability-num">03 / 06</span>
-        <h3>Provenance tracking</h3>
-        <p>Know which agent wrote which memory, when, and under which parent session. The reviewer can trace a decision back to the planner three sessions ago &mdash; not some unknown source.</p>
-      </div>
-      <div class="capability">
-        <span class="capability-num">04 / 06</span>
-        <h3>Cross-agent contradiction resolution</h3>
-        <p>Agent A learns "user works at Google." Agent B learns "user works at Meta." Attestor auto-supersedes. Full history preserved. Zero inference calls in the critical path.</p>
-      </div>
-      <div class="capability">
-        <span class="capability-num">05 / 06</span>
-        <h3>Token budgets per agent</h3>
-        <p><code>recall(query, budget=2000)</code> &mdash; a lightweight summarizer uses 500 tokens; a deep reasoner uses 5,000. Each agent receives exactly what fits in its context window.</p>
-      </div>
-      <div class="capability">
-        <span class="capability-num">06 / 06</span>
-        <h3>Write quotas &amp; review flags</h3>
-        <p>Prevent a runaway agent from flooding the store with noise. Rate-limit writes per namespace, flag writes for human review, add compliance tags for audit.</p>
-      </div>
-    </div>
-  </div>
-</section>
-
-<!-- ═══════════════════════════════════════════════════
-     § 03 · PIPELINE
-     ═══════════════════════════════════════════════════ -->
-<section id="how">
-  <div class="container">
-    <div class="section-filing reveal">
-      <span class="section-num">&sect; 03</span>
-      <span class="section-name">&mdash; The Retrieval Pipeline</span>
-      <span>Semantic-first &middot; zero inference calls</span>
+    <!-- ENT -->
+    <div class="panel" id="ent">
+      <h3>Deterministic recall and a bitemporal audit trail — without the exponential token tax.</h3>
+      <div class="hook">Cap context to control cost and you trigger silent memory loss: recall decays 100% → 0% by turn 10, identical across every model. Truncation is mechanical — bigger models don't save you.</div>
+      <p>Attestor replaces transcript replay with targeted retrieval over a graph + vector store with <strong>bitemporal semantics</strong>: every fact is timestamped across valid-time and transaction-time, so agent state is immutable, auditable, and reproducible. Per-call context stays flat at ~200 tokens whether the agent is on turn 1 or turn 100.</p>
+      <ul>
+        <li>Flat ~200 tok/call → cost fixed per turn, not compounding.</li>
+        <li>Bitemporal log → replayable, auditable agent state.</li>
+        <li>100% deterministic recall — no black-box forgetting at scale.</li>
+      </ul>
+      <div class="pcta"><a href="inside_attestor.html" class="btn btn-n">Read the architecture →</a><a href="https://github.com/bolnet/context-clock" class="btn btn-ghost">Run the benchmark</a></div>
     </div>
 
-    <div class="reveal">
-      <h2 class="section-head">Semantic-first. <em>No LLM.</em> Fully deterministic.</h2>
-      <p class="standfirst">When an agent calls <code style="font-family:var(--ff-mono);font-size:15px;color:var(--accent);background:var(--ink-raise);padding:2px 8px;border:1px solid var(--rule);">recall(query, budget)</code>, six cooperating steps find, narrow, rank, diversify, decay, and fit the most relevant memories into the requested token ceiling. Ten million memories in the store. Your context window never sees more than the budget. And because there&rsquo;s no LLM in the path, the same query always returns the same ranking. You can unit&#8209;test it.</p>
+    <!-- DEV -->
+    <div class="panel" id="dev">
+      <h3>Cut token burn 21× with two API calls. No model change, no prompt rewrite.</h3>
+      <div class="hook">By turn 100 your agent reads 8,700 input tokens per call just to answer one question. You built that in. Here's the entire fix:</div>
+      <div class="minicode">
+<span class="kw">await</span> attestor.<span class="fn">add</span>(namespace, content)<br>
+facts = <span class="kw">await</span> attestor.<span class="fn">recall</span>(namespace, query)
+      </div>
+      <p>That's it. Per-call context drops from a climbing parabola to a flat ~200 tokens, your session-length caps come off, and recall holds at 100% across all 100 turns. <strong>Measure first</strong> — context-clock runs locally on Ollama, no API keys.</p>
+      <ul>
+        <li>Drop-in: no pipeline overhaul, no lock-in (MIT).</li>
+        <li>DeepSeek-v3.2 session cost: <strong>$0.16 → $0.009</strong>.</li>
+        <li>99 tests — reproduce every number on this page.</li>
+      </ul>
+      <div class="pcta"><a href="inside_attestor.html" class="btn btn-g">Ship the fix →</a><a href="https://github.com/bolnet/context-clock" class="btn btn-ghost">Fork the benchmark</a></div>
     </div>
-
-    <!-- ── Interactive recall pipeline (live trace) ────────────────── -->
-    <style>
-      .recall-stage {
-        margin: 32px auto 8px;
-        max-width: 1080px;
-        background: var(--ink);
-        border: 1px solid var(--rule-strong);
-        padding: 22px 24px 18px;
-        font-family: var(--ff-mono);
-        position: relative;
-      }
-      .recall-stage::before {
-        content: "";
-        position: absolute;
-        top: 7px; left: 7px; right: 7px; bottom: 7px;
-        border: 1px solid var(--rule);
-        pointer-events: none;
-      }
-      .recall-stage__head {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        font-size: 10px;
-        letter-spacing: 0.22em;
-        text-transform: uppercase;
-        color: var(--paper-dim);
-        padding-bottom: 12px;
-        border-bottom: 1px dashed var(--rule);
-      }
-      .recall-stage__label { color: var(--accent); }
-      .recall-stage__status { display: inline-flex; align-items: center; gap: 8px; }
-      .recall-stage__status-dot {
-        width: 7px; height: 7px;
-        border-radius: 50%;
-        background: var(--paper-dim);
-      }
-      .recall-stage[data-state="playing"] .recall-stage__status-dot {
-        background: var(--accent);
-        animation: rs-pulse 1.2s ease-in-out infinite;
-        box-shadow: 0 0 6px var(--accent);
-      }
-      @keyframes rs-pulse {
-        0%, 100% { opacity: 1; }
-        50% { opacity: 0.35; }
-      }
-      .recall-stage__query {
-        font-family: var(--ff-mono);
-        font-size: 14px;
-        color: var(--paper);
-        padding: 18px 0 22px;
-        border-bottom: 1px dashed var(--rule);
-        white-space: nowrap;
-        overflow: hidden;
-      }
-      .recall-stage__prompt { color: var(--paper-dim); }
-      .recall-stage__query-text { color: var(--accent); }
-      .recall-stage__cursor {
-        display: inline-block;
-        width: 8px; height: 14px;
-        background: var(--accent);
-        margin-left: 1px;
-        vertical-align: -2px;
-        animation: rs-blink 1s steps(1) infinite;
-      }
-      @keyframes rs-blink {
-        0%, 50% { opacity: 1; }
-        51%, 100% { opacity: 0; }
-      }
-      .recall-stage__grid {
-        display: grid;
-        grid-template-columns: repeat(3, 1fr);
-        gap: 10px;
-        padding: 22px 0;
-      }
-      .recall-stage__cell {
-        position: relative;
-        border: 1px solid var(--rule);
-        background: transparent;
-        padding: 14px 16px 50px;
-        min-height: 150px;
-        transition: border-color 0.4s, background 0.4s;
-      }
-      .recall-stage__cell[data-active="true"] {
-        border-color: var(--accent);
-        background: var(--ink-raise);
-      }
-      .recall-stage__cell[data-passed="true"] {
-        border-color: rgba(193, 95, 60, 0.35);
-      }
-      .recall-stage__cell-num {
-        position: absolute;
-        top: 8px; right: 14px;
-        font-family: var(--ff-display);
-        font-size: 30px;
-        font-weight: 300;
-        color: var(--accent);
-        font-style: italic;
-        line-height: 1;
-        opacity: 0.65;
-      }
-      .recall-stage__cell[data-active="true"] .recall-stage__cell-num,
-      .recall-stage__cell[data-passed="true"] .recall-stage__cell-num { opacity: 1; }
-      .recall-stage__cell-tag {
-        display: block;
-        font-size: 9px;
-        letter-spacing: 0.22em;
-        text-transform: uppercase;
-        color: var(--paper-dim);
-        margin-bottom: 4px;
-      }
-      .recall-stage__cell-name {
-        display: block;
-        font-family: var(--ff-display);
-        font-size: 18px;
-        font-weight: 500;
-        color: var(--paper);
-        margin-bottom: 4px;
-        font-style: italic;
-      }
-      .recall-stage__cell-engine {
-        display: block;
-        font-size: 11px;
-        color: var(--paper-dim);
-        margin-bottom: 14px;
-      }
-      .recall-stage__tiles {
-        display: grid;
-        grid-template-columns: repeat(10, 1fr);
-        gap: 2px;
-        height: 28px;
-        margin-bottom: 8px;
-      }
-      .recall-stage__tiles > i {
-        display: block;
-        background: rgba(245, 241, 232, 0.06);
-        border-radius: 1px;
-        transition: background 0.25s, transform 0.35s, opacity 0.25s;
-      }
-      .recall-stage__tiles > i[data-state="kept"] { background: var(--paper-dim); }
-      .recall-stage__tiles > i[data-state="boosted"] {
-        background: var(--accent);
-        transform: scale(1.6);
-        box-shadow: 0 0 4px var(--accent);
-      }
-      .recall-stage__tiles > i[data-state="triple"] {
-        background: var(--accent-warm, #d6a574);
-        transform: rotate(45deg) scale(1.1);
-      }
-      .recall-stage__tiles > i[data-state="rejected"] {
-        background: rgba(245, 241, 232, 0.04);
-        opacity: 0.5;
-      }
-      .recall-stage__cell-count {
-        position: absolute;
-        bottom: 12px; right: 16px;
-        font-family: var(--ff-mono);
-        font-size: 22px;
-        color: var(--paper);
-        font-variant-numeric: tabular-nums;
-        letter-spacing: -0.02em;
-      }
-      .recall-stage__cell-count-label {
-        position: absolute;
-        bottom: 38px; right: 16px;
-        font-size: 9px;
-        letter-spacing: 0.18em;
-        text-transform: uppercase;
-        color: var(--paper-dim);
-      }
-      .recall-stage__result {
-        background: var(--ink-raise);
-        border: 1px solid var(--rule);
-        padding: 16px 20px;
-        min-height: 64px;
-        font-size: 12px;
-        color: var(--paper-dim);
-        margin: 8px 0 14px;
-        font-family: var(--ff-mono);
-        line-height: 1.85;
-      }
-      .recall-stage__result-line {
-        display: grid;
-        grid-template-columns: auto 1fr auto;
-        gap: 14px;
-        opacity: 0;
-        transform: translateY(4px);
-        transition: opacity 0.4s, transform 0.4s;
-        align-items: baseline;
-      }
-      .recall-stage__result-line[data-visible="true"] {
-        opacity: 1;
-        transform: translateY(0);
-      }
-      .recall-stage__result-score { color: var(--accent); font-variant-numeric: tabular-nums; }
-      .recall-stage__result-text { color: var(--paper); }
-      .recall-stage__result-meta { color: var(--rule-strong); font-size: 10px; letter-spacing: 0.06em; }
-      .recall-stage__result-empty {
-        color: var(--paper-dim);
-        font-style: italic;
-        font-size: 13px;
-      }
-      .recall-stage__proof {
-        font-size: 10px;
-        letter-spacing: 0.22em;
-        text-transform: uppercase;
-        text-align: center;
-        color: var(--paper-dim);
-        padding: 14px 0;
-        border-top: 1px dashed var(--rule);
-        border-bottom: 1px dashed var(--rule);
-      }
-      .recall-stage__proof-em { color: var(--accent); }
-      .recall-stage__sep { margin: 0 12px; color: var(--rule-strong); }
-      .recall-stage__controls {
-        display: flex;
-        align-items: center;
-        gap: 8px;
-        padding-top: 14px;
-        flex-wrap: wrap;
-      }
-      .recall-stage__btn {
-        background: transparent;
-        border: 1px solid var(--rule);
-        color: var(--paper-dim);
-        padding: 6px 12px;
-        font-family: var(--ff-mono);
-        font-size: 10px;
-        letter-spacing: 0.16em;
-        text-transform: uppercase;
-        cursor: pointer;
-        transition: border-color 0.2s, color 0.2s;
-      }
-      .recall-stage__btn:hover { color: var(--accent); border-color: var(--accent); }
-      .recall-stage__btn--active { color: var(--accent); border-color: var(--accent); }
-      .recall-stage__btn--small { padding: 5px 8px; font-size: 9px; letter-spacing: 0.12em; }
-      .recall-stage__scrub-wrap { display: flex; align-items: center; gap: 8px; flex: 1; min-width: 220px; }
-      .recall-stage__scrub {
-        flex: 1;
-        height: 2px;
-        background: var(--rule);
-        outline: none;
-        cursor: pointer;
-        -webkit-appearance: none;
-        appearance: none;
-      }
-      .recall-stage__scrub::-webkit-slider-thumb {
-        -webkit-appearance: none;
-        appearance: none;
-        width: 12px; height: 12px;
-        background: var(--accent);
-        border-radius: 50%;
-        cursor: pointer;
-      }
-      .recall-stage__scrub::-moz-range-thumb {
-        width: 12px; height: 12px;
-        background: var(--accent);
-        border: none;
-        border-radius: 50%;
-        cursor: pointer;
-      }
-      .recall-stage__time {
-        font-size: 10px;
-        color: var(--paper-dim);
-        font-variant-numeric: tabular-nums;
-        letter-spacing: 0.12em;
-        min-width: 78px;
-        text-align: right;
-      }
-      .recall-stage__artifacts {
-        font-size: 9px;
-        color: var(--paper-dim);
-        letter-spacing: 0.18em;
-        text-transform: uppercase;
-        text-align: center;
-        padding-top: 14px;
-        margin-top: 6px;
-      }
-      .recall-stage__art-link { color: var(--paper-dim); text-decoration: none; }
-      .recall-stage__art-link:hover { color: var(--accent); }
-      .recall-stage__art-link--soon { opacity: 0.55; cursor: not-allowed; }
-      @media (max-width: 760px) {
-        .recall-stage__grid { grid-template-columns: 1fr; }
-        .recall-stage__query { white-space: normal; }
-      }
-    </style>
-
-    <figure class="recall-stage reveal" data-state="idle">
-      <div class="recall-stage__head">
-        <span class="recall-stage__label">&sect; Live trace &middot; Recall pipeline</span>
-        <span class="recall-stage__status">
-          <span class="recall-stage__status-dot"></span>
-          <span data-status-text>Idle &middot; auto-plays on scroll</span>
-        </span>
-      </div>
-
-      <div class="recall-stage__query">
-        <span class="recall-stage__prompt">$ mem.recall(</span><span class="recall-stage__query-text" data-query></span><span class="recall-stage__cursor"></span><span class="recall-stage__prompt">, budget=2000)</span>
-      </div>
-
-      <div class="recall-stage__grid">
-        <div class="recall-stage__cell" data-cell="1">
-          <span class="recall-stage__cell-num">01</span>
-          <span class="recall-stage__cell-tag">Stage 01</span>
-          <span class="recall-stage__cell-name">Vector Top-K</span>
-          <span class="recall-stage__cell-engine">pgvector &middot; cosine &middot; k=50</span>
-          <div class="recall-stage__tiles" data-tiles></div>
-          <span class="recall-stage__cell-count-label">candidates</span>
-          <span class="recall-stage__cell-count" data-count>—</span>
-        </div>
-        <div class="recall-stage__cell" data-cell="2">
-          <span class="recall-stage__cell-num">02</span>
-          <span class="recall-stage__cell-tag">Stage 02</span>
-          <span class="recall-stage__cell-name">Graph Narrow</span>
-          <span class="recall-stage__cell-engine">Neo4j BFS &middot; depth &le; 2</span>
-          <div class="recall-stage__tiles" data-tiles></div>
-          <span class="recall-stage__cell-count-label">kept</span>
-          <span class="recall-stage__cell-count" data-count>—</span>
-        </div>
-        <div class="recall-stage__cell" data-cell="3">
-          <span class="recall-stage__cell-num">03</span>
-          <span class="recall-stage__cell-tag">Stage 03</span>
-          <span class="recall-stage__cell-name">Triples Inject</span>
-          <span class="recall-stage__cell-engine">typed edges &middot; uses &middot; auth-by</span>
-          <div class="recall-stage__tiles" data-tiles></div>
-          <span class="recall-stage__cell-count-label">+triples</span>
-          <span class="recall-stage__cell-count" data-count>—</span>
-        </div>
-        <div class="recall-stage__cell" data-cell="4">
-          <span class="recall-stage__cell-num">04</span>
-          <span class="recall-stage__cell-tag">Stage 04</span>
-          <span class="recall-stage__cell-name">MMR Diversity</span>
-          <span class="recall-stage__cell-engine">&lambda; = 0.7 &middot; drop near-dups</span>
-          <div class="recall-stage__tiles" data-tiles></div>
-          <span class="recall-stage__cell-count-label">distinct</span>
-          <span class="recall-stage__cell-count" data-count>—</span>
-        </div>
-        <div class="recall-stage__cell" data-cell="5">
-          <span class="recall-stage__cell-num">05</span>
-          <span class="recall-stage__cell-tag">Stage 05</span>
-          <span class="recall-stage__cell-name">Decay + Boost</span>
-          <span class="recall-stage__cell-engine">recency &middot; confidence</span>
-          <div class="recall-stage__tiles" data-tiles></div>
-          <span class="recall-stage__cell-count-label">re-ranked</span>
-          <span class="recall-stage__cell-count" data-count>—</span>
-        </div>
-        <div class="recall-stage__cell" data-cell="6">
-          <span class="recall-stage__cell-num">06</span>
-          <span class="recall-stage__cell-tag">Stage 06</span>
-          <span class="recall-stage__cell-name">Budget Fit</span>
-          <span class="recall-stage__cell-engine">greedy pack &middot; &le; 2000 tok</span>
-          <div class="recall-stage__tiles" data-tiles></div>
-          <span class="recall-stage__cell-count-label">packed</span>
-          <span class="recall-stage__cell-count" data-count>—</span>
-        </div>
-      </div>
-
-      <div class="recall-stage__result" data-result>
-        <div class="recall-stage__result-empty">Result frame &mdash; ranked memories will land here when the pipeline completes.</div>
-      </div>
-
-      <div class="recall-stage__proof">
-        <span class="recall-stage__proof-em">0 LLM calls</span>
-        <span class="recall-stage__sep">&middot;</span>
-        <span>6 deterministic steps</span>
-        <span class="recall-stage__sep">&middot;</span>
-        <span>same query &rarr; <span class="recall-stage__proof-em">same ranking</span></span>
-      </div>
-
-      <div class="recall-stage__controls">
-        <button class="recall-stage__btn" data-action="toggle">&#9654; Play</button>
-        <button class="recall-stage__btn" data-action="replay">&#8634; Replay</button>
-        <div class="recall-stage__scrub-wrap">
-          <input type="range" min="0" max="14000" value="0" step="50" data-scrub class="recall-stage__scrub" aria-label="Scrub timeline">
-          <span class="recall-stage__time" data-time>00.0 / 14.0</span>
-        </div>
-        <button class="recall-stage__btn recall-stage__btn--small" data-speed="0.5">0.5&times;</button>
-        <button class="recall-stage__btn recall-stage__btn--small recall-stage__btn--active" data-speed="1">1&times;</button>
-        <button class="recall-stage__btn recall-stage__btn--small" data-speed="2">2&times;</button>
-      </div>
-
-      <div class="recall-stage__artifacts">
-        <a href="pipeline.svg" download class="recall-stage__art-link">&darr; Static pipeline (SVG)</a>
-        <span class="recall-stage__sep">&middot;</span>
-        <a href="#" class="recall-stage__art-link recall-stage__art-link--soon" onclick="event.preventDefault();" title="Render with Remotion — coming soon">&darr; Render as MP4 <span style="opacity:.55">(soon)</span></a>
-      </div>
-    </figure>
-
-    <script>
-    (function () {
-      const root = document.querySelector('.recall-stage');
-      if (!root) return;
-
-      const STATE = {
-        duration: 14000,
-        speed: 1.0,
-        playing: false,
-        t: 0,
-        autoplayed: false,
-        lastTick: 0,
-      };
-
-      const PHASES = [
-        { name: 'query',  from: 0,     to: 1800 },
-        { name: 'stage1', from: 1800,  to: 3500 },
-        { name: 'stage2', from: 3500,  to: 5400 },
-        { name: 'stage3', from: 5400,  to: 7200 },
-        { name: 'stage4', from: 7200,  to: 9000 },
-        { name: 'stage5', from: 9000,  to: 10700 },
-        { name: 'stage6', from: 10700, to: 12500 },
-        { name: 'result', from: 12500, to: 14000 },
-      ];
-
-      const COUNTS = {
-        1: { entry: 0,  peak: 50, exit: 50 },
-        2: { entry: 50, peak: 50, exit: 38 },
-        3: { entry: 38, peak: 42, exit: 42 },
-        4: { entry: 42, peak: 42, exit: 24 },
-        5: { entry: 24, peak: 24, exit: 24 },
-        6: { entry: 24, peak: 24, exit: 8  },
-      };
-
-      const QUERY_FULL = '"who runs engineering at acme?"';
-
-      const RESULT_LINES = [
-        { score: 0.94, text: 'Alice promoted to VP Engineering',  meta: 'valid_from 2026-03-15' },
-        { score: 0.91, text: 'Engineering org reports to Alice',  meta: '[authored-by]' },
-        { score: 0.88, text: 'Alice was engineering manager',     meta: 'superseded 2026-03-15' },
-        { score: 0.82, text: 'Acme org chart Q1 2026',            meta: 'episode #4421' },
-        { score: 0.79, text: 'Alice hired at Acme',               meta: 'valid_from 2024-01-08' },
-        { score: 0.71, text: 'Acme leadership announce',          meta: 'agent: researcher-1' },
-        { score: 0.65, text: 'Engineering headcount: 142',        meta: 'q1-snapshot' },
-        { score: 0.58, text: 'Alice background: ex-Stripe',       meta: '[authored-by]' },
-      ];
-
-      // Pre-build tiles (50 per cell)
-      const cells = Array.from(root.querySelectorAll('[data-cell]'));
-      cells.forEach((cell) => {
-        const tiles = cell.querySelector('[data-tiles]');
-        tiles.innerHTML = '';
-        for (let i = 0; i < 50; i++) tiles.appendChild(document.createElement('i'));
-      });
-
-      // Pre-build result list
-      const resultNode = root.querySelector('[data-result]');
-      function renderResultLines(visibleCount) {
-        if (visibleCount <= 0) {
-          resultNode.innerHTML = '<div class="recall-stage__result-empty">Result frame &mdash; ranked memories will land here when the pipeline completes.</div>';
-          return;
-        }
-        resultNode.innerHTML = RESULT_LINES.map((line, i) => `
-          <div class="recall-stage__result-line" data-line="${i}" data-visible="${i < visibleCount ? 'true' : 'false'}">
-            <span class="recall-stage__result-score">${line.score.toFixed(2)}</span>
-            <span class="recall-stage__result-text">${line.text}</span>
-            <span class="recall-stage__result-meta">— ${line.meta}</span>
-          </div>
-        `).join('');
-      }
-
-      const queryNode  = root.querySelector('[data-query]');
-      const statusNode = root.querySelector('[data-status-text]');
-      const scrubNode  = root.querySelector('[data-scrub]');
-      const timeNode   = root.querySelector('[data-time]');
-      const playBtn    = root.querySelector('[data-action="toggle"]');
-
-      function statusFor(name) {
-        return ({
-          query:  'Embed query &middot; pgvector probe',
-          stage1: 'Stage 01 &middot; Vector top-K (cosine)',
-          stage2: 'Stage 02 &middot; Graph narrow (BFS &le; 2)',
-          stage3: 'Stage 03 &middot; Inject typed-edge triples',
-          stage4: 'Stage 04 &middot; MMR diversity rerank',
-          stage5: 'Stage 05 &middot; Decay + temporal boost',
-          stage6: 'Stage 06 &middot; Greedy budget pack',
-          result: 'Hydrate from doc store &middot; trace written',
-        })[name] || 'Idle';
-      }
-
-      function ease(p) { return p < 0.5 ? 2*p*p : 1 - Math.pow(-2*p+2, 2)/2; }
-
-      function render(t) {
-        const phase = PHASES.find(p => t >= p.from && t < p.to) || PHASES[PHASES.length - 1];
-        const phaseProgress = Math.min(1, Math.max(0, (t - phase.from) / (phase.to - phase.from)));
-        const phaseIdx = PHASES.indexOf(phase);
-
-        // Query typing
-        const qp = Math.min(1, t / 1800);
-        queryNode.textContent = QUERY_FULL.substring(0, Math.floor(QUERY_FULL.length * qp));
-
-        // Cells
-        cells.forEach((cell, idx) => {
-          const stageNum = idx + 1;
-          const expectedPhaseIdx = stageNum; // stage1 is idx 1
-          const isActive = phaseIdx === expectedPhaseIdx;
-          const hasPassed = phaseIdx > expectedPhaseIdx;
-          cell.setAttribute('data-active', isActive ? 'true' : 'false');
-          cell.setAttribute('data-passed', hasPassed ? 'true' : 'false');
-
-          const cfg = COUNTS[stageNum];
-          const tiles = cell.querySelectorAll('[data-tiles] > i');
-          const countNode = cell.querySelector('[data-count]');
-
-          let visible;
-          if (!isActive && !hasPassed) {
-            visible = -1;
-          } else if (isActive) {
-            const e = ease(phaseProgress);
-            if (phaseProgress < 0.5) {
-              visible = Math.round(cfg.entry + (cfg.peak - cfg.entry) * (e * 2));
-            } else {
-              visible = Math.round(cfg.peak + (cfg.exit - cfg.peak) * ((e - 0.5) * 2));
-            }
-          } else {
-            visible = cfg.exit;
-          }
-
-          countNode.textContent = visible < 0 ? '—' : visible;
-
-          tiles.forEach((tile, i) => {
-            if (visible < 0) {
-              tile.removeAttribute('data-state');
-              return;
-            }
-            if (i < visible) {
-              if (stageNum === 2 && i < 8) tile.setAttribute('data-state', 'boosted');
-              else if (stageNum === 3 && i >= 38) tile.setAttribute('data-state', 'triple');
-              else if (stageNum === 5 && (i % 4 === 0)) tile.setAttribute('data-state', 'boosted');
-              else tile.setAttribute('data-state', 'kept');
-            } else {
-              tile.setAttribute('data-state', 'rejected');
-            }
-          });
-        });
-
-        // Result frame
-        if (phase.name === 'result') {
-          const visCount = Math.ceil(RESULT_LINES.length * Math.min(1, phaseProgress * 1.2));
-          renderResultLines(visCount);
-        } else if (phaseIdx >= PHASES.findIndex(p => p.name === 'result')) {
-          renderResultLines(RESULT_LINES.length);
-        } else if (phase.name === 'stage6' && phaseProgress > 0.7) {
-          renderResultLines(Math.ceil(2 * (phaseProgress - 0.7) / 0.3));
-        } else {
-          renderResultLines(0);
-        }
-
-        // Scrub + time
-        if (!STATE._scrubbing) scrubNode.value = String(Math.round(t));
-        const sec = (t / 1000).toFixed(1);
-        timeNode.textContent = `${sec.padStart(4, '0')} / 14.0`;
-
-        // Status
-        if (STATE.playing) {
-          statusNode.innerHTML = statusFor(phase.name);
-        } else if (t === 0) {
-          statusNode.innerHTML = 'Idle &middot; auto-plays on scroll';
-        } else if (t >= STATE.duration - 1) {
-          statusNode.innerHTML = 'Done &middot; <span style="color:var(--accent)">0 LLM calls</span> &middot; replay anytime';
-        } else {
-          statusNode.innerHTML = 'Paused';
-        }
-
-        // Play button label
-        playBtn.innerHTML = STATE.playing ? '&#10074;&#10074; Pause' : '&#9654; Play';
-      }
-
-      function tick(now) {
-        if (!STATE.playing) return;
-        const dt = (now - STATE.lastTick) * STATE.speed;
-        STATE.lastTick = now;
-        STATE.t = Math.min(STATE.duration, STATE.t + dt);
-        render(STATE.t);
-        if (STATE.t >= STATE.duration) {
-          STATE.playing = false;
-          root.setAttribute('data-state', 'idle');
-          render(STATE.t);
-          return;
-        }
-        requestAnimationFrame(tick);
-      }
-      function play() {
-        if (STATE.t >= STATE.duration - 1) STATE.t = 0;
-        STATE.playing = true;
-        STATE.lastTick = performance.now();
-        root.setAttribute('data-state', 'playing');
-        requestAnimationFrame(tick);
-        render(STATE.t);
-      }
-      function pause() {
-        STATE.playing = false;
-        root.setAttribute('data-state', 'idle');
-        render(STATE.t);
-      }
-      function replay() { STATE.t = 0; play(); }
-      function setSpeed(s) {
-        STATE.speed = s;
-        root.querySelectorAll('[data-speed]').forEach(b => b.classList.remove('recall-stage__btn--active'));
-        const btn = root.querySelector(`[data-speed="${s}"]`);
-        if (btn) btn.classList.add('recall-stage__btn--active');
-      }
-
-      // Wire controls
-      playBtn.addEventListener('click', () => STATE.playing ? pause() : play());
-      root.querySelector('[data-action="replay"]').addEventListener('click', replay);
-      root.querySelectorAll('[data-speed]').forEach(b => {
-        b.addEventListener('click', () => setSpeed(parseFloat(b.dataset.speed)));
-      });
-      scrubNode.addEventListener('input', (e) => {
-        STATE._scrubbing = true;
-        if (STATE.playing) pause();
-        STATE.t = parseInt(e.target.value, 10);
-        render(STATE.t);
-      });
-      scrubNode.addEventListener('change', () => { STATE._scrubbing = false; });
-
-      // Auto-play on scroll into view (once)
-      const obs = new IntersectionObserver((entries) => {
-        entries.forEach(e => {
-          if (e.isIntersecting && !STATE.autoplayed) {
-            STATE.autoplayed = true;
-            STATE.t = 0;
-            play();
-          }
-        });
-      }, { threshold: 0.4 });
-      obs.observe(root);
-
-      // Initial paint
-      render(0);
-    })();
-    </script>
-
-    <p style="font-family:var(--ff-mono);font-size:11px;text-transform:uppercase;letter-spacing:0.16em;color:var(--paper-dim);text-align:center;margin:8px 0 28px;">Fig. 3 &mdash; Live trace. Same pipeline. Ten memories or ten million. Replay it; it ranks the same.</p>
-
-    <div class="pipeline reveal">
-      <div class="pipeline-step">
-        <div class="step-index">01</div>
-        <div class="step-body">
-          <h3>Vector Top-K</h3>
-          <p>Embed the query (local Ollama bge-m3 by default; cloud providers as fallback) and fetch the 50 nearest memories from pgvector by cosine similarity.</p>
-        </div>
-        <div class="step-engine"><b>pgvector</b>k=50 &middot; cosine</div>
-      </div>
-      <div class="pipeline-step">
-        <div class="step-index">02</div>
-        <div class="step-body">
-          <h3>Graph Narrow</h3>
-          <p>BFS depth&nbsp;&le;&nbsp;2 on the entity graph from each candidate's entity to the question entities. Boosts hits by hop distance; penalises unreachable.</p>
-        </div>
-        <div class="step-engine"><b>Neo4j + GDS</b>BFS &middot; depth &le; 2</div>
-      </div>
-      <div class="pipeline-step">
-        <div class="step-index">03</div>
-        <div class="step-body">
-          <h3>Triples Inject</h3>
-          <p>Inject typed-edge triples (<code>uses</code>, <code>authored-by</code>, <code>supersedes</code>) as synthetic memories so consumers reason over relations, not just text.</p>
-        </div>
-        <div class="step-engine"><b>Graph store</b>typed edges</div>
-      </div>
-      <div class="pipeline-step">
-        <div class="step-index">04</div>
-        <div class="step-body">
-          <h3>MMR Diversity</h3>
-          <p>Maximal Marginal Relevance rerank with &lambda;=0.7 trades relevance against diversity, eliminating near-duplicate candidates while preserving topical coverage.</p>
-        </div>
-        <div class="step-engine"><b>MMR</b>&lambda; = 0.7</div>
-      </div>
-      <div class="pipeline-step">
-        <div class="step-index">05</div>
-        <div class="step-body">
-          <h3>Decay + Boost</h3>
-          <p>Confidence decay penalises stale, low-confidence rows; temporal boost lifts recent writes. Optional BM25/FTS lane fuses with vector via RRF (k=60).</p>
-        </div>
-        <div class="step-engine"><b>Fusion</b>RRF &middot; k=60</div>
-      </div>
-      <div class="pipeline-step">
-        <div class="step-index">06</div>
-        <div class="step-body">
-          <h3>Budget Fit</h3>
-          <p>Greedy monotonic-by-score selection packs the surviving memories into the caller's token budget. The rest never enter context.</p>
-        </div>
-        <div class="step-engine"><b>Greedy</b>token pack</div>
-      </div>
-    </div>
-
-    <!-- Storage roles + flows -->
-    <div style="margin-top:56px;opacity:1;">
-      <h3 style="font-family:var(--ff-display);font-size:28px;letter-spacing:-0.01em;margin:0 0 8px;">Storage roles</h3>
-      <p class="standfirst" style="margin-top:0;">Every memory is persisted across three complementary stores. Every supported backend combo is just a different technology choice for one or more of these roles.</p>
-      <img src="storage-roles.svg" alt="Storage roles — document store, vector store, graph store" style="display:block;width:100%;height:auto;margin-top:24px;border:1px solid var(--rule);">
-      <div style="display:grid;grid-template-columns:repeat(3,1fr);gap:16px;margin-top:24px;">
-        <div style="padding:20px 22px;border:1px solid var(--rule-strong);background:var(--ink-raise);">
-          <div style="font-family:var(--ff-mono);font-size:10px;letter-spacing:0.2em;color:var(--accent);">ROLE &#183; 01</div>
-          <div style="font-family:var(--ff-display);font-size:22px;font-weight:700;margin-top:6px;">Document store</div>
-          <p style="font-size:14px;color:var(--muted);margin:10px 0 0;">Source of truth. Content, tags, entity, category, timestamps, provenance, confidence. Where <code>add()</code> commits and <code>recall()</code> hydrates final text.</p>
-        </div>
-        <div style="padding:20px 22px;border:1px solid var(--rule-strong);background:var(--ink-raise);">
-          <div style="font-family:var(--ff-mono);font-size:10px;letter-spacing:0.2em;color:var(--accent);">ROLE &#183; 02</div>
-          <div style="font-family:var(--ff-display);font-size:22px;font-weight:700;margin-top:6px;">Vector store</div>
-          <p style="font-size:14px;color:var(--muted);margin:10px 0 0;">Dense embedding per memory, keyed by memory ID. Finds memories by <em>meaning</em> when no tag or word overlaps the query.</p>
-        </div>
-        <div style="padding:20px 22px;border:1px solid var(--rule-strong);background:var(--ink-raise);">
-          <div style="font-family:var(--ff-mono);font-size:10px;letter-spacing:0.2em;color:var(--accent);">ROLE &#183; 03</div>
-          <div style="font-family:var(--ff-display);font-size:22px;font-weight:700;margin-top:6px;">Graph store</div>
-          <p style="font-size:14px;color:var(--muted);margin:10px 0 0;">Entity nodes + typed edges (<code>uses</code>, <code>authored-by</code>, <code>supersedes</code>). Query &ldquo;Python&rdquo; can surface &ldquo;Django&rdquo; via the graph.</p>
-        </div>
-      </div>
-    </div>
-
-    <div style="margin-top:48px;opacity:1;">
-      <h3 style="font-family:var(--ff-display);font-size:28px;letter-spacing:-0.01em;margin:0 0 8px;">Ingestion flow &mdash; <em>what happens on</em> <code>add()</code></h3>
-      <pre style="background:var(--ink-raise);border:1px solid var(--rule);padding:20px 24px;font-family:var(--ff-mono);font-size:12px;line-height:1.5;overflow-x:auto;color:var(--paper-dim);">
-                      mem.add(content, tags, entity, ...)
-                                    &#9474;
-              &#9484;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9532;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9488;
-              &#9660;                     &#9660;                     &#9660;
-      &#9484;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9488;     &#9484;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9488;     &#9484;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9488;
-      &#9474; Document      &#9474;     &#9474; Vector        &#9474;     &#9474; Graph         &#9474;
-      &#9474; store         &#9474;     &#9474; store         &#9474;     &#9474; store         &#9474;
-      &#9500;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9508;     &#9500;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9508;     &#9500;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9508;
-      &#9474; insert row    &#9474;     &#9474; embed(text)   &#9474;     &#9474; extract       &#9474;
-      &#9474;  content,     &#9474;     &#9474;  &#8594; 384-d vec  &#9474;     &#9474;  entities +   &#9474;
-      &#9474;  tags, meta,  &#9474;     &#9474; insert keyed  &#9474;     &#9474;  relations    &#9474;
-      &#9474;  provenance   &#9474;     &#9474;  by memory ID &#9474;     &#9474; upsert nodes, &#9474;
-      &#9474;               &#9474;     &#9474;               &#9474;     &#9474; add edges     &#9474;
-      &#9492;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9496;     &#9492;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9496;     &#9492;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9496;
-              &#9474;                     &#9474;                     &#9474;
-              &#9492;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9532;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9496;
-                                    &#9660;
-                     Contradiction check per entity
-                    (older conflicting facts &#8594; superseded,
-                         kept in timeline)
-                                    &#9474;
-                                    &#9660;
-                                  done
-</pre>
-      <p class="caption" style="font-size:13px;color:var(--muted);font-style:italic;">The three writes commit as one logical transaction. On SQL backends it&rsquo;s a real DB transaction; on distributed backends it&rsquo;s sequenced with best-effort rollback.</p>
-    </div>
-
-    <div style="margin-top:48px;opacity:1;">
-      <h3 style="font-family:var(--ff-display);font-size:28px;letter-spacing:-0.01em;margin:0 0 8px;">Recall flow &mdash; <em>what happens on</em> <code>recall()</code></h3>
-      <pre style="background:var(--ink-raise);border:1px solid var(--rule);padding:20px 24px;font-family:var(--ff-mono);font-size:12px;line-height:1.5;overflow-x:auto;color:var(--paper-dim);">
-                  mem.recall(query, budget=2000)
-                               &#9474;
-                               &#9660;
-            &#9484;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9488;
-            &#9474; 01  Vector top-K   &#8594; vec store &#9474;
-            &#9474;     pgvector &#183; cosine &#183; k=50    &#9474;
-            &#9492;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9516;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9496;
-                               &#9660;
-            &#9484;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9488;
-            &#9474; 02  Graph narrow   &#8594; graph     &#9474;
-            &#9474;     Neo4j BFS depth &#8804; 2          &#9474;
-            &#9474;     hop-affinity boost / penalty &#9474;
-            &#9492;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9516;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9496;
-                               &#9660;
-            &#9484;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9488;
-            &#9474; 03  Triples inject               &#9474;
-            &#9474;     uses &#183; authored-by &#183; supersedes &#9474;
-            &#9474;     synthetic-memory facts       &#9474;
-            &#9492;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9516;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9496;
-                               &#9660;
-            &#9484;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9488;
-            &#9474; 04  MMR diversity &#955; = 0.7        &#9474;
-            &#9474; 05  Decay + temporal boost        &#9474;
-            &#9474; 06  Greedy token pack &#8804; budget    &#9474;
-            &#9492;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9516;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9496;
-                               &#9660;
-                  List[RetrievalResult] &#8804; budget
-                          (zero LLM calls)
-
-   Optional BM25 / FTS lane &#8594; fused with the vector lane via RRF k=60
-   when the document store has the content_tsv tsvector column populated.
-</pre>
-      <p class="caption" style="font-size:13px;color:var(--muted);font-style:italic;">Each step takes the previous step&rsquo;s candidate set as input. Only memory IDs travel until the final budget-fit step hydrates the keepers from the document store. A store with ten million rows still returns a tight result set inside the caller&rsquo;s token ceiling.</p>
-    </div>
-
-    <!-- Three pillars — Isolation, Temporal, Provenance -->
-    <div style="margin-top:72px;">
-      <div class="reveal">
-        <h3 style="font-family:var(--ff-display);font-size:clamp(28px,3.2vw,40px);letter-spacing:-0.015em;margin:0 0 10px;">And three things <em style="color:var(--accent);font-style:italic;">most of the industry skipped.</em></h3>
-        <p class="standfirst" style="margin-top:0;">Isolation. Temporal correctness. Provenance. Not features we bolted on. Primitives we started from.</p>
-      </div>
-
-      <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:20px;margin-top:36px;">
-        <div class="reveal" style="padding:26px;border:1px solid var(--rule-strong);background:var(--ink-raise);border-left:3px solid var(--accent);">
-          <div style="font-family:var(--ff-mono);font-size:10px;letter-spacing:0.22em;color:var(--accent);">PILLAR &middot; 01</div>
-          <h4 style="font-family:var(--ff-display);font-size:26px;font-weight:600;margin:8px 0 12px;">Isolation</h4>
-          <p style="font-size:14.5px;line-height:1.65;color:var(--paper-dim);margin:0 0 10px;">Every memory lives inside a <b>namespace</b>. Every agent is bound to one of six <b>roles</b>. Every call is authorised before it touches storage. Enforced at the row level, not in application code.</p>
-          <div style="font-family:var(--ff-mono);font-size:12px;color:var(--muted);line-height:1.7;margin-top:14px;">
-            <span style="color:var(--accent);">&rarr;</span> <b>ORCHESTRATOR</b> &middot; spawns sub-agents<br>
-            <span style="color:var(--accent);">&rarr;</span> <b>PLANNER</b> &middot; writes decisions<br>
-            <span style="color:var(--accent);">&rarr;</span> <b>EXECUTOR</b> &middot; runs the work<br>
-            <span style="color:var(--accent);">&rarr;</span> <b>RESEARCHER</b> &middot; gathers facts<br>
-            <span style="color:var(--accent);">&rarr;</span> <b>REVIEWER</b> &middot; audits decisions<br>
-            <span style="color:var(--accent);">&rarr;</span> <b>MONITOR</b> &middot; observability only
-          </div>
-        </div>
-
-        <div class="reveal" style="padding:26px;border:1px solid var(--rule-strong);background:var(--ink-raise);border-left:3px solid var(--accent);">
-          <div style="font-family:var(--ff-mono);font-size:10px;letter-spacing:0.22em;color:var(--accent);">PILLAR &middot; 02</div>
-          <h4 style="font-family:var(--ff-display);font-size:26px;font-weight:600;margin:8px 0 12px;">Temporal</h4>
-          <p style="font-size:14.5px;line-height:1.65;color:var(--paper-dim);margin:0 0 14px;">Attestor doesn&rsquo;t overwrite. It <b>supersedes</b>. Every fact has a validity window. The timeline is replayable to any point in the past.</p>
-          <div style="font-family:var(--ff-mono);font-size:12px;color:var(--paper);background:var(--ink);border:1px solid var(--rule);padding:14px;line-height:1.6;">
-<b style="color:var(--muted);">v1</b> JPM CFO is Jeremy Barnum<br>
-<span style="color:var(--faint);">&nbsp;&nbsp;&nbsp;valid_from: 2022-05</span><br>
-<span style="color:var(--accent);">&nbsp;&nbsp;&nbsp;&darr; superseded</span><br>
-<b style="color:var(--accent-warm);">v2</b> JPM CFO is Jane Doe<br>
-<span style="color:var(--faint);">&nbsp;&nbsp;&nbsp;valid_from: 2026-04-11</span><br>
-<span style="color:var(--accent);">&nbsp;&nbsp;&nbsp;&darr; superseded</span><br>
-<b style="color:var(--accent);">v3</b> Appointment delayed<br>
-<span style="color:var(--faint);">&nbsp;&nbsp;&nbsp;valid_from: 2026-04-12</span>
-          </div>
-          <p style="font-size:13px;color:var(--muted);font-style:italic;margin:12px 0 0;line-height:1.55;">Ask <code style="font-family:var(--ff-mono);font-size:12px;color:var(--accent);">recall(as_of=&hellip;)</code> to replay the past. Nothing is deleted. Auditors can reconstruct what the desk knew and when.</p>
-        </div>
-
-        <div class="reveal" style="padding:26px;border:1px solid var(--rule-strong);background:var(--ink-raise);border-left:3px solid var(--accent);">
-          <div style="font-family:var(--ff-mono);font-size:10px;letter-spacing:0.22em;color:var(--accent);">PILLAR &middot; 03</div>
-          <h4 style="font-family:var(--ff-display);font-size:26px;font-weight:600;margin:8px 0 12px;">Provenance</h4>
-          <p style="font-size:14.5px;line-height:1.65;color:var(--paper-dim);margin:0 0 14px;">Every sentence the agent writes back is traceable to its source. A cryptographic chain from raw feed ingest to grounded answer.</p>
-          <div style="font-family:var(--ff-mono);font-size:12px;color:var(--paper);background:var(--ink);border:1px solid var(--rule);padding:14px;line-height:1.7;">
-<span style="color:var(--muted);">raw signal</span> <span style="color:var(--accent);">&rarr;</span> <span style="color:var(--muted);">ingest</span><br>
-&nbsp;&nbsp;<span style="color:var(--accent-warm);">source_id &middot; sha256 &middot; ts</span><br>
-<span style="color:var(--accent);">&darr;</span><br>
-<span style="color:var(--muted);">memory row</span><br>
-&nbsp;&nbsp;<span style="color:var(--accent-warm);">id &middot; content &middot; provenance</span><br>
-<span style="color:var(--accent);">&darr;</span><br>
-<span style="color:var(--muted);">semantic-first recall</span><br>
-<span style="color:var(--accent);">&darr;</span><br>
-<b style="color:var(--accent);">agent answer [mem_42]</b>
-          </div>
-          <p style="font-size:13px;color:var(--muted);font-style:italic;margin:12px 0 0;line-height:1.55;">The citation isn&rsquo;t a string the LLM chose. It&rsquo;s the <code style="font-family:var(--ff-mono);font-size:12px;color:var(--accent);">memory_id</code> carried through the pipeline. Click it, land on the raw wire, verify the hash. <em>Grounded, not plausible.</em></p>
-        </div>
-      </div>
-    </div>
-  </div>
-</section>
-
-<!-- ═══════════════════════════════════════════════════
-     § 03.5 · MULTI-LLM COOPERATION
-     ═══════════════════════════════════════════════════ -->
-<section id="cooperation" style="border-top:1px solid var(--rule);">
-  <div class="container">
-    <div class="section-filing reveal">
-      <span class="section-num">&sect; 03.5</span>
-      <span class="section-name">&mdash; Multi-LLM cooperation</span>
-      <span>Many models &middot; one auditable memory</span>
-    </div>
-
-    <div class="reveal">
-      <h2 class="section-head">Many LLMs, one memory. <em>Conflicts resolved on contract,</em> not vibes.</h2>
-      <p class="standfirst">Real agent teams have a planner, an executor, and a reviewer &mdash; often on different model families. They write to the same memory store. Without a contract for how those writes interact, you get duplicate facts, lost edits, and silent overwrites. Attestor ships five mechanisms that turn multi-LLM writes into an auditable transaction log.</p>
-    </div>
-
-    <!-- Five mechanisms grid -->
-    <div style="display:grid;grid-template-columns:repeat(2,1fr);gap:18px;margin-top:32px;">
-
-      <!-- 01 — Write-time supersession -->
-      <div class="reveal" style="padding:26px 28px;border:1px solid var(--rule-strong);background:var(--ink-raise);border-left:3px solid var(--accent);">
-        <div style="font-family:var(--ff-mono);font-size:10px;letter-spacing:0.22em;color:var(--accent);">MECHANISM &middot; 01</div>
-        <h4 style="font-family:var(--ff-display);font-size:24px;font-weight:600;margin:8px 0 12px;">Write-time supersession</h4>
-        <p style="font-size:14.5px;line-height:1.65;color:var(--paper-dim);margin:0 0 14px;">Deterministic. Zero LLM in the loop. On every <code style="font-family:var(--ff-mono);font-size:12px;color:var(--accent);">add()</code>, attestor checks for active rows with the same <code>(entity, category, namespace)</code> and different content. Each match is auto-marked <code>superseded</code> with <code>valid_until=now</code> and <code>superseded_by=&lt;new_id&gt;</code>.</p>
-        <div style="font-family:var(--ff-mono);font-size:12px;color:var(--paper);background:var(--ink);border:1px solid var(--rule);padding:14px;line-height:1.7;">
-<span style="color:var(--muted);"># add()</span><br>
-<span style="color:var(--muted);">  &darr;</span><br>
-<span style="color:var(--accent-warm);">  check_contradictions(memory)</span><br>
-<span style="color:var(--muted);">  &darr;</span><br>
-<span style="color:var(--accent-warm);">  store.insert(memory)</span><br>
-<span style="color:var(--muted);">  &darr;</span><br>
-<span style="color:var(--accent);">  for old in contradictions: supersede(old, memory.id)</span>
-        </div>
-        <p style="font-size:12.5px;color:var(--muted);font-style:italic;margin:12px 0 0;">Old facts are <strong>never deleted</strong>. <code style="font-family:var(--ff-mono);font-size:11px;">recall(as_of=&hellip;)</code> still returns them.</p>
-      </div>
-
-      <!-- 02 — Ingest-time 4-decision contract -->
-      <div class="reveal" style="padding:26px 28px;border:1px solid var(--rule-strong);background:var(--ink-raise);border-left:3px solid var(--accent);">
-        <div style="font-family:var(--ff-mono);font-size:10px;letter-spacing:0.22em;color:var(--accent);">MECHANISM &middot; 02</div>
-        <h4 style="font-family:var(--ff-display);font-size:24px;font-weight:600;margin:8px 0 12px;">Four-decision conflict resolver</h4>
-        <p style="font-size:14.5px;line-height:1.65;color:var(--paper-dim);margin:0 0 14px;">For conversation ingest, every newly extracted fact gets one of four decisions from the LLM. Each carries an <code style="font-family:var(--ff-mono);font-size:12px;color:var(--accent);">evidence_episode_id</code> &mdash; every supersession is auditable.</p>
-        <div style="display:grid;grid-template-columns:auto 1fr;gap:6px 16px;font-family:var(--ff-mono);font-size:12px;line-height:1.6;">
-          <code style="color:var(--accent);">ADD</code>          <span style="color:var(--paper-dim);">no existing match &mdash; write fresh</span>
-          <code style="color:var(--accent);">UPDATE</code>       <span style="color:var(--paper-dim);">refined value, keep id</span>
-          <code style="color:var(--accent);">INVALIDATE</code>   <span style="color:var(--paper-dim);">old contradicted &mdash; mark superseded</span>
-          <code style="color:var(--accent);">NOOP</code>         <span style="color:var(--paper-dim);">already represented &mdash; skip</span>
-        </div>
-        <p style="font-size:12.5px;color:var(--muted);font-style:italic;margin:14px 0 0;">Failsafe: any LLM/parse failure falls back to <code style="font-family:var(--ff-mono);font-size:11px;color:var(--accent);">ADD</code>-by-default. Better a duplicate-ish row than a silent drop.</p>
-      </div>
-
-      <!-- 03 — Speaker-locked extraction -->
-      <div class="reveal" style="padding:26px 28px;border:1px solid var(--rule-strong);background:var(--ink-raise);">
-        <div style="font-family:var(--ff-mono);font-size:10px;letter-spacing:0.22em;color:var(--accent);">MECHANISM &middot; 03</div>
-        <h4 style="font-family:var(--ff-display);font-size:24px;font-weight:600;margin:8px 0 12px;">Speaker-locked extraction</h4>
-        <p style="font-size:14.5px;line-height:1.65;color:var(--paper-dim);margin:0 0 14px;">Two passes per round, with separate prompts. User-turn extractor only emits facts attributable to the user; assistant-turn extractor only emits facts the assistant introduced. Stops cross-attribution &mdash; the &ldquo;Mem0 +53.6&rdquo; fix in our LongMemEval scores.</p>
-        <div style="font-family:var(--ff-mono);font-size:12px;color:var(--paper);background:var(--ink);border:1px solid var(--rule);padding:14px;line-height:1.7;">
-<span style="color:var(--muted);">user turn &rarr;</span> <span class="kw" style="color:var(--accent-warm);">extract_user_facts(turn)</span><br>
-<span style="color:var(--muted);">                     &darr; speaker = "user"</span><br>
-<br>
-<span style="color:var(--muted);">assistant turn &rarr;</span> <span class="kw" style="color:var(--accent-warm);">extract_agent_facts(turn)</span><br>
-<span style="color:var(--muted);">                          &darr; speaker = "&lt;agent_id&gt;"</span>
-        </div>
-      </div>
-
-      <!-- 04 — Sleep-time reflection -->
-      <div class="reveal" style="padding:26px 28px;border:1px solid var(--rule-strong);background:var(--ink-raise);">
-        <div style="font-family:var(--ff-mono);font-size:10px;letter-spacing:0.22em;color:var(--accent);">MECHANISM &middot; 04</div>
-        <h4 style="font-family:var(--ff-display);font-size:24px;font-weight:600;margin:8px 0 12px;">Sleep-time reflection</h4>
-        <p style="font-size:14.5px;line-height:1.65;color:var(--paper-dim);margin:0 0 14px;">Periodic synthesis across a user&rsquo;s recent facts. One LLM call distills many episodes into structured outputs:</p>
-        <ul style="font-family:var(--ff-mono);font-size:12px;color:var(--paper-dim);line-height:1.85;margin:0 0 12px;padding-left:20px;">
-          <li><code style="color:var(--accent);">stable_preferences</code> &mdash; patterns appearing in 3+ episodes</li>
-          <li><code style="color:var(--accent);">stable_constraints</code> &mdash; rules the user repeatedly invokes</li>
-          <li><code style="color:var(--accent);">changed_beliefs</code> &mdash; preferences shifted (old &rarr; new)</li>
-          <li><code style="color:var(--accent);">contradictions_for_review</code> &mdash; flagged, <strong>not auto-resolved</strong></li>
-        </ul>
-        <p style="font-size:12.5px;color:var(--muted);font-style:italic;margin:0;">Hard contradictions in regulated chat systems must be a human decision &mdash; the prompt is explicit: <em>do NOT auto-resolve</em>.</p>
-      </div>
-
-      <!-- 05 — Dual-judge anti-collusion -->
-      <div class="reveal" style="padding:26px 28px;border:1px solid var(--rule-strong);background:var(--ink-raise);grid-column:1 / span 2;border-left:3px solid var(--accent);">
-        <div style="font-family:var(--ff-mono);font-size:10px;letter-spacing:0.22em;color:var(--accent);">MECHANISM &middot; 05</div>
-        <h4 style="font-family:var(--ff-display);font-size:24px;font-weight:600;margin:8px 0 12px;">Dual-judge benchmarking &mdash; anti-collusion by construction</h4>
-        <p style="font-size:14.5px;line-height:1.65;color:var(--paper-dim);margin:0 0 14px;">Every LongMemEval answer is scored by <strong>two independent judges from different model families</strong> &mdash; the second judge anchors out answerer-judge collusion. Same model judging its own answer rewards itself; cross-family judging surfaces real disagreement.</p>
-        <div style="display:grid;grid-template-columns:1fr auto 1fr;gap:18px;align-items:center;">
-          <div style="font-family:var(--ff-mono);font-size:13px;background:var(--ink);border:1px solid var(--rule-strong);padding:14px;text-align:center;">
-            <div style="color:var(--muted);font-size:11px;letter-spacing:0.18em;">JUDGE 01</div>
-            <div style="color:var(--accent);margin-top:6px;">openai/gpt-5.2</div>
-          </div>
-          <div style="font-family:var(--ff-mono);font-size:11px;color:var(--muted);text-align:center;letter-spacing:0.16em;">vs cross<br>family</div>
-          <div style="font-family:var(--ff-mono);font-size:13px;background:var(--ink);border:1px solid var(--rule-strong);padding:14px;text-align:center;">
-            <div style="color:var(--muted);font-size:11px;letter-spacing:0.18em;">JUDGE 02</div>
-            <div style="color:var(--accent);margin-top:6px;">anthropic/claude-sonnet-4.6</div>
-          </div>
-        </div>
-        <p style="font-size:12.5px;color:var(--muted);font-style:italic;margin:14px 0 0;">The <code style="font-family:var(--ff-mono);font-size:11px;color:var(--accent);">scripts/lme_smoke_local.py</code> driver runs this exact dual-judge stack against your install. See the Quickstart &raquo; <em>Smoke benchmark</em> tab.</p>
-      </div>
-
-    </div>
-
-    <!-- Provenance closing line -->
-    <div class="reveal" style="margin-top:36px;padding:22px 26px;border:1px dashed var(--rule-strong);background:var(--ink-raise);">
-      <div style="font-family:var(--ff-mono);font-size:10px;letter-spacing:0.22em;color:var(--accent);margin-bottom:8px;">PROVENANCE INVARIANT</div>
-      <p style="font-size:14.5px;line-height:1.65;color:var(--paper);margin:0;">Every memory carries <code style="font-family:var(--ff-mono);font-size:12px;color:var(--accent);">agent_id</code>, <code style="font-family:var(--ff-mono);font-size:12px;color:var(--accent);">session_id</code>, and <code style="font-family:var(--ff-mono);font-size:12px;color:var(--accent);">source_episode_id</code>. Every <code style="font-family:var(--ff-mono);font-size:12px;color:var(--accent);">supersede</code> writes the prior id into <code style="font-family:var(--ff-mono);font-size:12px;color:var(--accent);">superseded_by</code>. Cryptographic signing is opt-in (Phase 8.1). The result: any disputed answer can be traced back to <em>which agent wrote which fact, when, and what it superseded</em>.</p>
-    </div>
-
-  </div>
-</section>
-
-<!-- ═══════════════════════════════════════════════════
-     § 05 · DEPLOY
-     ═══════════════════════════════════════════════════ -->
-<section id="platforms">
-  <div class="container">
-    <div class="section-filing reveal">
-      <span class="section-num">&sect; 04</span>
-      <span class="section-name">&mdash; Deployment Matrix</span>
-      <span>Your cloud &middot; your infrastructure &middot; Terraform included</span>
-    </div>
-
-    <div class="reveal">
-      <h2 class="section-head">Same API. <em>Every backend.</em> Your infrastructure.</h2>
-      <p class="standfirst">One Python library. One Starlette ASGI container. Six deployment targets &mdash; laptop, dev VM, AWS, Azure, GCP, on&#8209;prem. The three storage roles swap per column. Your agent code never learns which backend it&rsquo;s talking to. Terraform templates live under <code style="font-family:var(--ff-mono);font-size:15px;color:var(--accent);background:var(--ink-raise);padding:2px 8px;border:1px solid var(--rule);">agent_memory/infra/</code>. <em>Clone. Set your variables. <code style="font-family:var(--ff-mono);font-size:15px;color:var(--accent);background:var(--ink-raise);padding:2px 8px;border:1px solid var(--rule);">terraform apply</code>.</em></p>
-    </div>
-
-    <div class="reveal" style="margin:36px 0 40px;padding:28px 32px;background:var(--ink-raise);border:1px solid var(--rule-strong);border-left:4px solid var(--accent);border-radius:4px;">
-      <div style="font-family:var(--ff-mono);font-size:12px;text-transform:uppercase;letter-spacing:0.18em;color:var(--accent);margin-bottom:10px;">Run it on your laptop. No cloud, no cost.</div>
-      <h3 style="font-family:var(--ff-display);font-size:28px;font-weight:500;margin:0 0 14px;color:var(--paper);">Self-host locally in <em>one command</em>.</h3>
-      <pre style="background:var(--ink);color:var(--paper);font-family:var(--ff-mono);font-size:14px;padding:18px 22px;border:1px solid var(--rule-strong);border-radius:4px;overflow-x:auto;margin:0 0 14px;"><span style="color:var(--accent);">$</span> pip install attestor
-<span style="color:var(--accent);">$</span> attestor api --host 0.0.0.0 --port 8080</pre>
-      <p style="margin:0;color:var(--paper-dim);font-size:15px;line-height:1.7;">Starlette ASGI on <code style="font-family:var(--ff-mono);font-size:13px;background:var(--ink);color:var(--paper);padding:2px 6px;border:1px solid var(--rule-strong);border-radius:3px;">http://localhost:8080</code>. Run <code style="font-family:var(--ff-mono);font-size:13px;background:var(--ink);color:var(--paper);padding:2px 6px;border:1px solid var(--rule-strong);border-radius:3px;">attestor setup local</code> to bring up Postgres&nbsp;16 + Neo4j (with GDS) via the bundled Docker Compose. Point every agent in your stack at the same URL &mdash; they share memory instantly. No SaaS. No API keys. Air-gap it behind your firewall and walk away.</p>
-    </div>
-
-    <div class="matrix reveal">
-      <div class="matrix-cell">
-        <span class="matrix-tag">Cloud &middot; 01</span>
-        <h3>AWS</h3>
-        <p>App Runner with Starlette ASGI. Auto-scaling, HTTPS, custom domains.</p>
-        <div class="matrix-spec">2 CPU &middot; 4 GB &middot; us-west-2</div>
-      </div>
-      <div class="matrix-cell">
-        <span class="matrix-tag">Cloud &middot; 02</span>
-        <h3>Azure</h3>
-        <p>Container Apps with Cosmos DB DiskANN. Scale-to-zero. Same API, same results.</p>
-        <div class="matrix-spec">2 CPU &middot; 4 GB &middot; eastus</div>
-      </div>
-      <div class="matrix-cell">
-        <span class="matrix-tag">Cloud &middot; 03</span>
-        <h3>GCP</h3>
-        <p>Cloud Run with AlloyDB. Scale-to-zero. Google's managed infrastructure.</p>
-        <div class="matrix-spec">2 CPU &middot; 4 GB &middot; us-central1</div>
-      </div>
-      <div class="matrix-cell">
-        <span class="matrix-tag">Backend &middot; 04</span>
-        <h3>PostgreSQL</h3>
-        <p>pgvector + Apache AGE. Neon serverless or any Postgres 16.</p>
-        <div class="matrix-spec">Doc &middot; Vector &middot; Graph</div>
-      </div>
-      <div class="matrix-cell">
-        <span class="matrix-tag">Backend &middot; 05</span>
-        <h3>ArangoDB</h3>
-        <p>Multi-model: graph + document + vector in one engine. Oasis or self-hosted.</p>
-        <div class="matrix-spec">Native graph traversal</div>
-      </div>
-      <div class="matrix-cell">
-        <span class="matrix-tag">Backend &middot; 06</span>
-        <h3>Local / On-Prem</h3>
-        <p>Postgres + pgvector + Neo4j via Docker Compose. Air-gapped deployments. Full data sovereignty.</p>
-        <div class="matrix-spec">No network egress</div>
-      </div>
-    </div>
-
-    <!-- Same container, pluggable stores -->
-    <div style="margin-top:56px;opacity:1;">
-      <h3 style="font-family:var(--ff-display);font-size:28px;letter-spacing:-0.01em;margin:0 0 8px;">Same container. <em>Pluggable stores.</em></h3>
-      <p class="standfirst" style="margin-top:0;">One Attestor image. Six targets. The three storage roles swap per column. That&rsquo;s the whole trick.</p>
-      <figure class="reveal" style="margin:24px auto 8px;max-width:1100px;background:#f4efe3;border:1px solid var(--rule-strong);border-radius:6px;padding:20px;">
-        <img src="deployment-matrix.svg" alt="Deployment matrix — one container, six targets, stores swap per column" style="display:block;width:100%;height:auto;">
-        <figcaption style="font-family:var(--ff-mono);font-size:11px;text-transform:uppercase;letter-spacing:0.16em;color:#3a3530;text-align:center;margin-top:12px;">Fig. 4 &mdash; <em>DocumentStore</em>, <em>VectorStore</em>, <em>GraphStore</em> &mdash; three interfaces. Every column is one triple of implementations.</figcaption>
-      </figure>
-      <div style="display:grid;grid-template-columns:repeat(5,1fr);gap:12px;margin-top:20px;font-size:13px;">
-        <div style="padding:16px;border:1px solid var(--rule-strong);background:var(--ink-raise);">
-          <div style="font-family:var(--ff-mono);font-size:10px;letter-spacing:0.2em;color:var(--accent);">LANE &#183; 01</div>
-          <div style="font-family:var(--ff-display);font-size:18px;font-weight:700;margin:6px 0 10px;">Laptop</div>
-          <div style="color:var(--muted);line-height:1.6;"><code>attestor setup local</code><br><b>Doc:</b> Postgres 16<br><b>Vec:</b> pgvector<br><b>Graph:</b> Neo4j + GDS</div>
-        </div>
-        <div style="padding:16px;border:1px solid var(--rule-strong);background:var(--ink-raise);">
-          <div style="font-family:var(--ff-mono);font-size:10px;letter-spacing:0.2em;color:var(--accent);">LANE &#183; 02</div>
-          <div style="font-family:var(--ff-display);font-size:18px;font-weight:700;margin:6px 0 10px;">Self-host</div>
-          <div style="color:var(--muted);line-height:1.6;">Docker &middot; any cloud<br><b>Doc:</b> Postgres 16<br><b>Vec:</b> pgvector<br><b>Graph:</b> Apache AGE</div>
-        </div>
-        <div style="padding:16px;border:1px solid var(--rule-strong);background:var(--ink-raise);">
-          <div style="font-family:var(--ff-mono);font-size:10px;letter-spacing:0.2em;color:var(--accent);">LANE &#183; 03</div>
-          <div style="font-family:var(--ff-display);font-size:18px;font-weight:700;margin:6px 0 10px;">AWS</div>
-          <div style="color:var(--muted);line-height:1.6;">App Runner<br><b>All 3 roles:</b><br>ArangoDB Oasis<br><em>one engine</em></div>
-        </div>
-        <div style="padding:16px;border:1px solid var(--rule-strong);background:var(--ink-raise);">
-          <div style="font-family:var(--ff-mono);font-size:10px;letter-spacing:0.2em;color:var(--accent);">LANE &#183; 04</div>
-          <div style="font-family:var(--ff-display);font-size:18px;font-weight:700;margin:6px 0 10px;">GCP</div>
-          <div style="color:var(--muted);line-height:1.6;">Cloud Run<br><b>All 3 roles:</b><br>AlloyDB +<br>pgvector + AGE</div>
-        </div>
-        <div style="padding:16px;border:1px solid var(--rule-strong);background:var(--ink-raise);">
-          <div style="font-family:var(--ff-mono);font-size:10px;letter-spacing:0.2em;color:var(--accent);">LANE &#183; 05</div>
-          <div style="font-family:var(--ff-display);font-size:18px;font-weight:700;margin:6px 0 10px;">Azure</div>
-          <div style="color:var(--muted);line-height:1.6;">Container Apps<br><b>All 3 roles:</b><br>Cosmos DB<br>DiskANN</div>
-        </div>
-      </div>
-      <p class="caption" style="font-size:13px;color:var(--muted);font-style:italic;margin-top:14px;">Every deployment is the same Python library wrapped in the same Starlette ASGI container. <code>DocumentStore</code>, <code>VectorStore</code>, and <code>GraphStore</code> are three interfaces; each column above is one implementation triple.</p>
-    </div>
-
-    <!-- Promotion path -->
-    <div style="margin-top:56px;opacity:1;">
-      <h3 style="font-family:var(--ff-display);font-size:28px;letter-spacing:-0.01em;margin:0 0 8px;">Promotion path &mdash; <em>laptop to cloud, no rewrite.</em></h3>
-      <p class="standfirst" style="margin-top:0;">Prototype on a laptop. Promote to Docker Compose on a dev VM. Promote to a managed container runtime. Same API throughout. Only the storage URLs change.</p>
-      <figure class="reveal" style="margin:24px auto 8px;max-width:1100px;background:#f4efe3;border:1px solid var(--rule-strong);border-radius:6px;padding:20px;">
-        <img src="promotion-path.svg" alt="Promotion path — laptop to dev VM to managed cloud, same API rail throughout" style="display:block;width:100%;height:auto;">
-        <figcaption style="font-family:var(--ff-mono);font-size:11px;text-transform:uppercase;letter-spacing:0.16em;color:#3a3530;text-align:center;margin-top:12px;">Fig. 5 &mdash; The same rail runs under every stop. The code never learns which cloud it&rsquo;s on.</figcaption>
-      </figure>
-    </div>
-
-    <!-- Runtime topology — three integration modes -->
-    <div style="margin-top:56px;opacity:1;">
-      <h3 style="font-family:var(--ff-display);font-size:28px;letter-spacing:-0.01em;margin:0 0 8px;">Three shapes. <em>Pick by blast radius.</em></h3>
-      <p class="standfirst" style="margin-top:0;">Same engine. Same storage. Same retrieval. Different coupling. Pick by latency budget and how many agents share the tier.</p>
-      <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:16px;margin-top:24px;">
-        <div class="reveal" style="padding:22px;border:1px solid var(--rule-strong);background:var(--ink-raise);">
-          <div style="font-family:var(--ff-mono);font-size:10px;letter-spacing:0.22em;color:var(--accent);">MODE A</div>
-          <h4 style="font-family:var(--ff-display);font-size:22px;font-weight:600;margin:6px 0 10px;">Embedded library</h4>
-          <p style="font-size:14px;color:var(--paper-dim);line-height:1.6;margin:0 0 12px;"><code style="font-family:var(--ff-mono);font-size:12px;color:var(--accent);">AgentMemory(&rsquo;./store&rsquo;)</code> in&#8209;process. Sub&#8209;millisecond. Right for a single agent prototyping on a laptop.</p>
-          <div style="font-family:var(--ff-mono);font-size:11px;color:var(--muted);text-transform:uppercase;letter-spacing:0.12em;">Latency &middot; lowest</div>
-        </div>
-        <div class="reveal" style="padding:22px;border:1px solid var(--rule-strong);background:var(--ink-raise);">
-          <div style="font-family:var(--ff-mono);font-size:10px;letter-spacing:0.22em;color:var(--accent);">MODE B</div>
-          <h4 style="font-family:var(--ff-display);font-size:22px;font-weight:600;margin:6px 0 10px;">Sidecar container</h4>
-          <p style="font-size:14px;color:var(--paper-dim);line-height:1.6;margin:0 0 12px;"><code style="font-family:var(--ff-mono);font-size:12px;color:var(--accent);">attestor api</code> on <code style="font-family:var(--ff-mono);font-size:12px;color:var(--accent);">localhost:8080</code>. Any language. Go or Rust agents call HTTP without Python in the image.</p>
-          <div style="font-family:var(--ff-mono);font-size:11px;color:var(--muted);text-transform:uppercase;letter-spacing:0.12em;">Isolation &middot; process</div>
-        </div>
-        <div class="reveal" style="padding:22px;border:1px solid var(--rule-strong);background:var(--ink-raise);border:1px solid var(--accent);">
-          <div style="font-family:var(--ff-mono);font-size:10px;letter-spacing:0.22em;color:var(--accent);">MODE C</div>
-          <h4 style="font-family:var(--ff-display);font-size:22px;font-weight:600;margin:6px 0 10px;">Shared service</h4>
-          <p style="font-size:14px;color:var(--paper-dim);line-height:1.6;margin:0 0 12px;">One Attestor service in front of an agent mesh. App Runner &middot; Cloud Run &middot; Container Apps. Managed storage behind. This is the production shape.</p>
-          <div style="font-family:var(--ff-mono);font-size:11px;color:var(--muted);text-transform:uppercase;letter-spacing:0.12em;">Scale &middot; multi&#8209;agent mesh</div>
-        </div>
-      </div>
-      <p class="caption" style="font-size:13px;color:var(--muted);font-style:italic;margin-top:18px;">Code path is identical across all three. Only configuration changes.</p>
-    </div>
-  </div>
-</section>
-
-<!-- ═══════════════════════════════════════════════════
-     ONE MORE THING · CLAUDE CODE
-     ═══════════════════════════════════════════════════ -->
-<section id="claude-moment" style="padding:96px 0;background:var(--ink-raise);border-top:1px solid var(--rule);border-bottom:1px solid var(--rule);">
-  <div class="container">
-    <div class="reveal" style="text-align:center;">
-      <div style="font-family:var(--ff-mono);font-size:11px;letter-spacing:0.28em;text-transform:uppercase;color:var(--accent);margin-bottom:20px;">&mdash; And one more thing &mdash;</div>
-      <h2 style="font-family:var(--ff-display);font-variation-settings:'opsz' 144,'wght' 380;font-size:clamp(36px,5vw,64px);line-height:1.05;letter-spacing:-0.02em;color:var(--paper);max-width:20ch;margin:0 auto 20px;">For Claude Code, it&rsquo;s <em style="color:var(--accent);font-style:italic;font-variation-settings:'opsz' 144,'wght' 320;">three words.</em></h2>
-      <p style="font-family:var(--ff-display);font-variation-settings:'opsz' 18,'wght' 400;font-size:20px;line-height:1.55;color:var(--paper-dim);max-width:56ch;margin:0 auto 32px;">Not a config file. Not an MCP setup guide. Three words in your terminal. Attestor interviews you, installs itself, wires the hooks, and runs a health check before you&rsquo;ve put the kettle on.</p>
-      <div class="hero-install" onclick="copyToClipboard(this, 'install agent memory')" title="Click to copy" style="display:inline-flex;max-width:420px;margin:0 auto;">
-        <span>install agent memory</span>
-        <span class="copy-icon">&#x2398;</span>
-      </div>
-      <p style="font-family:var(--ff-mono);font-size:11px;letter-spacing:0.14em;text-transform:uppercase;color:var(--muted);margin-top:18px;">Paste into Claude Code &middot; global or project scope &middot; auto&#8209;merges MCP config</p>
-    </div>
-  </div>
-</section>
-
-<!-- ═══════════════════════════════════════════════════
-     § 06 · QUICKSTART
-     ═══════════════════════════════════════════════════ -->
-<section id="quickstart">
-  <div class="container">
-    <div class="section-filing reveal">
-      <span class="section-num">&sect; 05</span>
-      <span class="section-name">&mdash; Or do it yourself, in three lines</span>
-      <span>Python library &middot; REST API &middot; MCP protocol</span>
-    </div>
-
-    <div class="reveal">
-      <h2 class="section-head">Three lines of Python. <em>That&rsquo;s the integration.</em></h2>
-      <p class="standfirst">Same call surface whether Attestor runs in&#8209;process on your laptop or behind a Cloud Run service. Pick the interface. Ship.</p>
-    </div>
-
-    <div class="reveal">
-      <div class="tabs">
-        <button class="tab-btn active" onclick="switchTab(event, 'tab-python')"><span class="tab-num">01</span>Python API</button>
-        <button class="tab-btn" onclick="switchTab(event, 'tab-rest')"><span class="tab-num">02</span>REST API</button>
-        <button class="tab-btn" onclick="switchTab(event, 'tab-mcp')"><span class="tab-num">03</span>MCP</button>
-        <button class="tab-btn" onclick="switchTab(event, 'tab-smoke')"><span class="tab-num">04</span>Smoke benchmark</button>
-      </div>
-
-      <div id="tab-python" class="tab-panel active">
-        <div class="code-block" data-lang="Python &middot; Multi-agent pipeline"><button class="code-copy-btn" onclick="copyCodeBlock(this)">Copy</button><span class="keyword">from</span> <span class="fn">attestor</span> <span class="keyword">import</span> AgentMemory
-<span class="keyword">from</span> <span class="fn">agent_memory.context</span> <span class="keyword">import</span> AgentContext, AgentRole
-
-<span class="comment"># Orchestrator context &mdash; root of a multi-agent pipeline</span>
-ctx = AgentContext.<span class="fn">from_env</span>(
-    agent_id=<span class="string">"orchestrator"</span>,
-    namespace=<span class="string">"project:acme"</span>,
-    role=AgentRole.ORCHESTRATOR,
-    token_budget=<span class="string">20000</span>,
-)
-
-<span class="comment"># Spawn sub-agents with inherited provenance</span>
-planner = ctx.<span class="fn">as_agent</span>(<span class="string">"planner"</span>, role=AgentRole.PLANNER)
-planner.<span class="fn">add_memory</span>(<span class="string">"Use event sourcing for the order service"</span>,
-                   category=<span class="string">"technical"</span>, entity=<span class="string">"order-service"</span>)
-
-<span class="comment"># Executor reads what planner wrote &mdash; same namespace, ranked recall</span>
-executor = ctx.<span class="fn">as_agent</span>(<span class="string">"executor"</span>, role=AgentRole.EXECUTOR)
-results = executor.<span class="fn">recall</span>(<span class="string">"order service architecture"</span>, budget=<span class="string">2000</span>)</div>
-      </div>
-
-      <div id="tab-rest" class="tab-panel">
-        <div class="code-block" data-lang="Bash &middot; Starlette ASGI"><button class="code-copy-btn" onclick="copyCodeBlock(this)">Copy</button><span class="comment"># Run as a REST API (Starlette ASGI + Uvicorn)</span>
-<span class="cmd">$ attestor api --host 0.0.0.0 --port 8080</span>
-
-<span class="comment"># Same container ships to AWS App Runner, GCP Cloud Run,</span>
-<span class="comment"># or Azure Container Apps. Terraform templates in attestor/infra/.</span>
-
-<span class="comment"># Eight endpoints, Terraform included:</span>
-<span class="comment">#   POST /add         /recall       /search</span>
-<span class="comment">#   POST /timeline    /forget       GET /stats</span>
-<span class="comment">#   GET  /memory/:id  /health</span>
-<span class="comment"># Envelope: {"ok": true, "data": {...}}</span></div>
-      </div>
-
-      <div id="tab-mcp" class="tab-panel">
-        <div class="code-block" data-lang="JSON &middot; Any MCP client"><button class="code-copy-btn" onclick="copyCodeBlock(this)">Copy</button><span class="comment"># Any MCP-compatible client (Claude Code, Cursor,</span>
-<span class="comment"># Windsurf, or a custom agent speaking stdio MCP)</span>
-<span class="cmd">$ poetry add attestor</span>
-
-<span class="comment"># Add to your client's MCP config:</span>
-{
-  <span class="string">"mcpServers"</span>: {
-    <span class="string">"memory"</span>: {
-      <span class="string">"command"</span>: <span class="string">"attestor"</span>,
-      <span class="string">"args"</span>: [<span class="string">"mcp"</span>]
-    }
-  }
-}
-
-<span class="comment"># Agents get eight tools:</span>
-<span class="comment">#   memory_add        memory_recall     memory_search</span>
-<span class="comment">#   memory_get        memory_forget     memory_timeline</span>
-<span class="comment">#   memory_stats      memory_health</span></div>
-      </div>
-
-      <div id="tab-smoke" class="tab-panel">
-        <div class="code-block" data-lang="Bash &middot; Dual-LLM smoke benchmark"><button class="code-copy-btn" onclick="copyCodeBlock(this)">Copy</button><span class="comment"># Run a tiny LongMemEval smoke against your local install.</span>
-<span class="comment"># Defaults: dual-LLM cross-family judging + OpenAI embeddings.</span>
-<span class="cmd">$ export OPENAI_API_KEY=...</span>
-<span class="cmd">$ .venv/bin/python scripts/lme_smoke_local.py --n 2</span>
-
-<span class="comment"># Default stack (override any of these via env or CLI flag):</span>
-<span class="comment">#   answerer  : openai/gpt-5.2</span>
-<span class="comment">#   judges    : openai/gpt-5.2 + anthropic/claude-sonnet-4.6  (dual)</span>
-<span class="comment">#   distiller : openai/gpt-5.2  (Mem0-style fact extraction on)</span>
-<span class="comment">#   embedder  : text-embedding-3-large @ 1024-D (schema-compat)</span>
-
-<span class="comment"># Swap any slot in one line — env var or CLI flag, your call:</span>
-<span class="cmd">$ ANSWER_MODEL=openai/gpt-4.1-mini python scripts/lme_smoke_local.py --n 2</span>
-<span class="cmd">$ python scripts/lme_smoke_local.py --judge-model openai/gpt-5.2 \</span>
-<span class="cmd">                                   --judge-model anthropic/claude-haiku-4.5</span>
-
-<span class="comment"># Everything else is also configurable:</span>
-<span class="comment">#   --embedding-model / --embedding-dim   pin embedder + dim</span>
-<span class="comment">#   --variant {oracle,s,m}  --n N         dataset slice + size</span>
-<span class="comment">#   --parallel K  --budget T              concurrency + token budget</span>
-<span class="comment">#   --no-distill                          turn off Mem0-style distillation</span>
-<span class="comment">#   --pg-url postgres://&hellip;                target a different Postgres</span></div>
-      </div>
-    </div>
-  </div>
-</section>
-
-<!-- ═══════════════════════════════════════════════════
-     § 07 · PRINCIPLES
-     ═══════════════════════════════════════════════════ -->
-<section id="principles">
-  <div class="container">
-    <div class="section-filing reveal">
-      <span class="section-num">&sect; 06</span>
-      <span class="section-name">&mdash; Design Principles</span>
-      <span>Opinionated &middot; on purpose</span>
-    </div>
-
-    <div class="reveal">
-      <h2 class="section-head">Five stakes in the ground.</h2>
-      <p class="standfirst">What we won&rsquo;t compromise on &mdash; no matter how loud the pressure gets.</p>
-    </div>
-
-    <div class="manifesto">
-      <p class="manifesto-line reveal" data-num="I.">Your data stays in <em>your</em> infrastructure. Self&#8209;hosted, always.</p>
-      <p class="manifesto-line reveal" data-num="II.">Retrieval is <em>deterministic.</em> No LLM judges. No hidden inference in the path.</p>
-      <p class="manifesto-line reveal" data-num="III.">One <code>recall()</code>. Every backend. <em>Swap without rewriting.</em></p>
-      <p class="manifesto-line reveal" data-num="IV.">Agent teams are <em>first&#8209;class.</em> Not a bolt&#8209;on.</p>
-      <p class="manifesto-line reveal" data-num="V.">Boring where it counts. Proven, <em>debuggable</em>, no magic.</p>
-    </div>
-  </div>
-</section>
-
-<!-- ═══════════════════════════════════════════════════
-     LIVE BENCHMARK
-     ═══════════════════════════════════════════════════ -->
-<section id="bench-live" style="border-top:1px solid var(--rule);padding:64px 0;">
-  <div class="container">
-    <div class="section-filing reveal">
-      <span class="section-num">&sect; 06</span>
-      <span class="section-name">&mdash; Live benchmark</span>
-      <span>LongMemEval-S &middot; verdicts on demand</span>
-    </div>
-
-    <div class="reveal" style="margin-top:32px;">
-      <h2 class="section-head">Numbers we don't stamp here. <em>Numbers you watch live.</em></h2>
-      <p class="standfirst">
-        Attestor's LongMemEval-S verdicts &mdash; per question, per judge, per release &mdash;
-        are tracked on Braintrust. Every release reruns the four LME-S categories
-        (temporal&#8209;reasoning, multi&#8209;session, knowledge&#8209;update,
-        single&#8209;session-user) against the canonical configured stack. CI fails
-        any PR that regresses past threshold.
-      </p>
-      <p style="margin-top:24px;">
-        <a href="https://www.braintrust.dev/app/bolnet/p/attestor-lme-s"
-           target="_blank" rel="noopener"
-           style="font-family:var(--ff-mono);font-size:15px;color:var(--accent);background:var(--ink-raise);padding:10px 18px;border:1px solid var(--rule);text-decoration:none;display:inline-block;">
-          View live verdicts on Braintrust &rarr;
-        </a>
-      </p>
-    </div>
-  </div>
-</section>
-
-<!-- ═══════════════════════════════════════════════════
-     CLOSING
-     ═══════════════════════════════════════════════════ -->
-<section id="closing">
-  <div class="container">
-    <div class="section-filing reveal">
-      <span class="section-num">&sect; &infin;</span>
-      <span class="section-name">&mdash; Available today</span>
-      <span>MIT &middot; PyPI &middot; MCP Registry</span>
-    </div>
-
-    <h2 class="closing-head reveal">Point every agent at <em>one URL.</em><br>They share memory instantly.</h2>
-
-    <div class="closing-row reveal">
-      <div class="closing-install" onclick="copyToClipboard(this, 'pip install attestor')" title="Click to copy">
-        <span>pip install attestor</span>
-        <span class="copy-icon">&#x2398;</span>
-      </div>
-      <a href="https://github.com/bolnet/attestor" class="btn btn-primary" target="_blank" rel="noopener">GitHub &rarr;</a>
-      <a href="https://pypi.org/project/attestor/" class="btn btn-ghost" target="_blank" rel="noopener">PyPI</a>
-      <a href="https://registry.modelcontextprotocol.io/servers/io.github.bolnet/attestor" class="btn btn-ghost" target="_blank" rel="noopener">MCP Registry</a>
-    </div>
-
-    <p class="closing-byline reveal">MIT. Self&#8209;hosted. Deterministic. Production deploy in one command. Designed and built by <a href="https://www.linkedin.com/in/singhsurendra/" target="_blank" rel="noopener">Surendra Singh</a> &mdash; building auditable infrastructure for multi-agent AI, with fifteen years of production-systems discipline brought to the memory layer. <em>Thank you.</em></p>
-  </div>
-</section>
-
-<!-- ═══════════════════════════════════════════════════
-     COLOPHON (FOOTER)
-     ═══════════════════════════════════════════════════ -->
-<footer class="colophon">
-  <div class="container">
-    <div class="colophon-grid">
-      <div>
-        <div class="col-label">Colophon</div>
-        <p class="colophon-body">Attestor is typeset in <em>Fraunces</em> by Undercase Type and <em>IBM Plex Sans</em> by Bold Monday. Source listings are set in <em>JetBrains Mono</em>. The journal is published under MIT and may be forked, adapted, or redistributed without royalty.</p>
-      </div>
-      <div>
-        <div class="col-label">Masthead</div>
-        <ul class="colophon-list">
-          <li>Editor &mdash; <a href="https://www.linkedin.com/in/singhsurendra/" target="_blank" rel="noopener">Surendra Singh</a></li>
-          <li>Infrastructure &mdash; Your cloud</li>
-          <li>Retrieval &mdash; Deterministic</li>
-          <li>Publisher &mdash; Bolnet</li>
+  </section>
+
+  <!-- HOW -->
+  <section id="how">
+    <div class="sec-label">How it works</div>
+    <h2>Stop replaying. <span class="ital">Start retrieving.</span></h2>
+    <p class="sec-lede">Two failure modes, one architecture that beats both — without sacrificing what the model remembers.</p>
+    <div class="alt-compare">
+      <div class="alt-col bad">
+        <h4>Full-context replay — the default</h4>
+        <ul>
+          <li>O(n²) input-token growth</li>
+          <li>Cap the window → silent memory loss (100%→0% by t10)</li>
+          <li>Non-deterministic at scale, no audit trail</li>
+          <li>Cost compounds the more your users engage</li>
         </ul>
       </div>
-      <div>
-        <div class="col-label">Filing</div>
-        <ul class="colophon-list">
-          <li><a href="privacy.html">Privacy</a></li>
-          <li><a href="https://github.com/bolnet/attestor/blob/main/LICENSE" target="_blank" rel="noopener">License</a></li>
-          <li><a href="https://github.com/bolnet/attestor/blob/main/README.md" target="_blank" rel="noopener">Documentation</a></li>
-        </ul>
-      </div>
-      <div>
-        <div class="col-label">Distribution</div>
-        <ul class="colophon-list">
-          <li><a href="https://pypi.org/project/attestor/" target="_blank" rel="noopener">PyPI</a></li>
-          <li><a href="https://github.com/bolnet/attestor" target="_blank" rel="noopener">GitHub</a></li>
-          <li><a href="https://registry.modelcontextprotocol.io/servers/io.github.bolnet/attestor" target="_blank" rel="noopener">MCP Registry</a></li>
+      <div class="alt-col good">
+        <h4>Attestor — retrieved memory</h4>
+        <ul>
+          <li>O(n) linear growth — flat ~200 tok/call, always</li>
+          <li>100% recall, no truncation, no forgetting</li>
+          <li>Bitemporal audit log — reproducible state</li>
+          <li>Cost fixed per turn · two API calls · MIT</li>
         </ul>
       </div>
     </div>
+  </section>
 
-    <div class="colophon-mark">
-      <span class="left">Attestor<b>.</b></span>
-      <span>&copy; 2026 Bolnet &middot; MIT &middot; New York</span>
-      <span>Set in paper &middot; printed in terminal</span>
+  <!-- DETAIL (animated, scroll-revealed) -->
+  <style>
+  .reveal{opacity:0;transform:translateY(16px);transition:opacity .6s ease,transform .6s ease}
+  .reveal.in{opacity:1;transform:none}
+  .bignums{display:grid;grid-template-columns:repeat(4,1fr);gap:16px;margin-top:30px}
+  .bignums>div{text-align:center;padding:22px 10px;background:var(--paper);border:0.5px solid var(--rule);border-radius:10px}
+  .bignums .cu{font-family:var(--serif);font-size:clamp(30px,4vw,44px);font-weight:700;color:var(--g2);line-height:1;display:block}
+  .bignums small{display:block;margin-top:8px;font-size:11.5px;color:var(--ink3);line-height:1.4}
+  @media(max-width:680px){.bignums{grid-template-columns:repeat(2,1fr)}}
+  .detail-grid{display:grid;grid-template-columns:1fr 1fr;gap:18px;margin-top:24px}
+  .dcard{background:var(--paper);border:0.5px solid var(--rule);border-radius:12px;padding:24px}
+  .dcard h4{font-family:var(--serif);font-size:17px;font-weight:700;margin-bottom:16px}
+  .dcard p{font-size:13px;color:var(--ink3);margin-top:14px;line-height:1.5}
+  @media(max-width:680px){.detail-grid{grid-template-columns:1fr}}
+  .cbar{display:flex;align-items:center;gap:12px;margin-bottom:12px}
+  .cbar-lbl{font-family:var(--mono);font-size:11px;color:var(--ink3);min-width:112px}
+  .cbar-track{flex:1;height:18px;background:var(--paper3);border-radius:4px;overflow:hidden}
+  .cbar-fill{height:100%;width:0;border-radius:4px;transition:width 1.3s cubic-bezier(.2,.7,.2,1)}
+  .cbar-val{font-family:var(--serif);font-size:15px;font-weight:700;min-width:54px;text-align:right}
+  .rcurve{display:flex;flex-direction:column;gap:11px}
+  .rc{display:flex;align-items:center;gap:12px}
+  .rc>span{font-family:var(--mono);font-size:11px;color:var(--ink3);min-width:34px}
+  .rc-track{flex:1;height:16px;background:var(--paper3);border-radius:4px;overflow:hidden}
+  .rc-fill{height:100%;width:0;border-radius:4px;background:linear-gradient(90deg,#cfe8d4,#2a5c3a);transition:width 1.1s cubic-bezier(.2,.7,.2,1)}
+  .rc>b{font-family:var(--serif);font-size:15px;color:var(--g2);min-width:48px;text-align:right}
+  .method{margin-top:24px;background:var(--paper2);border:0.5px solid var(--rule);border-radius:12px;padding:24px}
+  .method ul{list-style:none;margin:10px 0 18px}
+  .method li{font-size:13.5px;color:var(--ink2);padding-left:20px;position:relative;margin-bottom:8px;line-height:1.5}
+  .method li::before{content:'·';position:absolute;left:4px;color:var(--g2);font-weight:700}
+  .method code{font-family:var(--mono);font-size:12px;background:var(--paper3);padding:1px 5px;border-radius:3px}
+  </style>
+  <section id="detail">
+    <div class="sec-label reveal">Under the hood · 100% reproducible</div>
+    <h2 class="reveal">The benchmark, in <span class="ital">detail</span>.</h2>
+    <p class="sec-lede reveal">Every claim here is measured on a deterministic, single-fact workload — verify it yourself with the open-source <a href="https://github.com/bolnet/context-clock" style="color:var(--g2)">context-clock</a> harness.</p>
+
+    <div class="bignums">
+      <div class="reveal"><span class="cu" data-to="6">0</span><small>models benchmarked · open + closed</small></div>
+      <div class="reveal"><span class="cu" data-to="100">0</span><small>turns per session</small></div>
+      <div class="reveal"><span class="cu" data-to="99">0</span><small>tests · every number reproducible</small></div>
+      <div class="reveal"><span class="cu" data-to="100" data-suffix="%">0</span><small>recall held, all turns</small></div>
     </div>
+
+    <div class="detail-grid">
+      <div class="dcard reveal">
+        <h4>Per-call context — what the model reads each turn</h4>
+        <div class="cbar"><span class="cbar-lbl">replay · turn 100</span><div class="cbar-track"><div class="cbar-fill grow" data-w="100" style="background:#7a1a1a"></div></div><span class="cbar-val" style="color:#7a1a1a">8,709</span></div>
+        <div class="cbar"><span class="cbar-lbl">attestor · any turn</span><div class="cbar-track"><div class="cbar-fill grow" data-w="2.4" style="background:#2a5c3a"></div></div><span class="cbar-val" style="color:#2a5c3a">~209</span></div>
+        <p>Replay climbs every turn toward the window; Attestor stays flat at ~209 tokens from turn 1 to turn 100.</p>
+      </div>
+      <div class="dcard reveal">
+        <h4>The gap widens with session length</h4>
+        <div class="rcurve">
+          <div class="rc"><span>t24</span><div class="rc-track"><div class="rc-fill grow" data-w="26"></div></div><b>5.6×</b></div>
+          <div class="rc"><span>t50</span><div class="rc-track"><div class="rc-fill grow" data-w="51"></div></div><b>11.0×</b></div>
+          <div class="rc"><span>t75</span><div class="rc-track"><div class="rc-fill grow" data-w="75"></div></div><b>16.2×</b></div>
+          <div class="rc"><span>t100</span><div class="rc-track"><div class="rc-fill grow" data-w="100"></div></div><b>21.5×</b></div>
+        </div>
+        <p>Input-token reduction (gpt-5.4). A straight line vs a parabola → the ratio is unbounded.</p>
+      </div>
+    </div>
+
+    <div class="method reveal">
+      <div class="sec-label">Method · honest scope</div>
+      <ul>
+        <li>One unique code per memo (needle-in-a-haystack), retrieved <b>top-1</b>, no distractors — isolates "does the agent still have the fact?"</li>
+        <li><b>Native context window</b> — models run at full capacity; capping is shown only to reproduce the cap-and-rot failure mode.</li>
+        <li>100% recall = the right memo is reliably found and read — not a claim about hard multi-hop or conflicting-fact retrieval.</li>
+        <li><b>temperature 0</b>, deterministic; real billed cost from OpenRouter <code>usage.cost</code>, never list-price math.</li>
+      </ul>
+      <a href="context-clock-benchmark.html" class="btn btn-n">Full methodology + per-turn data →</a>
+    </div>
+  </section>
+  <script>
+  (function(){
+    function cu(el){var to=+el.dataset.to,suf=el.dataset.suffix||'',st=null,d=1200;
+      function f(t){if(!st)st=t;var p=Math.min(1,(t-st)/d);el.textContent=Math.round(to*(1-Math.pow(1-p,3)))+suf;if(p<1)requestAnimationFrame(f)}requestAnimationFrame(f)}
+    var io=new IntersectionObserver(function(es){es.forEach(function(e){if(!e.isIntersecting)return;var t=e.target;
+      t.classList.add('in');
+      if(t.classList.contains('grow'))t.style.width=t.dataset.w+'%';
+      if(t.classList.contains('cu'))cu(t);
+      io.unobserve(t);})},{threshold:.25});
+    document.querySelectorAll('.reveal,.grow,.cu').forEach(function(el){io.observe(el)});
+  })();
+  </script>
+
+  <!-- CTA BAND -->
+  <div class="band">
+    <h3>Tokenmaxing isn't a model swap. It's an architecture.</h3>
+    <p>Measure your agent's token waste with context-clock, then fix it with Attestor — flat context, 21× fewer input tokens, 100% recall. Both free, both open source.</p>
+    <div class="band-cta">
+      <a href="inside_attestor.html" class="btn btn-white">Get started → attestor.dev</a>
+      <a href="https://github.com/bolnet/context-clock" class="btn btn-outline">Benchmark first → context-clock</a>
+    </div>
+  </div>
+
+</div>
+
+<footer>
+  <div class="wrap foot-in">
+    <div class="foot-links">
+      <a href="inside_attestor.html">attestor.dev</a>
+      <a href="https://github.com/bolnet/context-clock">github.com/bolnet/context-clock</a>
+    </div>
+    <span class="foot-note"><span class="tag">FREE · OPEN SOURCE · MIT</span> &nbsp; Attestor — bitemporal memory for agents</span>
   </div>
 </footer>
 
-<!-- ═══════════════════════════════════════════════════
-     JS
-     ═══════════════════════════════════════════════════ -->
 <script>
-/* ── Nav scroll ── */
-(function() {
-  var nav = document.getElementById('nav');
-  var scrolled = false;
-  window.addEventListener('scroll', function() {
-    var shouldScroll = window.scrollY > 40;
-    if (shouldScroll !== scrolled) {
-      scrolled = shouldScroll;
-      nav.classList.toggle('scrolled', scrolled);
-    }
-  }, { passive: true });
-})();
-
-/* ── Scroll reveal with stagger ── */
-(function() {
-  var reveals = document.querySelectorAll('.reveal');
-  var observer = new IntersectionObserver(function(entries) {
-    entries.forEach(function(entry) {
-      if (entry.isIntersecting) {
-        var parent = entry.target.parentElement;
-        if (parent && (parent.classList.contains('capabilities') || parent.classList.contains('matrix') || parent.classList.contains('manifesto'))) {
-          var siblings = parent.querySelectorAll('.reveal');
-          var idx = Array.prototype.indexOf.call(siblings, entry.target);
-          entry.target.style.transitionDelay = (idx * 70) + 'ms';
-        }
-        entry.target.classList.add('visible');
-        observer.unobserve(entry.target);
-      }
-    });
-  }, { threshold: 0.08, rootMargin: '0px 0px -40px 0px' });
-
-  reveals.forEach(function(el) { observer.observe(el); });
-})();
-
-/* ── Token chart animation ── */
-(function() {
-  var chart = document.getElementById('tokenChart');
-  if (!chart) return;
-  var animated = false;
-  var observer = new IntersectionObserver(function(entries) {
-    entries.forEach(function(entry) {
-      if (entry.isIntersecting && !animated) {
-        animated = true;
-        var bars = chart.querySelectorAll('.chart-bar');
-        bars.forEach(function(bar, i) {
-          var w = bar.getAttribute('data-width');
-          setTimeout(function() { bar.style.width = w + '%'; }, 120 + i * 80);
-        });
-        observer.unobserve(chart);
-      }
-    });
-  }, { threshold: 0.3 });
-  observer.observe(chart);
-})();
-
-/* ── Copy to clipboard ── */
-function copyToClipboard(el, text) {
-  navigator.clipboard.writeText(text).then(function() {
-    el.classList.add('copied');
-    var icon = el.querySelector('.copy-icon');
-    if (icon) {
-      var orig = icon.textContent;
-      icon.textContent = '\u2713';
-      setTimeout(function() {
-        icon.textContent = orig;
-        el.classList.remove('copied');
-      }, 2000);
-    }
-  });
-}
-
-function copyCodeBlock(btn) {
-  var block = btn.parentElement;
-  var text = block.textContent.replace('Copy', '').trim();
-  navigator.clipboard.writeText(text).then(function() {
-    btn.textContent = 'Copied';
-    setTimeout(function() { btn.textContent = 'Copy'; }, 2000);
-  });
-}
-
-/* ── Tab switching ── */
-function switchTab(e, tabId) {
-  var btns = document.querySelectorAll('.tab-btn');
-  var panels = document.querySelectorAll('.tab-panel');
-  btns.forEach(function(b) { b.classList.remove('active'); });
-  panels.forEach(function(p) { p.classList.remove('active'); });
-  e.currentTarget.classList.add('active');
-  document.getElementById(tabId).classList.add('active');
-}
-
-/* ── Smooth scroll for nav links ── */
-document.querySelectorAll('a[href^="#"]').forEach(function(a) {
-  a.addEventListener('click', function(e) {
-    var href = this.getAttribute('href');
-    if (href === '#') return;
-    var target = document.querySelector(href);
-    if (target) {
-      e.preventDefault();
-      var navHeight = document.getElementById('nav').offsetHeight;
-      window.scrollTo({
-        top: target.offsetTop - navHeight - 16,
-        behavior: 'smooth'
-      });
-      document.getElementById('nav').classList.remove('mobile-open');
-    }
-  });
-});
+  const tabs=[...document.querySelectorAll('.tab')];
+  const panels=[...document.querySelectorAll('.panel')];
+  tabs.forEach(t=>t.addEventListener('click',()=>{
+    tabs.forEach(x=>x.setAttribute('aria-selected', x===t));
+    panels.forEach(p=>p.setAttribute('data-active', p.id===t.dataset.tab));
+  }));
 </script>
+
+<script>
+/* Parabola growth — cumulative-input chart grows turn-by-turn (linear in turns,
+   y follows t²): creeps early, accelerates late. Dot + turn label ride the curve;
+   pulse ring every 10 turns. Triggers on scroll; click chart to replay. */
+(function(){
+  var reduce = window.matchMedia && matchMedia('(prefers-reduced-motion: reduce)').matches;
+  function fmt(n){return n>=1e6?(n/1e6).toFixed(2)+'M':n>=1e3?Math.round(n/1e3)+'K':Math.round(n);}
+  function run(svg){
+    var rl=svg.querySelector('.c-raw'),rf=svg.querySelector('.c-rawfill'),ml=svg.querySelector('.c-mem'),
+        rd=svg.querySelector('.c-rawdot'),md=svg.querySelector('.c-memdot'),lb=svg.querySelector('.c-lbl'),
+        tn=svg.querySelector('.c-turn'),pg=svg.querySelector('.c-pulses');
+    if(!rl)return;
+    var X0=70,X1=730,Y0=290,RT=42,MT=279,N=100,DUR=reduce?0:4200,RAWMAX=1326734,MEMMAX=61818;
+    var hud=(svg.parentNode&&svg.parentNode.querySelector)?svg.parentNode.querySelector('.chart-hud'):null,
+        ns=hud?hud.querySelectorAll('.hud-item .n'):[];
+    function x(t){return X0+(X1-X0)*t;} function ry(t){return Y0-(Y0-RT)*t*t;} function my(t){return Y0-(Y0-MT)*t;}
+    function pulse(cx,cy){
+      if(reduce||!pg)return;
+      var c=document.createElementNS('http://www.w3.org/2000/svg','circle');
+      c.setAttribute('cx',cx);c.setAttribute('cy',cy);c.setAttribute('fill','none');
+      c.setAttribute('stroke','#7a1a1a');c.setAttribute('stroke-width','2');pg.appendChild(c);
+      var s=null;(function pf(t){if(!s)s=t;var q=Math.min(1,(t-s)/640);
+        c.setAttribute('r',(6+q*24).toFixed(1));c.setAttribute('opacity',(0.7*(1-q)).toFixed(2));
+        if(q<1)requestAnimationFrame(pf);else if(c.parentNode)pg.removeChild(c);})(performance.now());
+      rd.setAttribute('r','8');setTimeout(function(){rd.setAttribute('r','5');},170);
+    }
+    while(pg&&pg.firstChild)pg.removeChild(pg.firstChild);
+    var lastMile=0,start=null;
+    (function frame(ts){if(!start)start=ts;var p=DUR?Math.min(1,(ts-start)/DUR):1;
+      var d='M'+X0+' '+Y0;
+      for(var i=1;i<=N;i++){var t=p*i/N;d+=' L'+x(t).toFixed(1)+' '+ry(t).toFixed(1);}
+      rl.setAttribute('d',d); rf.setAttribute('d',d+' L'+x(p).toFixed(1)+' '+Y0+' Z');
+      ml.setAttribute('d','M'+X0+' '+Y0+' L'+x(p).toFixed(1)+' '+my(p).toFixed(1));
+      rd.setAttribute('cx',x(p));rd.setAttribute('cy',ry(p));md.setAttribute('cx',x(p));md.setAttribute('cy',my(p));
+      var turn=Math.round(p*100);
+      if(tn){tn.setAttribute('opacity',(p>0.02&&p<0.99)?'1':'0');tn.setAttribute('x',x(p));tn.setAttribute('y',(ry(p)-12).toFixed(1));tn.textContent='t'+turn;}
+      if(ns.length>=3){ns[0].textContent='t'+turn;ns[1].textContent=fmt(RAWMAX*p*p);ns[2].textContent=fmt(MEMMAX*p);}
+      var mile=Math.floor(turn/10);
+      if(mile>lastMile&&turn>0&&turn<100){lastMile=mile;pulse(x(p),ry(p));}
+      if(lb)lb.setAttribute('opacity',(p>0.85?(p-0.85)/0.15:0).toFixed(2));
+      if(p<1)requestAnimationFrame(frame);
+      else{if(ns.length>=3){ns[0].textContent='t100';ns[1].textContent='1.33M';ns[2].textContent='61.8K';}
+           if(tn)tn.setAttribute('opacity','0');pulse(x(1),ry(1));}
+    })(performance.now());
+  }
+  document.querySelectorAll('svg').forEach(function(svg){
+    if(!svg.querySelector('.c-raw'))return;
+    var fired=false;
+    new IntersectionObserver(function(es){es.forEach(function(e){if(e.isIntersecting&&!fired){fired=true;run(svg);}});},{threshold:.35}).observe(svg);
+    var wrap=svg.closest('.chartwrap')||svg.parentNode;
+    if(wrap){wrap.style.cursor='pointer';wrap.setAttribute('title','click to replay');wrap.addEventListener('click',function(){run(svg);});}
+  });
+})();
+</script>
+
 </body>
 </html>

--- a/docs/inside_attestor.html
+++ b/docs/inside_attestor.html
@@ -1,0 +1,3216 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Attestor — Auditable memory for agent teams</title>
+<meta name="description" content="What did the agent know, and when did it know it? Auditable, deterministic, bitemporal memory for multi-agent systems. Namespace isolation, RBAC, provenance, ranked retrieval. Self-hosted, no LLM in the critical path.">
+<meta name="theme-color" content="#faf8f4">
+<meta property="og:title" content="Attestor — What did the agent know, and when did it know it?">
+<meta property="og:description" content="Auditable, deterministic, bitemporal memory for agent teams. Namespace isolation, RBAC, provenance, ranked retrieval. Self-hosted, no LLM in the critical path.">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://attestor.dev/inside_attestor.html">
+<meta property="og:image" content="https://attestor.dev/og-image.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:alt" content="Attestor — What did the agent know, and when did it know it? Open-source memory infrastructure for multi-agent AI.">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:image" content="https://attestor.dev/og-image.png">
+<meta name="twitter:image:alt" content="Attestor — What did the agent know, and when did it know it? Open-source memory infrastructure for multi-agent AI.">
+<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' font-family='serif' fill='%230d1f3c'>M</text></svg>">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300..900;1,9..144,300..900&family=IBM+Plex+Sans:wght@300;400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+/* ═══════════════════════════════════════════════════
+   SYSTEMS JOURNAL — ATTESTOR
+   Typography: Fraunces (display) · IBM Plex Sans (body) · JetBrains Mono (code)
+   ═══════════════════════════════════════════════════ */
+
+*, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+
+:root {
+  /* Cream editorial palette — remapped from the original dark theme.
+     Token names preserve the dark theme's structural roles:
+       --ink* = page/surface backgrounds (now cream)
+       --paper/--paper-dim/--muted/--faint = text (now dark on cream)
+       --accent = primary accent (now navy), --accent-warm = positive (green),
+       --accent-cool = secondary (green tint) */
+  --ink:           #faf8f4;   /* page background (cream) */
+  --ink-raise:     #f3f0ea;   /* raised surface */
+  --ink-surface:   #e8e3d8;   /* deeper surface */
+  --paper:         #0f0e0c;   /* primary text (near-black) */
+  --paper-dim:     #3a3630;   /* secondary text */
+  --muted:         #7a766e;   /* muted text */
+  --faint:         #a8a399;   /* faint text / hairline labels */
+  --rule:          #e0dccf;   /* hairline rule */
+  --rule-strong:   #d4cfc3;   /* stronger rule */
+  --accent:        #0d1f3c;   /* navy — primary accent */
+  --accent-2:      #1a3460;   /* navy lighter */
+  --accent-warm:   #2a5c3a;   /* green — positive/success */
+  --accent-cool:   #1a3460;   /* navy-2 — secondary (code fn names) */
+  --warn:          #7a1a1a;   /* red — warnings */
+  --green-tint:    #f0f7f2;   /* green wash */
+  --navy-tint:     #f0f4fb;   /* navy wash */
+
+  --ff-display: Georgia, 'Times New Roman', serif;
+  --ff-body:    -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+  --ff-mono:    'SF Mono', 'Fira Code', ui-monospace, monospace;
+
+  --max-w: 1120px;
+  --gutter: 32px;
+  --section-gap: 140px;
+}
+
+html { scroll-behavior: smooth; }
+
+body {
+  font-family: var(--ff-body);
+  background: var(--ink);
+  color: var(--paper);
+  font-size: 16px;
+  line-height: 1.65;
+  font-weight: 300;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  overflow-x: hidden;
+  position: relative;
+}
+
+/* Paper grain overlay */
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 200;
+  opacity: 0.04;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='3'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+  mix-blend-mode: overlay;
+}
+
+/* Subtle warm vignette at edges */
+body::after {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 1;
+  background: radial-gradient(ellipse 80% 60% at 50% 0%, rgba(13,31,60,0.035), transparent 60%);
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+  transition: color 0.2s;
+}
+a:hover { color: var(--accent-warm); }
+
+::selection { background: var(--accent); color: var(--ink); }
+
+.container {
+  max-width: var(--max-w);
+  margin: 0 auto;
+  padding: 0 var(--gutter);
+  position: relative;
+  z-index: 2;
+}
+
+/* ═══════════════════════════════════════════════════
+   TYPE SYSTEM
+   ═══════════════════════════════════════════════════ */
+
+.eyebrow {
+  font-family: var(--ff-mono);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--accent);
+  display: inline-flex;
+  align-items: center;
+  gap: 14px;
+  margin-bottom: 28px;
+}
+.eyebrow::before {
+  content: '';
+  width: 28px;
+  height: 1px;
+  background: var(--accent);
+}
+
+.section-head {
+  font-family: var(--ff-display);
+  font-weight: 700;
+  font-variation-settings: 'opsz' 144, 'wght' 380;
+  font-size: clamp(36px, 5.4vw, 68px);
+  line-height: 1.02;
+  letter-spacing: -0.02em;
+  color: var(--accent);
+  margin-bottom: 24px;
+  max-width: 20ch;
+}
+.section-head em {
+  font-style: italic;
+  font-weight: 400;
+  font-variation-settings: 'opsz' 144, 'wght' 320;
+  color: var(--accent-warm);
+}
+.section-head strong {
+  font-weight: 800;
+  font-variation-settings: 'opsz' 144, 'wght' 600;
+}
+
+.standfirst {
+  font-family: var(--ff-display);
+  font-variation-settings: 'opsz' 18, 'wght' 400;
+  font-size: clamp(18px, 2vw, 22px);
+  line-height: 1.5;
+  color: var(--paper-dim);
+  max-width: 62ch;
+  letter-spacing: -0.005em;
+}
+
+.rule {
+  height: 1px;
+  background: var(--rule-strong);
+  border: none;
+}
+
+.rule-cross {
+  text-align: center;
+  color: var(--faint);
+  font-family: var(--ff-mono);
+  font-size: 10px;
+  letter-spacing: 0.3em;
+  margin: 48px 0;
+}
+.rule-cross::before, .rule-cross::after {
+  content: '';
+  display: inline-block;
+  width: 80px;
+  height: 1px;
+  background: var(--rule-strong);
+  vertical-align: middle;
+  margin: 0 14px;
+}
+
+/* ═══════════════════════════════════════════════════
+   MASTHEAD STRIP
+   ═══════════════════════════════════════════════════ */
+
+.masthead-strip {
+  border-bottom: 1px solid var(--rule);
+  padding: 12px 0;
+  position: relative;
+  z-index: 10;
+  background: var(--ink);
+}
+.masthead-strip .container {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 20px;
+  font-family: var(--ff-mono);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--muted);
+  flex-wrap: wrap;
+}
+.masthead-strip .lead { color: var(--paper); }
+.masthead-strip .dot {
+  display: inline-block;
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--accent);
+  vertical-align: middle;
+  margin-right: 8px;
+  animation: pulse 2.4s ease-in-out infinite;
+}
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
+/* ═══════════════════════════════════════════════════
+   NAV
+   ═══════════════════════════════════════════════════ */
+
+nav {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  background: rgba(250, 248, 244, 0.9);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  border-bottom: 1px solid var(--rule);
+  padding: 18px 0;
+  transition: padding 0.3s;
+}
+nav.scrolled { padding: 12px 0; }
+
+.nav-inner {
+  max-width: var(--max-w);
+  margin: 0 auto;
+  padding: 0 var(--gutter);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.nav-logo {
+  font-family: var(--ff-display);
+  font-variation-settings: 'opsz' 144, 'wght' 500;
+  font-size: 26px;
+  letter-spacing: -0.02em;
+  color: var(--paper);
+  line-height: 1;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 8px;
+}
+.nav-logo::after {
+  content: '';
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  background: var(--accent);
+  border-radius: 50%;
+  transform: translateY(-2px);
+}
+
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: 32px;
+  list-style: none;
+}
+.nav-links a {
+  font-family: var(--ff-mono);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--muted);
+  position: relative;
+  padding: 4px 0;
+  transition: color 0.2s;
+}
+.nav-links a:hover { color: var(--paper); }
+.nav-links a::before {
+  content: attr(data-num);
+  color: var(--faint);
+  margin-right: 6px;
+}
+
+.nav-ctas {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 18px;
+  font-family: var(--ff-mono);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  cursor: pointer;
+  border: none;
+  text-decoration: none;
+  transition: all 0.2s;
+  line-height: 1;
+}
+.btn-primary {
+  background: var(--accent);
+  color: var(--ink);
+}
+.btn-primary:hover { background: var(--paper); color: var(--ink); }
+.btn-ghost {
+  background: transparent;
+  color: var(--paper);
+  border: 1px solid var(--rule-strong);
+}
+.btn-ghost:hover { border-color: var(--accent); color: var(--accent); }
+
+.nav-mobile-toggle {
+  display: none;
+  background: none;
+  border: none;
+  color: var(--paper);
+  font-size: 22px;
+  cursor: pointer;
+}
+
+/* ═══════════════════════════════════════════════════
+   HERO
+   ═══════════════════════════════════════════════════ */
+
+#hero {
+  padding: 110px 0 80px;
+  position: relative;
+  overflow: hidden;
+}
+
+.hero-dateline {
+  display: flex;
+  gap: 32px;
+  font-family: var(--ff-mono);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin-bottom: 56px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid var(--rule);
+  flex-wrap: wrap;
+}
+.hero-dateline span { color: var(--muted); }
+.hero-dateline .accent { color: var(--accent); }
+.hero-dateline .filing { color: var(--paper); }
+
+.hero-headline {
+  font-family: var(--ff-display);
+  font-weight: 700;
+  font-variation-settings: 'opsz' 144, 'wght' 340;
+  font-size: clamp(52px, 9vw, 124px);
+  line-height: 0.94;
+  letter-spacing: -0.035em;
+  color: var(--accent);
+  margin-bottom: 48px;
+  max-width: 16ch;
+}
+.hero-headline em {
+  font-style: italic;
+  font-weight: 400;
+  font-variation-settings: 'opsz' 144, 'wght' 300;
+  color: var(--accent-warm);
+  display: inline-block;
+}
+.hero-headline .soft {
+  color: var(--paper-dim);
+  font-variation-settings: 'opsz' 144, 'wght' 320;
+}
+
+.hero-grid {
+  display: grid;
+  grid-template-columns: 1.3fr 1fr;
+  gap: 72px;
+  margin-bottom: 64px;
+  align-items: start;
+}
+
+.hero-sub {
+  font-family: var(--ff-display);
+  font-variation-settings: 'opsz' 18, 'wght' 400;
+  font-size: 22px;
+  line-height: 1.45;
+  color: var(--paper);
+  margin-bottom: 28px;
+  letter-spacing: -0.005em;
+}
+.hero-sub-detail {
+  font-size: 15px;
+  color: var(--muted);
+  line-height: 1.7;
+  max-width: 48ch;
+  margin-bottom: 32px;
+}
+
+.hero-install {
+  display: inline-flex;
+  align-items: center;
+  gap: 14px;
+  background: var(--ink-raise);
+  border: 1px solid var(--rule-strong);
+  padding: 16px 20px;
+  font-family: var(--ff-mono);
+  font-size: 13px;
+  color: var(--paper);
+  cursor: pointer;
+  transition: border-color 0.2s;
+  max-width: 100%;
+  overflow-x: auto;
+  position: relative;
+}
+.hero-install::before {
+  content: '$';
+  color: var(--accent);
+  font-weight: 500;
+}
+.hero-install:hover { border-color: var(--accent); }
+.hero-install.copied { border-color: var(--accent); }
+.hero-install .copy-icon {
+  color: var(--muted);
+  font-size: 13px;
+  flex-shrink: 0;
+  margin-left: auto;
+  padding-left: 14px;
+}
+
+.hero-install-note {
+  display: block;
+  margin-top: 14px;
+  font-family: var(--ff-mono);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+/* Spec sheet right column */
+.hero-spec {
+  border-top: 1px solid var(--rule-strong);
+  padding-top: 0;
+}
+.hero-spec-title {
+  font-family: var(--ff-mono);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--accent);
+  padding: 14px 0;
+  border-bottom: 1px solid var(--rule);
+  margin-bottom: 0;
+}
+.hero-spec-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  padding: 14px 0;
+  border-bottom: 1px solid var(--rule);
+  align-items: baseline;
+  gap: 14px;
+}
+.hero-spec-row:last-child { border-bottom: none; }
+.hero-spec-label {
+  font-family: var(--ff-mono);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.hero-spec-value {
+  font-family: var(--ff-display);
+  font-variation-settings: 'opsz' 36, 'wght' 500;
+  font-size: 20px;
+  color: var(--paper);
+  letter-spacing: -0.01em;
+  font-variant-numeric: tabular-nums;
+}
+.hero-spec-value .unit {
+  font-family: var(--ff-mono);
+  font-size: 11px;
+  color: var(--muted);
+  font-variation-settings: normal;
+  letter-spacing: 0.1em;
+  margin-left: 4px;
+  font-weight: 500;
+}
+
+/* Ticker */
+.ticker {
+  border-top: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+  background: var(--ink);
+  padding: 18px 0;
+  overflow: hidden;
+  position: relative;
+  z-index: 2;
+}
+.ticker::before, .ticker::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 120px;
+  z-index: 3;
+  pointer-events: none;
+}
+.ticker::before { left: 0; background: linear-gradient(90deg, var(--ink), transparent); }
+.ticker::after { right: 0; background: linear-gradient(-90deg, var(--ink), transparent); }
+.ticker-track {
+  display: flex;
+  white-space: nowrap;
+  animation: scroll-ticker 62s linear infinite;
+  font-family: var(--ff-mono);
+  font-size: 12px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--muted);
+  gap: 0;
+}
+.ticker-track span {
+  padding: 0 32px;
+  border-right: 1px solid var(--rule);
+  flex-shrink: 0;
+}
+.ticker-track span b {
+  color: var(--accent);
+  font-weight: 500;
+  margin-right: 8px;
+}
+@keyframes scroll-ticker {
+  from { transform: translateX(0); }
+  to { transform: translateX(-50%); }
+}
+
+/* ═══════════════════════════════════════════════════
+   SECTIONS (common)
+   ═══════════════════════════════════════════════════ */
+
+section {
+  padding: var(--section-gap) 0;
+  position: relative;
+  z-index: 2;
+}
+
+.section-filing {
+  display: flex;
+  gap: 24px;
+  align-items: baseline;
+  padding-bottom: 14px;
+  margin-bottom: 40px;
+  border-bottom: 1px solid var(--rule);
+  font-family: var(--ff-mono);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--muted);
+  flex-wrap: wrap;
+}
+.section-filing .section-num {
+  font-family: var(--ff-display);
+  font-variation-settings: 'opsz' 36, 'wght' 500;
+  font-size: 18px;
+  letter-spacing: 0;
+  text-transform: none;
+  color: var(--accent);
+}
+.section-filing .section-name {
+  color: var(--paper);
+}
+
+.reveal {
+  opacity: 0;
+  transform: translateY(18px);
+  transition: opacity 0.8s cubic-bezier(0.2, 0.6, 0.2, 1), transform 0.8s cubic-bezier(0.2, 0.6, 0.2, 1);
+}
+.reveal.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* ═══════════════════════════════════════════════════
+   § 01 · THE PROBLEM
+   ═══════════════════════════════════════════════════ */
+
+#problem {
+  background: var(--ink-raise);
+  border-top: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+}
+
+.pullquote {
+  font-family: var(--ff-display);
+  font-style: italic;
+  font-variation-settings: 'opsz' 144, 'wght' 360;
+  font-size: clamp(26px, 3.6vw, 42px);
+  line-height: 1.25;
+  color: var(--paper);
+  max-width: 22ch;
+  margin: 56px 0;
+  letter-spacing: -0.015em;
+  position: relative;
+}
+.pullquote::before {
+  content: '"';
+  position: absolute;
+  left: -0.5em;
+  top: -0.3em;
+  font-size: 2.4em;
+  color: var(--accent);
+  font-style: normal;
+  line-height: 1;
+  font-variation-settings: 'opsz' 144, 'wght' 500;
+}
+.pullquote-attr {
+  display: block;
+  font-family: var(--ff-mono);
+  font-size: 11px;
+  font-style: normal;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin-top: 24px;
+}
+.pullquote-attr::before {
+  content: '— ';
+}
+
+.versus {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  border-top: 1px solid var(--rule-strong);
+  border-bottom: 1px solid var(--rule-strong);
+  margin: 56px 0;
+}
+.versus-col {
+  padding: 32px 28px 32px 0;
+}
+.versus-col + .versus-col {
+  padding-left: 40px;
+  padding-right: 0;
+  border-left: 1px solid var(--rule);
+}
+.versus-label {
+  font-family: var(--ff-mono);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  margin-bottom: 24px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.versus-bad .versus-label { color: var(--paper-dim); }
+.versus-good .versus-label { color: var(--accent); }
+.versus-label::before {
+  content: '';
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+.versus-bad .versus-label::before { background: var(--faint); }
+.versus-good .versus-label::before { background: var(--accent); }
+
+.versus-item {
+  display: flex;
+  gap: 16px;
+  align-items: flex-start;
+  padding: 14px 0;
+  border-bottom: 1px dashed var(--rule);
+  font-size: 14.5px;
+  line-height: 1.55;
+  color: var(--paper-dim);
+}
+.versus-item:last-child { border-bottom: none; }
+.versus-item .marker {
+  font-family: var(--ff-mono);
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--faint);
+  min-width: 22px;
+}
+.versus-good .versus-item .marker { color: var(--accent); }
+
+/* Token chart — reframed */
+.token-plate {
+  margin-top: 56px;
+  padding: 40px;
+  background: var(--ink);
+  border: 1px solid var(--rule-strong);
+}
+.plate-title {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 32px;
+  padding-bottom: 14px;
+  border-bottom: 1px solid var(--rule);
+  gap: 20px;
+  flex-wrap: wrap;
+}
+.plate-title h4 {
+  font-family: var(--ff-display);
+  font-variation-settings: 'opsz' 36, 'wght' 460;
+  font-size: 20px;
+  color: var(--paper);
+  letter-spacing: -0.01em;
+}
+.plate-title .plate-meta {
+  font-family: var(--ff-mono);
+  font-size: 10px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.chart-row {
+  display: grid;
+  grid-template-columns: 80px 1fr;
+  align-items: center;
+  gap: 18px;
+  margin-bottom: 18px;
+}
+.chart-row:last-child { margin-bottom: 0; }
+.chart-label {
+  font-family: var(--ff-mono);
+  font-size: 11px;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.chart-bars {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.chart-bar {
+  height: 22px;
+  display: flex;
+  align-items: center;
+  padding-left: 10px;
+  font-family: var(--ff-mono);
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--ink);
+  transition: width 1.3s cubic-bezier(0.2, 0.7, 0.2, 1);
+}
+.bar-memory { background: var(--warn); }
+.bar-attestor { background: var(--accent); }
+
+.chart-legend {
+  display: flex;
+  gap: 24px;
+  margin-top: 20px;
+  padding-top: 16px;
+  border-top: 1px solid var(--rule);
+  font-family: var(--ff-mono);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.legend-dot {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  margin-right: 8px;
+  vertical-align: middle;
+}
+
+.bottom-line {
+  font-family: var(--ff-display);
+  font-style: italic;
+  font-variation-settings: 'opsz' 24, 'wght' 400;
+  font-size: 20px;
+  color: var(--paper-dim);
+  margin-top: 40px;
+  line-height: 1.5;
+  max-width: 64ch;
+}
+
+/* ═══════════════════════════════════════════════════
+   § 02 · MULTI-AGENT
+   ═══════════════════════════════════════════════════ */
+
+.capabilities {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1px;
+  background: var(--rule-strong);
+  border: 1px solid var(--rule-strong);
+  margin-top: 56px;
+}
+.capability {
+  background: var(--ink);
+  padding: 40px 36px;
+  transition: background 0.3s;
+  position: relative;
+}
+.capability:hover { background: var(--ink-raise); }
+.capability-num {
+  font-family: var(--ff-mono);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.18em;
+  color: var(--accent);
+  margin-bottom: 20px;
+  display: block;
+}
+.capability h3 {
+  font-family: var(--ff-display);
+  font-variation-settings: 'opsz' 36, 'wght' 460;
+  font-size: 26px;
+  color: var(--paper);
+  margin-bottom: 14px;
+  letter-spacing: -0.015em;
+  line-height: 1.1;
+}
+.capability p {
+  font-size: 14.5px;
+  line-height: 1.7;
+  color: var(--paper-dim);
+}
+.capability code {
+  font-family: var(--ff-mono);
+  font-size: 12.5px;
+  background: var(--ink-surface);
+  color: var(--accent);
+  padding: 2px 7px;
+  border: 1px solid var(--rule);
+}
+
+/* ═══════════════════════════════════════════════════
+   § 03 · BENCHMARKS
+   ═══════════════════════════════════════════════════ */
+
+#compare {
+  background: var(--ink-raise);
+  border-top: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+}
+
+.table-heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-top: 48px;
+  padding-bottom: 14px;
+  border-bottom: 1px solid var(--rule-strong);
+  gap: 20px;
+  flex-wrap: wrap;
+}
+.table-heading h3 {
+  font-family: var(--ff-display);
+  font-variation-settings: 'opsz' 36, 'wght' 460;
+  font-size: 24px;
+  color: var(--paper);
+  letter-spacing: -0.01em;
+}
+.table-heading .table-meta {
+  font-family: var(--ff-mono);
+  font-size: 10px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.datatable-wrap {
+  overflow-x: auto;
+  margin-top: 0;
+  margin-bottom: 20px;
+}
+.datatable {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+  font-variant-numeric: tabular-nums;
+}
+.datatable th,
+.datatable td {
+  padding: 14px 18px 14px 0;
+  text-align: left;
+  border-bottom: 1px solid var(--rule);
+  white-space: nowrap;
+}
+.datatable th {
+  font-family: var(--ff-mono);
+  font-size: 10px;
+  font-weight: 500;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  padding-top: 18px;
+  padding-bottom: 14px;
+}
+.datatable td { color: var(--paper-dim); }
+.datatable td:first-child {
+  color: var(--paper);
+  font-weight: 400;
+  font-family: var(--ff-display);
+  font-variation-settings: 'opsz' 18, 'wght' 460;
+  font-size: 15px;
+  letter-spacing: -0.005em;
+}
+.datatable tr.row-hl td { color: var(--paper); }
+.datatable tr.row-hl td:first-child { color: var(--accent); }
+.datatable tr.row-hl td.num { color: var(--accent); font-weight: 500; }
+.datatable tr:last-child td { border-bottom: none; }
+.datatable .num {
+  font-family: var(--ff-mono);
+  font-weight: 500;
+  color: var(--paper);
+}
+
+.comp-footnote {
+  font-size: 13px;
+  color: var(--muted);
+  margin-top: 20px;
+  line-height: 1.6;
+  font-style: italic;
+  font-family: var(--ff-display);
+  font-variation-settings: 'opsz' 14, 'wght' 400;
+}
+.comp-footnote code {
+  font-family: var(--ff-mono);
+  font-style: normal;
+  font-size: 12px;
+  background: var(--ink);
+  color: var(--accent);
+  padding: 2px 7px;
+  border: 1px solid var(--rule);
+}
+
+/* ═══════════════════════════════════════════════════
+   § 04 · PIPELINE
+   ═══════════════════════════════════════════════════ */
+
+.pipeline {
+  margin-top: 56px;
+  border-top: 1px solid var(--rule-strong);
+}
+.pipeline-step {
+  display: grid;
+  grid-template-columns: 80px 1fr 240px;
+  align-items: baseline;
+  padding: 34px 0;
+  border-bottom: 1px solid var(--rule);
+  gap: 32px;
+  transition: background 0.3s;
+  position: relative;
+}
+.pipeline-step:hover {
+  background: linear-gradient(90deg, transparent, rgba(13,31,60,0.045), transparent);
+}
+.step-index {
+  font-family: var(--ff-display);
+  font-variation-settings: 'opsz' 144, 'wght' 320;
+  font-size: 58px;
+  line-height: 0.9;
+  color: var(--accent);
+  letter-spacing: -0.04em;
+  font-variant-numeric: tabular-nums;
+}
+.step-body h3 {
+  font-family: var(--ff-display);
+  font-variation-settings: 'opsz' 36, 'wght' 460;
+  font-size: 26px;
+  color: var(--paper);
+  letter-spacing: -0.015em;
+  margin-bottom: 6px;
+}
+.step-body p {
+  font-size: 14.5px;
+  line-height: 1.7;
+  color: var(--paper-dim);
+  max-width: 52ch;
+}
+.step-engine {
+  font-family: var(--ff-mono);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--muted);
+  text-align: right;
+  padding-top: 10px;
+}
+.step-engine b {
+  display: block;
+  color: var(--accent);
+  font-weight: 500;
+  margin-bottom: 4px;
+}
+
+/* ═══════════════════════════════════════════════════
+   § 05 · DEPLOY MATRIX
+   ═══════════════════════════════════════════════════ */
+
+.matrix {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1px;
+  background: var(--rule-strong);
+  border: 1px solid var(--rule-strong);
+  margin-top: 56px;
+}
+.matrix-cell {
+  background: var(--ink);
+  padding: 36px 32px;
+  transition: background 0.3s;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-height: 200px;
+}
+.matrix-cell:hover { background: var(--ink-raise); }
+.matrix-tag {
+  font-family: var(--ff-mono);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+.matrix-cell h3 {
+  font-family: var(--ff-display);
+  font-variation-settings: 'opsz' 36, 'wght' 480;
+  font-size: 24px;
+  color: var(--paper);
+  letter-spacing: -0.015em;
+  line-height: 1;
+}
+.matrix-cell p {
+  font-size: 14px;
+  line-height: 1.65;
+  color: var(--paper-dim);
+  margin-top: auto;
+}
+.matrix-spec {
+  font-family: var(--ff-mono);
+  font-size: 11px;
+  color: var(--muted);
+  letter-spacing: 0.08em;
+  padding-top: 14px;
+  margin-top: 14px;
+  border-top: 1px solid var(--rule);
+}
+
+/* ═══════════════════════════════════════════════════
+   § 06 · QUICKSTART
+   ═══════════════════════════════════════════════════ */
+
+#quickstart {
+  background: var(--ink-raise);
+  border-top: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+}
+
+.tabs {
+  display: flex;
+  gap: 0;
+  margin-top: 48px;
+  border-bottom: 1px solid var(--rule-strong);
+}
+.tab-btn {
+  padding: 14px 28px 14px 0;
+  margin-right: 28px;
+  font-family: var(--ff-mono);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  background: none;
+  border: none;
+  color: var(--muted);
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  transition: all 0.2s;
+  margin-bottom: -1px;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+}
+.tab-btn .tab-num {
+  font-family: var(--ff-display);
+  font-variation-settings: 'opsz' 18, 'wght' 500;
+  font-size: 13px;
+  color: var(--faint);
+  letter-spacing: 0;
+}
+.tab-btn.active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+.tab-btn.active .tab-num { color: var(--accent); }
+.tab-btn:hover:not(.active) { color: var(--paper); }
+
+.tab-panel {
+  display: none;
+  padding: 32px 0;
+}
+.tab-panel.active { display: block; }
+
+.code-block {
+  background: var(--ink);
+  border: 1px solid var(--rule-strong);
+  padding: 28px 32px;
+  font-family: var(--ff-mono);
+  font-size: 13px;
+  line-height: 1.9;
+  color: var(--paper-dim);
+  overflow-x: auto;
+  position: relative;
+  white-space: pre;
+}
+.code-block::before {
+  content: attr(data-lang);
+  position: absolute;
+  top: 0;
+  left: 32px;
+  font-size: 9px;
+  letter-spacing: 0.3em;
+  color: var(--accent);
+  background: var(--ink);
+  padding: 0 8px;
+  transform: translateY(-50%);
+  text-transform: uppercase;
+  font-weight: 500;
+}
+.code-block .comment { color: var(--faint); }
+.code-block .cmd { color: var(--paper); }
+.code-block .string { color: var(--accent-warm); }
+.code-block .keyword { color: var(--accent); }
+.code-block .fn { color: var(--accent-cool); }
+
+.code-copy-btn {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  background: var(--ink-raise);
+  border: 1px solid var(--rule-strong);
+  color: var(--muted);
+  font-size: 10px;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  padding: 6px 12px;
+  cursor: pointer;
+  font-family: var(--ff-mono);
+  font-weight: 500;
+  transition: all 0.2s;
+}
+.code-copy-btn:hover { border-color: var(--accent); color: var(--accent); }
+
+/* ═══════════════════════════════════════════════════
+   § 07 · PRINCIPLES
+   ═══════════════════════════════════════════════════ */
+
+.manifesto {
+  margin-top: 56px;
+  max-width: 68ch;
+}
+.manifesto-line {
+  font-family: var(--ff-display);
+  font-variation-settings: 'opsz' 144, 'wght' 360;
+  font-size: clamp(22px, 2.6vw, 30px);
+  line-height: 1.4;
+  color: var(--paper);
+  padding: 28px 0 28px 60px;
+  border-bottom: 1px solid var(--rule);
+  letter-spacing: -0.015em;
+  position: relative;
+  transition: color 0.3s;
+}
+.manifesto-line:hover { color: var(--accent); }
+.manifesto-line::before {
+  content: attr(data-num);
+  position: absolute;
+  left: 0;
+  top: 36px;
+  font-family: var(--ff-mono);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.15em;
+  color: var(--faint);
+  font-variation-settings: normal;
+}
+.manifesto-line em {
+  font-style: italic;
+  font-variation-settings: 'opsz' 144, 'wght' 320;
+  color: var(--accent);
+}
+
+/* ═══════════════════════════════════════════════════
+   CLOSING
+   ═══════════════════════════════════════════════════ */
+
+#closing {
+  padding: 160px 0 120px;
+  border-top: 1px solid var(--rule);
+  position: relative;
+  overflow: hidden;
+  text-align: left;
+}
+#closing::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 85% 15%, rgba(13,31,60,0.05), transparent 55%);
+  pointer-events: none;
+}
+.closing-head {
+  font-family: var(--ff-display);
+  font-weight: 700;
+  font-variation-settings: 'opsz' 144, 'wght' 340;
+  font-size: clamp(44px, 7vw, 92px);
+  line-height: 1;
+  letter-spacing: -0.03em;
+  color: var(--accent);
+  margin-bottom: 40px;
+  max-width: 20ch;
+}
+.closing-head em {
+  font-style: italic;
+  font-weight: 400;
+  font-variation-settings: 'opsz' 144, 'wght' 300;
+  color: var(--accent-warm);
+}
+
+.closing-row {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-bottom: 40px;
+}
+.closing-install {
+  display: inline-flex;
+  align-items: center;
+  gap: 14px;
+  background: var(--ink-raise);
+  border: 1px solid var(--rule-strong);
+  padding: 16px 22px;
+  font-family: var(--ff-mono);
+  font-size: 13px;
+  color: var(--paper);
+  cursor: pointer;
+  transition: border-color 0.2s;
+}
+.closing-install::before {
+  content: '$';
+  color: var(--accent);
+  font-weight: 500;
+}
+.closing-install:hover { border-color: var(--accent); }
+
+.closing-byline {
+  font-family: var(--ff-display);
+  font-variation-settings: 'opsz' 18, 'wght' 400;
+  font-size: 17px;
+  line-height: 1.6;
+  color: var(--paper-dim);
+  max-width: 56ch;
+  font-style: italic;
+}
+.closing-byline a {
+  color: var(--accent);
+  border-bottom: 1px solid currentColor;
+  padding-bottom: 1px;
+}
+
+/* ═══════════════════════════════════════════════════
+   COLOPHON (FOOTER)
+   ═══════════════════════════════════════════════════ */
+
+footer.colophon {
+  border-top: 1px solid var(--rule-strong);
+  padding: 80px 0 60px;
+  background: var(--ink);
+  position: relative;
+  z-index: 3;
+}
+.colophon-grid {
+  display: grid;
+  grid-template-columns: 2fr 1fr 1fr 1fr;
+  gap: 48px;
+  margin-bottom: 56px;
+}
+.col-label {
+  font-family: var(--ff-mono);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 20px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--rule);
+}
+.colophon-body {
+  font-family: var(--ff-display);
+  font-variation-settings: 'opsz' 14, 'wght' 400;
+  font-size: 14.5px;
+  line-height: 1.7;
+  color: var(--paper-dim);
+  max-width: 52ch;
+}
+.colophon-body em {
+  font-style: italic;
+  color: var(--paper);
+}
+.colophon-list {
+  list-style: none;
+  font-size: 13.5px;
+  line-height: 2;
+  color: var(--paper-dim);
+}
+.colophon-list a { color: var(--paper-dim); }
+.colophon-list a:hover { color: var(--accent); }
+
+.colophon-mark {
+  border-top: 1px solid var(--rule);
+  padding-top: 24px;
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 20px;
+  flex-wrap: wrap;
+  font-family: var(--ff-mono);
+  font-size: 10px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.colophon-mark .left {
+  font-family: var(--ff-display);
+  font-variation-settings: 'opsz' 144, 'wght' 500;
+  font-size: 32px;
+  color: var(--paper);
+  letter-spacing: -0.02em;
+  text-transform: none;
+  line-height: 1;
+}
+.colophon-mark .left b {
+  color: var(--accent);
+  font-weight: inherit;
+}
+
+/* ═══════════════════════════════════════════════════
+   RESPONSIVE
+   ═══════════════════════════════════════════════════ */
+
+@media (max-width: 960px) {
+  :root { --section-gap: 100px; }
+  .hero-grid { grid-template-columns: 1fr; gap: 48px; }
+  .versus { grid-template-columns: 1fr; border-bottom: none; }
+  .versus-col + .versus-col {
+    border-left: none;
+    border-top: 1px solid var(--rule);
+    padding-left: 0;
+    padding-top: 32px;
+  }
+  .capabilities { grid-template-columns: 1fr; }
+  .matrix { grid-template-columns: 1fr 1fr; }
+  .pipeline-step {
+    grid-template-columns: 60px 1fr;
+    gap: 20px;
+  }
+  .step-index { font-size: 44px; }
+  .step-engine {
+    grid-column: 2;
+    text-align: left;
+    padding-top: 4px;
+  }
+  .colophon-grid { grid-template-columns: 1fr 1fr; gap: 40px 32px; }
+  .nav-links { display: none; }
+  .nav-mobile-toggle { display: block; }
+  nav.mobile-open .nav-links {
+    display: flex;
+    flex-direction: column;
+    position: absolute;
+    top: 60px;
+    left: 0;
+    right: 0;
+    background: rgba(250, 248, 244, 0.96);
+    backdrop-filter: blur(18px);
+    padding: 28px var(--gutter);
+    border-bottom: 1px solid var(--rule-strong);
+    align-items: flex-start;
+    gap: 20px;
+  }
+}
+
+@media (max-width: 640px) {
+  :root { --section-gap: 80px; --gutter: 22px; }
+  #hero { padding: 70px 0 60px; }
+  .hero-dateline { font-size: 10px; gap: 18px; margin-bottom: 40px; }
+  .hero-headline { font-size: 44px; letter-spacing: -0.03em; }
+  .hero-sub { font-size: 18px; }
+  .section-head { font-size: 34px; }
+  .matrix { grid-template-columns: 1fr; }
+  .capability { padding: 28px 22px; }
+  .token-plate { padding: 24px; }
+  .chart-row { grid-template-columns: 60px 1fr; gap: 12px; }
+  .pullquote { font-size: 22px; margin: 36px 0; }
+  .pullquote::before { font-size: 2em; left: -0.3em; }
+  .closing-head { font-size: 40px; }
+  .colophon-grid { grid-template-columns: 1fr; }
+  .tab-btn { padding: 12px 16px 12px 0; margin-right: 14px; font-size: 10px; }
+  .datatable th, .datatable td { padding: 10px 12px 10px 0; font-size: 12px; }
+  .nav-ctas .btn-ghost { display: none; }
+  .manifesto-line { padding-left: 44px; font-size: 20px; }
+  .hero-install, .closing-install { font-size: 12px; padding: 14px 16px; }
+}
+</style>
+</head>
+<body>
+
+<!-- ═══════════════════════════════════════════════════
+     MASTHEAD STRIP
+     ═══════════════════════════════════════════════════ -->
+<div class="masthead-strip">
+  <div class="container">
+    <span class="lead"><span class="dot"></span>ATTESTOR &mdash; A MEMORY JOURNAL FOR AGENTIC SYSTEMS</span>
+    <span>VOL. 02 &middot; REV. 0.1</span>
+    <span>EST. 2026 &middot; NEW YORK</span>
+    <span>MIT</span>
+  </div>
+</div>
+
+<!-- ═══════════════════════════════════════════════════
+     NAV
+     ═══════════════════════════════════════════════════ -->
+<nav id="nav">
+  <div class="nav-inner">
+    <a href="index.html" class="nav-logo">Attestor</a>
+    <ul class="nav-links">
+      <li><a href="#problem" data-num="01">Problem</a></li>
+      <li><a href="#multiagent" data-num="02">Multi-Agent</a></li>
+      <li><a href="#how" data-num="03">Pipeline</a></li>
+      <li><a href="#platforms" data-num="04">Deploy</a></li>
+      <li><a href="#quickstart" data-num="05">Quickstart</a></li>
+      <li><a href="#principles" data-num="06">Principles</a></li>
+      <li><a href="index.html" data-num="07">Tokenmaxing</a></li>
+    </ul>
+    <div class="nav-ctas">
+      <a href="https://pypi.org/project/attestor/" class="btn btn-ghost" target="_blank" rel="noopener">PyPI</a>
+      <a href="https://github.com/bolnet/attestor" class="btn btn-primary" target="_blank" rel="noopener">GitHub &rarr;</a>
+    </div>
+    <button class="nav-mobile-toggle" onclick="document.getElementById('nav').classList.toggle('mobile-open')" aria-label="Toggle menu">&#9776;</button>
+  </div>
+</nav>
+
+<!-- ═══════════════════════════════════════════════════
+     HERO
+     ═══════════════════════════════════════════════════ -->
+<section id="hero">
+  <div class="container">
+    <div class="hero-dateline">
+      <span class="filing">&sect; 00 &middot; Masthead</span>
+      <span>Filed under Infrastructure</span>
+      <span>By <a href="https://www.linkedin.com/in/singhsurendra/" target="_blank" rel="noopener" style="color:inherit;text-decoration:underline;text-decoration-thickness:1px;text-underline-offset:3px;">Surendra Singh</a></span>
+      <span class="accent">&mdash; For publication &mdash;</span>
+    </div>
+
+    <h1 class="hero-headline">
+      What did the agent know, <em>and when did it know it?</em>
+    </h1>
+
+    <div class="hero-grid">
+      <div>
+        <p class="hero-sub">Auditable memory for agent teams. <em>Deterministic.</em> <em>Bitemporal.</em> Self&#8209;hosted, with no LLM in the critical path.</p>
+        <p class="hero-sub-detail">One tier your whole pipeline shares &mdash; planner writes, executor reads, reviewer sees both. Namespaces, RBAC, provenance, temporal correctness, ranked retrieval, token budgets &mdash; built in, not bolted on. Python library, REST API, or containerized service. No SaaS middleman. No per&#8209;seat fees. No vendor lock&#8209;in. It&rsquo;s yours.</p>
+
+        <div class="hero-install" onclick="copyToClipboard(this, 'poetry add attestor')" title="Click to copy">
+          <span>poetry add attestor</span>
+          <span class="copy-icon">&#x2398;</span>
+        </div>
+        <div class="hero-cta-row" style="display:flex;gap:12px;flex-wrap:wrap;margin-top:12px;">
+          <a href="https://github.com/bolnet/attestor" class="btn btn-primary" target="_blank" rel="noopener">Architecture &amp; deploy guide &rarr;</a>
+          <a href="https://github.com/bolnet/attestor/stargazers" target="_blank" rel="noopener"><img src="https://img.shields.io/github/stars/bolnet/attestor?style=for-the-badge&amp;label=GitHub&amp;color=0d1f3c" alt="GitHub stars"></a>
+          <a href="https://pypi.org/project/attestor/" target="_blank" rel="noopener" title="Live monthly installs from PyPI"><img src="https://img.shields.io/pypi/dm/attestor?style=for-the-badge&amp;label=Installs%2Fmo&amp;color=0d1f3c&amp;labelColor=2a5c3a" alt="PyPI monthly downloads" style="box-shadow:0 0 0 2px var(--accent);border-radius:4px;"></a>
+          <span style="display:inline-flex;align-items:center;font-family:var(--ff-mono);font-size:10px;letter-spacing:0.2em;color:var(--muted);text-transform:uppercase;">&larr;&nbsp;live from pypi</span>
+        </div>
+        <span class="hero-install-note">MIT &middot; Python 3.10&ndash;3.14 &middot; Production deploy in one command</span>
+      </div>
+
+      <aside class="hero-spec">
+        <div class="hero-spec-title">&sect; Spec Sheet</div>
+        <div class="hero-spec-row">
+          <span class="hero-spec-label">Storage Roles</span>
+          <span class="hero-spec-value">Doc &middot; Vector &middot; Graph</span>
+        </div>
+        <div class="hero-spec-row">
+          <span class="hero-spec-label">Interfaces</span>
+          <span class="hero-spec-value">Python &middot; REST &middot; MCP</span>
+        </div>
+        <div class="hero-spec-row">
+          <span class="hero-spec-label">Pipeline Steps</span>
+          <span class="hero-spec-value">6</span>
+        </div>
+        <div class="hero-spec-row">
+          <span class="hero-spec-label">RBAC Roles</span>
+          <span class="hero-spec-value">6</span>
+        </div>
+        <div class="hero-spec-row">
+          <span class="hero-spec-label">Cloud Targets</span>
+          <span class="hero-spec-value">AWS &middot; Azure &middot; GCP</span>
+        </div>
+        <div class="hero-spec-row">
+          <span class="hero-spec-label">License</span>
+          <span class="hero-spec-value">MIT</span>
+        </div>
+      </aside>
+    </div>
+  </div>
+
+  <div class="ticker">
+    <div class="ticker-track">
+      <span><b>MULTI-AGENT</b>NAMESPACE</span>
+      <span><b>ACCESS</b>RBAC</span>
+      <span><b>TRACE</b>PROVENANCE</span>
+      <span><b>CONTEXT</b>TOKEN BUDGETS</span>
+      <span><b>PIPELINE</b>SEMANTIC-FIRST</span>
+      <span><b>PYTHON</b>3.10 &mdash; 3.14</span>
+      <span><b>STACK</b>Postgres &middot; pgvector &middot; Neo4j</span>
+      <span><b>CLOUD</b>PostgreSQL &middot; ArangoDB &middot; Cosmos &middot; AlloyDB</span>
+      <span><b>DEPLOY</b>AWS &middot; Azure &middot; GCP</span>
+      <span><b>RETRIEVAL</b>Vector &middot; BM25 &middot; RRF &middot; MMR</span>
+      <span><b>LICENSE</b>MIT</span>
+      <!-- duplicate -->
+      <span><b>MULTI-AGENT</b>NAMESPACE</span>
+      <span><b>ACCESS</b>RBAC</span>
+      <span><b>TRACE</b>PROVENANCE</span>
+      <span><b>CONTEXT</b>TOKEN BUDGETS</span>
+      <span><b>PIPELINE</b>SEMANTIC-FIRST</span>
+      <span><b>PYTHON</b>3.10 &mdash; 3.14</span>
+      <span><b>STACK</b>Postgres &middot; pgvector &middot; Neo4j</span>
+      <span><b>CLOUD</b>PostgreSQL &middot; ArangoDB &middot; Cosmos &middot; AlloyDB</span>
+      <span><b>DEPLOY</b>AWS &middot; Azure &middot; GCP</span>
+      <span><b>RETRIEVAL</b>Vector &middot; BM25 &middot; RRF &middot; MMR</span>
+      <span><b>LICENSE</b>MIT</span>
+    </div>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════════════════════════
+     REVEAL · "IT REMEMBERS"
+     ═══════════════════════════════════════════════════ -->
+<section id="reveal" style="padding:96px 0 48px;border-top:1px solid var(--rule);">
+  <div class="container">
+    <figure class="reveal" style="margin:0 auto;max-width:1040px;text-align:center;">
+      <img src="constellation.svg" alt="Six stars out of eight hundred light up — Attestor recalls exactly what this moment needs" style="display:block;width:100%;height:auto;">
+      <figcaption style="margin-top:28px;font-family:var(--ff-display);font-variation-settings:'opsz' 144,'wght' 380;font-size:clamp(28px,4vw,46px);line-height:1.1;letter-spacing:-0.02em;color:var(--paper);"><em style="font-variation-settings:'opsz' 144,'wght' 320;color:var(--accent);">Attestor doesn&rsquo;t search.</em> It remembers.</figcaption>
+      <p style="margin:20px auto 0;max-width:60ch;font-family:var(--ff-display);font-variation-settings:'opsz' 18,'wght' 400;font-size:18px;line-height:1.6;color:var(--paper-dim);">Eight hundred memories in the store. Six light up. Not the six it <em>searched</em> &mdash; the six this moment <em>needs</em>. Your planner&rsquo;s decision from Monday. The researcher&rsquo;s finding from Wednesday. The reviewer&rsquo;s objection from yesterday. Ranked, deduped, fit to budget. <b>Zero LLM calls in the critical path.</b></p>
+    </figure>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════════════════════════
+     SOLUTION AT A GLANCE · TIMELINE
+     ═══════════════════════════════════════════════════ -->
+<section id="timeline-reveal" style="padding:48px 0 96px;">
+  <div class="container">
+    <div class="section-filing reveal">
+      <span class="section-num">&sect; 00.1</span>
+      <span class="section-name">&mdash; The solution, in one picture</span>
+      <span>Memory accumulates &middot; load primes</span>
+    </div>
+    <div class="reveal">
+      <h2 class="section-head">Memory accumulates. <em>Load primes.</em></h2>
+      <p class="standfirst">Four writes across Mon&ndash;Thu land as persisted memories. Friday morning a fresh Portfolio Planner wakes up to a new task, calls <code style="font-family:var(--ff-mono);font-size:15px;color:var(--accent);background:var(--ink-raise);padding:2px 8px;border:1px solid var(--rule);">mem.load_context()</code>, and Attestor ranks + dedupes + budget-fits all four back into the context window. The agent resumes with full continuity &mdash; earnings signal, risk cap, prior stance, compliance precedent.</p>
+    </div>
+    <figure class="reveal" style="margin:40px auto 16px;max-width:1040px;background:var(--ink-raise);border:1px solid var(--rule-strong);border-radius:6px;padding:24px;">
+      <img src="timeline.svg" alt="Write · Write · Write · Write ... Read — memories accumulate across sessions, load_context primes the next task" style="display:block;width:100%;height:auto;">
+      <figcaption style="font-family:var(--ff-mono);font-size:11px;text-transform:uppercase;letter-spacing:0.16em;color:var(--paper-dim);text-align:center;margin-top:14px;">Fig. 0.1 &mdash; Not RAG over documents. The agents&rsquo; <em>own history</em>, replayed into a fresh context.</figcaption>
+    </figure>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════════════════════════
+     § 01 · THE PROBLEM  (Act I — cold open)
+     ═══════════════════════════════════════════════════ -->
+<section id="problem">
+  <div class="container">
+    <div class="section-filing reveal">
+      <span class="section-num">&sect; 01</span>
+      <span class="section-name">&mdash; The Problem</span>
+      <span>Why agent prototypes don't survive production</span>
+    </div>
+
+    <div class="reveal">
+      <h2 class="section-head">Every agent starts the day with <em>amnesia.</em></h2>
+      <p class="standfirst">Single agents rediscover the same facts every run. Multi-agent pipelines are worse &mdash; the planner&rsquo;s decisions never reach the executor, the researcher&rsquo;s findings never reach the reviewer. So teams do the only thing they can: stuff giant prompts between agents. Burn tokens. Hope nothing important fell off the edge. That&rsquo;s not an architecture. That&rsquo;s a workaround.</p>
+    </div>
+
+    <blockquote class="pullquote reveal">
+      We had a planner, a coder, a reviewer, a deployer &mdash; four agents in a pipeline. None of them knew what the others learned. We were passing giant prompts between them and burning tokens on stale information.
+      <span class="pullquote-attr">Overheard &middot; Engineering Lead, Fortune 100 Bank</span>
+    </blockquote>
+
+    <div class="versus reveal">
+      <div class="versus-col versus-bad">
+        <div class="versus-label">Without Attestor</div>
+        <div class="versus-item"><span class="marker">01</span><span>Each agent starts blind &mdash; no knowledge of what others learned</span></div>
+        <div class="versus-item"><span class="marker">02</span><span>Giant prompts passed between agents burn context tokens</span></div>
+        <div class="versus-item"><span class="marker">03</span><span>No access control &mdash; any agent can overwrite any state</span></div>
+        <div class="versus-item"><span class="marker">04</span><span>Contradicting facts from different agents go undetected</span></div>
+        <div class="versus-item"><span class="marker">05</span><span>Session ends, everything learned is gone forever</span></div>
+      </div>
+      <div class="versus-col versus-good">
+        <div class="versus-label">With Attestor</div>
+        <div class="versus-item"><span class="marker">01</span><span>Shared memory &mdash; planner writes, coder reads, reviewer sees both</span></div>
+        <div class="versus-item"><span class="marker">02</span><span>Token-budget recall &mdash; each agent pulls only what fits</span></div>
+        <div class="versus-item"><span class="marker">03</span><span>Six RBAC roles, namespace isolation, write quotas per agent</span></div>
+        <div class="versus-item"><span class="marker">04</span><span>Contradictions auto-resolved &mdash; newer facts supersede older ones</span></div>
+        <div class="versus-item"><span class="marker">05</span><span>Persistent across sessions, pipelines, and agent restarts</span></div>
+      </div>
+    </div>
+
+    <div class="token-plate reveal" id="tokenChart">
+      <div class="plate-title">
+        <h4>Token cost per agent as memories grow</h4>
+        <span class="plate-meta">Fig. 01.1 &middot; Lower is better</span>
+      </div>
+      <div class="chart-row">
+        <div class="chart-label">Month 1</div>
+        <div class="chart-bars">
+          <div class="chart-bar bar-memory" data-width="13.3" style="width: 0%">2K</div>
+          <div class="chart-bar bar-attestor" data-width="13.3" style="width: 0%">2K</div>
+        </div>
+      </div>
+      <div class="chart-row">
+        <div class="chart-label">Month 3</div>
+        <div class="chart-bars">
+          <div class="chart-bar bar-memory" data-width="53.3" style="width: 0%">8K</div>
+          <div class="chart-bar bar-attestor" data-width="13.3" style="width: 0%">2K</div>
+        </div>
+      </div>
+      <div class="chart-row">
+        <div class="chart-label">Month 6</div>
+        <div class="chart-bars">
+          <div class="chart-bar bar-memory" data-width="100" style="width: 0%">15K</div>
+          <div class="chart-bar bar-attestor" data-width="13.3" style="width: 0%">2K</div>
+        </div>
+      </div>
+      <div class="chart-legend">
+        <span><span class="legend-dot" style="background:var(--warn)"></span>Prompt-passing</span>
+        <span><span class="legend-dot" style="background:var(--accent)"></span>Attestor</span>
+      </div>
+    </div>
+
+    <p class="bottom-line reveal">More agents, more sessions, more memories &mdash; retrieval gets <em>better</em> while context cost stays flat.</p>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════════════════════════
+     § 02 · MULTI-AGENT
+     ═══════════════════════════════════════════════════ -->
+<section id="multiagent">
+  <div class="container">
+    <div class="section-filing reveal">
+      <span class="section-num">&sect; 02</span>
+      <span class="section-name">&mdash; Built for teams, not chatbots</span>
+      <span>Orchestrator &middot; Planner &middot; Executor &middot; Reviewer</span>
+    </div>
+
+    <div class="reveal">
+      <h2 class="section-head">Not a chatbot plugin. <em>Infrastructure</em> for agent teams.</h2>
+      <p class="standfirst">Every recall and write is scoped to an <code style="font-family:var(--ff-mono);font-size:15px;color:var(--accent);background:var(--ink-raise);padding:2px 8px;border:1px solid var(--rule);">AgentContext</code> &mdash; identity, role, namespace, parent trail, token budget, write quota, visibility. Contexts are immutable. Spawning a sub-agent returns a new context with inherited provenance. Planner writes. Executor reads. Reviewer sees both. <em>Every call authorised before it touches storage.</em></p>
+    </div>
+
+    <figure class="reveal" style="margin:48px auto 24px;max-width:880px;background:var(--ink-raise);border:1px solid var(--rule-strong);border-radius:6px;padding:28px;">
+      <img src="architecture.svg" alt="Attestor high-level architecture" style="display:block;width:100%;height:auto;"/>
+      <figcaption style="font-family:var(--ff-mono);font-size:12px;text-transform:uppercase;letter-spacing:0.12em;color:var(--paper-dim);text-align:center;margin-top:16px;">Fig. 1 &mdash; Agents talk to Attestor through Python, REST, or MCP. Storage is pluggable.</figcaption>
+    </figure>
+
+    <div class="capabilities reveal">
+      <div class="capability">
+        <span class="capability-num">01 / 06</span>
+        <h3>Namespace isolation</h3>
+        <p>Every agent, project, or tenant gets its own namespace. Planner writes, coder reads, reviewer sees both. Isolated by default, shared when you configure it.</p>
+      </div>
+      <div class="capability">
+        <span class="capability-num">02 / 06</span>
+        <h3>Six RBAC roles</h3>
+        <p>Orchestrator, Planner, Executor, Researcher, Reviewer, Monitor. Read-only observers to full admins. Control who can read, write, or supersede in each namespace.</p>
+      </div>
+      <div class="capability">
+        <span class="capability-num">03 / 06</span>
+        <h3>Provenance tracking</h3>
+        <p>Know which agent wrote which memory, when, and under which parent session. The reviewer can trace a decision back to the planner three sessions ago &mdash; not some unknown source.</p>
+      </div>
+      <div class="capability">
+        <span class="capability-num">04 / 06</span>
+        <h3>Cross-agent contradiction resolution</h3>
+        <p>Agent A learns "user works at Google." Agent B learns "user works at Meta." Attestor auto-supersedes. Full history preserved. Zero inference calls in the critical path.</p>
+      </div>
+      <div class="capability">
+        <span class="capability-num">05 / 06</span>
+        <h3>Token budgets per agent</h3>
+        <p><code>recall(query, budget=2000)</code> &mdash; a lightweight summarizer uses 500 tokens; a deep reasoner uses 5,000. Each agent receives exactly what fits in its context window.</p>
+      </div>
+      <div class="capability">
+        <span class="capability-num">06 / 06</span>
+        <h3>Write quotas &amp; review flags</h3>
+        <p>Prevent a runaway agent from flooding the store with noise. Rate-limit writes per namespace, flag writes for human review, add compliance tags for audit.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════════════════════════
+     § 03 · PIPELINE
+     ═══════════════════════════════════════════════════ -->
+<section id="how">
+  <div class="container">
+    <div class="section-filing reveal">
+      <span class="section-num">&sect; 03</span>
+      <span class="section-name">&mdash; The Retrieval Pipeline</span>
+      <span>Semantic-first &middot; zero inference calls</span>
+    </div>
+
+    <div class="reveal">
+      <h2 class="section-head">Semantic-first. <em>No LLM.</em> Fully deterministic.</h2>
+      <p class="standfirst">When an agent calls <code style="font-family:var(--ff-mono);font-size:15px;color:var(--accent);background:var(--ink-raise);padding:2px 8px;border:1px solid var(--rule);">recall(query, budget)</code>, six cooperating steps find, narrow, rank, diversify, decay, and fit the most relevant memories into the requested token ceiling. Ten million memories in the store. Your context window never sees more than the budget. And because there&rsquo;s no LLM in the path, the same query always returns the same ranking. You can unit&#8209;test it.</p>
+    </div>
+
+    <!-- ── Interactive recall pipeline (live trace) ────────────────── -->
+    <style>
+      .recall-stage {
+        margin: 32px auto 8px;
+        max-width: 1080px;
+        background: var(--ink);
+        border: 1px solid var(--rule-strong);
+        padding: 22px 24px 18px;
+        font-family: var(--ff-mono);
+        position: relative;
+      }
+      .recall-stage::before {
+        content: "";
+        position: absolute;
+        top: 7px; left: 7px; right: 7px; bottom: 7px;
+        border: 1px solid var(--rule);
+        pointer-events: none;
+      }
+      .recall-stage__head {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        font-size: 10px;
+        letter-spacing: 0.22em;
+        text-transform: uppercase;
+        color: var(--paper-dim);
+        padding-bottom: 12px;
+        border-bottom: 1px dashed var(--rule);
+      }
+      .recall-stage__label { color: var(--accent); }
+      .recall-stage__status { display: inline-flex; align-items: center; gap: 8px; }
+      .recall-stage__status-dot {
+        width: 7px; height: 7px;
+        border-radius: 50%;
+        background: var(--paper-dim);
+      }
+      .recall-stage[data-state="playing"] .recall-stage__status-dot {
+        background: var(--accent);
+        animation: rs-pulse 1.2s ease-in-out infinite;
+        box-shadow: 0 0 6px rgba(13,31,60,0.45);
+      }
+      @keyframes rs-pulse {
+        0%, 100% { opacity: 1; }
+        50% { opacity: 0.35; }
+      }
+      .recall-stage__query {
+        font-family: var(--ff-mono);
+        font-size: 14px;
+        color: var(--paper);
+        padding: 18px 0 22px;
+        border-bottom: 1px dashed var(--rule);
+        white-space: nowrap;
+        overflow: hidden;
+      }
+      .recall-stage__prompt { color: var(--paper-dim); }
+      .recall-stage__query-text { color: var(--accent); }
+      .recall-stage__cursor {
+        display: inline-block;
+        width: 8px; height: 14px;
+        background: var(--accent);
+        margin-left: 1px;
+        vertical-align: -2px;
+        animation: rs-blink 1s steps(1) infinite;
+      }
+      @keyframes rs-blink {
+        0%, 50% { opacity: 1; }
+        51%, 100% { opacity: 0; }
+      }
+      .recall-stage__grid {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 10px;
+        padding: 22px 0;
+      }
+      .recall-stage__cell {
+        position: relative;
+        border: 1px solid var(--rule);
+        background: transparent;
+        padding: 14px 16px 50px;
+        min-height: 150px;
+        transition: border-color 0.4s, background 0.4s;
+      }
+      .recall-stage__cell[data-active="true"] {
+        border-color: var(--accent);
+        background: var(--ink-raise);
+      }
+      .recall-stage__cell[data-passed="true"] {
+        border-color: rgba(13, 31, 60, 0.35);
+      }
+      .recall-stage__cell-num {
+        position: absolute;
+        top: 8px; right: 14px;
+        font-family: var(--ff-display);
+        font-size: 30px;
+        font-weight: 300;
+        color: var(--accent);
+        font-style: italic;
+        line-height: 1;
+        opacity: 0.65;
+      }
+      .recall-stage__cell[data-active="true"] .recall-stage__cell-num,
+      .recall-stage__cell[data-passed="true"] .recall-stage__cell-num { opacity: 1; }
+      .recall-stage__cell-tag {
+        display: block;
+        font-size: 9px;
+        letter-spacing: 0.22em;
+        text-transform: uppercase;
+        color: var(--paper-dim);
+        margin-bottom: 4px;
+      }
+      .recall-stage__cell-name {
+        display: block;
+        font-family: var(--ff-display);
+        font-size: 18px;
+        font-weight: 500;
+        color: var(--paper);
+        margin-bottom: 4px;
+        font-style: italic;
+      }
+      .recall-stage__cell-engine {
+        display: block;
+        font-size: 11px;
+        color: var(--paper-dim);
+        margin-bottom: 14px;
+      }
+      .recall-stage__tiles {
+        display: grid;
+        grid-template-columns: repeat(10, 1fr);
+        gap: 2px;
+        height: 28px;
+        margin-bottom: 8px;
+      }
+      .recall-stage__tiles > i {
+        display: block;
+        background: rgba(15, 14, 12, 0.08);
+        border-radius: 1px;
+        transition: background 0.25s, transform 0.35s, opacity 0.25s;
+      }
+      .recall-stage__tiles > i[data-state="kept"] { background: var(--paper-dim); }
+      .recall-stage__tiles > i[data-state="boosted"] {
+        background: var(--accent);
+        transform: scale(1.6);
+        box-shadow: 0 0 4px rgba(13,31,60,0.4);
+      }
+      .recall-stage__tiles > i[data-state="triple"] {
+        background: var(--accent-warm, #2a5c3a);
+        transform: rotate(45deg) scale(1.1);
+      }
+      .recall-stage__tiles > i[data-state="rejected"] {
+        background: rgba(15, 14, 12, 0.05);
+        opacity: 0.5;
+      }
+      .recall-stage__cell-count {
+        position: absolute;
+        bottom: 12px; right: 16px;
+        font-family: var(--ff-mono);
+        font-size: 22px;
+        color: var(--paper);
+        font-variant-numeric: tabular-nums;
+        letter-spacing: -0.02em;
+      }
+      .recall-stage__cell-count-label {
+        position: absolute;
+        bottom: 38px; right: 16px;
+        font-size: 9px;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        color: var(--paper-dim);
+      }
+      .recall-stage__result {
+        background: var(--ink-raise);
+        border: 1px solid var(--rule);
+        padding: 16px 20px;
+        min-height: 64px;
+        font-size: 12px;
+        color: var(--paper-dim);
+        margin: 8px 0 14px;
+        font-family: var(--ff-mono);
+        line-height: 1.85;
+      }
+      .recall-stage__result-line {
+        display: grid;
+        grid-template-columns: auto 1fr auto;
+        gap: 14px;
+        opacity: 0;
+        transform: translateY(4px);
+        transition: opacity 0.4s, transform 0.4s;
+        align-items: baseline;
+      }
+      .recall-stage__result-line[data-visible="true"] {
+        opacity: 1;
+        transform: translateY(0);
+      }
+      .recall-stage__result-score { color: var(--accent); font-variant-numeric: tabular-nums; }
+      .recall-stage__result-text { color: var(--paper); }
+      .recall-stage__result-meta { color: var(--rule-strong); font-size: 10px; letter-spacing: 0.06em; }
+      .recall-stage__result-empty {
+        color: var(--paper-dim);
+        font-style: italic;
+        font-size: 13px;
+      }
+      .recall-stage__proof {
+        font-size: 10px;
+        letter-spacing: 0.22em;
+        text-transform: uppercase;
+        text-align: center;
+        color: var(--paper-dim);
+        padding: 14px 0;
+        border-top: 1px dashed var(--rule);
+        border-bottom: 1px dashed var(--rule);
+      }
+      .recall-stage__proof-em { color: var(--accent); }
+      .recall-stage__sep { margin: 0 12px; color: var(--rule-strong); }
+      .recall-stage__controls {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding-top: 14px;
+        flex-wrap: wrap;
+      }
+      .recall-stage__btn {
+        background: transparent;
+        border: 1px solid var(--rule);
+        color: var(--paper-dim);
+        padding: 6px 12px;
+        font-family: var(--ff-mono);
+        font-size: 10px;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        cursor: pointer;
+        transition: border-color 0.2s, color 0.2s;
+      }
+      .recall-stage__btn:hover { color: var(--accent); border-color: var(--accent); }
+      .recall-stage__btn--active { color: var(--accent); border-color: var(--accent); }
+      .recall-stage__btn--small { padding: 5px 8px; font-size: 9px; letter-spacing: 0.12em; }
+      .recall-stage__scrub-wrap { display: flex; align-items: center; gap: 8px; flex: 1; min-width: 220px; }
+      .recall-stage__scrub {
+        flex: 1;
+        height: 2px;
+        background: var(--rule);
+        outline: none;
+        cursor: pointer;
+        -webkit-appearance: none;
+        appearance: none;
+      }
+      .recall-stage__scrub::-webkit-slider-thumb {
+        -webkit-appearance: none;
+        appearance: none;
+        width: 12px; height: 12px;
+        background: var(--accent);
+        border-radius: 50%;
+        cursor: pointer;
+      }
+      .recall-stage__scrub::-moz-range-thumb {
+        width: 12px; height: 12px;
+        background: var(--accent);
+        border: none;
+        border-radius: 50%;
+        cursor: pointer;
+      }
+      .recall-stage__time {
+        font-size: 10px;
+        color: var(--paper-dim);
+        font-variant-numeric: tabular-nums;
+        letter-spacing: 0.12em;
+        min-width: 78px;
+        text-align: right;
+      }
+      .recall-stage__artifacts {
+        font-size: 9px;
+        color: var(--paper-dim);
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        text-align: center;
+        padding-top: 14px;
+        margin-top: 6px;
+      }
+      .recall-stage__art-link { color: var(--paper-dim); text-decoration: none; }
+      .recall-stage__art-link:hover { color: var(--accent); }
+      .recall-stage__art-link--soon { opacity: 0.55; cursor: not-allowed; }
+      @media (max-width: 760px) {
+        .recall-stage__grid { grid-template-columns: 1fr; }
+        .recall-stage__query { white-space: normal; }
+      }
+    </style>
+
+    <figure class="recall-stage reveal" data-state="idle">
+      <div class="recall-stage__head">
+        <span class="recall-stage__label">&sect; Live trace &middot; Recall pipeline</span>
+        <span class="recall-stage__status">
+          <span class="recall-stage__status-dot"></span>
+          <span data-status-text>Idle &middot; auto-plays on scroll</span>
+        </span>
+      </div>
+
+      <div class="recall-stage__query">
+        <span class="recall-stage__prompt">$ mem.recall(</span><span class="recall-stage__query-text" data-query></span><span class="recall-stage__cursor"></span><span class="recall-stage__prompt">, budget=2000)</span>
+      </div>
+
+      <div class="recall-stage__grid">
+        <div class="recall-stage__cell" data-cell="1">
+          <span class="recall-stage__cell-num">01</span>
+          <span class="recall-stage__cell-tag">Stage 01</span>
+          <span class="recall-stage__cell-name">Vector Top-K</span>
+          <span class="recall-stage__cell-engine">pgvector &middot; cosine &middot; k=50</span>
+          <div class="recall-stage__tiles" data-tiles></div>
+          <span class="recall-stage__cell-count-label">candidates</span>
+          <span class="recall-stage__cell-count" data-count>—</span>
+        </div>
+        <div class="recall-stage__cell" data-cell="2">
+          <span class="recall-stage__cell-num">02</span>
+          <span class="recall-stage__cell-tag">Stage 02</span>
+          <span class="recall-stage__cell-name">Graph Narrow</span>
+          <span class="recall-stage__cell-engine">Neo4j BFS &middot; depth &le; 2</span>
+          <div class="recall-stage__tiles" data-tiles></div>
+          <span class="recall-stage__cell-count-label">kept</span>
+          <span class="recall-stage__cell-count" data-count>—</span>
+        </div>
+        <div class="recall-stage__cell" data-cell="3">
+          <span class="recall-stage__cell-num">03</span>
+          <span class="recall-stage__cell-tag">Stage 03</span>
+          <span class="recall-stage__cell-name">Triples Inject</span>
+          <span class="recall-stage__cell-engine">typed edges &middot; uses &middot; auth-by</span>
+          <div class="recall-stage__tiles" data-tiles></div>
+          <span class="recall-stage__cell-count-label">+triples</span>
+          <span class="recall-stage__cell-count" data-count>—</span>
+        </div>
+        <div class="recall-stage__cell" data-cell="4">
+          <span class="recall-stage__cell-num">04</span>
+          <span class="recall-stage__cell-tag">Stage 04</span>
+          <span class="recall-stage__cell-name">MMR Diversity</span>
+          <span class="recall-stage__cell-engine">&lambda; = 0.7 &middot; drop near-dups</span>
+          <div class="recall-stage__tiles" data-tiles></div>
+          <span class="recall-stage__cell-count-label">distinct</span>
+          <span class="recall-stage__cell-count" data-count>—</span>
+        </div>
+        <div class="recall-stage__cell" data-cell="5">
+          <span class="recall-stage__cell-num">05</span>
+          <span class="recall-stage__cell-tag">Stage 05</span>
+          <span class="recall-stage__cell-name">Decay + Boost</span>
+          <span class="recall-stage__cell-engine">recency &middot; confidence</span>
+          <div class="recall-stage__tiles" data-tiles></div>
+          <span class="recall-stage__cell-count-label">re-ranked</span>
+          <span class="recall-stage__cell-count" data-count>—</span>
+        </div>
+        <div class="recall-stage__cell" data-cell="6">
+          <span class="recall-stage__cell-num">06</span>
+          <span class="recall-stage__cell-tag">Stage 06</span>
+          <span class="recall-stage__cell-name">Budget Fit</span>
+          <span class="recall-stage__cell-engine">greedy pack &middot; &le; 2000 tok</span>
+          <div class="recall-stage__tiles" data-tiles></div>
+          <span class="recall-stage__cell-count-label">packed</span>
+          <span class="recall-stage__cell-count" data-count>—</span>
+        </div>
+      </div>
+
+      <div class="recall-stage__result" data-result>
+        <div class="recall-stage__result-empty">Result frame &mdash; ranked memories will land here when the pipeline completes.</div>
+      </div>
+
+      <div class="recall-stage__proof">
+        <span class="recall-stage__proof-em">0 LLM calls</span>
+        <span class="recall-stage__sep">&middot;</span>
+        <span>6 deterministic steps</span>
+        <span class="recall-stage__sep">&middot;</span>
+        <span>same query &rarr; <span class="recall-stage__proof-em">same ranking</span></span>
+      </div>
+
+      <div class="recall-stage__controls">
+        <button class="recall-stage__btn" data-action="toggle">&#9654; Play</button>
+        <button class="recall-stage__btn" data-action="replay">&#8634; Replay</button>
+        <div class="recall-stage__scrub-wrap">
+          <input type="range" min="0" max="14000" value="0" step="50" data-scrub class="recall-stage__scrub" aria-label="Scrub timeline">
+          <span class="recall-stage__time" data-time>00.0 / 14.0</span>
+        </div>
+        <button class="recall-stage__btn recall-stage__btn--small" data-speed="0.5">0.5&times;</button>
+        <button class="recall-stage__btn recall-stage__btn--small recall-stage__btn--active" data-speed="1">1&times;</button>
+        <button class="recall-stage__btn recall-stage__btn--small" data-speed="2">2&times;</button>
+      </div>
+
+      <div class="recall-stage__artifacts">
+        <a href="pipeline.svg" download class="recall-stage__art-link">&darr; Static pipeline (SVG)</a>
+        <span class="recall-stage__sep">&middot;</span>
+        <a href="#" class="recall-stage__art-link recall-stage__art-link--soon" onclick="event.preventDefault();" title="Render with Remotion — coming soon">&darr; Render as MP4 <span style="opacity:.55">(soon)</span></a>
+      </div>
+    </figure>
+
+    <script>
+    (function () {
+      const root = document.querySelector('.recall-stage');
+      if (!root) return;
+
+      const STATE = {
+        duration: 14000,
+        speed: 1.0,
+        playing: false,
+        t: 0,
+        autoplayed: false,
+        lastTick: 0,
+      };
+
+      const PHASES = [
+        { name: 'query',  from: 0,     to: 1800 },
+        { name: 'stage1', from: 1800,  to: 3500 },
+        { name: 'stage2', from: 3500,  to: 5400 },
+        { name: 'stage3', from: 5400,  to: 7200 },
+        { name: 'stage4', from: 7200,  to: 9000 },
+        { name: 'stage5', from: 9000,  to: 10700 },
+        { name: 'stage6', from: 10700, to: 12500 },
+        { name: 'result', from: 12500, to: 14000 },
+      ];
+
+      const COUNTS = {
+        1: { entry: 0,  peak: 50, exit: 50 },
+        2: { entry: 50, peak: 50, exit: 38 },
+        3: { entry: 38, peak: 42, exit: 42 },
+        4: { entry: 42, peak: 42, exit: 24 },
+        5: { entry: 24, peak: 24, exit: 24 },
+        6: { entry: 24, peak: 24, exit: 8  },
+      };
+
+      const QUERY_FULL = '"who runs engineering at acme?"';
+
+      const RESULT_LINES = [
+        { score: 0.94, text: 'Alice promoted to VP Engineering',  meta: 'valid_from 2026-03-15' },
+        { score: 0.91, text: 'Engineering org reports to Alice',  meta: '[authored-by]' },
+        { score: 0.88, text: 'Alice was engineering manager',     meta: 'superseded 2026-03-15' },
+        { score: 0.82, text: 'Acme org chart Q1 2026',            meta: 'episode #4421' },
+        { score: 0.79, text: 'Alice hired at Acme',               meta: 'valid_from 2024-01-08' },
+        { score: 0.71, text: 'Acme leadership announce',          meta: 'agent: researcher-1' },
+        { score: 0.65, text: 'Engineering headcount: 142',        meta: 'q1-snapshot' },
+        { score: 0.58, text: 'Alice background: ex-Stripe',       meta: '[authored-by]' },
+      ];
+
+      // Pre-build tiles (50 per cell)
+      const cells = Array.from(root.querySelectorAll('[data-cell]'));
+      cells.forEach((cell) => {
+        const tiles = cell.querySelector('[data-tiles]');
+        tiles.innerHTML = '';
+        for (let i = 0; i < 50; i++) tiles.appendChild(document.createElement('i'));
+      });
+
+      // Pre-build result list
+      const resultNode = root.querySelector('[data-result]');
+      function renderResultLines(visibleCount) {
+        if (visibleCount <= 0) {
+          resultNode.innerHTML = '<div class="recall-stage__result-empty">Result frame &mdash; ranked memories will land here when the pipeline completes.</div>';
+          return;
+        }
+        resultNode.innerHTML = RESULT_LINES.map((line, i) => `
+          <div class="recall-stage__result-line" data-line="${i}" data-visible="${i < visibleCount ? 'true' : 'false'}">
+            <span class="recall-stage__result-score">${line.score.toFixed(2)}</span>
+            <span class="recall-stage__result-text">${line.text}</span>
+            <span class="recall-stage__result-meta">— ${line.meta}</span>
+          </div>
+        `).join('');
+      }
+
+      const queryNode  = root.querySelector('[data-query]');
+      const statusNode = root.querySelector('[data-status-text]');
+      const scrubNode  = root.querySelector('[data-scrub]');
+      const timeNode   = root.querySelector('[data-time]');
+      const playBtn    = root.querySelector('[data-action="toggle"]');
+
+      function statusFor(name) {
+        return ({
+          query:  'Embed query &middot; pgvector probe',
+          stage1: 'Stage 01 &middot; Vector top-K (cosine)',
+          stage2: 'Stage 02 &middot; Graph narrow (BFS &le; 2)',
+          stage3: 'Stage 03 &middot; Inject typed-edge triples',
+          stage4: 'Stage 04 &middot; MMR diversity rerank',
+          stage5: 'Stage 05 &middot; Decay + temporal boost',
+          stage6: 'Stage 06 &middot; Greedy budget pack',
+          result: 'Hydrate from doc store &middot; trace written',
+        })[name] || 'Idle';
+      }
+
+      function ease(p) { return p < 0.5 ? 2*p*p : 1 - Math.pow(-2*p+2, 2)/2; }
+
+      function render(t) {
+        const phase = PHASES.find(p => t >= p.from && t < p.to) || PHASES[PHASES.length - 1];
+        const phaseProgress = Math.min(1, Math.max(0, (t - phase.from) / (phase.to - phase.from)));
+        const phaseIdx = PHASES.indexOf(phase);
+
+        // Query typing
+        const qp = Math.min(1, t / 1800);
+        queryNode.textContent = QUERY_FULL.substring(0, Math.floor(QUERY_FULL.length * qp));
+
+        // Cells
+        cells.forEach((cell, idx) => {
+          const stageNum = idx + 1;
+          const expectedPhaseIdx = stageNum; // stage1 is idx 1
+          const isActive = phaseIdx === expectedPhaseIdx;
+          const hasPassed = phaseIdx > expectedPhaseIdx;
+          cell.setAttribute('data-active', isActive ? 'true' : 'false');
+          cell.setAttribute('data-passed', hasPassed ? 'true' : 'false');
+
+          const cfg = COUNTS[stageNum];
+          const tiles = cell.querySelectorAll('[data-tiles] > i');
+          const countNode = cell.querySelector('[data-count]');
+
+          let visible;
+          if (!isActive && !hasPassed) {
+            visible = -1;
+          } else if (isActive) {
+            const e = ease(phaseProgress);
+            if (phaseProgress < 0.5) {
+              visible = Math.round(cfg.entry + (cfg.peak - cfg.entry) * (e * 2));
+            } else {
+              visible = Math.round(cfg.peak + (cfg.exit - cfg.peak) * ((e - 0.5) * 2));
+            }
+          } else {
+            visible = cfg.exit;
+          }
+
+          countNode.textContent = visible < 0 ? '—' : visible;
+
+          tiles.forEach((tile, i) => {
+            if (visible < 0) {
+              tile.removeAttribute('data-state');
+              return;
+            }
+            if (i < visible) {
+              if (stageNum === 2 && i < 8) tile.setAttribute('data-state', 'boosted');
+              else if (stageNum === 3 && i >= 38) tile.setAttribute('data-state', 'triple');
+              else if (stageNum === 5 && (i % 4 === 0)) tile.setAttribute('data-state', 'boosted');
+              else tile.setAttribute('data-state', 'kept');
+            } else {
+              tile.setAttribute('data-state', 'rejected');
+            }
+          });
+        });
+
+        // Result frame
+        if (phase.name === 'result') {
+          const visCount = Math.ceil(RESULT_LINES.length * Math.min(1, phaseProgress * 1.2));
+          renderResultLines(visCount);
+        } else if (phaseIdx >= PHASES.findIndex(p => p.name === 'result')) {
+          renderResultLines(RESULT_LINES.length);
+        } else if (phase.name === 'stage6' && phaseProgress > 0.7) {
+          renderResultLines(Math.ceil(2 * (phaseProgress - 0.7) / 0.3));
+        } else {
+          renderResultLines(0);
+        }
+
+        // Scrub + time
+        if (!STATE._scrubbing) scrubNode.value = String(Math.round(t));
+        const sec = (t / 1000).toFixed(1);
+        timeNode.textContent = `${sec.padStart(4, '0')} / 14.0`;
+
+        // Status
+        if (STATE.playing) {
+          statusNode.innerHTML = statusFor(phase.name);
+        } else if (t === 0) {
+          statusNode.innerHTML = 'Idle &middot; auto-plays on scroll';
+        } else if (t >= STATE.duration - 1) {
+          statusNode.innerHTML = 'Done &middot; <span style="color:var(--accent)">0 LLM calls</span> &middot; replay anytime';
+        } else {
+          statusNode.innerHTML = 'Paused';
+        }
+
+        // Play button label
+        playBtn.innerHTML = STATE.playing ? '&#10074;&#10074; Pause' : '&#9654; Play';
+      }
+
+      function tick(now) {
+        if (!STATE.playing) return;
+        const dt = (now - STATE.lastTick) * STATE.speed;
+        STATE.lastTick = now;
+        STATE.t = Math.min(STATE.duration, STATE.t + dt);
+        render(STATE.t);
+        if (STATE.t >= STATE.duration) {
+          STATE.playing = false;
+          root.setAttribute('data-state', 'idle');
+          render(STATE.t);
+          return;
+        }
+        requestAnimationFrame(tick);
+      }
+      function play() {
+        if (STATE.t >= STATE.duration - 1) STATE.t = 0;
+        STATE.playing = true;
+        STATE.lastTick = performance.now();
+        root.setAttribute('data-state', 'playing');
+        requestAnimationFrame(tick);
+        render(STATE.t);
+      }
+      function pause() {
+        STATE.playing = false;
+        root.setAttribute('data-state', 'idle');
+        render(STATE.t);
+      }
+      function replay() { STATE.t = 0; play(); }
+      function setSpeed(s) {
+        STATE.speed = s;
+        root.querySelectorAll('[data-speed]').forEach(b => b.classList.remove('recall-stage__btn--active'));
+        const btn = root.querySelector(`[data-speed="${s}"]`);
+        if (btn) btn.classList.add('recall-stage__btn--active');
+      }
+
+      // Wire controls
+      playBtn.addEventListener('click', () => STATE.playing ? pause() : play());
+      root.querySelector('[data-action="replay"]').addEventListener('click', replay);
+      root.querySelectorAll('[data-speed]').forEach(b => {
+        b.addEventListener('click', () => setSpeed(parseFloat(b.dataset.speed)));
+      });
+      scrubNode.addEventListener('input', (e) => {
+        STATE._scrubbing = true;
+        if (STATE.playing) pause();
+        STATE.t = parseInt(e.target.value, 10);
+        render(STATE.t);
+      });
+      scrubNode.addEventListener('change', () => { STATE._scrubbing = false; });
+
+      // Auto-play on scroll into view (once)
+      const obs = new IntersectionObserver((entries) => {
+        entries.forEach(e => {
+          if (e.isIntersecting && !STATE.autoplayed) {
+            STATE.autoplayed = true;
+            STATE.t = 0;
+            play();
+          }
+        });
+      }, { threshold: 0.4 });
+      obs.observe(root);
+
+      // Initial paint
+      render(0);
+    })();
+    </script>
+
+    <p style="font-family:var(--ff-mono);font-size:11px;text-transform:uppercase;letter-spacing:0.16em;color:var(--paper-dim);text-align:center;margin:8px 0 28px;">Fig. 3 &mdash; Live trace. Same pipeline. Ten memories or ten million. Replay it; it ranks the same.</p>
+
+    <div class="pipeline reveal">
+      <div class="pipeline-step">
+        <div class="step-index">01</div>
+        <div class="step-body">
+          <h3>Vector Top-K</h3>
+          <p>Embed the query (local Ollama bge-m3 by default; cloud providers as fallback) and fetch the 50 nearest memories from pgvector by cosine similarity.</p>
+        </div>
+        <div class="step-engine"><b>pgvector</b>k=50 &middot; cosine</div>
+      </div>
+      <div class="pipeline-step">
+        <div class="step-index">02</div>
+        <div class="step-body">
+          <h3>Graph Narrow</h3>
+          <p>BFS depth&nbsp;&le;&nbsp;2 on the entity graph from each candidate's entity to the question entities. Boosts hits by hop distance; penalises unreachable.</p>
+        </div>
+        <div class="step-engine"><b>Neo4j + GDS</b>BFS &middot; depth &le; 2</div>
+      </div>
+      <div class="pipeline-step">
+        <div class="step-index">03</div>
+        <div class="step-body">
+          <h3>Triples Inject</h3>
+          <p>Inject typed-edge triples (<code>uses</code>, <code>authored-by</code>, <code>supersedes</code>) as synthetic memories so consumers reason over relations, not just text.</p>
+        </div>
+        <div class="step-engine"><b>Graph store</b>typed edges</div>
+      </div>
+      <div class="pipeline-step">
+        <div class="step-index">04</div>
+        <div class="step-body">
+          <h3>MMR Diversity</h3>
+          <p>Maximal Marginal Relevance rerank with &lambda;=0.7 trades relevance against diversity, eliminating near-duplicate candidates while preserving topical coverage.</p>
+        </div>
+        <div class="step-engine"><b>MMR</b>&lambda; = 0.7</div>
+      </div>
+      <div class="pipeline-step">
+        <div class="step-index">05</div>
+        <div class="step-body">
+          <h3>Decay + Boost</h3>
+          <p>Confidence decay penalises stale, low-confidence rows; temporal boost lifts recent writes. Optional BM25/FTS lane fuses with vector via RRF (k=60).</p>
+        </div>
+        <div class="step-engine"><b>Fusion</b>RRF &middot; k=60</div>
+      </div>
+      <div class="pipeline-step">
+        <div class="step-index">06</div>
+        <div class="step-body">
+          <h3>Budget Fit</h3>
+          <p>Greedy monotonic-by-score selection packs the surviving memories into the caller's token budget. The rest never enter context.</p>
+        </div>
+        <div class="step-engine"><b>Greedy</b>token pack</div>
+      </div>
+    </div>
+
+    <!-- Storage roles + flows -->
+    <div style="margin-top:56px;opacity:1;">
+      <h3 style="font-family:var(--ff-display);font-size:28px;letter-spacing:-0.01em;margin:0 0 8px;">Storage roles</h3>
+      <p class="standfirst" style="margin-top:0;">Every memory is persisted across three complementary stores. Every supported backend combo is just a different technology choice for one or more of these roles.</p>
+      <img src="storage-roles.svg" alt="Storage roles — document store, vector store, graph store" style="display:block;width:100%;height:auto;margin-top:24px;border:1px solid var(--rule);">
+      <div style="display:grid;grid-template-columns:repeat(3,1fr);gap:16px;margin-top:24px;">
+        <div style="padding:20px 22px;border:1px solid var(--rule-strong);background:var(--ink-raise);">
+          <div style="font-family:var(--ff-mono);font-size:10px;letter-spacing:0.2em;color:var(--accent);">ROLE &#183; 01</div>
+          <div style="font-family:var(--ff-display);font-size:22px;font-weight:700;margin-top:6px;">Document store</div>
+          <p style="font-size:14px;color:var(--muted);margin:10px 0 0;">Source of truth. Content, tags, entity, category, timestamps, provenance, confidence. Where <code>add()</code> commits and <code>recall()</code> hydrates final text.</p>
+        </div>
+        <div style="padding:20px 22px;border:1px solid var(--rule-strong);background:var(--ink-raise);">
+          <div style="font-family:var(--ff-mono);font-size:10px;letter-spacing:0.2em;color:var(--accent);">ROLE &#183; 02</div>
+          <div style="font-family:var(--ff-display);font-size:22px;font-weight:700;margin-top:6px;">Vector store</div>
+          <p style="font-size:14px;color:var(--muted);margin:10px 0 0;">Dense embedding per memory, keyed by memory ID. Finds memories by <em>meaning</em> when no tag or word overlaps the query.</p>
+        </div>
+        <div style="padding:20px 22px;border:1px solid var(--rule-strong);background:var(--ink-raise);">
+          <div style="font-family:var(--ff-mono);font-size:10px;letter-spacing:0.2em;color:var(--accent);">ROLE &#183; 03</div>
+          <div style="font-family:var(--ff-display);font-size:22px;font-weight:700;margin-top:6px;">Graph store</div>
+          <p style="font-size:14px;color:var(--muted);margin:10px 0 0;">Entity nodes + typed edges (<code>uses</code>, <code>authored-by</code>, <code>supersedes</code>). Query &ldquo;Python&rdquo; can surface &ldquo;Django&rdquo; via the graph.</p>
+        </div>
+      </div>
+    </div>
+
+    <div style="margin-top:48px;opacity:1;">
+      <h3 style="font-family:var(--ff-display);font-size:28px;letter-spacing:-0.01em;margin:0 0 8px;">Ingestion flow &mdash; <em>what happens on</em> <code>add()</code></h3>
+      <pre style="background:var(--ink-raise);border:1px solid var(--rule);padding:20px 24px;font-family:var(--ff-mono);font-size:12px;line-height:1.5;overflow-x:auto;color:var(--paper-dim);">
+                      mem.add(content, tags, entity, ...)
+                                    &#9474;
+              &#9484;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9532;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9488;
+              &#9660;                     &#9660;                     &#9660;
+      &#9484;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9488;     &#9484;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9488;     &#9484;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9488;
+      &#9474; Document      &#9474;     &#9474; Vector        &#9474;     &#9474; Graph         &#9474;
+      &#9474; store         &#9474;     &#9474; store         &#9474;     &#9474; store         &#9474;
+      &#9500;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9508;     &#9500;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9508;     &#9500;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9508;
+      &#9474; insert row    &#9474;     &#9474; embed(text)   &#9474;     &#9474; extract       &#9474;
+      &#9474;  content,     &#9474;     &#9474;  &#8594; 384-d vec  &#9474;     &#9474;  entities +   &#9474;
+      &#9474;  tags, meta,  &#9474;     &#9474; insert keyed  &#9474;     &#9474;  relations    &#9474;
+      &#9474;  provenance   &#9474;     &#9474;  by memory ID &#9474;     &#9474; upsert nodes, &#9474;
+      &#9474;               &#9474;     &#9474;               &#9474;     &#9474; add edges     &#9474;
+      &#9492;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9496;     &#9492;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9496;     &#9492;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9496;
+              &#9474;                     &#9474;                     &#9474;
+              &#9492;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9532;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9496;
+                                    &#9660;
+                     Contradiction check per entity
+                    (older conflicting facts &#8594; superseded,
+                         kept in timeline)
+                                    &#9474;
+                                    &#9660;
+                                  done
+</pre>
+      <p class="caption" style="font-size:13px;color:var(--muted);font-style:italic;">The three writes commit as one logical transaction. On SQL backends it&rsquo;s a real DB transaction; on distributed backends it&rsquo;s sequenced with best-effort rollback.</p>
+    </div>
+
+    <div style="margin-top:48px;opacity:1;">
+      <h3 style="font-family:var(--ff-display);font-size:28px;letter-spacing:-0.01em;margin:0 0 8px;">Recall flow &mdash; <em>what happens on</em> <code>recall()</code></h3>
+      <pre style="background:var(--ink-raise);border:1px solid var(--rule);padding:20px 24px;font-family:var(--ff-mono);font-size:12px;line-height:1.5;overflow-x:auto;color:var(--paper-dim);">
+                  mem.recall(query, budget=2000)
+                               &#9474;
+                               &#9660;
+            &#9484;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9488;
+            &#9474; 01  Vector top-K   &#8594; vec store &#9474;
+            &#9474;     pgvector &#183; cosine &#183; k=50    &#9474;
+            &#9492;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9516;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9496;
+                               &#9660;
+            &#9484;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9488;
+            &#9474; 02  Graph narrow   &#8594; graph     &#9474;
+            &#9474;     Neo4j BFS depth &#8804; 2          &#9474;
+            &#9474;     hop-affinity boost / penalty &#9474;
+            &#9492;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9516;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9496;
+                               &#9660;
+            &#9484;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9488;
+            &#9474; 03  Triples inject               &#9474;
+            &#9474;     uses &#183; authored-by &#183; supersedes &#9474;
+            &#9474;     synthetic-memory facts       &#9474;
+            &#9492;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9516;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9496;
+                               &#9660;
+            &#9484;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9488;
+            &#9474; 04  MMR diversity &#955; = 0.7        &#9474;
+            &#9474; 05  Decay + temporal boost        &#9474;
+            &#9474; 06  Greedy token pack &#8804; budget    &#9474;
+            &#9492;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9516;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9496;
+                               &#9660;
+                  List[RetrievalResult] &#8804; budget
+                          (zero LLM calls)
+
+   Optional BM25 / FTS lane &#8594; fused with the vector lane via RRF k=60
+   when the document store has the content_tsv tsvector column populated.
+</pre>
+      <p class="caption" style="font-size:13px;color:var(--muted);font-style:italic;">Each step takes the previous step&rsquo;s candidate set as input. Only memory IDs travel until the final budget-fit step hydrates the keepers from the document store. A store with ten million rows still returns a tight result set inside the caller&rsquo;s token ceiling.</p>
+    </div>
+
+    <!-- Three pillars — Isolation, Temporal, Provenance -->
+    <div style="margin-top:72px;">
+      <div class="reveal">
+        <h3 style="font-family:var(--ff-display);font-size:clamp(28px,3.2vw,40px);letter-spacing:-0.015em;margin:0 0 10px;">And three things <em style="color:var(--accent);font-style:italic;">most of the industry skipped.</em></h3>
+        <p class="standfirst" style="margin-top:0;">Isolation. Temporal correctness. Provenance. Not features we bolted on. Primitives we started from.</p>
+      </div>
+
+      <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:20px;margin-top:36px;">
+        <div class="reveal" style="padding:26px;border:1px solid var(--rule-strong);background:var(--ink-raise);border-left:3px solid var(--accent);">
+          <div style="font-family:var(--ff-mono);font-size:10px;letter-spacing:0.22em;color:var(--accent);">PILLAR &middot; 01</div>
+          <h4 style="font-family:var(--ff-display);font-size:26px;font-weight:600;margin:8px 0 12px;">Isolation</h4>
+          <p style="font-size:14.5px;line-height:1.65;color:var(--paper-dim);margin:0 0 10px;">Every memory lives inside a <b>namespace</b>. Every agent is bound to one of six <b>roles</b>. Every call is authorised before it touches storage. Enforced at the row level, not in application code.</p>
+          <div style="font-family:var(--ff-mono);font-size:12px;color:var(--muted);line-height:1.7;margin-top:14px;">
+            <span style="color:var(--accent);">&rarr;</span> <b>ORCHESTRATOR</b> &middot; spawns sub-agents<br>
+            <span style="color:var(--accent);">&rarr;</span> <b>PLANNER</b> &middot; writes decisions<br>
+            <span style="color:var(--accent);">&rarr;</span> <b>EXECUTOR</b> &middot; runs the work<br>
+            <span style="color:var(--accent);">&rarr;</span> <b>RESEARCHER</b> &middot; gathers facts<br>
+            <span style="color:var(--accent);">&rarr;</span> <b>REVIEWER</b> &middot; audits decisions<br>
+            <span style="color:var(--accent);">&rarr;</span> <b>MONITOR</b> &middot; observability only
+          </div>
+        </div>
+
+        <div class="reveal" style="padding:26px;border:1px solid var(--rule-strong);background:var(--ink-raise);border-left:3px solid var(--accent);">
+          <div style="font-family:var(--ff-mono);font-size:10px;letter-spacing:0.22em;color:var(--accent);">PILLAR &middot; 02</div>
+          <h4 style="font-family:var(--ff-display);font-size:26px;font-weight:600;margin:8px 0 12px;">Temporal</h4>
+          <p style="font-size:14.5px;line-height:1.65;color:var(--paper-dim);margin:0 0 14px;">Attestor doesn&rsquo;t overwrite. It <b>supersedes</b>. Every fact has a validity window. The timeline is replayable to any point in the past.</p>
+          <div style="font-family:var(--ff-mono);font-size:12px;color:var(--paper);background:var(--ink);border:1px solid var(--rule);padding:14px;line-height:1.6;">
+<b style="color:var(--muted);">v1</b> JPM CFO is Jeremy Barnum<br>
+<span style="color:var(--faint);">&nbsp;&nbsp;&nbsp;valid_from: 2022-05</span><br>
+<span style="color:var(--accent);">&nbsp;&nbsp;&nbsp;&darr; superseded</span><br>
+<b style="color:var(--accent-warm);">v2</b> JPM CFO is Jane Doe<br>
+<span style="color:var(--faint);">&nbsp;&nbsp;&nbsp;valid_from: 2026-04-11</span><br>
+<span style="color:var(--accent);">&nbsp;&nbsp;&nbsp;&darr; superseded</span><br>
+<b style="color:var(--accent);">v3</b> Appointment delayed<br>
+<span style="color:var(--faint);">&nbsp;&nbsp;&nbsp;valid_from: 2026-04-12</span>
+          </div>
+          <p style="font-size:13px;color:var(--muted);font-style:italic;margin:12px 0 0;line-height:1.55;">Ask <code style="font-family:var(--ff-mono);font-size:12px;color:var(--accent);">recall(as_of=&hellip;)</code> to replay the past. Nothing is deleted. Auditors can reconstruct what the desk knew and when.</p>
+        </div>
+
+        <div class="reveal" style="padding:26px;border:1px solid var(--rule-strong);background:var(--ink-raise);border-left:3px solid var(--accent);">
+          <div style="font-family:var(--ff-mono);font-size:10px;letter-spacing:0.22em;color:var(--accent);">PILLAR &middot; 03</div>
+          <h4 style="font-family:var(--ff-display);font-size:26px;font-weight:600;margin:8px 0 12px;">Provenance</h4>
+          <p style="font-size:14.5px;line-height:1.65;color:var(--paper-dim);margin:0 0 14px;">Every sentence the agent writes back is traceable to its source. A cryptographic chain from raw feed ingest to grounded answer.</p>
+          <div style="font-family:var(--ff-mono);font-size:12px;color:var(--paper);background:var(--ink);border:1px solid var(--rule);padding:14px;line-height:1.7;">
+<span style="color:var(--muted);">raw signal</span> <span style="color:var(--accent);">&rarr;</span> <span style="color:var(--muted);">ingest</span><br>
+&nbsp;&nbsp;<span style="color:var(--accent-warm);">source_id &middot; sha256 &middot; ts</span><br>
+<span style="color:var(--accent);">&darr;</span><br>
+<span style="color:var(--muted);">memory row</span><br>
+&nbsp;&nbsp;<span style="color:var(--accent-warm);">id &middot; content &middot; provenance</span><br>
+<span style="color:var(--accent);">&darr;</span><br>
+<span style="color:var(--muted);">semantic-first recall</span><br>
+<span style="color:var(--accent);">&darr;</span><br>
+<b style="color:var(--accent);">agent answer [mem_42]</b>
+          </div>
+          <p style="font-size:13px;color:var(--muted);font-style:italic;margin:12px 0 0;line-height:1.55;">The citation isn&rsquo;t a string the LLM chose. It&rsquo;s the <code style="font-family:var(--ff-mono);font-size:12px;color:var(--accent);">memory_id</code> carried through the pipeline. Click it, land on the raw wire, verify the hash. <em>Grounded, not plausible.</em></p>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════════════════════════
+     § 03.5 · MULTI-LLM COOPERATION
+     ═══════════════════════════════════════════════════ -->
+<section id="cooperation" style="border-top:1px solid var(--rule);">
+  <div class="container">
+    <div class="section-filing reveal">
+      <span class="section-num">&sect; 03.5</span>
+      <span class="section-name">&mdash; Multi-LLM cooperation</span>
+      <span>Many models &middot; one auditable memory</span>
+    </div>
+
+    <div class="reveal">
+      <h2 class="section-head">Many LLMs, one memory. <em>Conflicts resolved on contract,</em> not vibes.</h2>
+      <p class="standfirst">Real agent teams have a planner, an executor, and a reviewer &mdash; often on different model families. They write to the same memory store. Without a contract for how those writes interact, you get duplicate facts, lost edits, and silent overwrites. Attestor ships five mechanisms that turn multi-LLM writes into an auditable transaction log.</p>
+    </div>
+
+    <!-- Five mechanisms grid -->
+    <div style="display:grid;grid-template-columns:repeat(2,1fr);gap:18px;margin-top:32px;">
+
+      <!-- 01 — Write-time supersession -->
+      <div class="reveal" style="padding:26px 28px;border:1px solid var(--rule-strong);background:var(--ink-raise);border-left:3px solid var(--accent);">
+        <div style="font-family:var(--ff-mono);font-size:10px;letter-spacing:0.22em;color:var(--accent);">MECHANISM &middot; 01</div>
+        <h4 style="font-family:var(--ff-display);font-size:24px;font-weight:600;margin:8px 0 12px;">Write-time supersession</h4>
+        <p style="font-size:14.5px;line-height:1.65;color:var(--paper-dim);margin:0 0 14px;">Deterministic. Zero LLM in the loop. On every <code style="font-family:var(--ff-mono);font-size:12px;color:var(--accent);">add()</code>, attestor checks for active rows with the same <code>(entity, category, namespace)</code> and different content. Each match is auto-marked <code>superseded</code> with <code>valid_until=now</code> and <code>superseded_by=&lt;new_id&gt;</code>.</p>
+        <div style="font-family:var(--ff-mono);font-size:12px;color:var(--paper);background:var(--ink);border:1px solid var(--rule);padding:14px;line-height:1.7;">
+<span style="color:var(--muted);"># add()</span><br>
+<span style="color:var(--muted);">  &darr;</span><br>
+<span style="color:var(--accent-warm);">  check_contradictions(memory)</span><br>
+<span style="color:var(--muted);">  &darr;</span><br>
+<span style="color:var(--accent-warm);">  store.insert(memory)</span><br>
+<span style="color:var(--muted);">  &darr;</span><br>
+<span style="color:var(--accent);">  for old in contradictions: supersede(old, memory.id)</span>
+        </div>
+        <p style="font-size:12.5px;color:var(--muted);font-style:italic;margin:12px 0 0;">Old facts are <strong>never deleted</strong>. <code style="font-family:var(--ff-mono);font-size:11px;">recall(as_of=&hellip;)</code> still returns them.</p>
+      </div>
+
+      <!-- 02 — Ingest-time 4-decision contract -->
+      <div class="reveal" style="padding:26px 28px;border:1px solid var(--rule-strong);background:var(--ink-raise);border-left:3px solid var(--accent);">
+        <div style="font-family:var(--ff-mono);font-size:10px;letter-spacing:0.22em;color:var(--accent);">MECHANISM &middot; 02</div>
+        <h4 style="font-family:var(--ff-display);font-size:24px;font-weight:600;margin:8px 0 12px;">Four-decision conflict resolver</h4>
+        <p style="font-size:14.5px;line-height:1.65;color:var(--paper-dim);margin:0 0 14px;">For conversation ingest, every newly extracted fact gets one of four decisions from the LLM. Each carries an <code style="font-family:var(--ff-mono);font-size:12px;color:var(--accent);">evidence_episode_id</code> &mdash; every supersession is auditable.</p>
+        <div style="display:grid;grid-template-columns:auto 1fr;gap:6px 16px;font-family:var(--ff-mono);font-size:12px;line-height:1.6;">
+          <code style="color:var(--accent);">ADD</code>          <span style="color:var(--paper-dim);">no existing match &mdash; write fresh</span>
+          <code style="color:var(--accent);">UPDATE</code>       <span style="color:var(--paper-dim);">refined value, keep id</span>
+          <code style="color:var(--accent);">INVALIDATE</code>   <span style="color:var(--paper-dim);">old contradicted &mdash; mark superseded</span>
+          <code style="color:var(--accent);">NOOP</code>         <span style="color:var(--paper-dim);">already represented &mdash; skip</span>
+        </div>
+        <p style="font-size:12.5px;color:var(--muted);font-style:italic;margin:14px 0 0;">Failsafe: any LLM/parse failure falls back to <code style="font-family:var(--ff-mono);font-size:11px;color:var(--accent);">ADD</code>-by-default. Better a duplicate-ish row than a silent drop.</p>
+      </div>
+
+      <!-- 03 — Speaker-locked extraction -->
+      <div class="reveal" style="padding:26px 28px;border:1px solid var(--rule-strong);background:var(--ink-raise);">
+        <div style="font-family:var(--ff-mono);font-size:10px;letter-spacing:0.22em;color:var(--accent);">MECHANISM &middot; 03</div>
+        <h4 style="font-family:var(--ff-display);font-size:24px;font-weight:600;margin:8px 0 12px;">Speaker-locked extraction</h4>
+        <p style="font-size:14.5px;line-height:1.65;color:var(--paper-dim);margin:0 0 14px;">Two passes per round, with separate prompts. User-turn extractor only emits facts attributable to the user; assistant-turn extractor only emits facts the assistant introduced. Stops cross-attribution &mdash; the &ldquo;Mem0 +53.6&rdquo; fix in our LongMemEval scores.</p>
+        <div style="font-family:var(--ff-mono);font-size:12px;color:var(--paper);background:var(--ink);border:1px solid var(--rule);padding:14px;line-height:1.7;">
+<span style="color:var(--muted);">user turn &rarr;</span> <span class="kw" style="color:var(--accent-warm);">extract_user_facts(turn)</span><br>
+<span style="color:var(--muted);">                     &darr; speaker = "user"</span><br>
+<br>
+<span style="color:var(--muted);">assistant turn &rarr;</span> <span class="kw" style="color:var(--accent-warm);">extract_agent_facts(turn)</span><br>
+<span style="color:var(--muted);">                          &darr; speaker = "&lt;agent_id&gt;"</span>
+        </div>
+      </div>
+
+      <!-- 04 — Sleep-time reflection -->
+      <div class="reveal" style="padding:26px 28px;border:1px solid var(--rule-strong);background:var(--ink-raise);">
+        <div style="font-family:var(--ff-mono);font-size:10px;letter-spacing:0.22em;color:var(--accent);">MECHANISM &middot; 04</div>
+        <h4 style="font-family:var(--ff-display);font-size:24px;font-weight:600;margin:8px 0 12px;">Sleep-time reflection</h4>
+        <p style="font-size:14.5px;line-height:1.65;color:var(--paper-dim);margin:0 0 14px;">Periodic synthesis across a user&rsquo;s recent facts. One LLM call distills many episodes into structured outputs:</p>
+        <ul style="font-family:var(--ff-mono);font-size:12px;color:var(--paper-dim);line-height:1.85;margin:0 0 12px;padding-left:20px;">
+          <li><code style="color:var(--accent);">stable_preferences</code> &mdash; patterns appearing in 3+ episodes</li>
+          <li><code style="color:var(--accent);">stable_constraints</code> &mdash; rules the user repeatedly invokes</li>
+          <li><code style="color:var(--accent);">changed_beliefs</code> &mdash; preferences shifted (old &rarr; new)</li>
+          <li><code style="color:var(--accent);">contradictions_for_review</code> &mdash; flagged, <strong>not auto-resolved</strong></li>
+        </ul>
+        <p style="font-size:12.5px;color:var(--muted);font-style:italic;margin:0;">Hard contradictions in regulated chat systems must be a human decision &mdash; the prompt is explicit: <em>do NOT auto-resolve</em>.</p>
+      </div>
+
+      <!-- 05 — Dual-judge anti-collusion -->
+      <div class="reveal" style="padding:26px 28px;border:1px solid var(--rule-strong);background:var(--ink-raise);grid-column:1 / span 2;border-left:3px solid var(--accent);">
+        <div style="font-family:var(--ff-mono);font-size:10px;letter-spacing:0.22em;color:var(--accent);">MECHANISM &middot; 05</div>
+        <h4 style="font-family:var(--ff-display);font-size:24px;font-weight:600;margin:8px 0 12px;">Dual-judge benchmarking &mdash; anti-collusion by construction</h4>
+        <p style="font-size:14.5px;line-height:1.65;color:var(--paper-dim);margin:0 0 14px;">Every LongMemEval answer is scored by <strong>two independent judges from different model families</strong> &mdash; the second judge anchors out answerer-judge collusion. Same model judging its own answer rewards itself; cross-family judging surfaces real disagreement.</p>
+        <div style="display:grid;grid-template-columns:1fr auto 1fr;gap:18px;align-items:center;">
+          <div style="font-family:var(--ff-mono);font-size:13px;background:var(--ink);border:1px solid var(--rule-strong);padding:14px;text-align:center;">
+            <div style="color:var(--muted);font-size:11px;letter-spacing:0.18em;">JUDGE 01</div>
+            <div style="color:var(--accent);margin-top:6px;">openai/gpt-5.2</div>
+          </div>
+          <div style="font-family:var(--ff-mono);font-size:11px;color:var(--muted);text-align:center;letter-spacing:0.16em;">vs cross<br>family</div>
+          <div style="font-family:var(--ff-mono);font-size:13px;background:var(--ink);border:1px solid var(--rule-strong);padding:14px;text-align:center;">
+            <div style="color:var(--muted);font-size:11px;letter-spacing:0.18em;">JUDGE 02</div>
+            <div style="color:var(--accent);margin-top:6px;">anthropic/claude-sonnet-4.6</div>
+          </div>
+        </div>
+        <p style="font-size:12.5px;color:var(--muted);font-style:italic;margin:14px 0 0;">The <code style="font-family:var(--ff-mono);font-size:11px;color:var(--accent);">scripts/lme_smoke_local.py</code> driver runs this exact dual-judge stack against your install. See the Quickstart &raquo; <em>Smoke benchmark</em> tab.</p>
+      </div>
+
+    </div>
+
+    <!-- Provenance closing line -->
+    <div class="reveal" style="margin-top:36px;padding:22px 26px;border:1px dashed var(--rule-strong);background:var(--ink-raise);">
+      <div style="font-family:var(--ff-mono);font-size:10px;letter-spacing:0.22em;color:var(--accent);margin-bottom:8px;">PROVENANCE INVARIANT</div>
+      <p style="font-size:14.5px;line-height:1.65;color:var(--paper);margin:0;">Every memory carries <code style="font-family:var(--ff-mono);font-size:12px;color:var(--accent);">agent_id</code>, <code style="font-family:var(--ff-mono);font-size:12px;color:var(--accent);">session_id</code>, and <code style="font-family:var(--ff-mono);font-size:12px;color:var(--accent);">source_episode_id</code>. Every <code style="font-family:var(--ff-mono);font-size:12px;color:var(--accent);">supersede</code> writes the prior id into <code style="font-family:var(--ff-mono);font-size:12px;color:var(--accent);">superseded_by</code>. Cryptographic signing is opt-in (Phase 8.1). The result: any disputed answer can be traced back to <em>which agent wrote which fact, when, and what it superseded</em>.</p>
+    </div>
+
+  </div>
+</section>
+
+<!-- ═══════════════════════════════════════════════════
+     § 05 · DEPLOY
+     ═══════════════════════════════════════════════════ -->
+<section id="platforms">
+  <div class="container">
+    <div class="section-filing reveal">
+      <span class="section-num">&sect; 04</span>
+      <span class="section-name">&mdash; Deployment Matrix</span>
+      <span>Your cloud &middot; your infrastructure &middot; Terraform included</span>
+    </div>
+
+    <div class="reveal">
+      <h2 class="section-head">Same API. <em>Every backend.</em> Your infrastructure.</h2>
+      <p class="standfirst">One Python library. One Starlette ASGI container. Six deployment targets &mdash; laptop, dev VM, AWS, Azure, GCP, on&#8209;prem. The three storage roles swap per column. Your agent code never learns which backend it&rsquo;s talking to. Terraform templates live under <code style="font-family:var(--ff-mono);font-size:15px;color:var(--accent);background:var(--ink-raise);padding:2px 8px;border:1px solid var(--rule);">agent_memory/infra/</code>. <em>Clone. Set your variables. <code style="font-family:var(--ff-mono);font-size:15px;color:var(--accent);background:var(--ink-raise);padding:2px 8px;border:1px solid var(--rule);">terraform apply</code>.</em></p>
+    </div>
+
+    <div class="reveal" style="margin:36px 0 40px;padding:28px 32px;background:var(--ink-raise);border:1px solid var(--rule-strong);border-left:4px solid var(--accent);border-radius:4px;">
+      <div style="font-family:var(--ff-mono);font-size:12px;text-transform:uppercase;letter-spacing:0.18em;color:var(--accent);margin-bottom:10px;">Run it on your laptop. No cloud, no cost.</div>
+      <h3 style="font-family:var(--ff-display);font-size:28px;font-weight:500;margin:0 0 14px;color:var(--paper);">Self-host locally in <em>one command</em>.</h3>
+      <pre style="background:var(--ink);color:var(--paper);font-family:var(--ff-mono);font-size:14px;padding:18px 22px;border:1px solid var(--rule-strong);border-radius:4px;overflow-x:auto;margin:0 0 14px;"><span style="color:var(--accent);">$</span> pip install attestor
+<span style="color:var(--accent);">$</span> attestor api --host 0.0.0.0 --port 8080</pre>
+      <p style="margin:0;color:var(--paper-dim);font-size:15px;line-height:1.7;">Starlette ASGI on <code style="font-family:var(--ff-mono);font-size:13px;background:var(--ink);color:var(--paper);padding:2px 6px;border:1px solid var(--rule-strong);border-radius:3px;">http://localhost:8080</code>. Run <code style="font-family:var(--ff-mono);font-size:13px;background:var(--ink);color:var(--paper);padding:2px 6px;border:1px solid var(--rule-strong);border-radius:3px;">attestor setup local</code> to bring up Postgres&nbsp;16 + Neo4j (with GDS) via the bundled Docker Compose. Point every agent in your stack at the same URL &mdash; they share memory instantly. No SaaS. No API keys. Air-gap it behind your firewall and walk away.</p>
+    </div>
+
+    <div class="matrix reveal">
+      <div class="matrix-cell">
+        <span class="matrix-tag">Cloud &middot; 01</span>
+        <h3>AWS</h3>
+        <p>App Runner with Starlette ASGI. Auto-scaling, HTTPS, custom domains.</p>
+        <div class="matrix-spec">2 CPU &middot; 4 GB &middot; us-west-2</div>
+      </div>
+      <div class="matrix-cell">
+        <span class="matrix-tag">Cloud &middot; 02</span>
+        <h3>Azure</h3>
+        <p>Container Apps with Cosmos DB DiskANN. Scale-to-zero. Same API, same results.</p>
+        <div class="matrix-spec">2 CPU &middot; 4 GB &middot; eastus</div>
+      </div>
+      <div class="matrix-cell">
+        <span class="matrix-tag">Cloud &middot; 03</span>
+        <h3>GCP</h3>
+        <p>Cloud Run with AlloyDB. Scale-to-zero. Google's managed infrastructure.</p>
+        <div class="matrix-spec">2 CPU &middot; 4 GB &middot; us-central1</div>
+      </div>
+      <div class="matrix-cell">
+        <span class="matrix-tag">Backend &middot; 04</span>
+        <h3>PostgreSQL</h3>
+        <p>pgvector + Apache AGE. Neon serverless or any Postgres 16.</p>
+        <div class="matrix-spec">Doc &middot; Vector &middot; Graph</div>
+      </div>
+      <div class="matrix-cell">
+        <span class="matrix-tag">Backend &middot; 05</span>
+        <h3>ArangoDB</h3>
+        <p>Multi-model: graph + document + vector in one engine. Oasis or self-hosted.</p>
+        <div class="matrix-spec">Native graph traversal</div>
+      </div>
+      <div class="matrix-cell">
+        <span class="matrix-tag">Backend &middot; 06</span>
+        <h3>Local / On-Prem</h3>
+        <p>Postgres + pgvector + Neo4j via Docker Compose. Air-gapped deployments. Full data sovereignty.</p>
+        <div class="matrix-spec">No network egress</div>
+      </div>
+    </div>
+
+    <!-- Same container, pluggable stores -->
+    <div style="margin-top:56px;opacity:1;">
+      <h3 style="font-family:var(--ff-display);font-size:28px;letter-spacing:-0.01em;margin:0 0 8px;">Same container. <em>Pluggable stores.</em></h3>
+      <p class="standfirst" style="margin-top:0;">One Attestor image. Six targets. The three storage roles swap per column. That&rsquo;s the whole trick.</p>
+      <figure class="reveal" style="margin:24px auto 8px;max-width:1100px;background:var(--ink-raise);border:1px solid var(--rule-strong);border-radius:6px;padding:20px;">
+        <img src="deployment-matrix.svg" alt="Deployment matrix — one container, six targets, stores swap per column" style="display:block;width:100%;height:auto;">
+        <figcaption style="font-family:var(--ff-mono);font-size:11px;text-transform:uppercase;letter-spacing:0.16em;color:var(--paper-dim);text-align:center;margin-top:12px;">Fig. 4 &mdash; <em>DocumentStore</em>, <em>VectorStore</em>, <em>GraphStore</em> &mdash; three interfaces. Every column is one triple of implementations.</figcaption>
+      </figure>
+      <div style="display:grid;grid-template-columns:repeat(5,1fr);gap:12px;margin-top:20px;font-size:13px;">
+        <div style="padding:16px;border:1px solid var(--rule-strong);background:var(--ink-raise);">
+          <div style="font-family:var(--ff-mono);font-size:10px;letter-spacing:0.2em;color:var(--accent);">LANE &#183; 01</div>
+          <div style="font-family:var(--ff-display);font-size:18px;font-weight:700;margin:6px 0 10px;">Laptop</div>
+          <div style="color:var(--muted);line-height:1.6;"><code>attestor setup local</code><br><b>Doc:</b> Postgres 16<br><b>Vec:</b> pgvector<br><b>Graph:</b> Neo4j + GDS</div>
+        </div>
+        <div style="padding:16px;border:1px solid var(--rule-strong);background:var(--ink-raise);">
+          <div style="font-family:var(--ff-mono);font-size:10px;letter-spacing:0.2em;color:var(--accent);">LANE &#183; 02</div>
+          <div style="font-family:var(--ff-display);font-size:18px;font-weight:700;margin:6px 0 10px;">Self-host</div>
+          <div style="color:var(--muted);line-height:1.6;">Docker &middot; any cloud<br><b>Doc:</b> Postgres 16<br><b>Vec:</b> pgvector<br><b>Graph:</b> Apache AGE</div>
+        </div>
+        <div style="padding:16px;border:1px solid var(--rule-strong);background:var(--ink-raise);">
+          <div style="font-family:var(--ff-mono);font-size:10px;letter-spacing:0.2em;color:var(--accent);">LANE &#183; 03</div>
+          <div style="font-family:var(--ff-display);font-size:18px;font-weight:700;margin:6px 0 10px;">AWS</div>
+          <div style="color:var(--muted);line-height:1.6;">App Runner<br><b>All 3 roles:</b><br>ArangoDB Oasis<br><em>one engine</em></div>
+        </div>
+        <div style="padding:16px;border:1px solid var(--rule-strong);background:var(--ink-raise);">
+          <div style="font-family:var(--ff-mono);font-size:10px;letter-spacing:0.2em;color:var(--accent);">LANE &#183; 04</div>
+          <div style="font-family:var(--ff-display);font-size:18px;font-weight:700;margin:6px 0 10px;">GCP</div>
+          <div style="color:var(--muted);line-height:1.6;">Cloud Run<br><b>All 3 roles:</b><br>AlloyDB +<br>pgvector + AGE</div>
+        </div>
+        <div style="padding:16px;border:1px solid var(--rule-strong);background:var(--ink-raise);">
+          <div style="font-family:var(--ff-mono);font-size:10px;letter-spacing:0.2em;color:var(--accent);">LANE &#183; 05</div>
+          <div style="font-family:var(--ff-display);font-size:18px;font-weight:700;margin:6px 0 10px;">Azure</div>
+          <div style="color:var(--muted);line-height:1.6;">Container Apps<br><b>All 3 roles:</b><br>Cosmos DB<br>DiskANN</div>
+        </div>
+      </div>
+      <p class="caption" style="font-size:13px;color:var(--muted);font-style:italic;margin-top:14px;">Every deployment is the same Python library wrapped in the same Starlette ASGI container. <code>DocumentStore</code>, <code>VectorStore</code>, and <code>GraphStore</code> are three interfaces; each column above is one implementation triple.</p>
+    </div>
+
+    <!-- Promotion path -->
+    <div style="margin-top:56px;opacity:1;">
+      <h3 style="font-family:var(--ff-display);font-size:28px;letter-spacing:-0.01em;margin:0 0 8px;">Promotion path &mdash; <em>laptop to cloud, no rewrite.</em></h3>
+      <p class="standfirst" style="margin-top:0;">Prototype on a laptop. Promote to Docker Compose on a dev VM. Promote to a managed container runtime. Same API throughout. Only the storage URLs change.</p>
+      <figure class="reveal" style="margin:24px auto 8px;max-width:1100px;background:var(--ink-raise);border:1px solid var(--rule-strong);border-radius:6px;padding:20px;">
+        <img src="promotion-path.svg" alt="Promotion path — laptop to dev VM to managed cloud, same API rail throughout" style="display:block;width:100%;height:auto;">
+        <figcaption style="font-family:var(--ff-mono);font-size:11px;text-transform:uppercase;letter-spacing:0.16em;color:var(--paper-dim);text-align:center;margin-top:12px;">Fig. 5 &mdash; The same rail runs under every stop. The code never learns which cloud it&rsquo;s on.</figcaption>
+      </figure>
+    </div>
+
+    <!-- Runtime topology — three integration modes -->
+    <div style="margin-top:56px;opacity:1;">
+      <h3 style="font-family:var(--ff-display);font-size:28px;letter-spacing:-0.01em;margin:0 0 8px;">Three shapes. <em>Pick by blast radius.</em></h3>
+      <p class="standfirst" style="margin-top:0;">Same engine. Same storage. Same retrieval. Different coupling. Pick by latency budget and how many agents share the tier.</p>
+      <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:16px;margin-top:24px;">
+        <div class="reveal" style="padding:22px;border:1px solid var(--rule-strong);background:var(--ink-raise);">
+          <div style="font-family:var(--ff-mono);font-size:10px;letter-spacing:0.22em;color:var(--accent);">MODE A</div>
+          <h4 style="font-family:var(--ff-display);font-size:22px;font-weight:600;margin:6px 0 10px;">Embedded library</h4>
+          <p style="font-size:14px;color:var(--paper-dim);line-height:1.6;margin:0 0 12px;"><code style="font-family:var(--ff-mono);font-size:12px;color:var(--accent);">AgentMemory(&rsquo;./store&rsquo;)</code> in&#8209;process. Sub&#8209;millisecond. Right for a single agent prototyping on a laptop.</p>
+          <div style="font-family:var(--ff-mono);font-size:11px;color:var(--muted);text-transform:uppercase;letter-spacing:0.12em;">Latency &middot; lowest</div>
+        </div>
+        <div class="reveal" style="padding:22px;border:1px solid var(--rule-strong);background:var(--ink-raise);">
+          <div style="font-family:var(--ff-mono);font-size:10px;letter-spacing:0.22em;color:var(--accent);">MODE B</div>
+          <h4 style="font-family:var(--ff-display);font-size:22px;font-weight:600;margin:6px 0 10px;">Sidecar container</h4>
+          <p style="font-size:14px;color:var(--paper-dim);line-height:1.6;margin:0 0 12px;"><code style="font-family:var(--ff-mono);font-size:12px;color:var(--accent);">attestor api</code> on <code style="font-family:var(--ff-mono);font-size:12px;color:var(--accent);">localhost:8080</code>. Any language. Go or Rust agents call HTTP without Python in the image.</p>
+          <div style="font-family:var(--ff-mono);font-size:11px;color:var(--muted);text-transform:uppercase;letter-spacing:0.12em;">Isolation &middot; process</div>
+        </div>
+        <div class="reveal" style="padding:22px;border:1px solid var(--rule-strong);background:var(--ink-raise);border:1px solid var(--accent);">
+          <div style="font-family:var(--ff-mono);font-size:10px;letter-spacing:0.22em;color:var(--accent);">MODE C</div>
+          <h4 style="font-family:var(--ff-display);font-size:22px;font-weight:600;margin:6px 0 10px;">Shared service</h4>
+          <p style="font-size:14px;color:var(--paper-dim);line-height:1.6;margin:0 0 12px;">One Attestor service in front of an agent mesh. App Runner &middot; Cloud Run &middot; Container Apps. Managed storage behind. This is the production shape.</p>
+          <div style="font-family:var(--ff-mono);font-size:11px;color:var(--muted);text-transform:uppercase;letter-spacing:0.12em;">Scale &middot; multi&#8209;agent mesh</div>
+        </div>
+      </div>
+      <p class="caption" style="font-size:13px;color:var(--muted);font-style:italic;margin-top:18px;">Code path is identical across all three. Only configuration changes.</p>
+    </div>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════════════════════════
+     ONE MORE THING · CLAUDE CODE
+     ═══════════════════════════════════════════════════ -->
+<section id="claude-moment" style="padding:96px 0;background:var(--ink-raise);border-top:1px solid var(--rule);border-bottom:1px solid var(--rule);">
+  <div class="container">
+    <div class="reveal" style="text-align:center;">
+      <div style="font-family:var(--ff-mono);font-size:11px;letter-spacing:0.28em;text-transform:uppercase;color:var(--accent);margin-bottom:20px;">&mdash; And one more thing &mdash;</div>
+      <h2 style="font-family:var(--ff-display);font-variation-settings:'opsz' 144,'wght' 380;font-size:clamp(36px,5vw,64px);line-height:1.05;letter-spacing:-0.02em;color:var(--paper);max-width:20ch;margin:0 auto 20px;">For Claude Code, it&rsquo;s <em style="color:var(--accent);font-style:italic;font-variation-settings:'opsz' 144,'wght' 320;">three words.</em></h2>
+      <p style="font-family:var(--ff-display);font-variation-settings:'opsz' 18,'wght' 400;font-size:20px;line-height:1.55;color:var(--paper-dim);max-width:56ch;margin:0 auto 32px;">Not a config file. Not an MCP setup guide. Three words in your terminal. Attestor interviews you, installs itself, wires the hooks, and runs a health check before you&rsquo;ve put the kettle on.</p>
+      <div class="hero-install" onclick="copyToClipboard(this, 'install agent memory')" title="Click to copy" style="display:inline-flex;max-width:420px;margin:0 auto;">
+        <span>install agent memory</span>
+        <span class="copy-icon">&#x2398;</span>
+      </div>
+      <p style="font-family:var(--ff-mono);font-size:11px;letter-spacing:0.14em;text-transform:uppercase;color:var(--muted);margin-top:18px;">Paste into Claude Code &middot; global or project scope &middot; auto&#8209;merges MCP config</p>
+    </div>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════════════════════════
+     § 06 · QUICKSTART
+     ═══════════════════════════════════════════════════ -->
+<section id="quickstart">
+  <div class="container">
+    <div class="section-filing reveal">
+      <span class="section-num">&sect; 05</span>
+      <span class="section-name">&mdash; Or do it yourself, in three lines</span>
+      <span>Python library &middot; REST API &middot; MCP protocol</span>
+    </div>
+
+    <div class="reveal">
+      <h2 class="section-head">Three lines of Python. <em>That&rsquo;s the integration.</em></h2>
+      <p class="standfirst">Same call surface whether Attestor runs in&#8209;process on your laptop or behind a Cloud Run service. Pick the interface. Ship.</p>
+    </div>
+
+    <div class="reveal">
+      <div class="tabs">
+        <button class="tab-btn active" onclick="switchTab(event, 'tab-python')"><span class="tab-num">01</span>Python API</button>
+        <button class="tab-btn" onclick="switchTab(event, 'tab-rest')"><span class="tab-num">02</span>REST API</button>
+        <button class="tab-btn" onclick="switchTab(event, 'tab-mcp')"><span class="tab-num">03</span>MCP</button>
+        <button class="tab-btn" onclick="switchTab(event, 'tab-smoke')"><span class="tab-num">04</span>Smoke benchmark</button>
+      </div>
+
+      <div id="tab-python" class="tab-panel active">
+        <div class="code-block" data-lang="Python &middot; Multi-agent pipeline"><button class="code-copy-btn" onclick="copyCodeBlock(this)">Copy</button><span class="keyword">from</span> <span class="fn">attestor</span> <span class="keyword">import</span> AgentMemory
+<span class="keyword">from</span> <span class="fn">agent_memory.context</span> <span class="keyword">import</span> AgentContext, AgentRole
+
+<span class="comment"># Orchestrator context &mdash; root of a multi-agent pipeline</span>
+ctx = AgentContext.<span class="fn">from_env</span>(
+    agent_id=<span class="string">"orchestrator"</span>,
+    namespace=<span class="string">"project:acme"</span>,
+    role=AgentRole.ORCHESTRATOR,
+    token_budget=<span class="string">20000</span>,
+)
+
+<span class="comment"># Spawn sub-agents with inherited provenance</span>
+planner = ctx.<span class="fn">as_agent</span>(<span class="string">"planner"</span>, role=AgentRole.PLANNER)
+planner.<span class="fn">add_memory</span>(<span class="string">"Use event sourcing for the order service"</span>,
+                   category=<span class="string">"technical"</span>, entity=<span class="string">"order-service"</span>)
+
+<span class="comment"># Executor reads what planner wrote &mdash; same namespace, ranked recall</span>
+executor = ctx.<span class="fn">as_agent</span>(<span class="string">"executor"</span>, role=AgentRole.EXECUTOR)
+results = executor.<span class="fn">recall</span>(<span class="string">"order service architecture"</span>, budget=<span class="string">2000</span>)</div>
+      </div>
+
+      <div id="tab-rest" class="tab-panel">
+        <div class="code-block" data-lang="Bash &middot; Starlette ASGI"><button class="code-copy-btn" onclick="copyCodeBlock(this)">Copy</button><span class="comment"># Run as a REST API (Starlette ASGI + Uvicorn)</span>
+<span class="cmd">$ attestor api --host 0.0.0.0 --port 8080</span>
+
+<span class="comment"># Same container ships to AWS App Runner, GCP Cloud Run,</span>
+<span class="comment"># or Azure Container Apps. Terraform templates in attestor/infra/.</span>
+
+<span class="comment"># Eight endpoints, Terraform included:</span>
+<span class="comment">#   POST /add         /recall       /search</span>
+<span class="comment">#   POST /timeline    /forget       GET /stats</span>
+<span class="comment">#   GET  /memory/:id  /health</span>
+<span class="comment"># Envelope: {"ok": true, "data": {...}}</span></div>
+      </div>
+
+      <div id="tab-mcp" class="tab-panel">
+        <div class="code-block" data-lang="JSON &middot; Any MCP client"><button class="code-copy-btn" onclick="copyCodeBlock(this)">Copy</button><span class="comment"># Any MCP-compatible client (Claude Code, Cursor,</span>
+<span class="comment"># Windsurf, or a custom agent speaking stdio MCP)</span>
+<span class="cmd">$ poetry add attestor</span>
+
+<span class="comment"># Add to your client's MCP config:</span>
+{
+  <span class="string">"mcpServers"</span>: {
+    <span class="string">"memory"</span>: {
+      <span class="string">"command"</span>: <span class="string">"attestor"</span>,
+      <span class="string">"args"</span>: [<span class="string">"mcp"</span>]
+    }
+  }
+}
+
+<span class="comment"># Agents get eight tools:</span>
+<span class="comment">#   memory_add        memory_recall     memory_search</span>
+<span class="comment">#   memory_get        memory_forget     memory_timeline</span>
+<span class="comment">#   memory_stats      memory_health</span></div>
+      </div>
+
+      <div id="tab-smoke" class="tab-panel">
+        <div class="code-block" data-lang="Bash &middot; Dual-LLM smoke benchmark"><button class="code-copy-btn" onclick="copyCodeBlock(this)">Copy</button><span class="comment"># Run a tiny LongMemEval smoke against your local install.</span>
+<span class="comment"># Defaults: dual-LLM cross-family judging + OpenAI embeddings.</span>
+<span class="cmd">$ export OPENAI_API_KEY=...</span>
+<span class="cmd">$ .venv/bin/python scripts/lme_smoke_local.py --n 2</span>
+
+<span class="comment"># Default stack (override any of these via env or CLI flag):</span>
+<span class="comment">#   answerer  : openai/gpt-5.2</span>
+<span class="comment">#   judges    : openai/gpt-5.2 + anthropic/claude-sonnet-4.6  (dual)</span>
+<span class="comment">#   distiller : openai/gpt-5.2  (Mem0-style fact extraction on)</span>
+<span class="comment">#   embedder  : text-embedding-3-large @ 1024-D (schema-compat)</span>
+
+<span class="comment"># Swap any slot in one line — env var or CLI flag, your call:</span>
+<span class="cmd">$ ANSWER_MODEL=openai/gpt-4.1-mini python scripts/lme_smoke_local.py --n 2</span>
+<span class="cmd">$ python scripts/lme_smoke_local.py --judge-model openai/gpt-5.2 \</span>
+<span class="cmd">                                   --judge-model anthropic/claude-haiku-4.5</span>
+
+<span class="comment"># Everything else is also configurable:</span>
+<span class="comment">#   --embedding-model / --embedding-dim   pin embedder + dim</span>
+<span class="comment">#   --variant {oracle,s,m}  --n N         dataset slice + size</span>
+<span class="comment">#   --parallel K  --budget T              concurrency + token budget</span>
+<span class="comment">#   --no-distill                          turn off Mem0-style distillation</span>
+<span class="comment">#   --pg-url postgres://&hellip;                target a different Postgres</span></div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════════════════════════
+     § 07 · PRINCIPLES
+     ═══════════════════════════════════════════════════ -->
+<section id="principles">
+  <div class="container">
+    <div class="section-filing reveal">
+      <span class="section-num">&sect; 06</span>
+      <span class="section-name">&mdash; Design Principles</span>
+      <span>Opinionated &middot; on purpose</span>
+    </div>
+
+    <div class="reveal">
+      <h2 class="section-head">Five stakes in the ground.</h2>
+      <p class="standfirst">What we won&rsquo;t compromise on &mdash; no matter how loud the pressure gets.</p>
+    </div>
+
+    <div class="manifesto">
+      <p class="manifesto-line reveal" data-num="I.">Your data stays in <em>your</em> infrastructure. Self&#8209;hosted, always.</p>
+      <p class="manifesto-line reveal" data-num="II.">Retrieval is <em>deterministic.</em> No LLM judges. No hidden inference in the path.</p>
+      <p class="manifesto-line reveal" data-num="III.">One <code>recall()</code>. Every backend. <em>Swap without rewriting.</em></p>
+      <p class="manifesto-line reveal" data-num="IV.">Agent teams are <em>first&#8209;class.</em> Not a bolt&#8209;on.</p>
+      <p class="manifesto-line reveal" data-num="V.">Boring where it counts. Proven, <em>debuggable</em>, no magic.</p>
+    </div>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════════════════════════
+     LIVE BENCHMARK
+     ═══════════════════════════════════════════════════ -->
+<section id="bench-live" style="border-top:1px solid var(--rule);padding:64px 0;">
+  <div class="container">
+    <div class="section-filing reveal">
+      <span class="section-num">&sect; 06</span>
+      <span class="section-name">&mdash; Live benchmark</span>
+      <span>LongMemEval-S &middot; verdicts on demand</span>
+    </div>
+
+    <div class="reveal" style="margin-top:32px;">
+      <h2 class="section-head">Numbers we don't stamp here. <em>Numbers you watch live.</em></h2>
+      <p class="standfirst">
+        Attestor's LongMemEval-S verdicts &mdash; per question, per judge, per release &mdash;
+        are tracked on Braintrust. Every release reruns the four LME-S categories
+        (temporal&#8209;reasoning, multi&#8209;session, knowledge&#8209;update,
+        single&#8209;session-user) against the canonical configured stack. CI fails
+        any PR that regresses past threshold.
+      </p>
+      <p style="margin-top:24px;">
+        <a href="https://www.braintrust.dev/app/bolnet/p/attestor-lme-s"
+           target="_blank" rel="noopener"
+           style="font-family:var(--ff-mono);font-size:15px;color:var(--accent);background:var(--ink-raise);padding:10px 18px;border:1px solid var(--rule);text-decoration:none;display:inline-block;">
+          View live verdicts on Braintrust &rarr;
+        </a>
+      </p>
+    </div>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════════════════════════
+     CLOSING
+     ═══════════════════════════════════════════════════ -->
+<section id="closing">
+  <div class="container">
+    <div class="section-filing reveal">
+      <span class="section-num">&sect; &infin;</span>
+      <span class="section-name">&mdash; Available today</span>
+      <span>MIT &middot; PyPI &middot; MCP Registry</span>
+    </div>
+
+    <h2 class="closing-head reveal">Point every agent at <em>one URL.</em><br>They share memory instantly.</h2>
+
+    <div class="closing-row reveal">
+      <div class="closing-install" onclick="copyToClipboard(this, 'pip install attestor')" title="Click to copy">
+        <span>pip install attestor</span>
+        <span class="copy-icon">&#x2398;</span>
+      </div>
+      <a href="https://github.com/bolnet/attestor" class="btn btn-primary" target="_blank" rel="noopener">GitHub &rarr;</a>
+      <a href="https://pypi.org/project/attestor/" class="btn btn-ghost" target="_blank" rel="noopener">PyPI</a>
+      <a href="https://registry.modelcontextprotocol.io/servers/io.github.bolnet/attestor" class="btn btn-ghost" target="_blank" rel="noopener">MCP Registry</a>
+    </div>
+
+    <p class="closing-byline reveal">MIT. Self&#8209;hosted. Deterministic. Production deploy in one command. Designed and built by <a href="https://www.linkedin.com/in/singhsurendra/" target="_blank" rel="noopener">Surendra Singh</a> &mdash; building auditable infrastructure for multi-agent AI, with fifteen years of production-systems discipline brought to the memory layer. <em>Thank you.</em></p>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════════════════════════
+     COLOPHON (FOOTER)
+     ═══════════════════════════════════════════════════ -->
+<footer class="colophon">
+  <div class="container">
+    <div class="colophon-grid">
+      <div>
+        <div class="col-label">Colophon</div>
+        <p class="colophon-body">Attestor is typeset in <em>Fraunces</em> by Undercase Type and <em>IBM Plex Sans</em> by Bold Monday. Source listings are set in <em>JetBrains Mono</em>. The journal is published under MIT and may be forked, adapted, or redistributed without royalty.</p>
+      </div>
+      <div>
+        <div class="col-label">Masthead</div>
+        <ul class="colophon-list">
+          <li>Editor &mdash; <a href="https://www.linkedin.com/in/singhsurendra/" target="_blank" rel="noopener">Surendra Singh</a></li>
+          <li>Infrastructure &mdash; Your cloud</li>
+          <li>Retrieval &mdash; Deterministic</li>
+          <li>Publisher &mdash; Bolnet</li>
+        </ul>
+      </div>
+      <div>
+        <div class="col-label">Filing</div>
+        <ul class="colophon-list">
+          <li><a href="privacy.html">Privacy</a></li>
+          <li><a href="https://github.com/bolnet/attestor/blob/main/LICENSE" target="_blank" rel="noopener">License</a></li>
+          <li><a href="https://github.com/bolnet/attestor/blob/main/README.md" target="_blank" rel="noopener">Documentation</a></li>
+        </ul>
+      </div>
+      <div>
+        <div class="col-label">Distribution</div>
+        <ul class="colophon-list">
+          <li><a href="https://pypi.org/project/attestor/" target="_blank" rel="noopener">PyPI</a></li>
+          <li><a href="https://github.com/bolnet/attestor" target="_blank" rel="noopener">GitHub</a></li>
+          <li><a href="https://registry.modelcontextprotocol.io/servers/io.github.bolnet/attestor" target="_blank" rel="noopener">MCP Registry</a></li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="colophon-mark">
+      <span class="left">Attestor<b>.</b></span>
+      <span>&copy; 2026 Bolnet &middot; MIT &middot; New York</span>
+      <span>Set in paper &middot; printed in terminal</span>
+    </div>
+  </div>
+</footer>
+
+<!-- ═══════════════════════════════════════════════════
+     JS
+     ═══════════════════════════════════════════════════ -->
+<script>
+/* ── Nav scroll ── */
+(function() {
+  var nav = document.getElementById('nav');
+  var scrolled = false;
+  window.addEventListener('scroll', function() {
+    var shouldScroll = window.scrollY > 40;
+    if (shouldScroll !== scrolled) {
+      scrolled = shouldScroll;
+      nav.classList.toggle('scrolled', scrolled);
+    }
+  }, { passive: true });
+})();
+
+/* ── Scroll reveal with stagger ── */
+(function() {
+  var reveals = document.querySelectorAll('.reveal');
+  var observer = new IntersectionObserver(function(entries) {
+    entries.forEach(function(entry) {
+      if (entry.isIntersecting) {
+        var parent = entry.target.parentElement;
+        if (parent && (parent.classList.contains('capabilities') || parent.classList.contains('matrix') || parent.classList.contains('manifesto'))) {
+          var siblings = parent.querySelectorAll('.reveal');
+          var idx = Array.prototype.indexOf.call(siblings, entry.target);
+          entry.target.style.transitionDelay = (idx * 70) + 'ms';
+        }
+        entry.target.classList.add('visible');
+        observer.unobserve(entry.target);
+      }
+    });
+  }, { threshold: 0.08, rootMargin: '0px 0px -40px 0px' });
+
+  reveals.forEach(function(el) { observer.observe(el); });
+})();
+
+/* ── Token chart animation ── */
+(function() {
+  var chart = document.getElementById('tokenChart');
+  if (!chart) return;
+  var animated = false;
+  var observer = new IntersectionObserver(function(entries) {
+    entries.forEach(function(entry) {
+      if (entry.isIntersecting && !animated) {
+        animated = true;
+        var bars = chart.querySelectorAll('.chart-bar');
+        bars.forEach(function(bar, i) {
+          var w = bar.getAttribute('data-width');
+          setTimeout(function() { bar.style.width = w + '%'; }, 120 + i * 80);
+        });
+        observer.unobserve(chart);
+      }
+    });
+  }, { threshold: 0.3 });
+  observer.observe(chart);
+})();
+
+/* ── Copy to clipboard ── */
+function copyToClipboard(el, text) {
+  navigator.clipboard.writeText(text).then(function() {
+    el.classList.add('copied');
+    var icon = el.querySelector('.copy-icon');
+    if (icon) {
+      var orig = icon.textContent;
+      icon.textContent = '\u2713';
+      setTimeout(function() {
+        icon.textContent = orig;
+        el.classList.remove('copied');
+      }, 2000);
+    }
+  });
+}
+
+function copyCodeBlock(btn) {
+  var block = btn.parentElement;
+  var text = block.textContent.replace('Copy', '').trim();
+  navigator.clipboard.writeText(text).then(function() {
+    btn.textContent = 'Copied';
+    setTimeout(function() { btn.textContent = 'Copy'; }, 2000);
+  });
+}
+
+/* ── Tab switching ── */
+function switchTab(e, tabId) {
+  var btns = document.querySelectorAll('.tab-btn');
+  var panels = document.querySelectorAll('.tab-panel');
+  btns.forEach(function(b) { b.classList.remove('active'); });
+  panels.forEach(function(p) { p.classList.remove('active'); });
+  e.currentTarget.classList.add('active');
+  document.getElementById(tabId).classList.add('active');
+}
+
+/* ── Smooth scroll for nav links ── */
+document.querySelectorAll('a[href^="#"]').forEach(function(a) {
+  a.addEventListener('click', function(e) {
+    var href = this.getAttribute('href');
+    if (href === '#') return;
+    var target = document.querySelector(href);
+    if (target) {
+      e.preventDefault();
+      var navHeight = document.getElementById('nav').offsetHeight;
+      window.scrollTo({
+        top: target.offsetTop - navHeight - 16,
+        behavior: 'smooth'
+      });
+      document.getElementById('nav').classList.remove('mobile-open');
+    }
+  });
+});
+</script>
+</body>
+</html>

--- a/docs/superpowers/plans/2026-05-25-attestor-claude-code-native-plugin.md
+++ b/docs/superpowers/plans/2026-05-25-attestor-claude-code-native-plugin.md
@@ -1,0 +1,877 @@
+# Attestor Native Claude Code Plugin + Per-Project Isolation — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Attestor a marketplace-installable Claude Code plugin whose memory is hard-isolated per project (current working directory), with zero cross-project bleed across Postgres, Pinecone, and Neo4j.
+
+**Architecture:** Derive a stable project root from `cwd` (git root if present, else the cwd). Map that root to a dedicated RLS tenant via `AgentMemory.ensure_user(external_id="cc-project:<root>")`, and pass that `user_id` (plus `namespace="project:<root>"` as defense-in-depth) into every hook recall/add and into the MCP server's default tool tenant. Postgres Row-Level Security (keyed to `attestor.current_user_id`, already implemented) provides DB-enforced isolation; Pinecone namespaces and Neo4j namespace-scoped nodes (already implemented) isolate the vector and graph lanes. Then package the MCP server + hooks + skill + install command as a Claude Code plugin.
+
+**Tech Stack:** Python 3.12, Poetry, pytest. Existing modules: `attestor/core/agent_memory.py` (`AgentMemory`), `attestor/core/identity_service.py` (`_IdentityMixin`), `attestor/store/postgres_backend.py` (RLS via `_set_rls_user`), `attestor/hooks/*`, `attestor/mcp/server.py`. Claude Code plugin manifest format (`.claude-plugin/plugin.json`).
+
+---
+
+## File Structure
+
+**Create:**
+- `attestor/_project.py` — pure functions: `resolve_project_root(cwd)`, `project_external_id(root)`, `project_namespace(root)`.
+- `attestor/hooks/_tenant.py` — `resolve_tenant(mem, cwd) -> (user_id, namespace)`; the one place hooks turn a cwd into a tenant.
+- `.claude-plugin/plugin.json` — plugin manifest (MCP server + hooks + skill + command).
+- `.claude-plugin/marketplace.json` — single-plugin marketplace manifest.
+- `tests/test_project_resolution.py` — unit tests for `_project.py`.
+- `tests/test_hook_tenant.py` — unit tests for `_tenant.py` + hook wiring (fake `AgentMemory`).
+- `tests/test_tenant_isolation_live.py` — live, env-gated cross-store no-bleed test.
+
+**Modify:**
+- `attestor/hooks/session_start.py` — derive tenant from `payload["cwd"]`; pass `user_id` + `namespace` to `recall()`.
+- `attestor/hooks/post_tool_use.py` — pass `user_id` + `namespace` + `scope="project"` to `add()`.
+- `attestor/hooks/stop.py` — same tenant wiring on the summary write.
+- `attestor/mcp/server.py` — resolve a default tenant from the server launch `cwd`; use it as default `user_id`/`namespace` for every tool.
+- `commands/install-attestor.md` — note the plugin auto-wires MCP + hooks; trim those steps.
+- `CLAUDE.md` — fix the stale "Neo4j namespace isolation not enforced" claim.
+
+---
+
+## Task 1: Project root resolution (pure functions)
+
+**Files:**
+- Create: `attestor/_project.py`
+- Test: `tests/test_project_resolution.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/test_project_resolution.py
+# SPDX-License-Identifier: MIT
+from pathlib import Path
+
+import pytest
+
+from attestor._project import (
+    project_external_id,
+    project_namespace,
+    resolve_project_root,
+)
+
+
+def test_resolve_uses_git_root_when_present(tmp_path: Path):
+    repo = tmp_path / "repo"
+    (repo / ".git").mkdir(parents=True)
+    sub = repo / "src" / "pkg"
+    sub.mkdir(parents=True)
+    assert resolve_project_root(sub) == str(repo.resolve())
+
+
+def test_resolve_falls_back_to_cwd_without_git(tmp_path: Path):
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    assert resolve_project_root(plain) == str(plain.resolve())
+
+
+def test_resolve_handles_file_path_by_using_parent(tmp_path: Path):
+    f = tmp_path / "a.txt"
+    f.write_text("x")
+    assert resolve_project_root(f) == str(tmp_path.resolve())
+
+
+def test_unrelated_dirs_resolve_differently(tmp_path: Path):
+    a = tmp_path / "a"; a.mkdir()
+    b = tmp_path / "b"; b.mkdir()
+    assert resolve_project_root(a) != resolve_project_root(b)
+
+
+def test_external_id_and_namespace_are_prefixed():
+    root = "/Users/x/code/proj"
+    assert project_external_id(root) == "cc-project:/Users/x/code/proj"
+    assert project_namespace(root) == "project:/Users/x/code/proj"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/pytest tests/test_project_resolution.py -q`
+Expected: FAIL with `ModuleNotFoundError: No module named 'attestor._project'`
+
+- [ ] **Step 3: Write the implementation**
+
+```python
+# attestor/_project.py
+# SPDX-FileCopyrightText: 2026 Surendra Singh <66422685+bolnet@users.noreply.github.com>
+# SPDX-License-Identifier: MIT
+"""Resolve a Claude Code working directory to a stable project identity.
+
+A *project* is the unit of memory isolation: the git repository root if the
+working directory is inside one, otherwise the working directory itself. Two
+unrelated directories always resolve to different identities, so memory never
+bleeds across projects.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+# external_id of the RLS tenant that owns a project's memory. Distinct from the
+# SOLO singleton ("local") so per-project tenants never collide with it.
+_PROJECT_EXTERNAL_PREFIX = "cc-project:"
+
+# Defense-in-depth namespace stamped on Pinecone vectors and Neo4j nodes.
+_PROJECT_NAMESPACE_PREFIX = "project:"
+
+
+def resolve_project_root(cwd: str | Path) -> str:
+    """Return the project root for ``cwd``.
+
+    Git repository root if ``cwd`` is inside one (so subdirectories of a repo
+    share memory); otherwise the resolved absolute ``cwd``. If ``cwd`` is a
+    file, its parent directory is used.
+    """
+    start = Path(cwd).expanduser().resolve()
+    if start.is_file():
+        start = start.parent
+    for candidate in (start, *start.parents):
+        if (candidate / ".git").exists():
+            return str(candidate)
+    return str(start)
+
+
+def project_external_id(root: str) -> str:
+    """RLS tenant external_id for a project root."""
+    return f"{_PROJECT_EXTERNAL_PREFIX}{root}"
+
+
+def project_namespace(root: str) -> str:
+    """Vector/graph namespace for a project root."""
+    return f"{_PROJECT_NAMESPACE_PREFIX}{root}"
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/test_project_resolution.py -q`
+Expected: PASS (5 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add attestor/_project.py tests/test_project_resolution.py
+git commit -m "feat(cc): resolve a working directory to a stable project identity"
+```
+
+---
+
+## Task 2: Tenant resolution helper (cwd → RLS user + namespace)
+
+**Files:**
+- Create: `attestor/hooks/_tenant.py`
+- Test: `tests/test_hook_tenant.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_hook_tenant.py
+# SPDX-License-Identifier: MIT
+from pathlib import Path
+from types import SimpleNamespace
+
+from attestor.hooks._tenant import resolve_tenant
+
+
+class _FakeMem:
+    """Records ensure_user calls and returns a deterministic user id."""
+
+    def __init__(self):
+        self.ensured: list[str] = []
+
+    def ensure_user(self, external_id: str, **_):
+        self.ensured.append(external_id)
+        return SimpleNamespace(id=f"uid::{external_id}")
+
+
+def test_resolve_tenant_keys_user_to_project_root(tmp_path: Path):
+    repo = tmp_path / "repo"
+    (repo / ".git").mkdir(parents=True)
+    mem = _FakeMem()
+
+    user_id, namespace = resolve_tenant(mem, str(repo))
+
+    assert user_id == f"uid::cc-project:{repo.resolve()}"
+    assert namespace == f"project:{repo.resolve()}"
+    assert mem.ensured == [f"cc-project:{repo.resolve()}"]
+
+
+def test_resolve_tenant_distinct_dirs_distinct_users(tmp_path: Path):
+    a = tmp_path / "a"; a.mkdir()
+    b = tmp_path / "b"; b.mkdir()
+    mem = _FakeMem()
+
+    ua, _ = resolve_tenant(mem, str(a))
+    ub, _ = resolve_tenant(mem, str(b))
+
+    assert ua != ub
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/test_hook_tenant.py -q`
+Expected: FAIL with `ModuleNotFoundError: No module named 'attestor.hooks._tenant'`
+
+- [ ] **Step 3: Write the implementation**
+
+```python
+# attestor/hooks/_tenant.py
+# SPDX-FileCopyrightText: 2026 Surendra Singh <66422685+bolnet@users.noreply.github.com>
+# SPDX-License-Identifier: MIT
+"""Map a Claude Code working directory to the RLS tenant that owns its memory.
+
+This is the single chokepoint that enforces per-project isolation in the hook
+path. Every hook recall/add routes its ``cwd`` through here so the underlying
+Postgres Row-Level Security policy (keyed to ``attestor.current_user_id``)
+filters to exactly one project.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from attestor._project import (
+    project_external_id,
+    project_namespace,
+    resolve_project_root,
+)
+
+
+def resolve_tenant(mem: Any, cwd: str) -> tuple[str, str]:
+    """Return ``(user_id, namespace)`` for the project containing ``cwd``.
+
+    Idempotently ensures an RLS user keyed to the project root. ``ensure_user``
+    is a no-op lookup after first creation, so this is cheap to call per hook.
+    """
+    root = resolve_project_root(cwd)
+    user = mem.ensure_user(external_id=project_external_id(root))
+    return user.id, project_namespace(root)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/pytest tests/test_hook_tenant.py -q`
+Expected: PASS (2 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add attestor/hooks/_tenant.py tests/test_hook_tenant.py
+git commit -m "feat(cc): map a working directory to an RLS tenant for hooks"
+```
+
+---
+
+## Task 3: Wire SessionStart recall to the project tenant
+
+**Files:**
+- Modify: `attestor/hooks/session_start.py`
+- Test: `tests/test_hook_tenant.py` (extend)
+
+- [ ] **Step 1: Write the failing test (append to tests/test_hook_tenant.py)**
+
+```python
+def test_session_start_recall_is_tenant_scoped(monkeypatch, tmp_path):
+    """session_start must pass the project user_id + namespace to recall()."""
+    import attestor.hooks.session_start as ss
+
+    captured = {}
+
+    class _Mem:
+        def ensure_user(self, external_id, **_):
+            from types import SimpleNamespace
+            return SimpleNamespace(id=f"uid::{external_id}")
+
+        def recall(self, query, budget=None, user_id=None, namespace=None, **_):
+            captured["user_id"] = user_id
+            captured["namespace"] = namespace
+            return []
+
+        def pagerank(self):
+            return {}
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(ss, "AgentMemory", lambda *a, **k: _Mem(), raising=False)
+    monkeypatch.setattr(ss, "resolve_store_path", lambda *a, **k: str(tmp_path), raising=False)
+
+    out = ss.handle({"cwd": str(tmp_path)})
+
+    assert captured["user_id"] == f"uid::cc-project:{tmp_path.resolve()}"
+    assert captured["namespace"] == f"project:{tmp_path.resolve()}"
+    assert "additionalContext" in out
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/test_hook_tenant.py::test_session_start_recall_is_tenant_scoped -q`
+Expected: FAIL — `AgentMemory`/`resolve_store_path` are imported inside `_do_recall`, not module-level, so the monkeypatch + scoping don't apply yet. (This drives moving the imports to module scope and adding tenant wiring.)
+
+- [ ] **Step 3: Edit `attestor/hooks/session_start.py`**
+
+Replace the `_do_recall` function and `handle` so the tenant is resolved and module-level names exist for patching. New `_do_recall` signature takes `cwd`:
+
+```python
+# top of file, add to imports:
+from attestor._paths import resolve_store_path
+from attestor.core import AgentMemory
+from attestor.hooks._tenant import resolve_tenant
+from attestor.retrieval.scorer import pagerank_boost
+
+
+def _do_recall(cwd: str) -> dict[str, Any]:
+    """The actual recall + pagerank pass — runs inside the timeout shim."""
+    store_path = resolve_store_path()
+    mem = AgentMemory(store_path)
+    try:
+        user_id, namespace = resolve_tenant(mem, cwd)
+        results = mem.recall(
+            _SESSION_QUERY,
+            budget=_SESSION_BUDGET,
+            user_id=user_id,
+            namespace=namespace,
+        )
+
+        pr_scores = mem.pagerank()
+        if pr_scores and results:
+            results = pagerank_boost(results, pr_scores, weight=0.3)
+            results.sort(key=lambda r: r.score, reverse=True)
+
+        if not results:
+            return _EMPTY_RESPONSE
+
+        lines = ["Relevant memories:"]
+        for r in results:
+            prefix = f"[{r.match_source}:{r.score:.2f}]"
+            lines.append(f"- {prefix} {r.memory.content}")
+        return {"additionalContext": "\n".join(lines)}
+    finally:
+        mem.close()
+```
+
+And in `handle`, pass `cwd` into the worker:
+
+```python
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as ex:
+            fut = ex.submit(_do_recall, cwd)
+            try:
+                return fut.result(timeout=_HOOK_TIMEOUT_S)
+            except concurrent.futures.TimeoutError:
+                return _EMPTY_RESPONSE
+```
+
+Remove the now-duplicated lazy imports inside `_do_recall`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/pytest tests/test_hook_tenant.py::test_session_start_recall_is_tenant_scoped -q`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add attestor/hooks/session_start.py tests/test_hook_tenant.py
+git commit -m "feat(cc): scope SessionStart recall to the project tenant"
+```
+
+---
+
+## Task 4: Wire PostToolUse add to the project tenant
+
+**Files:**
+- Modify: `attestor/hooks/post_tool_use.py`
+- Test: `tests/test_hook_tenant.py` (extend)
+
+- [ ] **Step 1: Write the failing test (append)**
+
+```python
+def test_post_tool_use_add_is_tenant_scoped(monkeypatch, tmp_path):
+    import attestor.hooks.post_tool_use as ptu
+
+    captured = {}
+
+    class _Mem:
+        def ensure_user(self, external_id, **_):
+            from types import SimpleNamespace
+            return SimpleNamespace(id=f"uid::{external_id}")
+
+        def add(self, content, tags=None, category="general",
+                user_id=None, namespace=None, scope="user", **_):
+            captured.update(
+                user_id=user_id, namespace=namespace, scope=scope,
+                content=content,
+            )
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(ptu, "AgentMemory", lambda *a, **k: _Mem(), raising=False)
+    monkeypatch.setattr(ptu, "resolve_store_path", lambda *a, **k: str(tmp_path), raising=False)
+
+    ptu.handle({
+        "cwd": str(tmp_path),
+        "tool_name": "Write",
+        "tool_input": {"file_path": "foo.py"},
+    })
+
+    assert captured["user_id"] == f"uid::cc-project:{tmp_path.resolve()}"
+    assert captured["namespace"] == f"project:{tmp_path.resolve()}"
+    assert captured["scope"] == "project"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/test_hook_tenant.py::test_post_tool_use_add_is_tenant_scoped -q`
+Expected: FAIL — imports are lazy inside `handle`; `add()` is called without `user_id`/`namespace`/`scope`.
+
+- [ ] **Step 3: Edit `attestor/hooks/post_tool_use.py`**
+
+Move the lazy imports to module scope and add tenant wiring:
+
+```python
+# top of file, add:
+from attestor._paths import resolve_store_path
+from attestor.core import AgentMemory
+from attestor.hooks._tenant import resolve_tenant
+```
+
+Replace the `if content:` block body:
+
+```python
+        if content:
+            store_path = resolve_store_path()
+
+            def _do_add() -> None:
+                mem = AgentMemory(store_path)
+                try:
+                    user_id, namespace = resolve_tenant(mem, cwd)
+                    mem.add(
+                        content,
+                        tags=tags,
+                        category=category,
+                        user_id=user_id,
+                        namespace=namespace,
+                        scope="project",
+                    )
+                finally:
+                    mem.close()
+
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as ex:
+                fut = ex.submit(_do_add)
+                try:
+                    fut.result(timeout=_HOOK_TIMEOUT_S)
+                except concurrent.futures.TimeoutError:
+                    pass
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/pytest tests/test_hook_tenant.py::test_post_tool_use_add_is_tenant_scoped -q`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add attestor/hooks/post_tool_use.py tests/test_hook_tenant.py
+git commit -m "feat(cc): scope PostToolUse capture to the project tenant"
+```
+
+---
+
+## Task 5: Wire Stop summary to the project tenant
+
+**Files:**
+- Modify: `attestor/hooks/stop.py`
+- Test: `tests/test_hook_tenant.py` (extend)
+
+- [ ] **Step 1: Read `attestor/hooks/stop.py`** to find where it constructs `AgentMemory` and calls `add()` for the `session-summary` memory. It mirrors `post_tool_use` (lazy import + `_do_*` worker).
+
+- [ ] **Step 2: Write the failing test (append)**
+
+```python
+def test_stop_summary_is_tenant_scoped(monkeypatch, tmp_path):
+    import attestor.hooks.stop as st
+
+    captured = {}
+
+    class _Mem:
+        def ensure_user(self, external_id, **_):
+            from types import SimpleNamespace
+            return SimpleNamespace(id=f"uid::{external_id}")
+
+        def search(self, *a, **k):
+            return []
+
+        def recall(self, *a, **k):
+            return []
+
+        def add(self, content, tags=None, category="general",
+                user_id=None, namespace=None, scope="user", **_):
+            captured.update(user_id=user_id, namespace=namespace, scope=scope)
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(st, "AgentMemory", lambda *a, **k: _Mem(), raising=False)
+    monkeypatch.setattr(st, "resolve_store_path", lambda *a, **k: str(tmp_path), raising=False)
+
+    st.handle({"cwd": str(tmp_path)})
+
+    # If there were observations to summarize, the write is tenant-scoped.
+    if captured:
+        assert captured["user_id"] == f"uid::cc-project:{tmp_path.resolve()}"
+        assert captured["namespace"] == f"project:{tmp_path.resolve()}"
+        assert captured["scope"] == "project"
+```
+
+- [ ] **Step 3: Run test to verify it fails or trivially passes**
+
+Run: `.venv/bin/pytest tests/test_hook_tenant.py::test_stop_summary_is_tenant_scoped -q`
+Expected: FAIL if `stop.handle` queries observations and writes without scoping. (If `stop` reads observations via `search`/`recall`, those reads ALSO need `user_id` scoping — otherwise the summary is computed from other projects' data. Scope both the read and the write.)
+
+- [ ] **Step 4: Edit `attestor/hooks/stop.py`**
+
+Move imports to module scope (`resolve_store_path`, `AgentMemory`, `resolve_tenant`). In the worker, resolve the tenant once and pass `user_id`/`namespace` to BOTH the observation read (`search`/`recall`) and the summary `add(..., scope="project")`. Mirror the exact wiring shape from Task 4.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `.venv/bin/pytest tests/test_hook_tenant.py -q`
+Expected: PASS (all hook tenant tests)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add attestor/hooks/stop.py tests/test_hook_tenant.py
+git commit -m "feat(cc): scope Stop summary read+write to the project tenant"
+```
+
+---
+
+## Task 6: Default the MCP server's tools to the launch-cwd tenant
+
+**Files:**
+- Modify: `attestor/mcp/server.py`
+- Test: `tests/test_mcp_tenant_default.py`
+
+- [ ] **Step 1: Read `attestor/mcp/server.py`** around the `AgentMemory` construction and the tool handlers (lines ~440-525 for `memory_add`/`memory_recall`/`memory_search`/`memory_timeline`). Confirm where `mem` is built and where `namespace`/`user_id` are read from tool `args`.
+
+- [ ] **Step 2: Write the failing test**
+
+```python
+# tests/test_mcp_tenant_default.py
+# SPDX-License-Identifier: MIT
+import os
+from pathlib import Path
+
+from attestor.mcp import server as mcp_server
+
+
+def test_default_tenant_derives_from_cwd(tmp_path: Path, monkeypatch):
+    repo = tmp_path / "repo"
+    (repo / ".git").mkdir(parents=True)
+    monkeypatch.chdir(repo)
+
+    user_id, namespace = mcp_server._default_tenant_for_cwd()
+
+    assert namespace == f"project:{repo.resolve()}"
+    assert user_id == f"cc-project:{repo.resolve()}"  # external_id form pre-ensure
+```
+
+Note: `_default_tenant_for_cwd()` returns the external_id form (no DB call); the
+server calls `mem.ensure_user(...)` lazily on first tool use to get the real
+`user_id`. This keeps the unit test infra-free.
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/test_mcp_tenant_default.py -q`
+Expected: FAIL — `_default_tenant_for_cwd` not defined.
+
+- [ ] **Step 4: Edit `attestor/mcp/server.py`**
+
+Add a module-level helper and a cached per-server tenant resolver:
+
+```python
+import os
+from attestor._project import (
+    project_external_id, project_namespace, resolve_project_root,
+)
+
+
+def _default_tenant_for_cwd() -> tuple[str, str]:
+    """(external_id, namespace) for the server's launch directory.
+
+    Claude Code launches the MCP server with cwd = the workspace root, so the
+    project the user is working in is os.getcwd() at server start.
+    """
+    root = resolve_project_root(os.getcwd())
+    return project_external_id(root), project_namespace(root)
+```
+
+In the server's tool-dispatch path, resolve and memoize the real `user_id`
+once (lazily, on first tool call):
+
+```python
+        # one-time per server process
+        if self._project_user_id is None:
+            ext_id, self._project_namespace = _default_tenant_for_cwd()
+            self._project_user_id = self._mem.ensure_user(external_id=ext_id).id
+```
+
+Then change the tool handlers so the tenant defaults flow through:
+- `memory_add`: `user_id=self._project_user_id`, `scope="project"`, and
+  `namespace=args.get("namespace") or self._project_namespace` (was
+  `args.get("namespace", "default")`).
+- `memory_recall` / `memory_search` / `memory_timeline`: pass
+  `user_id=self._project_user_id` and
+  `namespace=args.get("namespace") or self._project_namespace`.
+
+Initialize `self._project_user_id = None` and `self._project_namespace = None`
+where the server stores `self._mem`.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `.venv/bin/pytest tests/test_mcp_tenant_default.py -q`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add attestor/mcp/server.py tests/test_mcp_tenant_default.py
+git commit -m "feat(cc): default MCP tools to the launch-directory project tenant"
+```
+
+---
+
+## Task 7: Live cross-store isolation test (env-gated)
+
+**Files:**
+- Create: `tests/test_tenant_isolation_live.py`
+
+This is the proof that there is no cross-project bleed across Postgres + Pinecone + Neo4j. It is **env-gated** (`ATTESTOR_LIVE=1`) and uses the live canonical stack. Do NOT run it during a benchmark (it writes to the live DB); see the project memory `feedback_no_pytest_during_live_bench`.
+
+- [ ] **Step 1: Write the test**
+
+```python
+# tests/test_tenant_isolation_live.py
+# SPDX-License-Identifier: MIT
+import os
+from pathlib import Path
+
+import pytest
+
+from attestor.core import AgentMemory
+from attestor.hooks._tenant import resolve_tenant
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("ATTESTOR_LIVE") != "1",
+    reason="requires live Postgres+Pinecone+Neo4j (set ATTESTOR_LIVE=1)",
+)
+
+
+def test_two_projects_do_not_share_memory(tmp_path: Path):
+    store = str(tmp_path / "store")
+    mem = AgentMemory(store)
+    try:
+        proj_a = tmp_path / "alpha"; (proj_a / ".git").mkdir(parents=True)
+        proj_b = tmp_path / "beta"; (proj_b / ".git").mkdir(parents=True)
+
+        ua, ns_a = resolve_tenant(mem, str(proj_a))
+        ub, ns_b = resolve_tenant(mem, str(proj_b))
+        assert ua != ub
+
+        mem.add(
+            "Alpha uses Rust for the parser",
+            tags=["decision"], category="project",
+            user_id=ua, namespace=ns_a, scope="project",
+        )
+
+        # Recall from project B must NOT see project A's memory.
+        hits_b = mem.recall(
+            "what language for the parser", user_id=ub, namespace=ns_b,
+        )
+        assert all("Alpha uses Rust" not in r.memory.content for r in hits_b)
+
+        # Recall from project A DOES see it.
+        hits_a = mem.recall(
+            "what language for the parser", user_id=ua, namespace=ns_a,
+        )
+        assert any("Alpha uses Rust" in r.memory.content for r in hits_a)
+    finally:
+        mem.close()
+```
+
+- [ ] **Step 2: Run the test (only if the live stack is up)**
+
+Run: `ATTESTOR_LIVE=1 .venv/bin/pytest tests/test_tenant_isolation_live.py -q`
+Expected: PASS. If the stack is not running, the test SKIPS (that is acceptable for CI without secrets).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_tenant_isolation_live.py
+git commit -m "test(cc): live cross-store per-project isolation proof (env-gated)"
+```
+
+---
+
+## Task 8: Claude Code plugin manifest
+
+**Files:**
+- Create: `.claude-plugin/plugin.json`
+
+- [ ] **Step 1: Verify the hook command names** that the CLI accepts: `grep -n "session-start\|post-tool-use\|stop" attestor/cli/commands/server.py` — confirm `attestor hook session-start|post-tool-use|stop` and `attestor mcp` exist (they do per the inventory).
+
+- [ ] **Step 2: Write the manifest**
+
+```json
+{
+  "name": "attestor",
+  "version": "4.0.0",
+  "description": "The memory layer for agent teams. Deterministic retrieval, per-project isolation, zero LLM in the critical path.",
+  "author": { "name": "Surendra Singh", "url": "https://github.com/bolnet/attestor" },
+  "license": "MIT",
+  "mcpServers": {
+    "attestor": {
+      "command": "attestor",
+      "args": ["mcp"]
+    }
+  },
+  "hooks": {
+    "SessionStart": [
+      { "matcher": "*", "hooks": [{ "type": "command", "command": "attestor hook session-start" }] }
+    ],
+    "PostToolUse": [
+      { "matcher": "Write|Edit|Bash", "hooks": [{ "type": "command", "command": "attestor hook post-tool-use" }] }
+    ],
+    "Stop": [
+      { "matcher": "*", "hooks": [{ "type": "command", "command": "attestor hook stop" }] }
+    ]
+  },
+  "skills": ["skills/attestor-memory"],
+  "commands": ["commands/install-attestor.md"]
+}
+```
+
+Note: `attestor mcp` is invoked with NO `--path`; the server resolves its store
+via `resolve_store_path()` and derives the project tenant from its launch cwd
+(Task 6). The hooks derive their tenant from each event's `cwd` (Tasks 3-5).
+
+- [ ] **Step 3: Validate JSON**
+
+Run: `python -c "import json,sys; json.load(open('.claude-plugin/plugin.json')); print('ok')"`
+Expected: `ok`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .claude-plugin/plugin.json
+git commit -m "feat(cc): add Claude Code plugin manifest"
+```
+
+---
+
+## Task 9: Marketplace manifest
+
+**Files:**
+- Create: `.claude-plugin/marketplace.json`
+
+- [ ] **Step 1: Write the manifest**
+
+```json
+{
+  "name": "attestor",
+  "owner": { "name": "bolnet", "url": "https://github.com/bolnet" },
+  "plugins": [
+    {
+      "name": "attestor",
+      "source": ".",
+      "description": "Self-hosted memory layer for Claude Code with hard per-project isolation."
+    }
+  ]
+}
+```
+
+- [ ] **Step 2: Validate JSON**
+
+Run: `python -c "import json; json.load(open('.claude-plugin/marketplace.json')); print('ok')"`
+Expected: `ok`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .claude-plugin/marketplace.json
+git commit -m "feat(cc): add single-plugin marketplace manifest"
+```
+
+---
+
+## Task 10: Trim the install command + fix the stale CLAUDE.md claim
+
+**Files:**
+- Modify: `commands/install-attestor.md`
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Edit `commands/install-attestor.md`**
+
+Add a note at the top: when installed as a plugin (`/plugin install attestor`),
+the MCP server and hooks are auto-wired by `.claude-plugin/plugin.json`, so the
+wizard only needs to (a) install the `attestor` package, (b) collect backend
+connection details (Postgres + Pinecone + Neo4j; local Docker or cloud), (c)
+collect the embedding provider, and (d) run `attestor doctor`. The
+`settings.json` MCP + hook writing steps are skipped in plugin mode (they only
+apply to manual, non-plugin installs).
+
+- [ ] **Step 2: Edit `CLAUDE.md`**
+
+Replace the stale sentence in the multi-agent primitives paragraph:
+
+> "Namespace isolation is row-level on Postgres but **not yet enforced on Neo4j** (graph entity nodes are global across namespaces)."
+
+with:
+
+> "Namespace isolation is enforced across all three roles: row-level + RLS on Postgres, per-namespace on Pinecone, and a `namespace` property with a composite `(key, namespace)` constraint and namespace-scoped BFS on Neo4j. The Claude Code plugin keys each project (git root, else cwd) to its own RLS tenant (`external_id=cc-project:<root>`) so memory never bleeds across projects."
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add commands/install-attestor.md CLAUDE.md
+git commit -m "docs(cc): plugin-mode install notes + correct Neo4j isolation claim"
+```
+
+---
+
+## Task 11: Full unit suite + lint gate
+
+- [ ] **Step 1: Run the new unit tests together**
+
+Run: `.venv/bin/pytest tests/test_project_resolution.py tests/test_hook_tenant.py tests/test_mcp_tenant_default.py -q`
+Expected: PASS (all)
+
+- [ ] **Step 2: Run the broader hook/MCP unit tests to catch regressions**
+
+Run: `.venv/bin/pytest tests/ -q -k "hook or mcp or identity or tenant" `
+Expected: PASS (no regressions). Do NOT run the full live suite here.
+
+- [ ] **Step 3: Lint the changed files**
+
+Run: `.venv/bin/ruff check attestor/_project.py attestor/hooks/_tenant.py attestor/hooks/session_start.py attestor/hooks/post_tool_use.py attestor/hooks/stop.py attestor/mcp/server.py`
+Expected: no errors.
+
+- [ ] **Step 4: Commit any lint fixes**
+
+```bash
+git add -A && git commit -m "chore(cc): lint fixes for project-isolation wiring"
+```
+
+---
+
+## Self-Review (completed during planning)
+
+- **Spec coverage:** Part 1 (isolation) → Tasks 1-7; Part 2 (plugin packaging) → Tasks 8-10; testing requirement → Tasks 1-7, 11. Stale-doc fix → Task 10. All spec sections mapped.
+- **Type consistency:** `resolve_project_root` / `project_external_id` / `project_namespace` (Task 1) used identically in Tasks 2 & 6. `resolve_tenant(mem, cwd) -> (user_id, namespace)` (Task 2) used identically in Tasks 3-5. `add(..., user_id, namespace, scope)` and `recall(..., user_id, namespace)` match the real signatures in `agent_memory.py:716` and `:1199`.
+- **Placeholder scan:** Tasks 5, 6, 8 contain a "Read X first" step (the existing files' internal shape must be confirmed before editing); the concrete edit is fully specified after it. No TODO/TBD left.
+
+## Open risk carried from the spec
+
+- **MCP launch cwd:** Task 6 assumes Claude Code starts the MCP server with `cwd = workspace`. If that proves false during integration, switch from a once-per-process tenant to per-tool-call resolution using a `cwd` the client provides. The hook path (Tasks 3-5) is unaffected — it always gets `cwd` per event.

--- a/docs/superpowers/reviews/2026-05-25-cc-native-plugin-review.md
+++ b/docs/superpowers/reviews/2026-05-25-cc-native-plugin-review.md
@@ -1,0 +1,83 @@
+# Code Review — Native Claude Code Plugin + Per-Project Isolation
+
+**Date:** 2026-05-25
+**Reviewer:** code-reviewer agent (merge-request review, pre-commit)
+**Scope:** this session's changes only (see plan `2026-05-25-attestor-claude-code-native-plugin.md`)
+**Verdict at review time:** BLOCK (2 CRITICAL). **After dispositions below: resolved.**
+
+Each finding was verified firsthand against the code before acting (some agent
+claims were inaccurate — noted).
+
+## CRITICAL
+
+### C1 — `external_id VARCHAR(256)` overflow degrades the RLS tenant ✅ FIXED
+`users.external_id` is `VARCHAR(256)` (`store/schema.sql:19`). The original
+`cc-project:<absolute-path>` could overflow on deep paths; Postgres raises
+`value too long`, `resolve_tenant` catches it and falls back to
+`user_id=None`, silently dropping RLS.
+- **Verified:** column width confirmed. Also confirmed the v4 doc read filters
+  by `metadata->>'_namespace'` (`_postgres_document.py:256,335,439`), so our
+  hooks/MCP (which always pass `namespace`) stay isolated even in the degraded
+  path — but losing RLS silently is still unacceptable.
+- **Fix:** `project_external_id`/`project_namespace` now hash the root
+  (`sha256`, `_project.py:_digest`) → fixed-length (~75 chars), charset-safe
+  (also fixes Pinecone namespace `/`-separator risk). Human path preserved in
+  the user's `display_name`/`metadata` via `resolve_tenant`.
+
+### C2 — `pagerank()` not namespace-scoped ✅ ADDRESSED (doc corrected)
+`pagerank()` takes no namespace (`neo4j_backend.py:341`) — it computes over the
+global entity graph.
+- **Verified:** confirmed no namespace param. However it only *reorders results
+  that are already namespace-filtered* (session_start recalls the project's
+  memories, then boosts) — it does **not** surface another project's memories.
+  The agent overstated this as a data leak; it is a global ranking *signal*.
+- **Disposition:** the real defect was the CLAUDE.md overclaim. Corrected to
+  state the PageRank GDS projection is global (ranking-only caveat, no data
+  leak). Scoping the GDS projection by namespace is a possible follow-up.
+
+## HIGH
+
+### H1 — stop hook vector `search()` path + RLS pin — NOT A BUG (current call is safe)
+The stop hook calls `search(after=..., limit=50)` with `query=None`, which
+takes the `list_memories` path (RLS-gated by the preceding `_resolve`), not the
+vector branch. The agent acknowledged this. Left as-is; documented constraint.
+
+### H2 — `ensure_user` is a sync DB call in an async handler — PRE-EXISTING, not fixed
+Valid latency note, but the entire `_handle_tool` is already synchronous and
+called directly in the async `call_tool`. This is the existing architecture,
+not a regression introduced here. Out of scope for this change; flagged for a
+future server-wide `asyncio.to_thread` pass.
+
+### H3/H4 — plugin.json `skills`/`commands` paths "missing" — ❌ AGENT WRONG, dismissed
+`skills/` and `commands/` exist at the **repo root**, and Claude Code resolves
+plugin component paths relative to the plugin root (the dir containing
+`.claude-plugin/`), i.e. the repo root. `./skills/` and `./commands/` are
+correct. The agent checked `.claude-plugin/skills/` (wrong base). Verified the
+dirs exist. No change.
+
+## MEDIUM
+
+- **M1 symlink divergence** ✅ added `test_symlink_resolves_to_canonical_tenant`
+  (confirms `resolve()` canonicalization → same tenant).
+- **M2 MCP tenant fixed at launch cwd** — documented design (one server per
+  workspace). Comment already states it. No change.
+- **M3 no lru_cache on `resolve_project_root`** — hooks are per-process (no
+  cross-call benefit); MCP resolves once. Negligible. No change.
+- **M4 `hooks.json` `$schema`** — matches the shape used by the shipped
+  `everything-claude-code/hooks/hooks.json`. No change.
+
+## LOW
+
+- **L1 live test leaves rows** ✅ added `mem.forget(written.id)` cleanup.
+- **L2 `configs/attestor.yaml` bench-narrative comments** — real (violates the
+  "no bench stats in repo" rule) but **outside this session's diff**. Flagged to
+  the user; not touched here.
+- **L3 `evals/longmemeval/runner.py` inline `import os`** — **outside this
+  session's diff**. Flagged; not touched.
+
+## Post-fix verification
+- `tests/test_project_resolution.py`, `test_hook_tenant.py`,
+  `test_mcp_tenant_default.py`: **19 passed**; `test_tenant_isolation_live.py`:
+  skipped (env-gated).
+- Existing MCP/hook suite: green (no regressions).
+- `_project.py`: ruff-clean.

--- a/docs/superpowers/specs/2026-05-25-attestor-claude-code-native-plugin-design.md
+++ b/docs/superpowers/specs/2026-05-25-attestor-claude-code-native-plugin-design.md
@@ -1,0 +1,132 @@
+# Attestor — Native Claude Code Plugin + Per-Project Memory Isolation
+
+**Date:** 2026-05-25
+**Status:** Design approved, pending implementation plan
+
+## Problem
+
+Attestor already ships Claude Code integration surfaces (an MCP server, three
+hooks, a skill, an install wizard), but two things are missing for it to feel
+*native*:
+
+1. **No plugin packaging.** There is no `.claude-plugin/plugin.json` and no
+   marketplace, so installation is a manual wizard rather than
+   `/plugin install attestor`.
+2. **No per-project memory isolation.** The single most important requirement.
+   Today every Claude Code project shares one store and one namespace, so
+   memory bleeds across unrelated projects.
+
+### The isolation requirement (non-negotiable)
+
+Memory must be **scoped to the current working directory**. The folder Claude
+Code runs in is the **default project and the home for that project's memory**.
+Memory must **never** leak across projects. A project is treated as a
+first-class tenant — the way Attestor treats a `user:` namespace.
+
+## What already exists (verified in code, 2026-05-25)
+
+CLAUDE.md is stale on isolation. Verified firsthand:
+
+| Capability | Status | Evidence |
+|---|---|---|
+| Postgres multi-tenancy + Row-Level Security | Exists | `store/schema.sql` (`users`→`projects`→`memories(scope, project_id)`); RLS on every tenant table keyed to `attestor.current_user_id`, set at `store/postgres_backend.py:157` |
+| Pinecone per-namespace isolation | Exists | threaded via `AgentMemory.add(namespace=…)` |
+| Neo4j namespace scoping | Exists (CLAUDE.md stale) | nodes/edges carry `namespace`; composite `(key, namespace)` unique constraint; BFS filters `coalesce(n.namespace,'default')=$ns` — `store/neo4j_backend.py:170-240` |
+| Identity by external id | Exists | `core/identity_service.py`: `ensure_user(external_id)`, `find_user_by_external_id`, `create_project` |
+| **Derive project identity from `cwd`** | **Missing** | hooks call `recall()`/`add()` with no namespace → all `default`; MCP `memory_add` defaults `namespace="default"`; `_paths.resolve_store_path()` → one shared `~/.attestor` |
+| **Plugin packaging** | **Missing** | no `.claude-plugin/plugin.json`, no marketplace manifest |
+
+The cross-project bleed exists **only** because the `cwd → tenant` mapping is
+never made. The isolation primitives are already built and tested.
+
+## Decisions
+
+- **"Native" = Claude Code plugin packaging + marketplace.** (Chosen over
+  zero-infra default and full-hook-coverage as the primary framing.)
+- **Isolation realized via project namespace across the canonical stack** —
+  NOT a new embedded backend, NOT per-project physical DBs. Keep the single
+  canonical PG+Pinecone+Neo4j stack.
+- **Project = git root if present, else cwd.** Subdirectories of one repo share
+  memory; unrelated folders never do.
+- **Project maps to an RLS tenant** via `ensure_user(external_id=project_root)`,
+  reusing the already-tested user-level Row-Level Security so the database
+  itself refuses cross-project reads/writes. Zero schema change. Writes use
+  `scope='project'`.
+
+## Design
+
+### Part 1 — Project = current directory = RLS tenant (isolation fix)
+
+1. **`attestor/_project.py`** (new, small): `resolve_project_id(cwd) ->
+   project_root`. Walk up for a `.git` dir; fall back to the absolute `cwd`.
+   Pure function, unit-testable, no I/O beyond filesystem stat.
+2. **Tenant mapping:** given a project root, `ensure_user(external_id=root)` and
+   set `attestor.current_user_id` to that user for the connection. RLS then
+   hard-isolates. Memory writes use `scope='project'`.
+3. **Hooks:** `hooks/session_start.py` (recall), `hooks/post_tool_use.py`
+   (add), `hooks/stop.py` (summary) each already receive `payload["cwd"]`;
+   derive the tenant there and pass it down. Preserve existing timeout /
+   never-crash-the-host contract.
+4. **MCP server (`mcp/server.py`):** derive the tenant from the server's launch
+   `cwd` and use it as the default tenant for every tool, replacing the
+   `namespace="default"` default. Explicit per-call namespace still overrides
+   (for intentional user/global-scope facts).
+5. **Defense-in-depth:** also stamp `namespace=project:<root>` so Pinecone and
+   Neo4j are scoped even on any path that bypasses RLS.
+
+### Part 2 — Plugin packaging
+
+6. **`.claude-plugin/plugin.json`** declaring the bundled MCP server
+   (`attestor mcp`), hooks (SessionStart / PostToolUse / Stop → `attestor hook
+   …`), the skill, and the `/install-attestor` command.
+7. **Marketplace manifest** so users do `/plugin marketplace add bolnet/attestor`
+   then `/plugin install attestor`.
+8. **Trim the install wizard:** the plugin auto-wires MCP + hooks, so install
+   only interviews for backend connection (canonical stack must be reachable —
+   local Docker or cloud) + embedding provider. No more hand-writing
+   `settings.json`.
+
+## Testing
+
+The isolation tests are the critical deliverable:
+
+- Two distinct `cwd`s → two tenants → assert **zero cross-read** across
+  Postgres **and** Pinecone **and** Neo4j.
+- RLS denial test: a connection scoped to tenant A cannot read tenant B rows
+  even with a missing `WHERE`.
+- Git-root-vs-subdir test: subdir of a repo resolves to the same tenant as the
+  repo root; an unrelated sibling folder resolves to a different tenant.
+- Hook contract tests: hooks still never crash the host and honor the timeout.
+- `resolve_project_id` unit tests (git present / absent, nested, symlinks).
+
+Target: maintain 80%+ coverage on new modules.
+
+## Effort estimate
+
+- Isolation core (`_project.py` + wire 3 hooks + MCP): ~1–1.5 days
+- Isolation tests (critical path): ~0.5 day
+- Plugin packaging + marketplace + install trim: ~1 day
+- Docs + fix stale CLAUDE.md Neo4j claim: ~0.5 day
+
+≈ **3–3.5 days**, isolation core + tests on the critical path.
+
+## Risks / open points
+
+- **Not zero-infra.** Keeps the canonical stack; the plugin still needs
+  PG+Pinecone+Neo4j reachable (local Docker or cloud). Install-and-go without
+  Docker would require reintroducing an embedded backend (declined).
+- **MCP `cwd` assumption.** Relies on Claude Code launching the MCP server with
+  `cwd = workspace`. If one global server serves multiple workspaces in a
+  single session, per-call tenant derivation is needed instead — verify launch
+  behavior during planning.
+- **Legacy `default` data.** Existing memories in the shared `~/.attestor`
+  remain under `default` and do not auto-migrate into project tenants. Clean
+  break for new installs.
+
+## Out of scope
+
+- Reintroducing an embedded/zero-infra backend.
+- Per-project physical databases (separate PG schema / Neo4j db / Pinecone
+  index per project).
+- Expanding hook coverage to UserPromptSubmit / PreToolUse / PreCompact /
+  SessionEnd (possible later; not part of this work).

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          { "type": "command", "command": "attestor hook session-start" }
+        ],
+        "description": "Inject this project's relevant memories at session start (project-scoped)."
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|Bash",
+        "hooks": [
+          { "type": "command", "command": "attestor hook post-tool-use" }
+        ],
+        "description": "Capture file changes and commands into this project's memory (secrets redacted)."
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "*",
+        "hooks": [
+          { "type": "command", "command": "attestor hook stop" }
+        ],
+        "description": "Write a project-scoped session summary on exit."
+      }
+    ]
+  }
+}

--- a/tests/test_hook_tenant.py
+++ b/tests/test_hook_tenant.py
@@ -1,0 +1,201 @@
+# SPDX-License-Identifier: MIT
+"""Unit tests for hook tenant resolution and per-project hook wiring.
+
+All tests use a fake AgentMemory so no live Postgres/Pinecone/Neo4j is needed.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from attestor._project import (
+    project_external_id,
+    project_namespace,
+    resolve_project_root,
+)
+from attestor.hooks._tenant import resolve_tenant
+
+
+class _FakeMem:
+    """Records ensure_user calls and returns a deterministic user id."""
+
+    def __init__(self):
+        self.ensured: list[str] = []
+
+    def ensure_user(self, external_id: str, **_):
+        self.ensured.append(external_id)
+        return SimpleNamespace(id=f"uid::{external_id}")
+
+
+def test_resolve_tenant_keys_user_to_project_root(tmp_path: Path):
+    repo = tmp_path / "repo"
+    (repo / ".git").mkdir(parents=True)
+    mem = _FakeMem()
+
+    user_id, namespace = resolve_tenant(mem, str(repo))
+
+    root = resolve_project_root(str(repo))
+    assert user_id == f"uid::{project_external_id(root)}"
+    assert namespace == project_namespace(root)
+    assert mem.ensured == [project_external_id(root)]
+
+
+def test_resolve_tenant_distinct_dirs_distinct_users(tmp_path: Path):
+    a = tmp_path / "a"
+    a.mkdir()
+    b = tmp_path / "b"
+    b.mkdir()
+    mem = _FakeMem()
+
+    ua, _ = resolve_tenant(mem, str(a))
+    ub, _ = resolve_tenant(mem, str(b))
+
+    assert ua != ub
+
+
+def test_resolve_tenant_degrades_when_ensure_user_missing(tmp_path: Path):
+    """A store without ensure_user (v3) yields user_id=None but keeps ns."""
+    user_id, namespace = resolve_tenant(object(), str(tmp_path))
+    assert user_id is None
+    assert namespace == project_namespace(resolve_project_root(str(tmp_path)))
+
+
+def test_resolve_tenant_degrades_when_ensure_user_raises(tmp_path: Path):
+    class _Raises:
+        def ensure_user(self, **_):
+            raise RuntimeError("postgres down")
+
+    user_id, namespace = resolve_tenant(_Raises(), str(tmp_path))
+    assert user_id is None
+    assert namespace == project_namespace(resolve_project_root(str(tmp_path)))
+
+
+def test_session_start_recall_is_tenant_scoped(monkeypatch, tmp_path):
+    """session_start must pass the project user_id + namespace to recall()."""
+    import attestor._paths
+    import attestor.core
+    import attestor.hooks.session_start as ss
+
+    captured = {}
+
+    class _Mem:
+        def __init__(self, *a, **k):
+            pass
+
+        def ensure_user(self, external_id, **_):
+            return SimpleNamespace(id=f"uid::{external_id}")
+
+        def recall(self, query, budget=None, user_id=None, namespace=None, **_):
+            captured["user_id"] = user_id
+            captured["namespace"] = namespace
+            return []
+
+        def pagerank(self):
+            return {}
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(attestor.core, "AgentMemory", _Mem)
+    monkeypatch.setattr(attestor._paths, "resolve_store_path", lambda *a, **k: str(tmp_path))
+
+    out = ss.handle({"cwd": str(tmp_path)})
+
+    root = resolve_project_root(str(tmp_path))
+    assert captured["user_id"] == f"uid::{project_external_id(root)}"
+    assert captured["namespace"] == project_namespace(root)
+    assert "additionalContext" in out
+
+
+def test_post_tool_use_add_is_tenant_scoped(monkeypatch, tmp_path):
+    import attestor._paths
+    import attestor.core
+    import attestor.hooks.post_tool_use as ptu
+
+    captured = {}
+
+    class _Mem:
+        def __init__(self, *a, **k):
+            pass
+
+        def ensure_user(self, external_id, **_):
+            return SimpleNamespace(id=f"uid::{external_id}")
+
+        def add(self, content, tags=None, category="general",
+                user_id=None, namespace=None, scope="user", **_):
+            captured.update(
+                user_id=user_id, namespace=namespace, scope=scope,
+                content=content,
+            )
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(attestor.core, "AgentMemory", _Mem)
+    monkeypatch.setattr(attestor._paths, "resolve_store_path", lambda *a, **k: str(tmp_path))
+
+    ptu.handle({
+        "cwd": str(tmp_path),
+        "tool_name": "Write",
+        "tool_input": {"file_path": "foo.py"},
+    })
+
+    root = resolve_project_root(str(tmp_path))
+    assert captured["user_id"] == f"uid::{project_external_id(root)}"
+    assert captured["namespace"] == project_namespace(root)
+    assert captured["scope"] == "project"
+
+
+def test_stop_summary_reads_and_writes_are_tenant_scoped(monkeypatch, tmp_path):
+    import attestor._paths
+    import attestor.core
+    import attestor.hooks.stop as st
+
+    captured = {}
+
+    class _Mem:
+        def __init__(self, *a, **k):
+            self._store = SimpleNamespace(_v4=True)
+            self.resolved: list[str] = []
+
+        def ensure_user(self, external_id, **_):
+            return SimpleNamespace(id=f"uid::{external_id}")
+
+        def _resolve(self, user_id=None, autostart=True, **_):
+            self.resolved.append(user_id)
+            return SimpleNamespace(
+                user=SimpleNamespace(id=user_id),
+                project=SimpleNamespace(id="p"),
+                session=None,
+            )
+
+        def search(self, query=None, after=None, before=None, limit=10,
+                   namespace=None, **_):
+            captured["search_ns"] = namespace
+            captured["resolved"] = list(self.resolved)
+            return [SimpleNamespace(
+                category="project", tags=["file-change"],
+                content="Edited file foo.py",
+            )]
+
+        def add(self, content, tags=None, category="general",
+                user_id=None, namespace=None, scope="user", **_):
+            captured.update(user_id=user_id, namespace=namespace, scope=scope)
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(attestor.core, "AgentMemory", _Mem)
+    monkeypatch.setattr(attestor._paths, "resolve_store_path", lambda *a, **k: str(tmp_path))
+
+    st.handle({"cwd": str(tmp_path)})
+
+    root = resolve_project_root(str(tmp_path))
+    expected_uid = f"uid::{project_external_id(root)}"
+    expected_ns = project_namespace(root)
+    # RLS switched to the project user BEFORE the time-window read.
+    assert captured["resolved"] == [expected_uid]
+    assert captured["search_ns"] == expected_ns
+    # Summary write is project-scoped.
+    assert captured["user_id"] == expected_uid
+    assert captured["namespace"] == expected_ns
+    assert captured["scope"] == "project"

--- a/tests/test_mcp_tenant_default.py
+++ b/tests/test_mcp_tenant_default.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: MIT
+"""Unit tests for the MCP server's per-project default tenant."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from attestor._project import (
+    project_external_id,
+    project_namespace,
+    resolve_project_root,
+)
+from attestor.mcp import server as mcp_server
+
+
+def test_default_tenant_derives_from_cwd(tmp_path: Path, monkeypatch):
+    repo = tmp_path / "repo"
+    (repo / ".git").mkdir(parents=True)
+    monkeypatch.chdir(repo)
+
+    external_id, namespace = mcp_server._default_tenant_for_cwd()
+
+    root = resolve_project_root(str(repo))
+    assert namespace == project_namespace(root)
+    assert external_id == project_external_id(root)
+
+
+def test_handle_tool_add_applies_default_tenant():
+    captured = {}
+
+    class _Mem:
+        def add(self, content, tags=None, category="general", entity=None,
+                namespace=None, event_date=None, confidence=1.0,
+                user_id=None, scope="user", **_):
+            captured.update(namespace=namespace, user_id=user_id, scope=scope)
+            return SimpleNamespace(id="m1", content=content)
+
+    mcp_server._handle_tool(
+        _Mem(), "memory_add", {"content": "hi"},
+        default_user_id="u1", default_namespace="project:/x",
+    )
+
+    assert captured["namespace"] == "project:/x"
+    assert captured["user_id"] == "u1"
+    assert captured["scope"] == "project"
+
+
+def test_handle_tool_explicit_namespace_overrides_default():
+    captured = {}
+
+    class _Mem:
+        def add(self, content, tags=None, category="general", entity=None,
+                namespace=None, event_date=None, confidence=1.0,
+                user_id=None, scope="user", **_):
+            captured.update(namespace=namespace)
+            return SimpleNamespace(id="m1", content=content)
+
+    mcp_server._handle_tool(
+        _Mem(), "memory_add", {"content": "hi", "namespace": "custom"},
+        default_user_id="u1", default_namespace="project:/x",
+    )
+
+    assert captured["namespace"] == "custom"
+
+
+def test_handle_tool_recall_applies_default_tenant():
+    captured = {}
+
+    class _Mem:
+        def recall(self, query, budget=2000, namespace=None, user_id=None, **_):
+            captured.update(namespace=namespace, user_id=user_id)
+            return []
+
+    mcp_server._handle_tool(
+        _Mem(), "memory_recall", {"query": "q"},
+        default_user_id="u1", default_namespace="project:/x",
+    )
+
+    assert captured["namespace"] == "project:/x"
+    assert captured["user_id"] == "u1"

--- a/tests/test_project_resolution.py
+++ b/tests/test_project_resolution.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: MIT
+"""Unit tests for working-directory -> project identity resolution."""
+
+from pathlib import Path
+
+from attestor._project import (
+    project_external_id,
+    project_namespace,
+    resolve_project_root,
+)
+
+
+def test_resolve_uses_git_root_when_present(tmp_path: Path):
+    repo = tmp_path / "repo"
+    (repo / ".git").mkdir(parents=True)
+    sub = repo / "src" / "pkg"
+    sub.mkdir(parents=True)
+    assert resolve_project_root(sub) == str(repo.resolve())
+
+
+def test_resolve_falls_back_to_cwd_without_git(tmp_path: Path):
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    assert resolve_project_root(plain) == str(plain.resolve())
+
+
+def test_resolve_handles_file_path_by_using_parent(tmp_path: Path):
+    f = tmp_path / "a.txt"
+    f.write_text("x")
+    assert resolve_project_root(f) == str(tmp_path.resolve())
+
+
+def test_unrelated_dirs_resolve_differently(tmp_path: Path):
+    a = tmp_path / "a"
+    a.mkdir()
+    b = tmp_path / "b"
+    b.mkdir()
+    assert resolve_project_root(a) != resolve_project_root(b)
+
+
+def test_external_id_is_prefixed_bounded_and_deterministic():
+    root = "/Users/x/code/proj"
+    eid = project_external_id(root)
+    assert eid.startswith("cc-project:")
+    # Must fit users.external_id VARCHAR(256) regardless of path depth.
+    assert len(eid) <= 80
+    assert eid == project_external_id(root)  # deterministic
+    assert project_external_id("/other/proj") != eid  # collision-free
+
+
+def test_namespace_is_prefixed_and_deterministic():
+    root = "/Users/x/code/proj"
+    ns = project_namespace(root)
+    assert ns.startswith("project:")
+    assert ns == project_namespace(root)
+    assert project_namespace("/other/proj") != ns
+
+
+def test_external_id_unaffected_by_path_length():
+    """A pathologically deep path still yields a bounded external_id."""
+    deep = "/" + "/".join(f"segment-{i}" for i in range(50))
+    assert len(project_external_id(deep)) <= 80
+
+
+def test_symlink_resolves_to_canonical_tenant(tmp_path: Path):
+    """A symlink and its target resolve to the same project identity."""
+    real = tmp_path / "real"
+    (real / ".git").mkdir(parents=True)
+    link = tmp_path / "link"
+    link.symlink_to(real)
+    assert resolve_project_root(link) == resolve_project_root(real)

--- a/tests/test_tenant_isolation_live.py
+++ b/tests/test_tenant_isolation_live.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: MIT
+"""Live, env-gated proof of cross-store per-project isolation.
+
+Requires the canonical stack (Postgres + Pinecone + Neo4j). Gated behind
+`POSTGRES_URL` (same convention as the rest of the live suite; see conftest).
+Do NOT run during a benchmark — it writes to the live DB.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from attestor.core import AgentMemory
+from attestor.hooks._tenant import resolve_tenant
+
+# Same gate + credential wiring as the rest of the live suite: backend creds
+# come from POSTGRES_URL via the conftest ``test_config`` fixture (a bare
+# AgentMemory(path) has no password and fails with "no password supplied").
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("POSTGRES_URL"),
+    reason="requires a live Postgres backend (set POSTGRES_URL) + Pinecone + Neo4j",
+)
+
+
+def test_two_projects_do_not_share_memory(tmp_path: Path):
+    # Build the canonical v4 stack config from configs/attestor.yaml — same
+    # recipe the benches use. The shared DB already has the v4 schema, so skip
+    # re-init. (A bare AgentMemory(path) or the minimal conftest test_config
+    # runs the v3 schema path and collides with the v4 columns.)
+    from attestor.config import build_backend_config, get_stack
+
+    backend_config = build_backend_config(get_stack())
+    backend_config["backend_configs"]["postgres"]["skip_schema_init"] = True
+    store = str(tmp_path / "store")
+    mem = AgentMemory(store, config=backend_config)
+    try:
+        proj_a = tmp_path / "alpha"
+        (proj_a / ".git").mkdir(parents=True)
+        proj_b = tmp_path / "beta"
+        (proj_b / ".git").mkdir(parents=True)
+
+        ua, ns_a = resolve_tenant(mem, str(proj_a))
+        ub, ns_b = resolve_tenant(mem, str(proj_b))
+        assert ua != ub
+
+        written = mem.add(
+            "Alpha uses Rust for the parser",
+            tags=["decision"], category="project",
+            user_id=ua, namespace=ns_a, scope="project",
+        )
+        try:
+            # Recall from project B must NOT see project A's memory.
+            hits_b = mem.recall(
+                "what language for the parser", user_id=ub, namespace=ns_b,
+            )
+            assert all("Alpha uses Rust" not in r.memory.content for r in hits_b)
+
+            # Recall from project A DOES see it.
+            hits_a = mem.recall(
+                "what language for the parser", user_id=ua, namespace=ns_a,
+            )
+            assert any("Alpha uses Rust" in r.memory.content for r in hits_a)
+        finally:
+            # Don't accumulate rows across repeated live runs.
+            mem.forget(written.id)
+    finally:
+        mem.close()


### PR DESCRIPTION
## Summary
Advances `quant_master` to `main` (3 commits), headlined by a native Claude Code plugin that gives Attestor hard per-project memory isolation.

## Commits
- `53c296b` feat(claude-code): native plugin + hard per-project memory isolation
- `f699617` feat(docs): tokenmaxing landing as homepage; re-theme product site
- `0902fc8` fix(infra): local Docker stack runs the default Voyage+Pinecone stack out of the box

## Highlight — native Claude Code plugin + per-project isolation
- Marketplace-installable plugin: `.claude-plugin/{plugin,marketplace}.json` + `hooks/hooks.json` + `.mcp.json` (metadata-only manifest; CC v2.1+ auto-loads hooks/.mcp by convention).
- Each project (git root, else cwd) maps to its own RLS tenant (`ensure_user(external_id=cc-project:<sha256>)`) + hashed namespace. Memory never bleeds across projects, enforced across Postgres (RLS), Pinecone (per-namespace), and Neo4j (namespace-scoped).
- SessionStart / PostToolUse / Stop hooks and the MCP server default every operation to the project tenant; an explicit `namespace` still overrides.
- `docs/INSTALL.md` Chapter 00 adds a cold-start "install attestor to claude code" prompt (scan-first, Context7-first, three clearly-named `attestor-` backend containers); CLAUDE.md install section rewritten; corrected the stale "Neo4j isolation not enforced" claim.
- Capture hook now also redacts Pinecone `pcsk_` keys.

## Verification
- 19 unit tests (project resolution, tenant wiring, MCP default tenant) pass.
- Live cross-store isolation proven end-to-end against a fresh DB: a memory added in project A is invisible in project B and visible in A, across Postgres (RLS) + Pinecone + Neo4j.
- Pre-commit multi-agent review verdict: 0 CRITICAL, 0 HIGH — READY TO COMMIT.

## Follow-up (not a blocker)
- MCP `memory_get` / `memory_forget` take a bare memory ID with no tenant argument. On a non-superuser v4 Postgres connection they are RLS-isolated; on a superuser dev role (which bypasses RLS) a caller who knows another project's memory UUID could read/forget it (no cross-project enumeration path; `schema.sql` already warns against superuser roles). Defense-in-depth: scope get/forget by tenant.

## Test plan
- [ ] Unit: `.venv/bin/python -m pytest tests/test_project_resolution.py tests/test_hook_tenant.py tests/test_mcp_tenant_default.py`
- [ ] Live (canonical-dim DB): `POSTGRES_URL=… .venv/bin/python -m pytest tests/test_tenant_isolation_live.py`
- [ ] Plugin smoke: `/plugin marketplace add bolnet/attestor` → `/plugin install attestor` → `memory_health`