### PR TITLE
feat(uninstall): attestor teardown — zero-question reverse of quickstart (4.1.5)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "attestor",
       "source": "./",
       "description": "Self-hosted memory layer for Claude Code with hard per-project isolation (Postgres RLS + Pinecone + Neo4j).",
-      "version": "4.1.4",
+      "version": "4.1.5",
       "author": {
         "name": "Surendra Singh",
         "url": "https://github.com/bolnet/attestor"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "attestor",
-  "version": "4.1.4",
+  "version": "4.1.5",
   "description": "The memory layer for agent teams. Deterministic retrieval, hard per-project isolation, zero LLM in the critical path.",
   "author": {
     "name": "Surendra Singh",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to Attestor (formerly Memwright) are documented in this file. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.1.5] — 2026-05-26
+
+**`attestor teardown` — zero-question reverse of `quickstart`.** One command removes exactly what `quickstart` created: the `postgres` + `neo4j` + `pinecone` containers, the store config (`~/.attestor`), the MCP entry in `./.mcp.json`, and the Attestor lifecycle hooks in `~/.claude/settings.json` (content-matched on `attestor hook` — never other tools'). **Data-safe by default** (Docker named volumes kept → a later `quickstart` reconnects to the same memories); `--purge` deletes the volumes (wipes memories), `--dry-run` previews. It leaves the pipx package + plugin alone (separate surfaces) and prints their removal commands. The `/uninstall-attestor` prompt now leads with this quick path.
+
 ## [4.1.4] — 2026-05-26
 
 **Fix: the default vector lane actually works on a fresh install.** With Pinecone Local as the canonical default vector role (4.1.2), a fresh `pipx install attestor` had **no `pinecone` module** — it was only an optional extra — so the vector backend silently fell back to tag+graph (`doctor` reported `healthy: false`, "No module named 'pinecone'"). `pinecone>=5.0.0` and `grpcio>=1.60.0` are now **base dependencies**. (Pinecone 9.x dropped the `[grpc]` extra, so `grpcio` — needed by the `pinecone.grpc` local-emulator client — must be declared explicitly; it ships cp310–cp314 wheels, so no source build, incl. Python 3.14.)

--- a/attestor/cli/commands/teardown.py
+++ b/attestor/cli/commands/teardown.py
@@ -1,0 +1,176 @@
+# SPDX-FileCopyrightText: 2026 Surendra Singh <66422685+bolnet@users.noreply.github.com>
+# SPDX-License-Identifier: MIT
+"""``attestor teardown`` — zero-question reverse of ``attestor quickstart``.
+
+Removes exactly what ``quickstart`` created, in one command, printing every
+step:
+
+  1. the local Docker backends (postgres + neo4j + pinecone),
+  2. the store config dir (``~/.attestor``),
+  3. the MCP server entry from the project ``./.mcp.json``,
+  4. the Attestor lifecycle hooks from ``~/.claude/settings.json``
+     (content-matched on ``attestor hook`` — never touches other tools' hooks).
+
+**Data-safe by default:** Docker named volumes (your actual memories) are KEPT,
+so a later ``attestor quickstart`` reconnects to the same data. Pass ``--purge``
+to also delete the volumes (wipes all stored memories). ``--dry-run`` previews
+without changing anything.
+
+It does NOT remove the pipx package or the Claude Code plugin (separate
+surfaces, like ``quickstart`` doesn't install them) — it prints those commands
+for you to run.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from attestor.cli.commands.quickstart import (
+    DEFAULT_STORE,
+    _compose_file,
+    _docker_available,
+)
+
+if TYPE_CHECKING:
+    import argparse
+
+HOOK_MARKER = "attestor hook"  # content-match: only Attestor's own hooks
+MCP_KEYS = ("attestor", "memory")  # current + pre-2026-05 server names
+
+
+def _compose_down(*, purge: bool, dry_run: bool) -> None:
+    compose = _compose_file()
+    cmd = ["docker", "compose", "-f", str(compose), "down"]
+    if purge:
+        cmd.append("--volumes")
+        label = "remove containers + VOLUMES (wipes memories)"
+    else:
+        label = "remove containers (keep data volumes)"
+    if dry_run:
+        print(f"  [dry-run] would run: {' '.join(cmd)}   # {label}")
+        return
+    if not _docker_available():
+        print(f"  Docker not available — run yourself: {' '.join(cmd)}")
+        return
+    print(f"  {' '.join(cmd)}   # {label}")
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=180)
+    except (OSError, subprocess.SubprocessError) as exc:
+        print(f"  docker compose down failed: {exc}")
+        return
+    if proc.returncode != 0:
+        print(f"  docker compose down returned {proc.returncode}: {proc.stderr.strip()[-400:]}")
+
+
+def _remove_store(store: Path, *, purge: bool, dry_run: bool) -> None:
+    """Remove the store config dir. Always removable (regenerable by quickstart)."""
+    if not store.exists():
+        print(f"  {store} — not present")
+        return
+    if dry_run:
+        print(f"  [dry-run] would remove {store} (config; data lives in Docker volumes)")
+        return
+    import shutil
+
+    shutil.rmtree(store)
+    print(f"  removed {store}")
+
+
+def _remove_mcp_entry(*, dry_run: bool) -> None:
+    mcp_path = Path.cwd() / ".mcp.json"
+    if not mcp_path.exists():
+        print(f"  {mcp_path} — not present")
+        return
+    try:
+        data = json.loads(mcp_path.read_text())
+    except json.JSONDecodeError:
+        print(f"  {mcp_path} — unparseable, leaving untouched")
+        return
+    servers = data.get("mcpServers", {})
+    removed = [k for k in MCP_KEYS if k in servers]
+    if not removed:
+        print(f"  {mcp_path} — no attestor entry")
+        return
+    if dry_run:
+        print(f"  [dry-run] would remove mcpServers {removed} from {mcp_path}")
+        return
+    for k in removed:
+        servers.pop(k, None)
+    mcp_path.write_text(json.dumps(data, indent=2) + "\n")
+    print(f"  removed mcpServers {removed} from {mcp_path}")
+
+
+def _remove_hooks(*, dry_run: bool) -> None:
+    settings_path = Path.home() / ".claude" / "settings.json"
+    if not settings_path.exists():
+        print(f"  {settings_path} — not present")
+        return
+    try:
+        settings = json.loads(settings_path.read_text())
+    except json.JSONDecodeError:
+        print(f"  {settings_path} — unparseable, leaving untouched")
+        return
+    hooks = settings.get("hooks", {})
+    removed = 0
+    for event, entries in list(hooks.items()):
+        if not isinstance(entries, list):
+            continue
+        kept_entries = []
+        for entry in entries:
+            inner = entry.get("hooks", []) if isinstance(entry, dict) else []
+            kept_inner = [h for h in inner if HOOK_MARKER not in str(h.get("command", ""))]
+            removed += len(inner) - len(kept_inner)
+            if kept_inner:
+                kept_entries.append({**entry, "hooks": kept_inner})
+            # entries whose only hooks were attestor's are dropped entirely
+        if kept_entries:
+            hooks[event] = kept_entries
+        else:
+            hooks.pop(event, None)
+    if removed == 0:
+        print(f"  {settings_path} — no attestor hooks")
+        return
+    if dry_run:
+        print(f"  [dry-run] would remove {removed} attestor hook(s) from {settings_path}")
+        return
+    settings_path.write_text(json.dumps(settings, indent=2) + "\n")
+    print(f"  removed {removed} attestor hook(s) from {settings_path}")
+
+
+def _cmd_teardown(args: argparse.Namespace) -> None:
+    store = Path(getattr(args, "path", None) or DEFAULT_STORE).expanduser()
+    purge = bool(getattr(args, "purge", False))
+    dry_run = bool(getattr(args, "dry_run", False))
+
+    if dry_run:
+        mode = "DRY-RUN (no changes)"
+    elif purge:
+        mode = "PURGE (also deletes stored memories)"
+    else:
+        mode = "default (keeps data volumes)"
+    print("Attestor Teardown — reverse of `attestor quickstart` (zero questions)")
+    print("=" * 66)
+    print(f"  store ............... {store}")
+    print(f"  mode ................ {mode}")
+    print()
+
+    print("[1/4] Docker backends (postgres + neo4j + pinecone)")
+    _compose_down(purge=purge, dry_run=dry_run)
+
+    print("\n[2/4] Store config (~/.attestor)")
+    _remove_store(store, purge=purge, dry_run=dry_run)
+
+    print("\n[3/4] MCP server entry (./.mcp.json)")
+    _remove_mcp_entry(dry_run=dry_run)
+
+    print("\n[4/4] Lifecycle hooks (~/.claude/settings.json)")
+    _remove_hooks(dry_run=dry_run)
+
+    print("\nDone. Not removed (separate surfaces — run yourself if you want them gone):")
+    print("  • package:  cd ~ && pipx uninstall attestor   (run from $HOME, not the repo)")
+    print("  • plugin:   /plugin uninstall attestor   (in Claude Code)")
+    if not purge:
+        print("\nData volumes KEPT — `attestor quickstart` reconnects to the same memories.")
+        print("To wipe everything including stored memories, re-run with --purge.")

--- a/attestor/cli/main.py
+++ b/attestor/cli/main.py
@@ -46,6 +46,7 @@ from attestor.cli.commands.server import (
     _cmd_ui,
 )
 from attestor.cli.commands.setup import _cmd_doctor, _cmd_setup_claude_code
+from attestor.cli.commands.teardown import _cmd_teardown
 
 
 def main(argv=None):
@@ -127,6 +128,24 @@ def main(argv=None):
     )
     p_quickstart.add_argument(
         "--no-verify", action="store_true", help="Skip the post-install health check"
+    )
+
+    # teardown (zero-question reverse of quickstart)
+    p_teardown = subparsers.add_parser(
+        "teardown",
+        help="Zero-question reverse of quickstart: remove the local backends + "
+        "store config + MCP entry + hooks. Data volumes kept unless --purge.",
+    )
+    p_teardown.add_argument(
+        "path", nargs="?", default=None, help="Store path (default: ~/.attestor)"
+    )
+    p_teardown.add_argument(
+        "--purge",
+        action="store_true",
+        help="Also delete Docker volumes (WIPES stored memories) + the store dir",
+    )
+    p_teardown.add_argument(
+        "--dry-run", action="store_true", help="Print what would be removed; change nothing"
     )
 
     # add
@@ -436,6 +455,7 @@ def main(argv=None):
     # Dispatch
     handlers = {
         "quickstart": _cmd_quickstart,
+        "teardown": _cmd_teardown,
         "init": _cmd_init,
         "add": _cmd_add,
         "recall": _cmd_recall,

--- a/commands/uninstall-attestor.md
+++ b/commands/uninstall-attestor.md
@@ -10,6 +10,26 @@ You are completely uninstalling **Attestor** (PyPI: `attestor`) from this machin
 
 A full install touches **six surfaces** — reverse each, in this order. Scan first, report, then act. Destructive steps (data deletion) need explicit confirmation; config/wiring removal does not.
 
+---
+
+## Quick path (one command — recommended if installed via `attestor quickstart`)
+
+```bash
+attestor teardown            # removes containers + ~/.attestor + MCP entry + hooks (KEEPS data volumes)
+attestor teardown --purge    # ALSO deletes Docker volumes — wipes all stored memories
+attestor teardown --dry-run  # preview only; changes nothing
+```
+
+`attestor teardown` is the zero-question reverse of `quickstart`: it tears down surfaces **[2] store config**, **[3] MCP entry (`./.mcp.json`) + the 3 lifecycle hooks** (content-matched on `attestor hook` — never other tools'), and **[4] the `postgres` + `neo4j` + `pinecone` containers**, printing each step. **Data-safe by default** (named volumes kept → a later `quickstart` reconnects to the same memories); `--purge` wipes them.
+
+It deliberately does **not** touch the two remaining surfaces — run those yourself:
+- **[1] package:** `cd ~ && pipx uninstall attestor` (from `$HOME`, not the repo — the source tree's `attestor/` dir shadows the name)
+- **[6] plugin:** `/plugin uninstall attestor` (inside Claude Code)
+
+For a manual / forensic reverse — or if the `attestor` binary isn't on PATH — follow the six-surface procedure below.
+
+---
+
 Rules:
 - **Never** remove another tool's hooks. Match Attestor hooks by command content `attestor hook` only.
 - **Back up** every JSON settings file to `*.bak` before editing; read → parse → mutate in memory → write atomically. Never `jq -e` mid-edit.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "attestor"
-version = "4.1.4"
+version = "4.1.5"
 description = "Production-grade memory infrastructure for multi-agent systems. Namespace isolation, RBAC, provenance, ranked retrieval."
 readme = "README.md"
 license = "MIT"

--- a/skills/attestor-memory/SKILL.md
+++ b/skills/attestor-memory/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: attestor-memory
 description: Enterprise memory layer for agent teams — durable, deterministic recall with bi-temporal facts, RBAC, and audit trails. Self-hosted Postgres + Pinecone + Neo4j; zero LLM in the critical path.
-version: 4.1.4
+version: 4.1.5
 capabilities:
   - memory.recall
   - memory.add

--- a/tests/test_quickstart.py
+++ b/tests/test_quickstart.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import stat
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -14,6 +14,9 @@ from attestor.cli.commands.quickstart import (
     _ensure_env,
     _write_config_toml,
 )
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 pytestmark = pytest.mark.unit
 
@@ -47,7 +50,9 @@ def test_write_config_toml_is_three_role_with_env_refs(tmp_path: Path) -> None:
     assert 'password = "$NEO4J_PASSWORD"' in text
     assert "v4 = true" in text
     # Canonical three roles — Postgres (document) + Pinecone (vector) + Neo4j (graph).
-    assert "[postgres]" in text and "[neo4j]" in text and "[pinecone]" in text
+    assert "[postgres]" in text
+    assert "[neo4j]" in text
+    assert "[pinecone]" in text
     assert 'backends = ["postgres", "pinecone", "neo4j"]' in text
     # Pinecone Local routed for the vector role at the default host + 1024-D index.
     assert "localhost:5080" in text

--- a/tests/test_teardown.py
+++ b/tests/test_teardown.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: 2026 Surendra Singh <66422685+bolnet@users.noreply.github.com>
+# SPDX-License-Identifier: MIT
+"""Unit tests for ``attestor teardown`` removal logic (MCP entry + hooks)."""
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from attestor.cli.commands.teardown import _remove_hooks, _remove_mcp_entry
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+pytestmark = pytest.mark.unit
+
+
+def test_remove_mcp_entry_drops_attestor_keeps_others(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    mcp = tmp_path / ".mcp.json"
+    mcp.write_text(json.dumps({"mcpServers": {
+        "attestor": {"command": "bash"},
+        "memory": {"command": "bash"},      # legacy name — also dropped
+        "other-tool": {"command": "node"},  # must be preserved
+    }}))
+
+    _remove_mcp_entry(dry_run=False)
+
+    servers = json.loads(mcp.read_text())["mcpServers"]
+    assert "attestor" not in servers
+    assert "memory" not in servers
+    assert "other-tool" in servers  # never touch another tool's entry
+
+
+def test_remove_mcp_entry_dry_run_changes_nothing(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    mcp = tmp_path / ".mcp.json"
+    original = json.dumps({"mcpServers": {"attestor": {"command": "bash"}}})
+    mcp.write_text(original)
+
+    _remove_mcp_entry(dry_run=True)
+
+    assert mcp.read_text() == original  # untouched
+
+
+def test_remove_hooks_content_matched(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    settings_dir = tmp_path / ".claude"
+    settings_dir.mkdir()
+    settings = settings_dir / "settings.json"
+    settings.write_text(json.dumps({"hooks": {
+        "PostToolUse": [
+            {"hooks": [
+                {"type": "command", "command": "bash -c '... attestor hook post-tool-use'"},
+                {"type": "command", "command": "prettier --write"},  # another tool — keep
+            ]},
+        ],
+        "Stop": [
+            {"hooks": [{"type": "command", "command": "bash -c '... attestor hook stop'"}]},
+        ],
+    }}))
+
+    _remove_hooks(dry_run=False)
+
+    hooks = json.loads(settings.read_text())["hooks"]
+    # The Stop event had only Attestor's hook -> event dropped entirely.
+    assert "Stop" not in hooks
+    # PostToolUse keeps the other tool's hook, drops Attestor's.
+    commands = [h["command"] for entry in hooks["PostToolUse"] for h in entry["hooks"]]
+    assert all("attestor hook" not in c for c in commands)
+    assert any("prettier" in c for c in commands)
+
+
+def test_remove_hooks_no_attestor_is_noop(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    settings_dir = tmp_path / ".claude"
+    settings_dir.mkdir()
+    settings = settings_dir / "settings.json"
+    original = json.dumps({"hooks": {"PostToolUse": [
+        {"hooks": [{"type": "command", "command": "eslint ."}]},
+    ]}})
+    settings.write_text(original)
+
+    _remove_hooks(dry_run=False)
+
+    assert json.loads(settings.read_text()) == json.loads(original)  # unchanged


### PR DESCRIPTION
## Summary
Adds **`attestor teardown`** — the one-command, zero-question reverse of `attestor quickstart`. Removes the `postgres`+`neo4j`+`pinecone` containers, `~/.attestor` config, the `./.mcp.json` MCP entry, and the lifecycle hooks (content-matched on `attestor hook` — never other tools'). **Data-safe by default** (named volumes kept); `--purge` wipes volumes, `--dry-run` previews. Leaves the pipx package + plugin alone (separate surfaces) and prints their removal commands. `/uninstall-attestor` now leads with this quick path.

## Test plan
- [x] `tests/test_teardown.py` (4): MCP entry removal (keeps other tools), hooks content-match (keeps other tools), dry-run no-op
- [x] Full fast suite green (1343 pass); ruff clean
- [ ] Live: `attestor teardown --dry-run` then real run on a quickstart'd box

🤖 Generated with [Claude Code](https://claude.com/claude-code)