### PR TITLE
chore(docker): consistent attestor_ naming for all containers + resources (4.1.8)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "attestor",
       "source": "./",
       "description": "Self-hosted memory layer for Claude Code with hard per-project isolation (Postgres RLS + Pinecone + Neo4j).",
-      "version": "4.1.7",
+      "version": "4.1.8",
       "author": {
         "name": "Surendra Singh",
         "url": "https://github.com/bolnet/attestor"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "attestor",
-  "version": "4.1.7",
+  "version": "4.1.8",
   "description": "The memory layer for agent teams. Deterministic retrieval, hard per-project isolation, zero LLM in the critical path.",
   "author": {
     "name": "Surendra Singh",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to Attestor (formerly Memwright) are documented in this file. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.1.8] — 2026-05-26
+
+**Consistent `attestor_` Docker naming.** Every container, volume, and the compose network/project is now named `attestor_…`, so `docker ps -a | grep attestor` (and `docker volume ls | grep attestor`, `docker network ls | grep attestor`) lists everything Attestor owns. Renamed: `attestor_postgres_document_db`, `attestor_pinecone_vector_db`, `attestor_neo4j_graph_db` (+ `attestor_api`); compose project → `attestor` (volumes become `attestor_postgres_data`, … and the network `attestor_default`). `quickstart`'s health-wait + all docs/uninstall scans updated to match; the uninstall docker filter broadened to `name=attestor` so it catches both the new underscore names and the legacy `attestor-*-local` ones.
+
 ## [4.1.7] — 2026-05-26
 
 **Docs: refreshed the README (the PyPI page was dated).** Replaced the old manual install (pip + separately-started Pinecone Local container + Pinecone-Inference cloud key + manual `doctor`) with the one-command `attestor quickstart` flow; fixed the stale `4.0.0` version stamps → 4.1.x; corrected the "Install for Claude Code" section (namespaced `/attestor:install-attestor`, plugin-must-be-enabled, real `attestor-*-local` container names); added `quickstart` + `teardown` to the CLI table and dropped the nonexistent `attestor setup local`. No code changes.

--- a/README.md
+++ b/README.md
@@ -827,9 +827,11 @@ The local backends come up as three Docker containers (the bundled `attestor/inf
 
 | Container | Type | Storage role |
 |---|---|---|
-| `attestor-pg-local` | Postgres 16 + pgvector | Document — source of truth |
-| `attestor-pinecone-local` | Pinecone Local | Vector — embeddings |
-| `attestor-neo4j-local` | Neo4j 5 + GDS | Graph — PageRank / BFS |
+| `attestor_postgres_document_db` | Postgres 16 + pgvector | Document — source of truth |
+| `attestor_pinecone_vector_db` | Pinecone Local | Vector — embeddings |
+| `attestor_neo4j_graph_db` | Neo4j 5 + GDS | Graph — PageRank / BFS |
+
+> Every container, volume, and the compose network/project is named `attestor_…`, so `docker ps -a \| grep attestor` (and `docker volume ls \| grep attestor`) lists everything Attestor owns.
 
 Cloud / managed backends (Neon · RDS · Cloud SQL, Pinecone Cloud, Neo4j AuraDB) and alternative embedders (Pinecone Inference `llama-text-embed-v2`, Voyage `voyage-4`, OpenAI `text-embedding-3`) are configured in `~/.attestor/attestor.yaml` — see [`docs/INSTALL.md`](docs/INSTALL.md).
 

--- a/attestor/cli/commands/quickstart.py
+++ b/attestor/cli/commands/quickstart.py
@@ -47,8 +47,8 @@ OLLAMA_BASE_URL = "http://localhost:11434/v1"
 OLLAMA_EMBED_MODEL = "bge-m3"
 EMBED_DIM = 1024  # bge-m3 output dim == Pinecone index dim
 PINECONE_LOCAL_HOST = "http://localhost:5080"
-PG_CONTAINER = "attestor-pg-local"
-NEO4J_CONTAINER = "attestor-neo4j-local"
+PG_CONTAINER = "attestor_postgres_document_db"
+NEO4J_CONTAINER = "attestor_neo4j_graph_db"
 HEALTH_TIMEOUT_S = 120
 
 # Ports the local stack uses — scanned up front so the user sees what's already

--- a/attestor/infra/local/README.md
+++ b/attestor/infra/local/README.md
@@ -8,18 +8,18 @@ decision (2026-04-18): **Postgres SQL + pgvector + Neo4j**.
 
 | Container | Image | Role |
 |---|---|---|
-| `attestor-api-local` | `attestor/api:3.0.0` | Slim HTTP API. **No** embedded DB, no sentence-transformers, no torch. |
-| `attestor-pg-local` | `attestor/db-postgres:16` (built from `pgvector/pgvector:pg16`) | Postgres 16 + `pgvector` — document store + vector HNSW. |
-| `attestor-neo4j-local` | `neo4j:5.24-community` | Neo4j 5 + GDS Community plugin — graph + community detection. |
+| `attestor_api` | `attestor/api:3.0.0` | Slim HTTP API. **No** embedded DB, no sentence-transformers, no torch. |
+| `attestor_postgres_document_db` | `attestor/db-postgres:16` (built from `pgvector/pgvector:pg16`) | Postgres 16 + `pgvector` — document store + vector HNSW. |
+| `attestor_neo4j_graph_db` | `neo4j:5.24-community` | Neo4j 5 + GDS Community plugin — graph + community detection. |
 
 ## Topology
 
 ```
 ┌────── localhost ─────────┐
 │                          │
-│  :8080  attestor-api  ───┼──► attestor-pg-local      :5432  (doc + vector)
+│  :8080  attestor-api  ───┼──► attestor_postgres_document_db      :5432  (doc + vector)
 │                          │
-│                          └──► attestor-neo4j-local   :7687  (graph)
+│                          └──► attestor_neo4j_graph_db   :7687  (graph)
 │                                                      :7474  (browser UI)
 └──────────────────────────┘
 ```

--- a/attestor/infra/local/bench_latency.py
+++ b/attestor/infra/local/bench_latency.py
@@ -5,8 +5,8 @@
 Measures P50/P95/P99 latency for `/add` and `/recall` against the single
 API container started by `docker-compose.yml` in this directory:
 
-    http://localhost:8080  ->  attestor-api-local
-    (talks to attestor-pg-local and attestor-neo4j-local)
+    http://localhost:8080  ->  attestor_api
+    (talks to attestor_postgres_document_db and attestor_neo4j_graph_db)
 
 Usage:
     python bench_latency.py                    # 50 iters, 10x seed corpus

--- a/attestor/infra/local/docker-attestor.yaml
+++ b/attestor/infra/local/docker-attestor.yaml
@@ -1,0 +1,133 @@
+# Docker-specific Attestor config for the local compose stack.
+#
+# Differences from ~/.attestor/attestor.yaml (host MCP config):
+#   - Pinecone Local uses compose service name (pinecone:5080), not localhost
+#   - Ollama uses host.docker.internal instead of localhost
+#   - LLM routes through OpenRouter (same as production default)
+#
+# Mounted read-only into attestor_api at /data/config/attestor.yaml.
+# Do not use this file for the host MCP server — use ~/.attestor/attestor.yaml.
+
+stack:
+
+  postgres:
+    url: postgresql://postgres:${POSTGRES_PASSWORD:-attestor}@postgres:5432/attestor
+    v4: true
+    skip_schema_init: false
+
+  # Pinecone Local running as a compose service — reachable at pinecone:5080
+  # within the Docker network.
+  pinecone:
+    host: http://pinecone:5080
+    api_key_env: PINECONE_API_KEY
+    index_name: attestor
+    metric: cosine
+    cloud: aws
+    region: us-east-1
+
+  neo4j:
+    url: bolt://neo4j:7687
+    auth:
+      username: neo4j
+      password_env: NEO4J_PASSWORD
+    database: neo4j
+
+  # Ollama running on the Docker host — reachable via host.docker.internal.
+  # OPENAI_BASE_URL and OPENAI_API_KEY are set by the compose environment.
+  embedder:
+    provider: openai
+    model: bge-m3
+    dimensions: 1024
+    api_key_env: OPENAI_API_KEY
+
+  llm:
+    provider: openrouter
+    providers:
+      openai:
+        base_url: https://api.openai.com/v1
+        api_key_env: OPENAI_API_KEY
+      openrouter:
+        base_url: https://openrouter.ai/api/v1
+        api_key_env: OPENROUTER_API_KEY
+      anthropic:
+        base_url: https://api.anthropic.com/v1/
+        api_key_env: ANTHROPIC_API_KEY
+    default_provider: openai
+
+  models:
+    answerer: openrouter/openai/gpt-5.4-mini
+    judge: openrouter/openai/gpt-4o-2024-08-06
+    extraction: openrouter/openai/gpt-4.1
+    distill: anthropic/claude-haiku-4-5-20251001
+    verifier: anthropic/claude-sonnet-4-6
+    planner: anthropic/claude-opus-4.7
+    benchmark_default: openrouter/openai/gpt-4o-2024-08-06
+
+  retrieval:
+    vector_top_k: 50
+    mmr_lambda: 0.7
+    vector_weight: 0.7
+    graph_weight: 0.3
+    graph_affinity_bonus:
+      0: 0.30
+      1: 0.20
+      2: 0.10
+    graph_unreachable_penalty: -0.05
+    temporal_prefilter:
+      enabled: true
+      tolerance_days: 3
+    hyde:
+      enabled: true
+      generator_model: null
+      generator_reasoning_effort: low
+      merge: rrf
+    reranker:
+      enabled: false
+      provider: bge
+      top_k: 10
+      top_n_input: 50
+    global_query:
+      enabled: false
+      classifier_model: anthropic/claude-haiku-4.5
+      summary_model: anthropic/claude-haiku-4.5
+      max_clusters: 8
+
+  budget: 4000
+  parallel: 2
+
+  self_consistency:
+    enabled: false
+    k: 5
+    temperature: 0.7
+    voter: majority
+
+  memory:
+    layers:
+      default_recall: ["episodic", "semantic"]
+      weights:
+        episodic: 0.0
+        semantic: 0.05
+        procedural: 0.0
+        working: 0.0
+
+  ingest:
+    contextual_embedding:
+      enabled: false
+    llm_entity_extraction:
+      enabled: false
+
+  critique_revise:
+    enabled: false
+
+  compliance:
+    pii:
+      mode: "off"
+    retention:
+      apply_on_schedule: false
+
+  consolidation:
+    enabled: false
+
+audit:
+  dashboard:
+    enabled: false

--- a/attestor/infra/local/docker-compose.yml
+++ b/attestor/infra/local/docker-compose.yml
@@ -1,20 +1,20 @@
-# Attestor local stack — three independent containers.
+# Attestor local stack — three storage-role containers (+ optional API).
 #
-#   attestor-api-local      Slim HTTP API. Talks to PG (doc + vector) + Neo4j (graph).
-#   attestor-pg-local       Postgres 16 + pgvector — document store + vector HNSW.
-#   attestor-neo4j-local    Neo4j 5 Community + GDS plugin — graph + community detection.
+#   attestor_postgres_document_db   Postgres 16 + pgvector — document store.
+#   attestor_pinecone_vector_db     Pinecone Local emulator — vector store.
+#   attestor_neo4j_graph_db         Neo4j 5 Community + GDS plugin — graph store.
+#   attestor_api                    Optional slim HTTP API (not started by quickstart).
 #
-# Layer 0 backend per project decision (2026-04-18):
-#   PG (relational SQL + pgvector) is SoT for doc + vector + bi-temporal.
-#   Neo4j is graph (Cypher + GDS).
+# Naming convention: every container/resource is `attestor_<meaningful>` — the
+# compose project name (`attestor`) also prefixes the named volumes
+# (attestor_postgres_data, attestor_neo4j_data, …).
 #
 # Usage:
-#   cp .env.example .env && $EDITOR .env       # add OPENROUTER_API_KEY
-#   docker compose up --build                  # builds + starts everything
-#   curl localhost:8080/health                 # API
-#   docker compose down -v                     # stop + wipe volumes
+#   docker compose up -d postgres neo4j pinecone   # what `attestor quickstart` runs
+#   docker compose down                            # stop (keeps volumes/data)
+#   docker compose down -v                         # stop + wipe volumes (deletes memories)
 
-name: attestor-local
+name: attestor
 
 services:
 
@@ -24,7 +24,7 @@ services:
       context: .
       dockerfile: postgres.Dockerfile
     image: attestor/db-postgres:16
-    container_name: attestor-pg-local
+    container_name: attestor_postgres_document_db
     ports:
       - "5432:5432"
     environment:
@@ -44,7 +44,7 @@ services:
   # ─────────────────── DB: Neo4j 5 Community + GDS ────────────────────────
   neo4j:
     image: neo4j:5.24-community
-    container_name: attestor-neo4j-local
+    container_name: attestor_neo4j_graph_db
     ports:
       - "7474:7474"   # HTTP / Browser UI
       - "7687:7687"   # Bolt
@@ -75,7 +75,7 @@ services:
   pinecone:
     image: ghcr.io/pinecone-io/pinecone-local:latest
     platform: linux/amd64
-    container_name: attestor-pinecone-local
+    container_name: attestor_pinecone_vector_db
     ports:
       - "5080-5090:5080-5090"
     environment:
@@ -89,7 +89,7 @@ services:
       context: ../../..
       dockerfile: attestor/infra/local/api.Dockerfile
     image: attestor/api:4.0.0
-    container_name: attestor-api-local
+    container_name: attestor_api
     ports:
       - "8080:8080"
     environment:
@@ -116,7 +116,7 @@ services:
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
       ATTESTOR_DATA_DIR: /data/attestor
     volumes:
-      - attestor_data:/data/attestor
+      - api_data:/data/attestor
       - ./docker-attestor.yaml:/data/config/attestor.yaml:ro
     depends_on:
       postgres:
@@ -127,9 +127,12 @@ services:
         condition: service_started
     restart: unless-stopped
 
+# Project name `attestor` (above) prefixes every named volume → they all become
+# attestor_postgres_data, attestor_neo4j_data, … so `docker volume ls | grep attestor`
+# catches them all.
 volumes:
   postgres_data:
   neo4j_data:
   neo4j_logs:
   neo4j_plugins:
-  attestor_data:
+  api_data:

--- a/commands/uninstall-attestor.md
+++ b/commands/uninstall-attestor.md
@@ -44,7 +44,7 @@ Rules:
 echo "[1] package:"   ; (command -v attestor && pipx list 2>/dev/null | grep attestor) || echo "  none"
 echo "[2] ~/.attestor:"; ls -la ~/.attestor 2>/dev/null || echo "  none"
 echo "[3] wiring:"     ; for f in ~/.claude/settings.json ~/.claude/.mcp.json ~/.claude.json ./.claude/settings.json ./.mcp.json; do echo "  $f"; grep -o '"attestor"\|attestor hook' "$f" 2>/dev/null | sort -u | sed 's/^/    /'; done
-echo "[4] docker:"     ; docker ps -a --filter name=attestor- --format '  {{.Names}}' 2>/dev/null; docker volume ls -q --filter name=attestor 2>/dev/null | sed 's/^/  vol /'
+echo "[4] docker:"     ; docker ps -a --filter name=attestor --format '  {{.Names}}' 2>/dev/null; docker volume ls -q --filter name=attestor 2>/dev/null | sed 's/^/  vol /'
 echo "[5] artifacts:"  ; ls -d .cc_attestor_probe_store config.json logs 2>/dev/null | sed 's/^/  /' || echo "  none"
 echo "[6] plugin:"     ; grep -l "bolnet/attestor" ~/.claude.json 2>/dev/null && echo "  plugin ref present" || echo "  none"
 ```
@@ -92,7 +92,7 @@ Ask via `AskUserQuestion`: "Remove the Attestor Docker containers and volumes? T
 On yes:
 
 ```bash
-docker rm -f $(docker ps -aq --filter name=attestor-) 2>/dev/null
+docker rm -f $(docker ps -aq --filter name=attestor) 2>/dev/null
 docker volume rm $(docker volume ls -q --filter name=attestor) 2>/dev/null
 ```
 
@@ -119,7 +119,7 @@ command -v attestor || echo "binary gone"
 pipx list 2>/dev/null | grep -c attestor
 [ -e ~/.attestor ] && echo "HOME present" || echo "HOME gone"
 for f in ~/.claude/settings.json ~/.claude/.mcp.json ~/.claude.json ./.claude/settings.json ./.mcp.json; do grep -c "attestor hook\|\"attestor\"" "$f" 2>/dev/null; done
-docker ps -aq --filter name=attestor- | wc -l
+docker ps -aq --filter name=attestor | wc -l
 ```
 
 Report a ≤8-line summary of what was **removed** vs **preserved** (and which `*.bak` backups were left). Remind the user to **restart Claude Code** so it drops the now-orphaned MCP server process + hooks.

--- a/docs/CLAUDE_LOCAL_SETUP_PROMPT.md
+++ b/docs/CLAUDE_LOCAL_SETUP_PROMPT.md
@@ -49,7 +49,7 @@ compose file's own directory and misses the repo-root .env), and build:
   docker compose --env-file .env -f attestor/infra/local/docker-compose.yml up -d --build
   Then show status: `docker compose --env-file .env -f attestor/infra/local/docker-compose.yml ps`
   Confirm the key reached the container (presence only, no value):
-  `docker exec attestor-api-local sh -c '[ -n "$PINECONE_API_KEY" ] && echo SET || echo EMPTY'`
+  `docker exec attestor_api sh -c '[ -n "$PINECONE_API_KEY" ] && echo SET || echo EMPTY'`
 
 STEP 4 — Verify the FULLY-GREEN path with a host-run API. The containerized API
 at :8080 cannot reach Pinecone Local (its config pins host=localhost:5080, which

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -139,9 +139,9 @@ This brings up three containers:
 
 | Container | Image | Port | Role |
 |-----------|-------|------|------|
-| `attestor-pg-local` | `attestor/db-postgres:16` (pgvector) | `5432` | Document |
-| `attestor-pinecone-local` | `ghcr.io/pinecone-io/pinecone-local:latest` | `5080-5090` | Vector |
-| `attestor-neo4j-local` | `neo4j:5.24-community` (+ GDS plugin) | `7474`, `7687` | Graph |
+| `attestor_postgres_document_db` | `attestor/db-postgres:16` (pgvector) | `5432` | Document |
+| `attestor_pinecone_vector_db` | `ghcr.io/pinecone-io/pinecone-local:latest` | `5080-5090` | Vector |
+| `attestor_neo4j_graph_db` | `neo4j:5.24-community` (+ GDS plugin) | `7474`, `7687` | Graph |
 
 Wait for all three to report healthy:
 
@@ -286,7 +286,7 @@ docker compose up -d            # postgres + pinecone + neo4j + attestor-api
 curl localhost:8080/health      # {"ok": true, "data": {"healthy": true, ...}}
 ```
 
-The API container (`attestor-api-local`) serves the same routes as the library — `/add`, `/recall`, `/search`, `/timeline`, `/forget`, `/memory/{id}`, `/health`, `/stats` (see [`attestor/api.py`](../attestor/api.py)). Any language can drive it via `MemoryClient` or raw REST. Backend config resolves from env (`POSTGRES_URL` / `NEO4J_URI` + `PINECONE_*`) and otherwise from `configs/attestor.yaml`; the vector (Pinecone) role is always preserved.
+The API container (`attestor_api`) serves the same routes as the library — `/add`, `/recall`, `/search`, `/timeline`, `/forget`, `/memory/{id}`, `/health`, `/stats` (see [`attestor/api.py`](../attestor/api.py)). Any language can drive it via `MemoryClient` or raw REST. Backend config resolves from env (`POSTGRES_URL` / `NEO4J_URI` + `PINECONE_*`) and otherwise from `configs/attestor.yaml`; the vector (Pinecone) role is always preserved.
 
 ---
 

--- a/docs/LOCAL_DOCKER_SETUP.md
+++ b/docs/LOCAL_DOCKER_SETUP.md
@@ -80,9 +80,9 @@ client libraries and bakes in `configs/`) and starts:
 
 | Container             | Role     | Port(s)      |
 | --------------------- | -------- | ------------ |
-| `attestor-pg-local`   | Document | `5432`       |
-| `attestor-neo4j-local`| Graph    | `7474`, `7687` |
-| `attestor-api-local`  | REST API | `8080`       |
+| `attestor_postgres_document_db`   | Document | `5432`       |
+| `attestor_neo4j_graph_db`| Graph    | `7474`, `7687` |
+| `attestor_api`  | REST API | `8080`       |
 
 Watch them become healthy:
 
@@ -215,7 +215,7 @@ docker compose --env-file .env -f attestor/infra/local/docker-compose.yml up -d 
 Confirm a key reached the container (presence only, never print the value):
 
 ```bash
-docker exec attestor-api-local sh -c '[ -n "$PINECONE_API_KEY" ] && echo SET || echo EMPTY'
+docker exec attestor_api sh -c '[ -n "$PINECONE_API_KEY" ] && echo SET || echo EMPTY'
 ```
 
 ### 4. Vector Store: "Not initialized (localhost:5080 connection refused)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "attestor"
-version = "4.1.7"
+version = "4.1.8"
 description = "Production-grade memory infrastructure for multi-agent systems. Namespace isolation, RBAC, provenance, ranked retrieval."
 readme = "README.md"
 license = "MIT"

--- a/scripts/attestor_uninstall.py
+++ b/scripts/attestor_uninstall.py
@@ -161,7 +161,7 @@ def _remove_containers(*, dry: bool) -> None:
         print("  (docker not available)")
         return
     names = subprocess.run(
-        ["docker", "ps", "-aq", "--filter", "name=attestor-"],
+        ["docker", "ps", "-aq", "--filter", "name=attestor"],
         capture_output=True, text=True, check=False,
     ).stdout.split()
     if names:

--- a/skills/attestor-memory/SKILL.md
+++ b/skills/attestor-memory/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: attestor-memory
 description: Enterprise memory layer for agent teams — durable, deterministic recall with bi-temporal facts, RBAC, and audit trails. Self-hosted Postgres + Pinecone + Neo4j; zero LLM in the critical path.
-version: 4.1.7
+version: 4.1.8
 capabilities:
   - memory.recall
   - memory.add


### PR DESCRIPTION
Every Docker container, volume, network, and the compose project is now named `attestor_…` so `docker ps -a | grep attestor` lists everything Attestor owns. Renamed `attestor_postgres_document_db` / `attestor_pinecone_vector_db` / `attestor_neo4j_graph_db` (+ `attestor_api`); compose project → `attestor`. `quickstart` health-wait + all docs + uninstall scans updated; uninstall docker filter broadened to `name=attestor` (matches new + legacy names). Compose validated with `docker compose config`; full suite green (1365).

🤖 Generated with [Claude Code](https://claude.com/claude-code)