### PR TITLE
feat(recall): unify recall token budget to 2048 (4.1.9)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "attestor",
       "source": "./",
       "description": "Self-hosted memory layer for Claude Code with hard per-project isolation (Postgres RLS + Pinecone + Neo4j).",
-      "version": "4.1.8",
+      "version": "4.1.9",
       "author": {
         "name": "Surendra Singh",
         "url": "https://github.com/bolnet/attestor"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "attestor",
-  "version": "4.1.8",
+  "version": "4.1.9",
   "description": "The memory layer for agent teams. Deterministic retrieval, hard per-project isolation, zero LLM in the critical path.",
   "author": {
     "name": "Surendra Singh",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to Attestor (formerly Memwright) are documented in this file. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.1.9] — 2026-05-26
+
+**One consistent recall token budget: 2048.** The recall cap was inconsistent across paths (MCP `memory_recall` default 2000, CLI `recall` 16000, store config 10000). Unified to **2048** everywhere: MCP tool schema + default, CLI `--budget` default, `init`'s generated `config.toml` (`default_token_budget`), and the bundled `local.yaml` (`stack.budget`). Per-benchmark budgets (locomo/mab/longmemeval) are left as-is (they're harness-tuned). Per-call override via `--budget` / the MCP `budget` arg still works.
+
 ## [4.1.8] — 2026-05-26
 
 **Consistent `attestor_` Docker naming.** Every container, volume, and the compose network/project is now named `attestor_…`, so `docker ps -a | grep attestor` (and `docker volume ls | grep attestor`, `docker network ls | grep attestor`) lists everything Attestor owns. Renamed: `attestor_postgres_document_db`, `attestor_pinecone_vector_db`, `attestor_neo4j_graph_db` (+ `attestor_api`); compose project → `attestor` (volumes become `attestor_postgres_data`, … and the network `attestor_default`). `quickstart`'s health-wait + all docs/uninstall scans updated to match; the uninstall docker filter broadened to `name=attestor` so it catches both the new underscore names and the legacy `attestor-*-local` ones.

--- a/attestor/cli/commands/quickstart.py
+++ b/attestor/cli/commands/quickstart.py
@@ -289,7 +289,7 @@ def _print_profile(store: Path) -> None:
     print(f"  embedder ........ Ollama {OLLAMA_EMBED_MODEL} @{EMBED_DIM}d (local, zero cloud key)")
     print("  llm keys ........ none required (recall/add work fully local)")
     print(f"  passwords ....... '{DEFAULT_PASSWORD}' (localhost dev default; Pinecone key 'local')")
-    print("  token budget ........ 10000")
+    print("  token budget ........ 2048")
     print()
 
 

--- a/attestor/cli/main.py
+++ b/attestor/cli/main.py
@@ -186,7 +186,7 @@ def main(argv=None):
     p_recall = subparsers.add_parser("recall", help="Recall relevant memories")
     p_recall.add_argument("path", help="Memory store path")
     p_recall.add_argument("query", help="Query string")
-    p_recall.add_argument("--budget", type=int, default=16000, help="Token budget")
+    p_recall.add_argument("--budget", type=int, default=2048, help="Token budget")
     p_recall.add_argument("--namespace", default=None, help="Namespace filter")
 
     # search

--- a/attestor/config/defaults/local.yaml
+++ b/attestor/config/defaults/local.yaml
@@ -106,7 +106,7 @@ stack:
       max_entities_per_cluster: 20
       subgraph_depth: 2
       cost_per_summary_usd: 0.005
-  budget: 10000
+  budget: 2048
   parallel: 2
   self_consistency:
     enabled: false

--- a/attestor/init_wizard.py
+++ b/attestor/init_wizard.py
@@ -58,7 +58,7 @@ def _build_config(backend: str, backend_options: Mapping[str, Any] | None) -> to
     doc.add(tomlkit.nl())
 
     doc["backends"] = ["postgres", "neo4j"]
-    doc["default_token_budget"] = 10000
+    doc["default_token_budget"] = 2048
     doc.add(tomlkit.nl())
 
     # Document + vector role. v4 enables the pgvector embedding column (vector

--- a/attestor/mcp/server.py
+++ b/attestor/mcp/server.py
@@ -325,8 +325,8 @@ def create_server(memory_path: str):
                         },
                         "budget": {
                             "type": "integer",
-                            "description": "Max tokens to return (default: 2000)",
-                            "default": 2000,
+                            "description": "Max tokens to return (default: 2048)",
+                            "default": 2048,
                         },
                         "namespace": {
                             "type": "string",
@@ -525,7 +525,7 @@ def _handle_tool(
     elif name == "memory_recall":
         results = mem.recall(
             args["query"],
-            budget=args.get("budget", 2000),
+            budget=args.get("budget", 2048),
             namespace=_ns,
             user_id=args.get("user_id") or default_user_id,
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "attestor"
-version = "4.1.8"
+version = "4.1.9"
 description = "Production-grade memory infrastructure for multi-agent systems. Namespace isolation, RBAC, provenance, ranked retrieval."
 readme = "README.md"
 license = "MIT"

--- a/skills/attestor-memory/SKILL.md
+++ b/skills/attestor-memory/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: attestor-memory
 description: Enterprise memory layer for agent teams — durable, deterministic recall with bi-temporal facts, RBAC, and audit trails. Self-hosted Postgres + Pinecone + Neo4j; zero LLM in the critical path.
-version: 4.1.8
+version: 4.1.9
 capabilities:
   - memory.recall
   - memory.add


### PR DESCRIPTION
Recall cap was inconsistent (MCP 2000 / CLI 16000 / config 10000). Unified to **2048** across MCP tool schema+default, CLI `--budget`, `init`'s `config.toml`, and bundled `local.yaml`. Per-benchmark budgets unchanged. 🤖 Generated with [Claude Code](https://claude.com/claude-code)