### PR TITLE
fix(cli,pinecone): auto-load store .env + pinecone 9.x gRPC compat (4.1.6)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "attestor",
       "source": "./",
       "description": "Self-hosted memory layer for Claude Code with hard per-project isolation (Postgres RLS + Pinecone + Neo4j).",
-      "version": "4.1.5",
+      "version": "4.1.6",
       "author": {
         "name": "Surendra Singh",
         "url": "https://github.com/bolnet/attestor"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "attestor",
-  "version": "4.1.5",
+  "version": "4.1.6",
   "description": "The memory layer for agent teams. Deterministic retrieval, hard per-project isolation, zero LLM in the critical path.",
   "author": {
     "name": "Surendra Singh",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to Attestor (formerly Memwright) are documented in this file. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.1.6] — 2026-05-26
+
+**Two install papercuts from the live 4.1.5 test.**
+
+- **CLI auto-loads `<store>/.env`.** A bare `attestor add/recall/doctor <store>` ran without the MCP/hook wrapper's `.env` sourcing, so `$PGPASSWORD` (referenced by `config.toml`) was unset and Postgres auth failed. The CLI now loads the store's `.env` itself (`setdefault` — an already-exported shell value still wins), so direct commands work without `source ~/.attestor/.env` (and no more repeated shell-source permission prompts).
+- **Pinecone 9.x gRPC compatibility.** The local-emulator path imported `GRPCClientConfig`, which pinecone 9.x removed; init died with an import error and the vector lane fell back to tag+graph. Now constructs `GrpcIndex(host=…, api_key=…, secure=False)` directly (the 9.x way to select insecure http transport for Pinecone Local).
+
 ## [4.1.5] — 2026-05-26
 
 **`attestor teardown` — zero-question reverse of `quickstart`.** One command removes exactly what `quickstart` created: the `postgres` + `neo4j` + `pinecone` containers, the store config (`~/.attestor`), the MCP entry in `./.mcp.json`, and the Attestor lifecycle hooks in `~/.claude/settings.json` (content-matched on `attestor hook` — never other tools'). **Data-safe by default** (Docker named volumes kept → a later `quickstart` reconnects to the same memories); `--purge` deletes the volumes (wipes memories), `--dry-run` previews. It leaves the pipx package + plugin alone (separate surfaces) and prints their removal commands. The `/uninstall-attestor` prompt now leads with this quick path.

--- a/attestor/cli/main.py
+++ b/attestor/cli/main.py
@@ -12,6 +12,7 @@ byte-identical.
 from __future__ import annotations
 
 import argparse
+import contextlib
 import os
 import sys
 from pathlib import Path
@@ -47,6 +48,30 @@ from attestor.cli.commands.server import (
 )
 from attestor.cli.commands.setup import _cmd_doctor, _cmd_setup_claude_code
 from attestor.cli.commands.teardown import _cmd_teardown
+
+
+def _autoload_store_env(args: argparse.Namespace) -> None:
+    """Load ``<store>/.env`` into the environment for store-scoped commands.
+
+    Claude Code's MCP/hook wrappers source ``~/.attestor/.env`` before invoking
+    ``attestor``, but a bare ``attestor add/recall/doctor <store>`` runs without
+    it — so ``$PGPASSWORD`` (referenced by ``config.toml``) is unset and Postgres
+    auth fails. Mirror the wrappers: when a store path is given and has a
+    ``.env``, load it. ``setdefault`` means an already-exported shell value wins.
+    """
+    store = getattr(args, "path", None)
+    if not store:
+        return
+    env_file = Path(store).expanduser() / ".env"
+    if not env_file.is_file():
+        return
+    # never let env loading break the command
+    with contextlib.suppress(Exception):
+        from dotenv import dotenv_values
+
+        for key, value in dotenv_values(env_file).items():
+            if value is not None:
+                os.environ.setdefault(key, value)
 
 
 def main(argv=None):
@@ -451,6 +476,10 @@ def main(argv=None):
         # previous fall-through returned 0 silently.
         parser.print_help()
         sys.exit(1)
+
+    # Bare CLI calls don't get the MCP/hook wrapper's `.env` sourcing — load
+    # the store's .env here so `attestor add/recall/doctor <store>` just work.
+    _autoload_store_env(args)
 
     # Dispatch
     handlers = {

--- a/attestor/store/pinecone_backend.py
+++ b/attestor/store/pinecone_backend.py
@@ -104,9 +104,8 @@ class PineconeBackend:
         )
 
         if self._is_local:
-            from pinecone.grpc import PineconeGRPC, GRPCClientConfig
             from pinecone import ServerlessSpec
-            self._grpc_config_cls = GRPCClientConfig
+            from pinecone.grpc import PineconeGRPC
             self._serverless_spec_cls = ServerlessSpec
             self._pc = PineconeGRPC(api_key=self._api_key, host=self._host)
         else:
@@ -146,9 +145,12 @@ class PineconeBackend:
         # falls back to a different backend). See ``_ensure_ready``.
         if self._is_local:
             desc = self._pc.describe_index(self._index_name)
-            self._index = self._pc.Index(
-                host=desc.host,
-                grpc_config=self._grpc_config_cls(secure=False),
+            # pinecone 9.x: GRPCClientConfig is gone and PineconeGRPC.Index()
+            # rejects a `secure=` kwarg, so construct GrpcIndex directly —
+            # `secure=False` selects http (the local emulator's transport).
+            from pinecone.grpc import GrpcIndex
+            self._index = GrpcIndex(
+                host=desc.host, api_key=self._api_key, secure=False
             )
         else:
             self._index = self._pc.Index(name=self._index_name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "attestor"
-version = "4.1.5"
+version = "4.1.6"
 description = "Production-grade memory infrastructure for multi-agent systems. Namespace isolation, RBAC, provenance, ranked retrieval."
 readme = "README.md"
 license = "MIT"

--- a/skills/attestor-memory/SKILL.md
+++ b/skills/attestor-memory/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: attestor-memory
 description: Enterprise memory layer for agent teams — durable, deterministic recall with bi-temporal facts, RBAC, and audit trails. Self-hosted Postgres + Pinecone + Neo4j; zero LLM in the critical path.
-version: 4.1.5
+version: 4.1.6
 capabilities:
   - memory.recall
   - memory.add

--- a/tests/test_cli_env_autoload.py
+++ b/tests/test_cli_env_autoload.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: 2026 Surendra Singh <66422685+bolnet@users.noreply.github.com>
+# SPDX-License-Identifier: MIT
+"""Unit tests for the CLI auto-loading ``<store>/.env`` (bare-command parity)."""
+from __future__ import annotations
+
+import argparse
+import os
+
+import pytest
+
+from attestor.cli.main import _autoload_store_env
+
+pytestmark = pytest.mark.unit
+
+
+def test_autoload_loads_store_env(tmp_path, monkeypatch) -> None:
+    (tmp_path / ".env").write_text("ATTESTOR_AUTOLOAD_PROBE=loaded\n")
+    monkeypatch.delenv("ATTESTOR_AUTOLOAD_PROBE", raising=False)
+
+    _autoload_store_env(argparse.Namespace(path=str(tmp_path)))
+
+    assert os.environ.get("ATTESTOR_AUTOLOAD_PROBE") == "loaded"
+
+
+def test_autoload_does_not_override_existing(tmp_path, monkeypatch) -> None:
+    (tmp_path / ".env").write_text("ATTESTOR_AUTOLOAD_PROBE2=fromfile\n")
+    monkeypatch.setenv("ATTESTOR_AUTOLOAD_PROBE2", "fromshell")
+
+    _autoload_store_env(argparse.Namespace(path=str(tmp_path)))
+
+    # setdefault → an already-exported shell value wins (don't clobber).
+    assert os.environ["ATTESTOR_AUTOLOAD_PROBE2"] == "fromshell"
+
+
+def test_autoload_noop_without_path() -> None:
+    # No path attr / None → no error, nothing loaded.
+    _autoload_store_env(argparse.Namespace(path=None))
+    _autoload_store_env(argparse.Namespace())
+
+
+def test_autoload_noop_when_no_env_file(tmp_path) -> None:
+    # Store dir exists but has no .env → silent no-op.
+    _autoload_store_env(argparse.Namespace(path=str(tmp_path)))


### PR DESCRIPTION
## Summary
Two papercuts surfaced by the live 4.1.5 `quickstart` test:

1. **CLI auto-loads `<store>/.env`** — bare `attestor add/recall/doctor <store>` ran without the MCP/hook wrapper's `.env` sourcing, so `$PGPASSWORD` was unset → Postgres auth failed. `main.py` now loads the store's `.env` (`setdefault`, exported shell value wins). Fixes the failure *and* the repeated shell-source permission prompts.
2. **Pinecone 9.x gRPC compat** — the local path imported `GRPCClientConfig` (removed in pinecone 9.x) → import error, vector lane fell back to tag+graph. Now builds `GrpcIndex(host=…, api_key=…, secure=False)` directly (verified to construct on pinecone 9.0.1 / Python 3.14).

## Test plan
- [x] `tests/test_cli_env_autoload.py` (4) + full fast suite green (1347 pass)
- [x] Pinecone 9.x: `GrpcIndex(secure=False)` construct verified in a clean 3.14 venv
- [ ] **Live Pinecone Local round-trip on 9.x** (create_index / upsert / query) — to validate on a quickstart'd box; further 9.x API drift may surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)