### PR TITLE
feat(recall): --show-tokens (4.1.11)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "attestor",
       "source": "./",
       "description": "Self-hosted memory layer for Claude Code with hard per-project isolation (Postgres RLS + Pinecone + Neo4j).",
-      "version": "4.1.10",
+      "version": "4.1.11",
       "author": {
         "name": "Surendra Singh",
         "url": "https://github.com/bolnet/attestor"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "attestor",
-  "version": "4.1.10",
+  "version": "4.1.11",
   "description": "The memory layer for agent teams. Deterministic retrieval, hard per-project isolation, zero LLM in the critical path.",
   "author": {
     "name": "Surendra Singh",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to Attestor (formerly Memwright) are documented in this file. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.1.11] — 2026-05-26
+
+**`attestor recall --show-tokens`.** Prints the packed token count of the recall payload (`[tokens] packed N tokens across M memories (cap …)`) so you can *see* the flat per-call size and decide a tuned budget from real data — the missing readout for the token-savings story.
+
 ## [4.1.10] — 2026-05-26
 
 **Recall budget set very high (1,000,000) instead of capped at 2048.** Rather than artificially limiting recall now, the budget is effectively uncapped so recall returns everything relevant (still bounded by `vector_top_k`); we'll analyze real token usage and tune the cap from data later. Applied consistently: MCP default, CLI `--budget`, `init`'s `config.toml`, bundled `local.yaml`. Per-call override still works.

--- a/attestor/cli/commands/memory.py
+++ b/attestor/cli/commands/memory.py
@@ -128,6 +128,15 @@ def _cmd_recall(args: argparse.Namespace) -> None:
             print(f"[{r.match_source}:{r.score:.2f}] ({m.id}) {m.content}")
             if m.tags:
                 print(f"  tags: {', '.join(m.tags)}")
+        if getattr(args, "show_tokens", False):
+            from attestor.utils.tokens import estimate_tokens
+
+            packed = sum(estimate_tokens(r.memory.content) for r in results)
+            print(
+                f"\n[tokens] packed {packed} tokens across {len(results)} memories "
+                f"(cap {args.budget}). This payload is flat regardless of conversation "
+                f"length — full-context replay grows unbounded."
+            )
 
 
 def _cmd_search(args: argparse.Namespace) -> None:

--- a/attestor/cli/main.py
+++ b/attestor/cli/main.py
@@ -188,6 +188,11 @@ def main(argv=None):
     p_recall.add_argument("query", help="Query string")
     p_recall.add_argument("--budget", type=int, default=1000000, help="Token budget")
     p_recall.add_argument("--namespace", default=None, help="Namespace filter")
+    p_recall.add_argument(
+        "--show-tokens",
+        action="store_true",
+        help="Print the packed token count of the recall payload (flat per call)",
+    )
 
     # search
     p_search = subparsers.add_parser("search", help="Search memories with filters")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "attestor"
-version = "4.1.10"
+version = "4.1.11"
 description = "Production-grade memory infrastructure for multi-agent systems. Namespace isolation, RBAC, provenance, ranked retrieval."
 readme = "README.md"
 license = "MIT"

--- a/skills/attestor-memory/SKILL.md
+++ b/skills/attestor-memory/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: attestor-memory
 description: Enterprise memory layer for agent teams — durable, deterministic recall with bi-temporal facts, RBAC, and audit trails. Self-hosted Postgres + Pinecone + Neo4j; zero LLM in the critical path.
-version: 4.1.10
+version: 4.1.11
 capabilities:
   - memory.recall
   - memory.add


### PR DESCRIPTION
Adds `attestor recall --show-tokens` — prints packed payload token count so per-call recall size is visible. 🤖 Generated with [Claude Code](https://claude.com/claude-code)