### PR TITLE
fix(deps): ship pinecone + grpcio in base install (4.1.4)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "attestor",
       "source": "./",
       "description": "Self-hosted memory layer for Claude Code with hard per-project isolation (Postgres RLS + Pinecone + Neo4j).",
-      "version": "4.1.3",
+      "version": "4.1.4",
       "author": {
         "name": "Surendra Singh",
         "url": "https://github.com/bolnet/attestor"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "attestor",
-  "version": "4.1.3",
+  "version": "4.1.4",
   "description": "The memory layer for agent teams. Deterministic retrieval, hard per-project isolation, zero LLM in the critical path.",
   "author": {
     "name": "Surendra Singh",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to Attestor (formerly Memwright) are documented in this file. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.1.4] — 2026-05-26
+
+**Fix: the default vector lane actually works on a fresh install.** With Pinecone Local as the canonical default vector role (4.1.2), a fresh `pipx install attestor` had **no `pinecone` module** — it was only an optional extra — so the vector backend silently fell back to tag+graph (`doctor` reported `healthy: false`, "No module named 'pinecone'"). `pinecone>=5.0.0` and `grpcio>=1.60.0` are now **base dependencies**. (Pinecone 9.x dropped the `[grpc]` extra, so `grpcio` — needed by the `pinecone.grpc` local-emulator client — must be declared explicitly; it ships cp310–cp314 wheels, so no source build, incl. Python 3.14.)
+
 ## [4.1.3] — 2026-05-26
 
 **Fix: MCP server + hooks now find `attestor` on PATH.** Claude Code spawns hooks and the MCP server with a minimal, non-interactive PATH that excludes `~/.local/bin` (the pipx shim), so the wrappers hit `bash: attestor: command not found` — the MCP server failed to attach and lifecycle hooks silently captured nothing. Both the hook command and the MCP entry now prepend `export PATH="$HOME/.local/bin:$PATH"` before invoking `attestor`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "attestor"
-version = "4.1.3"
+version = "4.1.4"
 description = "Production-grade memory infrastructure for multi-agent systems. Namespace isolation, RBAC, provenance, ranked retrieval."
 readme = "README.md"
 license = "MIT"
@@ -37,10 +37,17 @@ dependencies = [
     # The codebase imports postgres + neo4j eagerly
     # (attestor/conversation/episodes.py, store/postgres_backend.py,
     # store/neo4j_backend.py), so they must be present at install time for
-    # `import attestor.conversation` to even resolve. Pinecone is lazy-loaded
-    # so the dependency is declared as the `pinecone` extra below.
+    # `import attestor.conversation` to even resolve.
     "psycopg2-binary>=2.9.0",
     "neo4j>=5.0.0",
+    # Pinecone is the DEFAULT vector role (incl. Pinecone Local via `attestor
+    # quickstart`), so it must ship in the base install — not an optional extra.
+    # The local emulator path goes through `pinecone.grpc.PineconeGRPC`, and
+    # pinecone 9.x DROPPED the `[grpc]` extra, so `grpcio` must be declared
+    # explicitly or the local vector lane dies with "No module named 'pinecone'"
+    # / a missing-grpc import. grpcio ships cp310–cp314 wheels (no source build).
+    "pinecone>=5.0.0",
+    "grpcio>=1.60.0",
     # `requests` is used by health probes and ad-hoc HTTP calls
     # throughout the codebase (e.g. cloud doctor, MCP health pings).
     "requests>=2.28.0",

--- a/skills/attestor-memory/SKILL.md
+++ b/skills/attestor-memory/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: attestor-memory
 description: Enterprise memory layer for agent teams — durable, deterministic recall with bi-temporal facts, RBAC, and audit trails. Self-hosted Postgres + Pinecone + Neo4j; zero LLM in the critical path.
-version: 4.1.3
+version: 4.1.4
 capabilities:
   - memory.recall
   - memory.add


### PR DESCRIPTION
## Summary
Fixes the default vector lane being dead on a fresh install. Pinecone Local is the canonical default vector role (4.1.2), but `pinecone` was only an optional extra — so `pipx install attestor` had no `pinecone` module and the vector backend silently fell back to tag+graph (`doctor`: `healthy: false`, "No module named 'pinecone'").

`pinecone>=5.0.0` + `grpcio>=1.60.0` are now **base dependencies**. Pinecone 9.x dropped the `[grpc]` extra, so `grpcio` (needed by the `pinecone.grpc` local-emulator client) must be explicit. Verified on Python 3.14: `grpcio` ships a cp314 wheel and `pinecone.grpc.PineconeGRPC` imports cleanly.

## Test plan
- [x] Probed on a clean 3.14 venv: `pinecone` 9.0.1 + `grpcio` 1.80.0 (cp314 wheel) install; `pinecone.grpc.PineconeGRPC` imports
- [ ] `pipx install attestor==4.1.4` → `attestor quickstart` → `doctor` shows Vector store **ok** + recall returns a real `[vector:...]` hit from Pinecone Local

🤖 Generated with [Claude Code](https://claude.com/claude-code)