### PR TITLE
docs: make `attestor quickstart` the canonical Claude Code install path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,24 +108,15 @@ Same API across all three. Only configuration changes.
 
 ## Install for Claude Code
 
-**The one instruction:** a user tells Claude Code **"install attestor to claude code"** (or runs `/install-attestor`) and Claude does the rest — installs the package, wires the MCP server + hooks, sets up the backends, and verifies. The full guide, **including the copy-paste install prompt for a cold session**, is **[`docs/INSTALL.md`](docs/INSTALL.md)** (start at *Chapter 00 — Install via Claude Code*).
+**The one install:** `pipx install attestor && attestor quickstart` — zero questions, one default profile. It writes `~/.attestor/{config.toml,attestor.yaml,.env}`, brings up the **three-role local stack** in Docker, uses a local **Ollama `bge-m3`** embedder (no cloud key), wires the Claude Code MCP server (`./.mcp.json`) + lifecycle hooks, and runs `attestor doctor`.
 
-**Prompt-first.** Install / setup / uninstall are driven by **prompts that Claude Code executes itself** — `commands/install-attestor.md` and `commands/uninstall-attestor.md` are the source of truth. The Python helpers (`attestor setup-claude-code`, `scripts/attestor_uninstall.py`) encode the same steps for **testing/CI only**; keep them in sync with the prompts, but the prompt is the canonical path.
+**Prerequisites:** Docker running + Ollama serving `bge-m3` (`ollama pull bge-m3`). `quickstart` runs a preflight that scans for these and reports what's missing — it never prompts.
 
