### PR TITLE
docs(install): one guided wizard, four ≤3-word launch triggers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,11 +112,16 @@ Same API across all three. Only configuration changes.
 
 **Prompt-first.** Install / setup / uninstall are driven by **prompts that Claude Code executes itself** — `commands/install-attestor.md` and `commands/uninstall-attestor.md` are the source of truth. The Python helpers (`attestor setup-claude-code`, `scripts/attestor_uninstall.py`) encode the same steps for **testing/CI only**; keep them in sync with the prompts, but the prompt is the canonical path.
 
-Three install paths (all detailed in `docs/INSTALL.md`):
+**One install path — the guided wizard** (`commands/install-attestor.md`): an interactive, Claude-driven interview (scope, Postgres / Pinecone / Neo4j connections, embedder = Pinecone Inference default, hook wiring) that installs the package, brings up the backends, wires MCP + hooks, and runs `attestor doctor`. **Four ways to launch the same wizard** (≤3 words each — Claude reads this repo and runs it end-to-end):
 
-1. **Plugin (recommended).** `/plugin marketplace add bolnet/attestor` then `/plugin install attestor`. The plugin manifest (`.claude-plugin/plugin.json`) auto-wires the MCP server (`.mcp.json`) and the SessionStart / PostToolUse / Stop hooks (`hooks/hooks.json`) by convention. Still requires `pipx install attestor` (so the `attestor` binary is on PATH) plus reachable backends.
-2. **Guided wizard.** `/install-attestor` runs `commands/install-attestor.md`, an interactive interview — scope (global `~/.claude` vs project), Postgres / Pinecone / Neo4j connections, embedding provider (Pinecone Inference default, or Voyage / OpenAI / Ollama), hook wiring — then installs `attestor`, merges the MCP + hook config, and runs `attestor doctor`.
-3. **Copy-paste prompt.** For a cold Claude Code session with nothing installed, paste the detailed install prompt from `docs/INSTALL.md` and Claude executes the whole flow.
+| # | Way | Type this |
+|---|-----|-----------|
+| 1 | Plugin (recommended) | `/plugin install attestor` |
+| 2 | Command | `/install-attestor` |
+| 3 | Repo URL | `github.com/bolnet/attestor` |
+| 4 | Natural language | `install attestor` |
+
+First-time plugin use needs `/plugin marketplace add bolnet/attestor` once; the plugin manifest (`.claude-plugin/plugin.json`) additionally auto-wires the MCP server (`.mcp.json`) + hooks (`hooks/hooks.json`) by convention, but the wizard still handles package install + backends + verify. All require the `attestor` binary on PATH (`pipx install attestor`, 4.1.0) + reachable backends.
 
 **Uninstall.** `/uninstall-attestor` (or "uninstall attestor") runs `commands/uninstall-attestor.md` — Claude reverses all six install surfaces itself: package (pipx — run from `$HOME` so the repo `attestor/` subdir doesn't shadow the name), `~/.attestor/`, the MCP entry + Attestor's own hooks (content-matched on `attestor hook`, never other tools'), the Docker backends + volumes (confirm — deletes memory), the plugin, and stray repo artifacts.
 

--- a/README.md
+++ b/README.md
@@ -838,11 +838,16 @@ https://github.com/bolnet/attestor  — install attestor to claude code
 
 Claude Code reads this repo's install guide ([`docs/INSTALL.md` → Chapter 00](docs/INSTALL.md#chapter-00--install-via-claude-code-recommended)), then **scans your machine first, looks up current docs via Context7, and installs** — it brings up the three backend containers, installs the `attestor` package, wires the MCP server + hooks, and verifies. It assumes you start with nothing installed.
 
-Three ways in (full detail in [`docs/INSTALL.md`](docs/INSTALL.md)):
+**One install path — the guided wizard** ([`commands/install-attestor.md`](commands/install-attestor.md)). Whatever you type, Claude reads this repo and runs the wizard end-to-end: scan → package → Postgres + Pinecone + Neo4j backends → MCP server + hooks → `attestor doctor`. Four ways to launch it — type any of:
 
-1. **Plugin (recommended)** — `/plugin marketplace add bolnet/attestor` then `/plugin install attestor`. On **Claude Code v2.1+** the MCP server (`.mcp.json`) and the SessionStart / PostToolUse / Stop hooks (`hooks/hooks.json`) are auto-loaded by convention; on older versions, use the wizard (below) to wire them. Either way you still need `pipx install attestor` (so the `attestor` binary is on PATH) plus reachable backends.
-2. **Guided wizard** — `/install-attestor` runs an interactive interview (scope, Postgres / Pinecone / Neo4j connections, embedding provider, hook wiring), installs `attestor`, merges the config, and runs `attestor doctor`.
-3. **Copy-paste prompt** — for a cold session, paste the detailed install prompt from [`docs/INSTALL.md` Chapter 00](docs/INSTALL.md#chapter-00--install-via-claude-code-recommended).
+| # | Way | Type this |
+|---|-----|-----------|
+| 1 | Plugin (recommended) | `/plugin install attestor` |
+| 2 | Command | `/install-attestor` |
+| 3 | Repo URL | `github.com/bolnet/attestor` |
+| 4 | Natural language | `install attestor` |
+
+> All four launch the same guided wizard. First-time plugin use needs `/plugin marketplace add bolnet/attestor` once. The plugin also auto-wires the MCP server + hooks; the wizard handles package + backends + verify.
 
 **Memory is isolated per project automatically** — each working directory (git root, else cwd) is its own hard-isolated tenant, so projects never share memory. No namespace to configure.
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -15,7 +15,16 @@ A step-by-step guide to installing and verifying Attestor across different topol
 
 ## Chapter 00 — Install via Claude Code (recommended)
 
-**The one instruction.** Tell Claude Code **"install attestor to claude code"** (or run `/install-attestor`, or paste the prompt below). Claude **scans your machine first, looks up the current docs for every tool via Context7, then installs** — it brings up the three backend containers, installs the `attestor` package, wires the MCP server + hooks, and verifies. It assumes you start with **nothing installed**.
+**One install path — the guided wizard** ([`../commands/install-attestor.md`](../commands/install-attestor.md)). Whatever you type, Claude reads this repo and runs the wizard end-to-end: it **scans your machine first, looks up current docs via Context7**, then installs the `attestor` package, brings up the three backend containers, wires the MCP server + hooks, and verifies. It assumes you start with **nothing installed**. Four ways to launch it — type any of:
+
+| # | Way | Type this |
+|---|-----|-----------|
+| 1 | Plugin (recommended) | `/plugin install attestor` |
+| 2 | Command | `/install-attestor` |
+| 3 | Repo URL | `github.com/bolnet/attestor` |
+| 4 | Natural language | `install attestor` |
+
+First-time plugin use needs `/plugin marketplace add bolnet/attestor` once. The detailed cold-start prompt below is what the wizard runs — paste it directly only if you want to drive a bare session by hand.
 
 > Every chapter targets the same **canonical stack: Postgres (document) + Pinecone (vector) + Neo4j (graph)**, with the embedder, models, and retrieval budget coming from the single source of truth, [`configs/attestor.yaml`](../configs/attestor.yaml). Chapter 00 is the fastest path; 01–03 are the manual local / sidecar / cloud setups.
 


### PR DESCRIPTION
Collapses the install story to a single mechanism — the guided wizard (`commands/install-attestor.md`) — launched four ways, each ≤3 words: `/plugin install attestor`, `/install-attestor`, `github.com/bolnet/attestor`, `install attestor`. Updated README, INSTALL.md Ch00, CLAUDE.md.