### PR TITLE
fix(install): PATH for MCP + hooks (4.1.3)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "attestor",
       "source": "./",
       "description": "Self-hosted memory layer for Claude Code with hard per-project isolation (Postgres RLS + Pinecone + Neo4j).",
-      "version": "4.1.2",
+      "version": "4.1.3",
       "author": {
         "name": "Surendra Singh",
         "url": "https://github.com/bolnet/attestor"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "attestor",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "description": "The memory layer for agent teams. Deterministic retrieval, hard per-project isolation, zero LLM in the critical path.",
   "author": {
     "name": "Surendra Singh",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to Attestor (formerly Memwright) are documented in this file. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.1.3] — 2026-05-26
+
+**Fix: MCP server + hooks now find `attestor` on PATH.** Claude Code spawns hooks and the MCP server with a minimal, non-interactive PATH that excludes `~/.local/bin` (the pipx shim), so the wrappers hit `bash: attestor: command not found` — the MCP server failed to attach and lifecycle hooks silently captured nothing. Both the hook command and the MCP entry now prepend `export PATH="$HOME/.local/bin:$PATH"` before invoking `attestor`.
+
 ## [4.1.2] — 2026-05-26
 
 **Zero-question install: `attestor quickstart`.** A single command that stands up the canonical three-role local stack — Postgres (document) + Pinecone Local (vector) + Neo4j (graph) + Ollama `bge-m3` embedder — with no prompts and one default profile. It prints everything, asks nothing.

--- a/attestor/cli/_setup_helpers.py
+++ b/attestor/cli/_setup_helpers.py
@@ -43,6 +43,10 @@ def _mcp_entry(binary: str, store_path: str) -> dict:
         "command": "bash",
         "args": [
             "-c",
+            # Claude Code spawns the MCP server with a minimal, non-interactive
+            # PATH that excludes ~/.local/bin (the pipx shim), so a bare
+            # `attestor` is "command not found". Prepend it explicitly first.
+            'export PATH="$HOME/.local/bin:$PATH"; '
             'set -a; [ -f "$HOME/.attestor/.env" ] && . "$HOME/.attestor/.env"; '
             f"set +a; exec attestor mcp --path {shlex.quote(str(store_path))}",
         ],
@@ -149,9 +153,12 @@ def _hook_command(binary: str, subcommand: str) -> str:
     """
     cfg = os.environ.get("ATTESTOR_CONFIG")
     cfg_prefix = f'ATTESTOR_CONFIG="{cfg}" ' if cfg else ""
+    # ~/.local/bin (pipx shim) is not on the hook subprocess's minimal PATH, so
+    # a bare `attestor` is "command not found" and the hook silently saves
+    # nothing. Prepend it before anything else.
     return (
-        'bash -c \'set -a; [ -f "$HOME/.attestor/.env" ] && '
-        '. "$HOME/.attestor/.env"; set +a; '
+        'bash -c \'export PATH="$HOME/.local/bin:$PATH"; set -a; '
+        '[ -f "$HOME/.attestor/.env" ] && . "$HOME/.attestor/.env"; set +a; '
         f"{cfg_prefix}{binary} hook {subcommand}'"
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "attestor"
-version = "4.1.2"
+version = "4.1.3"
 description = "Production-grade memory infrastructure for multi-agent systems. Namespace isolation, RBAC, provenance, ranked retrieval."
 readme = "README.md"
 license = "MIT"

--- a/skills/attestor-memory/SKILL.md
+++ b/skills/attestor-memory/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: attestor-memory
 description: Enterprise memory layer for agent teams — durable, deterministic recall with bi-temporal facts, RBAC, and audit trails. Self-hosted Postgres + Pinecone + Neo4j; zero LLM in the critical path.
-version: 4.1.2
+version: 4.1.3
 capabilities:
   - memory.recall
   - memory.add


### PR DESCRIPTION
## Summary
Fixes the MCP server + lifecycle hooks failing with `bash: attestor: command not found`. Claude Code spawns them with a minimal PATH that excludes `~/.local/bin` (the pipx shim); the `.env`-sourcing wrappers (`_mcp_entry`, `_hook_command`) now prepend `export PATH="$HOME/.local/bin:$PATH"` before invoking `attestor`.

Impact: without this, `/mcp` never attached the attestor server and auto-capture hooks silently saved nothing on a pipx install. Surfaced during the 4.1.2 clean-machine re-test.

## Test plan
- [x] `tests/test_uninstall.py` + `tests/test_hooks.py` + `tests/test_skill_md.py` green (content-match on `attestor hook` still holds)
- [ ] Post-restart `/mcp` shows attestor (8 tools); a Bash/Write action no longer prints the hook "command not found" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)