-**One install path — the guided wizard** (`commands/install-attestor.md`): an interactive, Claude-driven interview (scope, Postgres / Pinecone / Neo4j connections, embedder = Pinecone Inference default, hook wiring) that installs the package, brings up the backends, wires MCP + hooks, and runs `attestor doctor`. **Four ways to launch the same wizard** (≤3 words each — Claude reads this repo and runs it end-to-end):
-
-| # | Way | Type this |
-|---|-----|-----------|
-| 1 | Plugin (recommended) | `/plugin install attestor` |
-| 2 | Command | `/install-attestor` |
-| 3 | Repo URL | `github.com/bolnet/attestor` |
-| 4 | Natural language | `install attestor` |
-
-First-time plugin use needs `/plugin marketplace add bolnet/attestor` once; the plugin manifest (`.claude-plugin/plugin.json`) additionally auto-wires the MCP server (`.mcp.json`) + hooks (`hooks/hooks.json`) by convention, but the wizard still handles package install + backends + verify. All require the `attestor` binary on PATH (`pipx install attestor`, 4.1.0) + reachable backends.
-
-**Uninstall.** `/uninstall-attestor` (or "uninstall attestor") runs `commands/uninstall-attestor.md` — Claude reverses all six install surfaces itself: package (pipx — run from `$HOME` so the repo `attestor/` subdir doesn't shadow the name), `~/.attestor/`, the MCP entry + Attestor's own hooks (content-matched on `attestor hook`, never other tools'), the Docker backends + volumes (confirm — deletes memory), the plugin, and stray repo artifacts.
+**Reverse it:** `attestor teardown` (zero-question; keeps your data by default — `--purge` also wipes Docker volumes; `--dry-run` previews).
 
 **Per-project isolation is automatic.** Each working directory (git root, else cwd) is its own hard-isolated memory tenant (`attestor/_project.py` + `attestor/hooks/_tenant.py`) — no namespace to configure, and memory never bleeds across projects. Other MCP clients (Cursor, etc.) and runtimes (library / sidecar / shared service) are covered in `docs/INSTALL.md`.
+
+**Plugin path (optional, secondary):** `/plugin marketplace add bolnet/attestor` → `/plugin install attestor` (then ENABLE it in the `/plugin` menu) → run `/attestor:install-attestor` (namespaced!), which just runs `attestor quickstart`. Note the command is `/attestor:install-attestor`, NOT bare `/install-attestor`.
 
 ## Health Check
 

--- a/docs/CLAUDE_LOCAL_SETUP_PROMPT.md
+++ b/docs/CLAUDE_LOCAL_SETUP_PROMPT.md
@@ -1,97 +1,60 @@
-# Claude prompt — stand up Attestor locally with containers
+# Claude prompt — stand up Attestor locally (manual)
 
-Copy everything in the fenced block below and paste it to Claude (Claude Code)
+**Recommended:** Use `attestor quickstart` instead (see [docs/INSTALL.md](INSTALL.md) Chapter 00 for one-command setup).
+
+For manual setup, copy everything in the fenced block below and paste it to Claude (Claude Code)
 from the **root of the Attestor repo**. It is a self-contained, imperative,
 step-by-step prompt that drives an agent to bring up the full local stack and
 verify all four health checks.
 
 > Before running: make sure Docker is running and a repo-root `.env` exists with
-> `PINECONE_API_KEY`, `NEO4J_PASSWORD`, and `OPENROUTER_API_KEY` (the
-> `configs/attestor.yaml` default uses the Pinecone Inference embedder, so
-> `VOYAGE_API_KEY` is only needed if you flip the embedder to voyage). The agent
-> must **never** print, commit, or echo these values.
+> `NEO4J_PASSWORD`. The agent must **never** print, commit, or echo these values.
 
 ---
 
 ```text
-You are setting up Attestor to run locally with Docker containers. Work from the
-repository root. The default stack is: Postgres (document) + Pinecone (vector,
-via the Pinecone Local emulator) + Neo4j (graph), with the Pinecone Inference
-llama-text-embed-v2 embedder (cloud-only, from configs/attestor.yaml). Do all of
+You are setting up Attestor to run locally with Docker containers (manual setup).
+Work from the repository root. The canonical stack is: Postgres (document) +
+Pinecone Local (vector, the :5080 Docker emulator) + Neo4j (graph). Do all of
 the following, in order, and report results after each step.
 
 SAFETY RULES (follow strictly):
-- Never print, echo, log, or commit secret values. The required keys live in the
-  repo-root .env (PINECONE_API_KEY, NEO4J_PASSWORD, OPENROUTER_API_KEY;
-  VOYAGE_API_KEY only if the embedder is flipped to voyage). .env is gitignored —
-  leave it untouched.
+- Never print, echo, log, or commit secret values. The required key (NEO4J_PASSWORD)
+  lives in the repo-root .env. .env is gitignored — leave it untouched.
 - Do NOT edit configs/attestor.yaml.
 - Reference keys only via ${VAR} interpolation or by extracting a single value
   from .env at the moment you export it — and only check presence, never value.
 
 STEP 1 — Preconditions.
 - Confirm Docker is running: `docker info` (just check it succeeds).
-- Confirm the repo-root .env exists and lists the 3 required keys by NAME only:
-  `grep -oE '^(PINECONE_API_KEY|NEO4J_PASSWORD|OPENROUTER_API_KEY)=' .env | sort -u`
-  Report which of the three are present. If any are missing, STOP and tell the user.
+- Confirm the repo-root .env exists and lists NEO4J_PASSWORD:
+  `grep -E '^NEO4J_PASSWORD=' .env`
+  If missing, STOP and tell the user.
 
-STEP 2 — Start Pinecone Local (the vector emulator; it is a SEPARATE container,
-not in the compose file). If a container named `pinecone-local` is already
-running, reuse it. Otherwise start it:
-  docker run -d --name pinecone-local -e PORT=5080 -e PINECONE_HOST=localhost \
-    -p 5080-5090:5080-5090 --platform linux/amd64 \
-    ghcr.io/pinecone-io/pinecone-local:latest
-  Verify with: `docker ps --filter name=pinecone-local`
+STEP 2 — Bring up the compose stack (Postgres + Pinecone Local + Neo4j).
+Pass the repo-root .env explicitly with --env-file:
+  docker compose --env-file .env -f attestor/infra/local/docker-compose.yml up -d
+  Then show status:
+  `docker compose --env-file .env -f attestor/infra/local/docker-compose.yml ps`
 
-STEP 3 — Bring up the compose stack (Postgres + Neo4j + API). Pass the repo-root
-.env explicitly with --env-file (Compose otherwise reads its env file from the
-compose file's own directory and misses the repo-root .env), and build:
-  docker compose --env-file .env -f attestor/infra/local/docker-compose.yml up -d --build
-  Then show status: `docker compose --env-file .env -f attestor/infra/local/docker-compose.yml ps`
-  Confirm the key reached the container (presence only, no value):
-  `docker exec attestor_api sh -c '[ -n "$PINECONE_API_KEY" ] && echo SET || echo EMPTY'`
+STEP 3 — Verify all four health checks with doctor.
+  attestor doctor
+  Expect all four "ok": Document Store (Postgres), Vector Store (Pinecone Local),
+  Graph Store (Neo4j), and Retrieval Pipeline (3/3 layers).
 
-STEP 4 — Verify the FULLY-GREEN path with a host-run API. The containerized API
-at :8080 cannot reach Pinecone Local (its config pins host=localhost:5080, which
-inside the container is the container itself, not the host) — so its Vector
-Store will read "Not initialized". The verified all-green path is the host-run
-API. Export ONLY the three required keys (do not `source` the whole .env — a stray
-NEO4J_URI/POSTGRES_URL in it would hijack backend resolution), and unset those
-overrides:
-  export PINECONE_API_KEY=$(grep -E '^PINECONE_API_KEY=' .env | cut -d= -f2-)
-  export OPENROUTER_API_KEY=$(grep -E '^OPENROUTER_API_KEY=' .env | cut -d= -f2-)
-  export NEO4J_PASSWORD=attestor
-  unset NEO4J_URI POSTGRES_URL ARANGO_URL
-  # Use a Python environment that has the pinecone client installed (e.g. the
-  # project virtualenv at .venv). If `attestor` isn't on PATH, run the module:
-  attestor api --port 8090     # or: .venv/bin/python -m attestor.cli api --port 8090
-Then check health (retry a few times; first hit may race on cold init):
-  curl -s http://127.0.0.1:8090/health | python3 -m json.tool
-Confirm "healthy": true with all four checks "ok": Document Store (Postgres),
-Vector Store (Pinecone), Graph Store (Neo4j), and Retrieval Pipeline (3/3 layers:
-tag_match + graph_expansion + vector_similarity).
-
-STEP 5 — Report.
-- Which of the four health checks are green, and via which path (host-run API at
-  :8090 vs containerized API at :8080).
-- Note the expected, documented nuance: the containerized :8080 API shows Vector
-  Store "Not initialized" because localhost:5080 inside the container is not the
-  host; this is by design and not a failure of the setup.
+STEP 4 — Report.
+Report which of the four health checks are green. If any fail, show the error
+message and suggest the matching Troubleshooting section below.
 
 TROUBLESHOOTING (apply if a step fails):
-- ModuleNotFoundError voyageai/pinecone at startup → rebuild the image with
-  --build (the local Dockerfile installs voyageai>=0.3.0 + pinecone>=5.0.0); for
-  the host-run API, use an env that has those libs (e.g. .venv).
-- "... missing in configs/attestor.yaml" → the image must COPY configs/ (the
-  local Dockerfile does this); rebuild with --build.
-- Services can't read keys → you forgot `--env-file .env`.
-- Vector Store "connection refused localhost:5080" → pinecone-local isn't running
-  (Step 2).
-- Host API KeyError 'document' or only the Neo4j check passes → a stray NEO4J_URI
-  /POSTGRES_URL is set; export only the 4 keys and unset those (Step 4).
+- Containers not running → check `docker compose ps` and wait for them to become healthy
+- Can't read keys → you forgot `--env-file .env`; pass it explicitly on every docker compose command
+- Vector Store "connection refused localhost:5080" → the pinecone container isn't healthy yet; wait and retry
 ```
 
 ---
+
+**Recommended:** Use `attestor quickstart` instead (see [docs/INSTALL.md](INSTALL.md) Chapter 00).
 
 For the full human-readable walkthrough and a deeper Troubleshooting section, see
 [LOCAL_DOCKER_SETUP.md](LOCAL_DOCKER_SETUP.md).

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -15,87 +15,30 @@ A step-by-step guide to installing and verifying Attestor across different topol
 
 ## Chapter 00 — Install via Claude Code (recommended)
 
-**One install path — the guided wizard** ([`../commands/install-attestor.md`](../commands/install-attestor.md)). Whatever you type, Claude reads this repo and runs the wizard end-to-end: it **scans your machine first, looks up current docs via Context7**, then installs the `attestor` package, brings up the three backend containers, wires the MCP server + hooks, and verifies. It assumes you start with **nothing installed**. Four ways to launch it — type any of:
+**The one install:** `pipx install attestor && attestor quickstart` — zero questions, one default profile. It brings up the local backends (Postgres + Pinecone Local + Neo4j), uses a local **Ollama `bge-m3`** embedder (no cloud key), wires the Claude Code MCP server (`./.mcp.json`) + lifecycle hooks, and runs `attestor doctor`.
 
-| # | Way | Type this |
-|---|-----|-----------|
-| 1 | Plugin (recommended) | `/plugin install attestor` |
-| 2 | Command | `/install-attestor` |
-| 3 | Repo URL | `github.com/bolnet/attestor` |
-| 4 | Natural language | `install attestor` |
+**Prerequisites:** Docker running, and Ollama serving `bge-m3` (`ollama pull bge-m3`). `quickstart` runs a preflight that scans the ports/tools and tells you if anything is missing — it never prompts.
 
-First-time plugin use needs `/plugin marketplace add bolnet/attestor` once. The detailed cold-start prompt below is what the wizard runs — paste it directly only if you want to drive a bare session by hand.
+Alternatively, **drive it from inside Claude Code via the plugin** (optional):
+1. `/plugin marketplace add bolnet/attestor` (one-time)
+2. `/plugin install attestor` (then ENABLE it in the `/plugin` → Installed menu)
+3. `/attestor:install-attestor` (namespaced command — runs `attestor quickstart` for you)
+
+> **Note:** Plugin commands are namespaced — the command is `/attestor:install-attestor`, not bare `/install-attestor`. A freshly-installed plugin can be disabled; enable it in the `/plugin` → Installed menu and `/reload-plugins`, or the command won't resolve.
 
 > Every chapter targets the same **canonical stack: Postgres (document) + Pinecone (vector) + Neo4j (graph)**, with the embedder, models, and retrieval budget coming from the single source of truth, [`configs/attestor.yaml`](../configs/attestor.yaml). Chapter 00 is the fastest path; 01–03 are the manual local / sidecar / cloud setups.
 
-### The three backends — one clearly-named Docker instance per storage role
+### The three backends — three Docker containers (attestor_ prefix), one per role
 
-Each storage role is its own container, all `attestor-`prefixed and labeled by type:
+Each storage role is its own container, all `attestor_*` prefixed:
 
-| Container | Type | Storage role | Image | Ports |
-|-----------|------|--------------|-------|-------|
-| `attestor-postgres` | **Postgres 16 + pgvector** | **Document** — source of truth (content, tags, entity, ts, provenance, confidence) | `pgvector/pgvector:pg16` | `5432` |
-| `attestor-pinecone` | **Pinecone Local** | **Vector** — dense embeddings, per-namespace cosine search | `ghcr.io/pinecone-io/pinecone-local:latest` | `5080-5090` |
-| `attestor-neo4j` | **Neo4j 5 + GDS** | **Graph** — entity nodes + typed edges, PageRank / BFS | `neo4j:5.24-community` | `7474`, `7687` |
+| Container | Type | Storage role | Ports |
+|-----------|------|--------------|-------|
+| `attestor_postgres_document_db` | **Postgres 16 + pgvector** | **Document** — source of truth (content, tags, entity, ts, provenance, confidence) | `5432` |
+| `attestor_pinecone_vector_db` | **Pinecone Local** | **Vector** — dense embeddings, per-namespace cosine search | `5080-5089` |
+| `attestor_neo4j_graph_db` | **Neo4j 5 + GDS** | **Graph** — entity nodes + typed edges, PageRank / BFS | `7687` |
 
-### The install prompt — paste into a fresh Claude Code session
-
-```text
-Install Attestor as my agent-memory layer and wire it natively into Claude Code.
-Assume a COLD machine — I may have nothing installed. Work in this order and ask
-me only when you hit a real decision or need a secret.
-
-PHASE 1 — SCAN (install nothing yet)
-Detect and show me a table of present vs missing:
-- OS + arch; Python (need >=3.10); pip / pipx; Docker + Docker Compose (running?).
-- Existing Attestor: `attestor --version`, ~/.attestor, an MCP entry in
-  ~/.claude or ./.mcp.json, attestor hooks in settings.json.
-- Running backend containers (`docker ps`) and listeners on 5432 / 5080 / 7687.
-Then tell me what you'll INSTALL, REUSE, and SKIP before doing anything.
-
-PHASE 2 — LOOK UP CURRENT DOCS WITH CONTEXT7 (before every install step)
-Before you install or run ANY tool, fetch its current docs via the Context7 MCP
-(resolve-library-id -> query-docs): pipx, pgvector, Pinecone Local, Neo4j GDS,
-the `attestor` PyPI package, and the Claude Code plugin / MCP / hooks format.
-Use the commands and versions Context7 returns — not ones from memory. If
-Context7 is unavailable, tell me and pause.
-
-PHASE 3 — BACKENDS: three clearly-named Docker instances (attestor- prefix), one per role
-Start exactly these and confirm each reports healthy:
-- attestor-postgres  Postgres 16 + pgvector   DOCUMENT store   :5432         pgvector/pgvector:pg16
-- attestor-pinecone  Pinecone Local           VECTOR store     :5080-5090    ghcr.io/pinecone-io/pinecone-local:latest
-- attestor-neo4j     Neo4j 5 + GDS            GRAPH store      :7474/:7687   neo4j:5.24-community (NEO4J_PLUGINS=["graph-data-science"])
-Use a single password (default `attestor`) and put every secret in a gitignored
-.env — never hardcode. Persist data in named volumes.
-
-PHASE 4 — INSTALL THE ATTESTOR PACKAGE
-`pipx install attestor` (fallback `pip install --user attestor`). Confirm
-`attestor --version`. The `attestor` binary must be on PATH — the plugin's hooks
-and MCP server call it directly.
-
-PHASE 5 — WIRE INTO CLAUDE CODE (prefer the plugin)
-Ask my scope: global (~/.claude) or this project only. Then:
-- Plugin (recommended): `/plugin marketplace add bolnet/attestor` then
-  `/plugin install attestor` — this auto-wires the MCP server (.mcp.json) and the
-  SessionStart / PostToolUse / Stop hooks by convention.
-- If I decline the plugin: merge the attestor MCP server into .mcp.json and the
-  three hooks into settings.json yourself, without clobbering existing entries.
-Ask my embedding provider (Pinecone Inference default, else Voyage / OpenAI /
-Ollama) and store its API key in .env.
-
-PHASE 6 — VERIFY
-Run `attestor doctor <store-path>` (expect Document / Vector / Graph / Retrieval
-all healthy) and call the `memory_health` MCP tool. Then prove per-project
-isolation: add a memory here, and confirm a different project directory does NOT
-see it. Show me the results.
-
-NOTES
-- Memory is automatically isolated per project — each git-root (else cwd) is its
-  own tenant. There is no namespace to configure.
-- If any phase fails, STOP and tell me exactly what failed. Do not continue silently.
-```
-
-After it finishes you can use the `memory_*` tools immediately, and every project you open gets its own hard-isolated memory automatically.
+After `attestor quickstart` finishes, you can use the `memory_*` MCP tools immediately, and every project you open gets its own hard-isolated memory automatically.
 
 > Hooks load the user environment before calling `attestor`. The wired hook command is
 > `bash -c 'set -a; [ -f "$HOME/.attestor/.env" ] && . "$HOME/.attestor/.env"; set +a; attestor hook <event>'`.
@@ -105,13 +48,14 @@ After it finishes you can use the `memory_*` tools immediately, and every projec
 
 ---
 
-## Chapter 01 — Local stack with Docker Compose
+## Chapter 01 — Manual local stack (Docker Compose only)
+
+**Recommended: use `attestor quickstart` (Chapter 00) instead.** This chapter is for advanced users who want to bring up the backends manually without the preflight checks and auto-wiring.
 
 Attestor's canonical stack is three services: **Postgres** (document role, source of truth), **Pinecone Local** (vector role, the free `:5080` Docker emulator), and **Neo4j + GDS** (graph role). The bundled Compose stack in `attestor/infra/local/` brings all three up on a laptop.
 
 > The detailed, copy-paste-ready walkthrough — including the four health checks — lives in
-> **[`docs/LOCAL_DOCKER_SETUP.md`](LOCAL_DOCKER_SETUP.md)** (and its agent-driven variant
-> **[`docs/CLAUDE_LOCAL_SETUP_PROMPT.md`](CLAUDE_LOCAL_SETUP_PROMPT.md)**). This chapter is the short version.
+> **[`docs/LOCAL_DOCKER_SETUP.md`](LOCAL_DOCKER_SETUP.md)**. This chapter is the short version.
 
 ### Prerequisites
 
@@ -132,21 +76,21 @@ Attestor's canonical stack is three services: **Postgres** (document role, sourc
 ```bash
 cd attestor/infra/local
 cp .env.example .env            # fill in the keys above
-docker compose up -d postgres neo4j pinecone
+docker compose up -d
 ```
 
 This brings up three containers:
 
-| Container | Image | Port | Role |
-|-----------|-------|------|------|
-| `attestor_postgres_document_db` | `attestor/db-postgres:16` (pgvector) | `5432` | Document |
-| `attestor_pinecone_vector_db` | `ghcr.io/pinecone-io/pinecone-local:latest` | `5080-5090` | Vector |
-| `attestor_neo4j_graph_db` | `neo4j:5.24-community` (+ GDS plugin) | `7474`, `7687` | Graph |
+| Container | Port | Role |
+|-----------|------|------|
+| `attestor_postgres_document_db` | `5432` | Document |
+| `attestor_pinecone_vector_db` | `5080-5090` | Vector |
+| `attestor_neo4j_graph_db` | `7474`, `7687` | Graph |
 
 Wait for all three to report healthy:
 
 ```bash
-docker ps --filter name=attestor- --format '{{.Names}}\t{{.Status}}'
+docker compose ps
 ```
 
 ### Step 2 — Install the CLI
@@ -230,7 +174,7 @@ Non-fatal errors in the vector or graph layers are caught and logged; the docume
 
 ### Claude Code integration
 
-The fastest path is Chapter 00. To wire it manually, add the MCP server to `.mcp.json` (project) or `~/.claude/settings.json` (global):
+The fastest path is Chapter 00 (`attestor quickstart`). To wire MCP + hooks manually afterward, add to `.mcp.json` (project) or `~/.claude/settings.json` (global):
 
 ```json
 {
@@ -246,7 +190,7 @@ The fastest path is Chapter 00. To wire it manually, add the MCP server to `.mcp
 }
 ```
 
-The MCP server inherits the `env` block above. The lifecycle hooks (SessionStart / PostToolUse / Stop) run as separate subprocesses that do **not** inherit your interactive shell, so they load `~/.attestor/.env` themselves:
+The lifecycle hooks (SessionStart / PostToolUse / Stop) run as separate subprocesses that do **not** inherit your interactive shell, so they load `~/.attestor/.env` themselves:
 
 ```json
 {
@@ -261,7 +205,7 @@ The MCP server inherits the `env` block above. The lifecycle hooks (SessionStart
 }
 ```
 
-`attestor setup-claude-code` writes exactly this wiring for you. The `set -a` is required — without it, un-exported `.env` vars never reach the hook subprocess and hooks save nothing.
+The `set -a` is required — without it, un-exported `.env` vars never reach the hook subprocess and hooks save nothing.
 
 ### Troubleshooting
 
@@ -316,13 +260,12 @@ Run the API container (or your own image) with those env vars; `configs/attestor
 
 ## Uninstall
 
-Attestor is **prompt-first**: tell Claude Code **"uninstall attestor"** (or run **`/uninstall-attestor`**) and it reverses all six install surfaces itself — following `commands/uninstall-attestor.md`:
+**The one command:** `attestor teardown` — zero-question reverse of `attestor quickstart`. It removes Docker backends + volumes (confirm — deletes all memory), MCP entry, hooks, plugin, and stray artifacts. Keeps `~/.attestor/` by default; add `--purge` to also wipe config + `.env`.
 
-1. **Package** — `pipx uninstall attestor` (run from `$HOME`, not the repo: a local `attestor/` dir makes pipx read the name as a path).
-2. **`~/.attestor/`** — config + `.env` (no memory data lives here).
-3. **Claude Code wiring** — the `attestor` MCP entry + Attestor's own hooks, content-matched on `attestor hook` so other tools' hooks are never touched (project `.claude/settings.json` / `.mcp.json`; the global file usually has none).
-4. **Docker backends** — `attestor-*` containers + volumes (**confirm — this deletes all stored memory**).
-5. **Plugin** — `/plugin uninstall attestor` (interactive).
-6. **Stray repo artifacts** — `.cc_attestor_probe_store`, root `config.json`, `logs/`.
+```bash
+attestor teardown                    # preview only
+attestor teardown --yes              # execute (keeps data volumes)
+attestor teardown --yes --purge      # also wipe data volumes + ~/.attestor
+```
 
-For local testing / CI there's a dry-run-by-default script that encodes the same procedure: `python scripts/attestor_uninstall.py` (add `--yes --containers --artifacts` to execute). It is a test/reference of the prompt above, not the primary path. Restart Claude Code afterward so it drops the orphaned MCP server + hooks.
+You can also drive this from inside Claude Code: `/uninstall-attestor` runs the same uninstall. Restart Claude Code afterward so it drops the orphaned MCP server + hooks.

--- a/docs/LOCAL_DOCKER_SETUP.md
+++ b/docs/LOCAL_DOCKER_SETUP.md
@@ -1,14 +1,15 @@
-# Running Attestor locally with containers
+# Running Attestor locally with Docker (Manual setup)
+
+**Recommended:** Use `attestor quickstart` instead (see [docs/INSTALL.md](INSTALL.md) Chapter 00). This guide is for advanced manual setup.
 
 A step-by-step guide to stand up the full default Attestor stack
-(**Postgres** document store + **Pinecone** vector store + **Neo4j** graph
+(**Postgres** document store + **Pinecone Local** vector store + **Neo4j** graph
 store) on your own machine using Docker, and verify that all four health
 checks go green.
 
-This guide reflects the **out-of-the-box default stack** declared in
-`configs/attestor.yaml`: the **Pinecone Inference `llama-text-embed-v2`**
-embedder (1024-D, cloud-only) and the **Pinecone** vector role, backed by
-**Pinecone Local** (the `:5080` emulator).
+This guide reflects the **canonical local stack**: **Postgres 16 + pgvector**
+(document), **Pinecone Local** (the `:5080` Docker emulator for vector), and
+**Neo4j 5 + GDS** (graph).
 
 ---
 
@@ -16,73 +17,41 @@ embedder (1024-D, cloud-only) and the **Pinecone** vector role, backed by
 
 1. **Docker** (Desktop or Engine) with Compose v2 (`docker compose`, not the
    legacy `docker-compose`). The Pinecone Local image is `linux/amd64`; on
-   Apple Silicon it runs under emulation automatically (`--platform
-   linux/amd64`, shown below).
-2. **A repo-root `.env`** with the three keys the default stack needs:
+   Apple Silicon it runs under emulation automatically.
+2. **A repo-root `.env`** with the keys needed. For the canonical local stack
+   (Postgres + Pinecone Local + Neo4j + Ollama embedder):
 
    ```dotenv
-   PINECONE_API_KEY=...      # Pinecone Inference embedder (cloud-only) + Pinecone Cloud vector role
-   NEO4J_PASSWORD=...        # Neo4j graph store (compose default: "attestor")
-   OPENROUTER_API_KEY=...    # LLM calls (extraction / answerer)
-   # VOYAGE_API_KEY=...      # optional — only if you flip the embedder to voyage in configs/attestor.yaml
+   NEO4J_PASSWORD=...        # Neo4j graph store (quickstart default: "attestor")
+   OPENROUTER_API_KEY=...    # LLM calls (extraction / answerer) — only if you run benchmarks
+   # PINECONE_API_KEY=...    # Not needed for Pinecone Local; only for Pinecone Cloud
    ```
 
-   `.env` is **gitignored** (`.gitignore` lists `.env` and `.env.*`) — never
-   commit it. The compose file and Dockerfile reference these only via
-   `${VAR}` interpolation, so no secret is ever baked into an image.
+   `.env` is **gitignored** — never commit it. The compose file references these
+   only via `${VAR}` interpolation, so no secret is ever baked into an image.
 
-> **Note on the `PINECONE_API_KEY` value.** For **Pinecone Local** the key is
-> ignored by the emulator (any non-empty value works). For Pinecone **Cloud**
-> it must be a real key from app.pinecone.io.
+> **Note:** `attestor quickstart` auto-generates and wires `.env` for you. This
+> manual guide is for advanced setup.
 
 ---
 
-## Step 1 — Start Pinecone Local (the vector emulator)
+## Step 1 — Start the three containers
 
-Pinecone Local is the default vector store, but it is **not** part of the
-compose file — it runs as its own container. Start it first:
-
-```bash
-docker run -d --name pinecone-local \
-  -e PORT=5080 -e PINECONE_HOST=localhost \
-  -p 5080-5090:5080-5090 \
-  --platform linux/amd64 \
-  ghcr.io/pinecone-io/pinecone-local:latest
-```
-
-(This is the canonical command documented in
-`attestor/store/pinecone_backend.py`.) If a `pinecone-local` container is
-already running, reuse it — no need to start a second one.
-
-Verify it is up:
-
-```bash
-docker ps --filter name=pinecone-local
-# Expect: Up ... 0.0.0.0:5080-5090->5080-5090/tcp
-```
-
----
-
-## Step 2 — Bring up the compose stack (Postgres + Neo4j + API)
-
-From the **repo root**, build and start the three-service stack. Pass the
-repo-root `.env` explicitly with `--env-file` (see Troubleshooting #3 for why
-this is required):
+From the **repo root**, start the three-role stack:
 
 ```bash
 docker compose --env-file .env \
   -f attestor/infra/local/docker-compose.yml \
-  up -d --build
+  up -d
 ```
 
-This builds the `attestor/api` image (which now bundles the Voyage + Pinecone
-client libraries and bakes in `configs/`) and starts:
+This starts:
 
 | Container             | Role     | Port(s)      |
 | --------------------- | -------- | ------------ |
 | `attestor_postgres_document_db`   | Document | `5432`       |
+| `attestor_pinecone_vector_db` | Vector | `5080-5090` |
 | `attestor_neo4j_graph_db`| Graph    | `7474`, `7687` |
-| `attestor_api`  | REST API | `8080`       |
 
 Watch them become healthy:
 
@@ -92,38 +61,12 @@ docker compose --env-file .env -f attestor/infra/local/docker-compose.yml ps
 
 ---
 
-## Step 3 — Verify (the recommended, fully-green path)
+## Step 2 — Verify with attestor doctor
 
-There are two ways to reach the API. **Use the host-run API for a clean,
-fully-green verification** — it can reach Pinecone Local at `localhost:5080`,
-whereas the containerized API cannot (see the important note below).
-
-### Recommended: host-run API → all 4 checks green
-
-Run the API on the host (it talks to the containers via their published
-ports). Export **only the three required keys** — do **not** `source` your whole
-`.env`, which may contain unrelated vars (e.g. a stray `NEO4J_URI` /
-`POSTGRES_URL`) that hijack the API's backend resolution (Troubleshooting #5):
+Run the CLI health check:
 
 ```bash
-export PINECONE_API_KEY=$(grep -E '^PINECONE_API_KEY=' .env | cut -d= -f2-)
-export OPENROUTER_API_KEY=$(grep -E '^OPENROUTER_API_KEY=' .env | cut -d= -f2-)
-export NEO4J_PASSWORD=attestor
-unset NEO4J_URI POSTGRES_URL ARANGO_URL    # avoid env-based backend override
-
-attestor api --port 8090
-```
-
-Then, in another shell, check health:
-
-```bash
-curl -s http://127.0.0.1:8090/health | python3 -m json.tool
-```
-
-or use the doctor CLI (point it at your data dir):
-
-```bash
-attestor doctor ~/.attestor
+attestor doctor
 ```
 
 You should see **all four checks OK**:
@@ -138,70 +81,23 @@ Overall: ALL HEALTHY
 ```
 
 The four checks correspond to: **Document Store** (Postgres), **Vector Store**
-(Pinecone), **Graph Store** (Neo4j), and the **Retrieval Pipeline** (3/3 layers
-= `tag_match` + `graph_expansion` + `vector_similarity`).
-
-### Containerized API at `:8080`
-
-The compose API is also reachable:
-
-```bash
-curl -s http://127.0.0.1:8080/health | python3 -m json.tool
-```
-
-It will report **Document Store, Graph Store, and Retrieval Pipeline green**,
-but **Vector Store "Not initialized"** — see the important nuance below.
-
----
-
-## Important: why the *containerized* API's Vector Store stays "Not initialized"
-
-`configs/attestor.yaml` pins the Pinecone host to `pinecone.host:
-http://localhost:5080`. Inside the `attestor-api` container, `localhost` is the
-**container itself**, not the host machine — so the containerized API cannot
-reach the host's `pinecone-local` container that way, and its Vector Store
-check reports `Not initialized`. Retrieval still works in a **degraded** mode
-on the remaining two layers (`tag_match` + `graph_expansion`, 2/3).
-
-Attestor reads the Pinecone host **only** from `configs/attestor.yaml`
-(`build_backend_config` does `host = pcn.get("host")`); there is **no
-environment-variable override** for the Pinecone host in the loader. Making the
-*fully-containerized* path reach Pinecone would therefore require editing
-`configs/attestor.yaml` to a Docker-network-reachable host (e.g. a
-`pinecone-local` service name) — which is intentionally **out of scope** here.
-
-**The verified fully-green path is the host-run API in Step 3.** Use that to
-confirm your install, and use the containerized `:8080` API for the three
-non-vector roles.
+(Pinecone Local), **Graph Store** (Neo4j), and the **Retrieval Pipeline** (3/3 layers).
 
 ---
 
 ## Troubleshooting — first-run gotchas
 
-These are the issues a brand-new user hits, in the order they tend to surface.
+### 1. Containers not starting / `connection refused`
 
-### 1. `ModuleNotFoundError: No module named 'pinecone'` (or `voyageai`) at API startup
+Check if all three are running:
 
-The base image historically installed only the Postgres + Neo4j + OpenAI
-clients, but the **default** stack is the **Pinecone Inference embedder +
-Pinecone vector**. The local API Dockerfile (`attestor/infra/local/api.Dockerfile`)
-now pip-installs `pinecone>=5.0.0` (and `voyageai>=0.3.0` for the voyage
-alternative) so the image can honor the default `configs/attestor.yaml` out of
-the box. If you see this error, rebuild with `--build`.
+```bash
+docker compose --env-file .env -f attestor/infra/local/docker-compose.yml ps
+```
 
-> Running the API **on the host** (Step 3)? Use an environment that has the
-> `pinecone` client installed (e.g. a project virtualenv: `pip install pinecone`),
-> otherwise the embedder fails with *"embedder provider 'pinecone' failed to
-> initialize"*.
+Wait a few seconds; services take time to initialize.
 
-### 2. Config loader hard-fails: `... missing in configs/attestor.yaml`
-
-`configs/attestor.yaml` is the **only source of truth** for the stack (embedder,
-vector, models) — the loader raises rather than falling back to constants. The
-local API Dockerfile now does `COPY configs/ configs/` so the YAML is baked into
-the image. Without it the container can't start. Rebuild with `--build`.
-
-### 3. Health checks fail / services can't read their keys → **pass `--env-file .env`**
+### 2. Health checks fail / services can't read their keys → **pass `--env-file .env`**
 
 Docker Compose reads its env file from **the compose file's own directory**, not
 your current working directory. Since the keys live in the **repo-root** `.env`
@@ -209,51 +105,36 @@ but the compose file is at `attestor/infra/local/docker-compose.yml`, the
 `.env` is **not** picked up automatically. Always pass it explicitly:
 
 ```bash
-docker compose --env-file .env -f attestor/infra/local/docker-compose.yml up -d --build
+docker compose --env-file .env -f attestor/infra/local/docker-compose.yml up -d
 ```
 
 Confirm a key reached the container (presence only, never print the value):
 
 ```bash
-docker exec attestor_api sh -c '[ -n "$PINECONE_API_KEY" ] && echo SET || echo EMPTY'
+docker exec attestor_postgres_document_db sh -c '[ -n "$POSTGRES_PASSWORD" ] && echo SET || echo EMPTY'
 ```
 
-### 4. Vector Store: "Not initialized (localhost:5080 connection refused)"
+### 3. Vector Store: "Not initialized (localhost:5080 connection refused)"
 
-The `pinecone-local` container isn't running. Start it (Step 1). Pinecone Local
-is the default vector store but is **not** part of the compose file, so a fresh
-machine won't have it until you run the `docker run … pinecone-local` command.
-Without it, retrieval runs degraded on `tag_match` + `graph_expansion` only
-(2/3 layers).
+The `attestor_pinecone_vector_db` container isn't running or healthy. Check:
 
-### 5. Host-run API shows `KeyError: 'document'` or only the Neo4j check
+```bash
+docker compose --env-file .env -f attestor/infra/local/docker-compose.yml logs attestor_pinecone_vector_db
+```
 
-The host API's config resolver checks **explicit env vars first**
-(`POSTGRES_URL`, `NEO4J_URI`, `ARANGO_URL`) before the YAML. If your `.env`
-contains a stray `NEO4J_URI` (or `POSTGRES_URL`) meant for other tooling and you
-`source` the whole file, the API short-circuits to an env-only backend set and
-drops the document/vector roles. Export **only** the four required keys and
-`unset NEO4J_URI POSTGRES_URL ARANGO_URL` before starting the host API (see
-Step 3).
+Wait for it to become healthy and retry `attestor doctor`.
 
 ---
 
 ## Quick reference
 
 ```bash
-# 1. Vector emulator (separate container; reuse if already running)
-docker run -d --name pinecone-local -e PORT=5080 -e PINECONE_HOST=localhost \
-  -p 5080-5090:5080-5090 --platform linux/amd64 \
-  ghcr.io/pinecone-io/pinecone-local:latest
+# Bring up the stack (note --env-file .env)
+docker compose --env-file .env \
+  -f attestor/infra/local/docker-compose.yml up -d
 
-# 2. Compose stack (note --env-file .env and --build)
-docker compose --env-file .env -f attestor/infra/local/docker-compose.yml up -d --build
-
-# 3. Verify (host-run API → all 4 green)
-export PINECONE_API_KEY=$(grep -E '^PINECONE_API_KEY=' .env | cut -d= -f2-)
-export OPENROUTER_API_KEY=$(grep -E '^OPENROUTER_API_KEY=' .env | cut -d= -f2-)
-export NEO4J_PASSWORD=attestor
-unset NEO4J_URI POSTGRES_URL ARANGO_URL
-attestor api --port 8090
-curl -s http://127.0.0.1:8090/health | python3 -m json.tool
+# Verify
+attestor doctor
 ```
+
+**Recommended:** Use `attestor quickstart` instead (automatic setup, all wiring included).


### PR DESCRIPTION
## Summary

Makes **`attestor quickstart`** the single, canonical Claude Code install path across all docs, replacing the dated "guided wizard / 4 ways to launch / manual bring-up" framing.

The one install is now:

\`\`\`bash
pipx install attestor && attestor quickstart   # zero questions, one default profile
attestor teardown                              # reverse it (--purge wipes data)
\`\`\`

## Changes (docs only — no code, config, or version changes)

- **CLAUDE.md** — Install section leads with `quickstart`; plugin path kept as optional/secondary (namespaced `/attestor:install-attestor`, not bare `/install-attestor`).
- **docs/INSTALL.md** — Chapter 00 rewritten to quickstart; Chapter 01 reframed as manual/advanced; container tables use canonical `attestor_postgres_document_db` / `attestor_pinecone_vector_db` / `attestor_neo4j_graph_db` names.
- **docs/LOCAL_DOCKER_SETUP.md** + **docs/CLAUDE_LOCAL_SETUP_PROMPT.md** — quickstart banner up top; manual compose walkthrough demoted to appendix.

Prereqs stated as Docker + Ollama `bge-m3` (no cloud key for the default local stack). README and `commands/install-attestor.md` were already quickstart-correct and are unchanged.

## Test plan

- [x] `grep` for stragglers (`guided wizard`, `4 ways`, old `attestor-*` container names, `4.0.0`, `setup-claude-code`) returns no matches.
- [x] Container names consistent (`attestor_*_db`) across all tables.
- [ ] No PyPI release needed — README (only PyPI-facing doc) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)